### PR TITLE
Use `emitc.ptr` for `iree_vm_ref_t*` type

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -62,8 +62,7 @@ Optional<std::string> getCType(Type type) {
 }
 
 /// Create a call to memset to clear a struct
-LogicalResult clearStruct(OpBuilder builder, Value structValue,
-                          bool isPointer) {
+LogicalResult clearStruct(OpBuilder builder, Value structValue) {
   auto ctx = structValue.getContext();
   auto loc = structValue.getLoc();
 
@@ -247,8 +246,7 @@ LogicalResult convertFuncOp(IREE::VM::FuncOp funcOp,
     // the first slots.
     vmAnalysis.getValue().get().cacheLocalRef(i + numRefArgs, refPtrOp);
 
-    if (failed(
-            clearStruct(builder, refPtrOp.getResult(), /*isPointer=*/true))) {
+    if (failed(clearStruct(builder, refPtrOp.getResult()))) {
       return failure();
     }
   }
@@ -359,8 +357,7 @@ Optional<emitc::ApplyOp> createVmTypeDefPtr(ConversionPatternRewriter &rewriter,
       /*resultType=*/emitc::OpaqueType::get(ctx, "iree_vm_type_def_t"),
       /*value=*/emitc::OpaqueAttr::get(ctx, ""));
 
-  if (failed(clearStruct(rewriter, elementTypeOp.getResult(),
-                         /*isPointer=*/false))) {
+  if (failed(clearStruct(rewriter, elementTypeOp.getResult()))) {
     return None;
   }
 
@@ -964,8 +961,7 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
             /*templateArgs=*/ArrayAttr{},
             /*operands=*/ArrayRef<Value>{refs.getResult(0)});
 
-        if (failed(clearStruct(builder, refPtrOp.getResult(0),
-                               /*isPointer=*/true))) {
+        if (failed(clearStruct(builder, refPtrOp.getResult(0)))) {
           return failure();
         }
       }
@@ -2652,7 +2648,7 @@ class ImportOpConversion : public OpConversionPattern<IREE::VM::ImportOp> {
             .getResult();
 
     // memset(&result, 0, sizeof(result));
-    if (failed(clearStruct(rewriter, executionResult, false))) {
+    if (failed(clearStruct(rewriter, executionResult))) {
       emitError(loc) << "failed to clear struct";
       return failure();
     }
@@ -2999,8 +2995,7 @@ class CallOpConversion : public OpConversionPattern<CallOpTy> {
             /*applicableOperator=*/StringAttr::get(ctx, "&"),
             /*operand=*/refOp.getResult());
 
-        if (failed(clearStruct(rewriter, refPtrOp.getResult(),
-                               /*isPointer=*/true))) {
+        if (failed(clearStruct(rewriter, refPtrOp.getResult()))) {
           return failure();
         }
 
@@ -3669,8 +3664,7 @@ class ReturnOpConversion : public OpConversionPattern<IREE::VM::ReturnOp> {
             /*applicableOperator=*/StringAttr::get(ctx, "&"),
             /*operand=*/refOp.getResult());
 
-        if (failed(clearStruct(rewriter, refPtrOp.getResult(),
-                               /*isPointer=*/true))) {
+        if (failed(clearStruct(rewriter, refPtrOp.getResult()))) {
           return failure();
         }
 

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -67,47 +67,31 @@ LogicalResult clearStruct(OpBuilder builder, Value structValue,
   auto ctx = structValue.getContext();
   auto loc = structValue.getLoc();
 
-  Type type = structValue.getType();
-
-  if (!type.isa<emitc::OpaqueType>()) {
-    return failure();
-  }
-
-  Optional<std::string> cType = getCType(type);
-  if (!cType.hasValue()) {
-    return failure();
-  }
-  std::string cPtrType = cType.getValue();
-
   Value structPointerValue;
   Value sizeValue;
 
-  if (isPointer) {
-    std::string pointerType;
-    if (type.isa<IREE::VM::RefType>()) {
-      pointerType = cPtrType + "*";
-    } else {
-      pointerType = cPtrType;
-    }
+  Type type = structValue.getType();
+  auto ptrType = type.dyn_cast<emitc::PointerType>();
 
-    if (pointerType.back() != '*') {
-      return failure();
-    }
-
-    std::string nonPointerType = pointerType.substr(0, pointerType.size() - 1);
-
+  if (ptrType) {
     auto size = builder.create<emitc::CallOp>(
         /*location=*/loc,
         /*type=*/builder.getI32Type(),
         /*callee=*/StringAttr::get(ctx, "sizeof"),
         /*args=*/
-        ArrayAttr::get(ctx, {emitc::OpaqueAttr::get(ctx, nonPointerType)}),
+        ArrayAttr::get(ctx, {TypeAttr::get(ptrType.getPointee())}),
         /*templateArgs=*/ArrayAttr{},
         /*operands=*/ArrayRef<Value>{});
 
     structPointerValue = structValue;
     sizeValue = size.getResult(0);
   } else {
+    Optional<std::string> cType = getCType(type);
+    if (!cType.hasValue()) {
+      return failure();
+    }
+    std::string cPtrType = cType.getValue();
+
     auto structPointer = builder.create<emitc::ApplyOp>(
         /*location=*/loc,
         /*result=*/
@@ -180,12 +164,8 @@ LogicalResult convertFuncOp(IREE::VM::FuncOp funcOp,
     // We pass refs as iree_vm_ref_t* regardless of whether it is an in or out
     // parameter
     std::string cPtrType = cType.getValue();
-    Type type;
-    if (resultType.isa<IREE::VM::RefType>()) {
-      type = emitc::OpaqueType::get(ctx, cPtrType + "*");
-    } else {
-      type = emitc::PointerType::get(emitc::OpaqueType::get(ctx, cPtrType));
-    }
+    Type type = emitc::PointerType::get(emitc::OpaqueType::get(ctx, cPtrType));
+
     inputTypes.push_back(type);
     outputTypes.push_back(type);
   }
@@ -257,7 +237,8 @@ LogicalResult convertFuncOp(IREE::VM::FuncOp funcOp,
 
     auto refPtrOp = builder.create<emitc::ApplyOp>(
         /*location=*/loc,
-        /*result=*/emitc::OpaqueType::get(ctx, "iree_vm_ref_t*"),
+        /*result=*/
+        emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_ref_t")),
         /*applicableOperator=*/StringAttr::get(ctx, "&"),
         /*operand=*/refOp.getResult());
 
@@ -508,7 +489,8 @@ void releaseRefs(OpBuilder &builder, Location location, mlir::FuncOp funcOp,
   // as further operands.
   size_t refArgumentsReleased = 0;
   for (auto arg : funcOp.getArguments()) {
-    if (arg.getType() == emitc::OpaqueType::get(ctx, "iree_vm_ref_t*")) {
+    if (arg.getType() ==
+        emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_ref_t"))) {
       if (vmAnalysis.getValue().get().numRefArguments <=
           refArgumentsReleased++) {
         break;
@@ -960,7 +942,8 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
     if (numGlobalRefs > 0) {
       auto refs = builder.create<emitc::CallOp>(
           /*location=*/loc,
-          /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_ref_t*"),
+          /*type=*/
+          emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_ref_t")),
           /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER"),
           /*args=*/
           ArrayAttr::get(ctx, {builder.getIndexAttr(0),
@@ -971,7 +954,9 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
       for (int i = 0; i < numGlobalRefs; i++) {
         auto refPtrOp = builder.create<emitc::CallOp>(
             /*location=*/loc,
-            /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_ref_t*"),
+            /*type=*/
+            emitc::PointerType::get(
+                emitc::OpaqueType::get(ctx, "iree_vm_ref_t")),
             /*callee=*/StringAttr::get(ctx, "EMITC_ARRAY_ELEMENT_ADDRESS"),
             /*args=*/
             ArrayAttr::get(
@@ -1072,7 +1057,8 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
     if (numGlobalRefs > 0) {
       auto refs = builder.create<emitc::CallOp>(
           /*location=*/loc,
-          /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_ref_t*"),
+          /*type=*/
+          emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_ref_t")),
           /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER"),
           /*args=*/
           ArrayAttr::get(ctx, {builder.getIndexAttr(0),
@@ -1083,7 +1069,9 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
       for (int i = 0; i < numGlobalRefs; i++) {
         auto refPtrOp = builder.create<emitc::CallOp>(
             /*location=*/loc,
-            /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_ref_t*"),
+            /*type=*/
+            emitc::PointerType::get(
+                emitc::OpaqueType::get(ctx, "iree_vm_ref_t")),
             /*callee=*/StringAttr::get(ctx, "EMITC_ARRAY_ELEMENT_ADDRESS"),
             /*args=*/
             ArrayAttr::get(
@@ -1940,7 +1928,8 @@ class ExportOpConversion : public OpConversionPattern<IREE::VM::ExportOp> {
       auto value = argumentStruct.value.getValue();
 
       if (input.value().isa<IREE::VM::RefType>()) {
-        Type ptrType = emitc::OpaqueType::get(ctx, "iree_vm_ref_t*");
+        Type ptrType = emitc::PointerType::get(
+            emitc::OpaqueType::get(ctx, "iree_vm_ref_t"));
         std::string memberName = "arg" + std::to_string(input.index());
         auto memberPtr = rewriter.create<emitc::CallOp>(
             /*location=*/loc,
@@ -2002,12 +1991,8 @@ class ExportOpConversion : public OpConversionPattern<IREE::VM::ExportOp> {
       auto value = resultStruct.value.getValue();
 
       auto cType = getCType(result.value()).getValue();
-      Type ptrType;
-      if (result.value().isa<IREE::VM::RefType>()) {
-        ptrType = emitc::OpaqueType::get(ctx, "iree_vm_ref_t*");
-      } else {
-        ptrType = emitc::PointerType::get(emitc::OpaqueType::get(ctx, cType));
-      }
+      Type ptrType =
+          emitc::PointerType::get(emitc::OpaqueType::get(ctx, cType));
       std::string memberName = "res" + std::to_string(result.index());
       auto memberPtr = rewriter.create<emitc::CallOp>(
           /*location=*/loc,
@@ -2223,12 +2208,8 @@ class ImportOpConversion : public OpConversionPattern<IREE::VM::ImportOp> {
       // We pass refs as iree_vm_ref_t* regardless of whether it is an in or out
       // parameter
       std::string cPtrType = cType.getValue();
-      Type type;
-      if (resultType.isa<IREE::VM::RefType>()) {
-        type = emitc::OpaqueType::get(ctx, cPtrType + "*");
-      } else {
-        type = emitc::PointerType::get(emitc::OpaqueType::get(ctx, cPtrType));
-      }
+      Type type =
+          emitc::PointerType::get(emitc::OpaqueType::get(ctx, cPtrType));
 
       types.push_back(type);
     }
@@ -2480,8 +2461,10 @@ class ImportOpConversion : public OpConversionPattern<IREE::VM::ImportOp> {
                   /*operands=*/ArrayRef<Value>{})
               .getResult(0);
 
-      if (arg.getType() == emitc::OpaqueType::get(ctx, "iree_vm_ref_t*")) {
-        Type refPtrType = emitc::OpaqueType::get(ctx, "iree_vm_ref_t*");
+      if (arg.getType() == emitc::PointerType::get(
+                               emitc::OpaqueType::get(ctx, "iree_vm_ref_t"))) {
+        Type refPtrType = emitc::PointerType::get(
+            emitc::OpaqueType::get(ctx, "iree_vm_ref_t"));
         Value refPtr = rewriter
                            .create<emitc::CallOp>(
                                /*location=*/loc,
@@ -2603,8 +2586,10 @@ class ImportOpConversion : public OpConversionPattern<IREE::VM::ImportOp> {
                   /*operands=*/ArrayRef<Value>{})
               .getResult(0);
 
-      if (arg.getType() == emitc::OpaqueType::get(ctx, "iree_vm_ref_t*")) {
-        Type refPtrType = emitc::OpaqueType::get(ctx, "iree_vm_ref_t*");
+      if (arg.getType() == emitc::PointerType::get(
+                               emitc::OpaqueType::get(ctx, "iree_vm_ref_t"))) {
+        Type refPtrType = emitc::PointerType::get(
+            emitc::OpaqueType::get(ctx, "iree_vm_ref_t"));
         Value refPtr = rewriter
                            .create<emitc::CallOp>(
                                /*location=*/loc,
@@ -2991,7 +2976,8 @@ class CallOpConversion : public OpConversionPattern<CallOpTy> {
       }
 
       assert(operand.getType() !=
-             emitc::OpaqueType::get(ctx, "iree_vm_ref_t*"));
+             emitc::PointerType::get(
+                 emitc::OpaqueType::get(ctx, "iree_vm_ref_t")));
 
       if (operand.getType().isa<IREE::VM::RefType>()) {
         Optional<Value> operandRef = typeConverter->materializeRef(operand);
@@ -3007,7 +2993,9 @@ class CallOpConversion : public OpConversionPattern<CallOpTy> {
 
         auto refPtrOp = rewriter.create<emitc::ApplyOp>(
             /*location=*/loc,
-            /*result=*/emitc::OpaqueType::get(ctx, "iree_vm_ref_t*"),
+            /*result=*/
+            emitc::PointerType::get(
+                emitc::OpaqueType::get(ctx, "iree_vm_ref_t")),
             /*applicableOperator=*/StringAttr::get(ctx, "&"),
             /*operand=*/refOp.getResult());
 
@@ -3675,7 +3663,9 @@ class ReturnOpConversion : public OpConversionPattern<IREE::VM::ReturnOp> {
 
         auto refPtrOp = rewriter.create<emitc::ApplyOp>(
             /*location=*/loc,
-            /*result=*/emitc::OpaqueType::get(ctx, "iree_vm_ref_t*"),
+            /*result=*/
+            emitc::PointerType::get(
+                emitc::OpaqueType::get(ctx, "iree_vm_ref_t")),
             /*applicableOperator=*/StringAttr::get(ctx, "&"),
             /*operand=*/refOp.getResult());
 
@@ -3706,7 +3696,8 @@ class ReturnOpConversion : public OpConversionPattern<IREE::VM::ReturnOp> {
 
       if (operand.getType().isa<IREE::VM::RefType>()) {
         assert(operand.getType() !=
-               emitc::OpaqueType::get(ctx, "iree_vm_ref_t*"));
+               emitc::PointerType::get(
+                   emitc::OpaqueType::get(ctx, "iree_vm_ref_t")));
 
         Optional<Value> operandRef = typeConverter->materializeRef(operand);
 
@@ -3989,7 +3980,8 @@ class GlobalLoadStoreRefOpConversion
     BlockArgument stateArg = funcOp.getArgument(2);
     auto refs = rewriter.create<emitc::CallOp>(
         /*location=*/loc,
-        /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_ref_t*"),
+        /*type=*/
+        emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_ref_t")),
         /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER"),
         /*args=*/
         ArrayAttr::get(ctx, {rewriter.getIndexAttr(0),
@@ -3999,7 +3991,8 @@ class GlobalLoadStoreRefOpConversion
 
     auto stateRef = rewriter.create<emitc::CallOp>(
         /*location=*/loc,
-        /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_ref_t*"),
+        /*type=*/
+        emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_ref_t")),
         /*callee=*/StringAttr::get(ctx, "EMITC_ARRAY_ELEMENT_ADDRESS"),
         /*args=*/
         ArrayAttr::get(ctx, {rewriter.getIndexAttr(0),

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.cpp
@@ -20,10 +20,11 @@ EmitCTypeConverter::EmitCTypeConverter() {
   addConversion([](emitc::OpaqueType type) { return type; });
 
   addConversion([](IREE::VM::RefType type) {
-    return emitc::OpaqueType::get(type.getContext(), "iree_vm_ref_t*");
+    return emitc::PointerType::get(
+        emitc::OpaqueType::get(type.getContext(), "iree_vm_ref_t"));
   });
 
-  addTargetMaterialization([this](OpBuilder &builder, emitc::OpaqueType type,
+  addTargetMaterialization([this](OpBuilder &builder, emitc::PointerType type,
                                   ValueRange inputs, Location loc) -> Value {
     assert(inputs.size() == 1);
     assert(inputs[0].getType().isa<IREE::VM::RefType>());
@@ -47,7 +48,7 @@ EmitCTypeConverter::EmitCTypeConverter() {
   addSourceMaterialization([this](OpBuilder &builder, IREE::VM::RefType type,
                                   ValueRange inputs, Location loc) -> Value {
     assert(inputs.size() == 1);
-    assert(inputs[0].getType().isa<emitc::OpaqueType>());
+    assert(inputs[0].getType().isa<emitc::PointerType>());
 
     Type objectType = IREE::VM::OpaqueType::get(builder.getContext());
     Type refType = IREE::VM::RefType::get(objectType);
@@ -102,7 +103,8 @@ Optional<Value> EmitCTypeConverter::materializeRef(Value ref) {
   for (BlockArgument arg : funcOp.getArguments()) {
     assert(!arg.getType().isa<IREE::VM::RefType>());
 
-    if (arg.getType() == emitc::OpaqueType::get(ctx, "iree_vm_ref_t*")) {
+    if (arg.getType() ==
+        emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_ref_t"))) {
       if (ordinal == refArgCounter++) {
         return arg;
       }

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
@@ -31,10 +31,10 @@ vm.module @my_module {
   // CHECK-LABEL: @my_module_const_ref_zero
   vm.func @const_ref_zero() {
     // CHECK: %[[REF:.+]] = "emitc.constant"() {value = #emitc.opaque<"">} : () -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.opaque<"iree_vm_ref_t*">
-    // CHECK-NEXT: %[[SIZE:.+]] = emitc.call "sizeof"() {args = [#emitc.opaque<"iree_vm_ref_t">]} : () -> i32
-    // CHECK-NEXT: emitc.call "memset"(%[[REFPTR]], %[[SIZE]]) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.opaque<"iree_vm_ref_t*">, i32) -> ()
-    // CHECK-NEXT: emitc.call "iree_vm_ref_release"(%[[REFPTR]]) : (!emitc.opaque<"iree_vm_ref_t*">) -> ()
+    // CHECK-NEXT: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK-NEXT: %[[SIZE:.+]] = emitc.call "sizeof"() {args = [!emitc.opaque<"iree_vm_ref_t">]} : () -> i32
+    // CHECK-NEXT: emitc.call "memset"(%[[REFPTR]], %[[SIZE]]) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, i32) -> ()
+    // CHECK-NEXT: emitc.call "iree_vm_ref_release"(%[[REFPTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> ()
     %null = vm.const.ref.zero : !vm.ref<?>
     vm.return
   }

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/type_conversion.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/type_conversion.mlir
@@ -4,10 +4,10 @@ vm.module @my_module {
   // CHECK-LABEL: @my_module_list_alloc
   vm.func @list_alloc(%arg0: i32) {
     // CHECK: %[[REF:.+]] = "emitc.constant"() {value = #emitc.opaque<"">} : () -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.opaque<"iree_vm_ref_t*">
+    // CHECK: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
     %list = vm.list.alloc %arg0 : (i32) -> !vm.list<i32>
     %list_dno = util.do_not_optimize(%list) : !vm.list<i32>
-    // CHECK: util.do_not_optimize(%[[REFPTR]]) : !emitc.opaque<"iree_vm_ref_t*">
+    // CHECK: util.do_not_optimize(%[[REFPTR]]) : !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
     vm.return
   }
 
@@ -15,7 +15,7 @@ vm.module @my_module {
   vm.func @list_size(%arg0: i32) {
     %list = vm.list.alloc %arg0 : (i32) -> !vm.list<i32>
     // CHECK: %[[REF:.+]] = "emitc.constant"() {value = #emitc.opaque<"">} : () -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.opaque<"iree_vm_ref_t*">
+    // CHECK: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
     %size = vm.list.size %list : (!vm.list<i32>) -> i32
     // CHECK: %[[SIZE:.+]] = emitc.call "iree_vm_list_size"(%{{.+}})
     %size_dno = util.do_not_optimize(%size) : i32
@@ -32,10 +32,10 @@ vm.module @my_module {
   vm.export @ref
   vm.func @ref(%arg0: i32) {
     // CHECK: %[[REF:.+]] = "emitc.constant"() {value = #emitc.opaque<"">} : () -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.opaque<"iree_vm_ref_t*">
+    // CHECK: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
     %buffer = vm.const.ref.rodata @byte_buffer : !vm.buffer
     %buffer_dno = util.do_not_optimize(%buffer) : !vm.buffer
-    // CHECK: util.do_not_optimize(%[[REFPTR]]) : !emitc.opaque<"iree_vm_ref_t*">
+    // CHECK: util.do_not_optimize(%[[REFPTR]]) : !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
     vm.return
   }
 }


### PR DESCRIPTION
Co-authored-by: Simon Camphausen <simon.camphausen@iml.fraunhofer.de>