### PR TITLE
Build out dynamic web sample to behave like iree-run-module.

### DIFF
--- a/experimental/web/sample_dynamic/CMakeLists.txt
+++ b/experimental/web/sample_dynamic/CMakeLists.txt
@@ -33,10 +33,13 @@ target_link_libraries(${_NAME}
 
 target_link_options(${_NAME} PRIVATE
   # https://emscripten.org/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.html#interacting-with-code-ccall-cwrap
-  "-sEXPORTED_FUNCTIONS=['_load_program']"
+  "-sEXPORTED_FUNCTIONS=['_setup_sample', '_cleanup_sample', '_load_program', '_unload_program', '_call_function']"
   "-sEXPORTED_RUNTIME_METHODS=['ccall','cwrap']"
   #
   "-sASSERTIONS=1"
+  #
+  # Programs loaded dynamically can require additional memory, so allow growth.
+  "-sALLOW_MEMORY_GROWTH"
   #
   # https://developer.chrome.com/blog/wasm-debugging-2020/
   "-g"

--- a/experimental/web/sample_dynamic/README.md
+++ b/experimental/web/sample_dynamic/README.md
@@ -1,8 +1,8 @@
 # Dynamic Web Sample
 
 This experimental sample demonstrates one way to target the web platform with
-IREE. The output artifact is a web page that loads a separately provided IREE
-`.vmfb` (compiled ML model) and tests calling functions on it.
+IREE. The output artifact is a web page that loads separately provided IREE
+`.vmfb` (compiled ML model) files and allows for calling functions on them.
 
 ## Quickstart
 

--- a/experimental/web/sample_dynamic/build_sample.sh
+++ b/experimental/web/sample_dynamic/build_sample.sh
@@ -35,18 +35,23 @@ mkdir -p ${BINARY_DIR}
 INSTALL_ROOT="D:\dev\projects\iree-build\install\bin"
 TRANSLATE_TOOL="${INSTALL_ROOT?}/iree-translate.exe"
 EMBED_DATA_TOOL="${INSTALL_ROOT?}/generate_embed_data.exe"
-INPUT_NAME="simple_abs"
-INPUT_PATH="${ROOT_DIR?}/iree/samples/models/simple_abs.mlir"
 
-echo "=== Translating MLIR to Wasm VM flatbuffer output (.vmfb) ==="
-${TRANSLATE_TOOL?} ${INPUT_PATH} \
-  --iree-mlir-to-vm-bytecode-module \
-  --iree-input-type=mhlo \
-  --iree-hal-target-backends=llvm \
-  --iree-llvm-target-triple=wasm32-unknown-emscripten \
-  --iree-llvm-target-cpu-features=+atomics,+bulk-memory,+simd128 \
-  --iree-llvm-link-embedded=false \
-  --o ${BINARY_DIR}/${INPUT_NAME}.vmfb
+translate_sample() {
+  echo "  Translating '$1' sample..."
+  ${TRANSLATE_TOOL?} $2 \
+    --iree-mlir-to-vm-bytecode-module \
+    --iree-input-type=mhlo \
+    --iree-hal-target-backends=llvm \
+    --iree-llvm-target-triple=wasm32-unknown-emscripten \
+    --iree-llvm-target-cpu-features=+atomics,+bulk-memory,+simd128 \
+    --iree-llvm-link-embedded=false \
+    --o ${BINARY_DIR}/$1.vmfb
+}
+
+echo "=== Translating sample MLIR files to VM flatbuffer outputs (.vmfb) ==="
+translate_sample "simple_abs"     "${ROOT_DIR?}/iree/samples/models/simple_abs.mlir"
+translate_sample "fullyconnected" "${ROOT_DIR?}/iree/test/e2e/models/fullyconnected.mlir"
+translate_sample "collatz"        "${ROOT_DIR?}/iree/test/e2e/models/collatz.mlir"
 
 ###############################################################################
 # Build the web artifacts using Emscripten                                    #

--- a/experimental/web/sample_dynamic/index.html
+++ b/experimental/web/sample_dynamic/index.html
@@ -11,35 +11,312 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 <head>
   <meta charset="utf-8" />
-  <title>IREE Dynamic Web Sample (dlopen)</title>
+  <title>IREE Dynamic Web Sample</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <style>
+    body {
+      padding: 16px;
+    }
+
+    .drop-target {
+      border: 3px solid #2244CC;
+      background-color: #c0c0c0;
+      color: #222222;
+      width:  300px;
+      height: 140px;
+      margin: 20px;
+      padding: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      user-select: none;
+    }
+
+    .drop-target p {
+      pointer-events: none;
+    }
+  </style>
+
+  <!-- https://getbootstrap.com/ for some webpage styling-->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
 
   <script src="./iree_api.js"></script>
 </head>
 
-<body style="background-color: #2b2c30; color: #ABB2BF">
-  <h1>IREE Dynamic Web Sample (dlopen)</h1>
+<body>
+  <div class="container">
+    <h1>IREE Dynamic Web Sample</h1>
 
-  <!-- TODO(scotttodd): drag and drop UI -->
-  <!-- TODO(scotttodd): <div>s with output (or just console.log?)-->
+    <p>
+      This tool works similarly to
+      <a href="https://github.com/google/iree/blob/main/iree/tools/iree-run-module-main.cc"><code>iree-run-module</code></a>
+      (<a href="https://github.com/google/iree/blob/main/docs/developers/developing_iree/developer_overview.md#iree-run-module">docs</a>).
+      <br>It loads a compiled IREE program then lets you call exported functions.
+      <br><b>Note:</b> Some outputs are logged to the console.</p>
+    </p>
+
+    <h2>1. Load a program</h2>
+
+    <div id="drop-zone" class="drop-target">
+      <p style="margin:0px">Drag a compiled IREE program<br>(.vmfb file) here to load it</p>
+    </div>
+    <p>
+      Currently loaded program:
+      <b><span id="loaded-program-name" style="display: inline;">(None)</span></b>
+    </p>
+
+    <h2>2. Call functions on a loaded program</h2>
+
+    <form>
+      <p>
+        <label for="function-name-input" class="form-label">Function name:</label>
+        <input type="text" id="function-name-input"
+              class="form-control" style="width:400px; font-family: monospace;" value="main"></input>
+      </p>
+
+      <p>
+        <label for="function-arguments-input" class="form-label">Function arguments:</label>
+        <br><span class="form-text">In the form <code>dim1xdim2xtype=val1,val2,...</code>, one per line</span>
+        <textarea type="text" id="function-arguments-input" spellcheck="false" class="form-control"
+                  style="min-width:400px; width:initial; min-height:100px; resize:both; font-family: monospace;">
+        </textarea>
+      </p>
+
+      <button id="call-function" class="btn btn-primary" type="button"
+              onclick="callFunctionWithFormInputs()" disabled>Call function</button>
+      <button id="update-url" class="btn btn-secondary" type="button"
+              onclick="updateUrlWithFormValues()">Update URL</button>
+      <button id="update-url" class="btn btn-secondary" type="button"
+              onclick="clearUrl()">Clear URL</button>
+    </form>
+
+    <p>
+      <h4><label for="function-outputs" class="form-label">Function outputs:</label></h4>
+      <textarea type="text" id="function-outputs" readonly spellcheck="false" class="form-control"
+                style="min-width:400px; width:initial; height:100px; resize:both; font-family: monospace;">
+      </textarea>
+    </p>
+
+    <hr>
+    <h2>Samples</h2>
+
+    <p>
+      Click to load a sample program, function, and arguments list.
+      <br>These links will automatically update the URL.
+    </p>
+
+    <div class="container" style="width:fit-content; margin-left:0px">
+      <div class="row" style="padding:4px">
+        <div class="col-sm">
+          simple_abs
+          (<a href="https://github.com/google/iree/blob/main/iree/samples/models/simple_abs.mlir">source</a>)
+        </div>
+        <div class="col-sm-auto">
+          <button class="btn btn-secondary" onclick="loadSample('simple_abs')">Load sample</button>
+        </div>
+      </div>
+      <div class="row" style="padding:4px">
+        <div class="col-sm">
+          fullyconnected
+          (<a href="https://github.com/google/iree/blob/main/iree/test/e2e/models/fullyconnected.mlir">source</a>)
+        </div>
+        <div class="col-sm-auto">
+          <button class="btn btn-secondary" onclick="loadSample('fullyconnected')">Load sample</button>
+        </div>
+      </div>
+      <div class="row" style="padding:4px">
+        <div class="col-sm">
+          collatz
+          (<a href="https://github.com/google/iree/blob/main/iree/test/e2e/models/collatz.mlir">source</a>)
+        </div>
+        <div class="col-sm-auto">
+          <button class="btn btn-secondary" onclick="loadSample('collatz')">Load sample</button>
+        </div>
+      </div>
+    </div>
+
+    <hr>
+    <h2>Compile your own program</h2>
+
+    <p>
+      Programs must be compiled for WebAssembly to run on this page, using
+      options to <code>iree-translate</code> such as:
+    </p>
+
+    <textarea type="text" readonly spellcheck="false"
+    class="form-control" style="width:600px; height:110px; font-family: monospace;">
+--iree-hal-target-backends=llvm \
+--iree-llvm-target-triple=wasm32-unknown-emscripten \
+--iree-llvm-target-cpu-features=+atomics,+bulk-memory,+simd128 \
+--iree-llvm-link-embedded=false \</textarea>
+
+  </div>
 
   <script>
-    let ireeInitialized = false;
+    const initializePromise = ireeInitializeWorker();
+    initializePromise.then(() => {
+      console.log("IREE initialized, ready to load programs.");
+    });
 
-    // TODO(scotttodd): rewrite with async + await?
-    // TODO(scotttodd): call ireeLoadProgram after some user interaction?
-    ireeInitializeWorker().then((result) => {
-      ireeInitialized = true;
+    let loadedProgram = null;
+    const programNameElement = document.getElementById("loaded-program-name");
+    const callFunctionButton = document.getElementById("call-function");
+    const functionNameInput = document.getElementById("function-name-input");
+    const functionArgumentsInput = document.getElementById("function-arguments-input");
+    const functionOutputsElement = document.getElementById("function-outputs");
 
-      console.log("IREE initialized, loading program...");
+    async function finishLoadingProgram(newProgram, newProgramName) {
+      if (loadedProgram !== null) {
+        // Unload the previous program. We could keep a list of loaded programs
+        // and let users select between them.
+        await ireeUnloadProgram(loadedProgram);
+      }
 
-      ireeLoadProgram("./simple_abs.vmfb").then((result) => {
-        console.log("Load program success!");
-      }).catch((error) => {
-        console.error("Failed to load program, error: '" + error + "'");
+      loadedProgram = newProgram;
+      programNameElement.innerText = newProgramName;
+      callFunctionButton.disabled = false;
+    }
+
+    async function tryLoadFromUrlParams() {
+      // Fetch IREE program from ?program=[file.vmfb] URL query parameter.
+      const searchParams = new URLSearchParams(window.location.search);
+
+      if (searchParams.has("function")) {
+        functionNameInput.value = searchParams.get("function");
+      }
+
+      if (searchParams.has("arguments")) {
+        functionArgumentsInput.value = searchParams.get("arguments");
+      }
+
+      if (searchParams.has("program")) {
+        const programPath = searchParams.get("program");
+
+        await initializePromise;
+        const program = await ireeLoadProgram(programPath);
+
+        // Set name to what is hopefully the file component of the path.
+        finishLoadingProgram(program, programPath.split("/").pop());
+      }
+    }
+
+    async function tryLoadFromBuffer(programDataBuffer, programName) {
+      await initializePromise;
+      const program = await ireeLoadProgram(programDataBuffer);
+
+      finishLoadingProgram(program, programName);
+    }
+
+    // ------------------------------------------------------------------------
+    // Drag-and-drop to load from your local filesystem.
+    const dropZone = document.getElementById("drop-zone");
+    dropZone.addEventListener("drop", (dropEvent) => {
+      dropEvent.preventDefault();
+      dropEvent.target.style.border = "";
+
+      // Assume exactly one file was dropped.
+      const uploadedFile = dropEvent.dataTransfer.items[0].getAsFile();
+      const fileReader = new FileReader();
+      fileReader.onload = (fileLoadEvent) => {
+        tryLoadFromBuffer(fileLoadEvent.target.result, uploadedFile.name)
+          .catch((error) => {
+            console.error("Error loading program from drop: '" + error + "'");
+          });
+      };
+      fileReader.readAsArrayBuffer(uploadedFile);
+    });
+    dropZone.addEventListener("dragover", (event) => {
+      event.preventDefault();
+    });
+    dropZone.addEventListener("dragenter", (event) => {
+      if (event.target !== dropZone) return;
+      event.target.style.border = "3px dotted red";
+    });
+    dropZone.addEventListener("dragleave", (event) => {
+      if (event.target !== dropZone) return;
+      event.target.style.border = "";
+    });
+    // ------------------------------------------------------------------------
+
+    // ------------------------------------------------------------------------
+    // Form inputs.
+    function callFunctionWithFormInputs() {
+      if (loadedProgram === null) {
+        console.error("Can't call a function with no loaded program");
+        return;
+      }
+
+      const functionName = functionNameInput.value;
+      const functionArguments = functionArgumentsInput.value.split("\n");
+
+      ireeCallFunction(loadedProgram, functionName, functionArguments)
+          .then((result) => {
+            functionOutputsElement.value = result.replace(";", "\n");
+          })
+          .catch((error) => {
+            console.error("Function call error: '" + error + "'");
+          });
+    }
+
+    function replaceUrlWithSearchParams(searchParams) {
+      let newUrl = window.location.protocol + "//" + window.location.host +
+          window.location.pathname;
+      const searchString = searchParams.toString();
+      if (searchString !== "") newUrl += "?" + searchParams;
+      window.history.replaceState({path: newUrl}, "", newUrl);
+    }
+
+    function updateUrlWithFormValues() {
+      const searchParams = new URLSearchParams(window.location.search);
+      searchParams.set("function", functionNameInput.value);
+      searchParams.set("arguments", functionArgumentsInput.value);
+      replaceUrlWithSearchParams(searchParams);
+    }
+
+    function clearUrl() {
+      const searchParams = new URLSearchParams(window.location.search);
+      searchParams.delete("program");
+      searchParams.delete("function");
+      searchParams.delete("arguments");
+      replaceUrlWithSearchParams(searchParams);
+    }
+    // ------------------------------------------------------------------------
+
+    // ------------------------------------------------------------------------
+    // Load samples programs / inputs.
+    function loadSample(sampleName) {
+      const searchParams = new URLSearchParams(window.location.search);
+      searchParams.set("program", sampleName + ".vmfb");
+      replaceUrlWithSearchParams(searchParams);
+
+      if (sampleName === "simple_abs") {
+        functionNameInput.value = "abs";
+        functionArgumentsInput.value = "f32=-1.23";
+      } else if (sampleName === "fullyconnected") {
+        functionNameInput.value = "main";
+        functionArgumentsInput.value = [
+          "1x5xf32=1,-2,-3,4,-5",
+          "1x5x3x1xf32=15,14,13,12,11,10,9,8,7,6,5,4,3,2,1",
+        ].join("\n");
+      } else if (sampleName === "collatz") {
+        functionNameInput.value = "collatz";
+        functionArgumentsInput.value = "";
+      }
+
+      updateUrlWithFormValues();
+
+      tryLoadFromUrlParams().catch((error) => {
+        console.error("Error loading sample program: '" + error + "'");
       });
-    }).catch((error) => {
-      console.error("Failed to initialize IREE, error: '" + error + "'");
+    }
+    // ------------------------------------------------------------------------
+
+    window.addEventListener("load", () => {
+      tryLoadFromUrlParams().catch((error) => {
+        console.error("Error loading program from URL: '" + error + "'");
+      });
     });
   </script>
 </body>

--- a/experimental/web/sample_dynamic/iree_worker.js
+++ b/experimental/web/sample_dynamic/iree_worker.js
@@ -8,7 +8,14 @@
 // const MAIN_SCRIPT_URL = 'web-sample-dynamic-multithreaded.js';
 const MAIN_SCRIPT_URL = 'web-sample-dynamic-sync.js';
 
+let wasmSetupSampleFn;
+let wasmCleanupSampleFn;
 let wasmLoadProgramFn;
+let wasmUnloadProgramFn;
+let wasmCallFunctionFn;
+
+let sampleState;
+
 var Module = {
   print: function(text) {
     console.log('(C)', text);
@@ -17,10 +24,15 @@ var Module = {
     console.error('(C)', text);
   },
   onRuntimeInitialized: function() {
-    console.log('WebAssembly module onRuntimeInitialized()');
-
+    wasmSetupSampleFn = Module.cwrap('setup_sample', 'number', []);
+    wasmCleanupSampleFn = Module.cwrap('cleanup_sample', null, ['number']);
     wasmLoadProgramFn =
-        Module.cwrap('load_program', 'number', ['number', 'number']);
+        Module.cwrap('load_program', 'number', ['number', 'number', 'number']);
+    wasmUnloadProgramFn = Module.cwrap('unload_program', null, ['number']);
+    wasmCallFunctionFn =
+        Module.cwrap('call_function', 'string', ['number', 'string', 'string']);
+
+    sampleState = wasmSetupSampleFn();
 
     postMessage({
       'messageType': 'initialized',
@@ -29,53 +41,106 @@ var Module = {
   noInitialRun: true,
 };
 
-function loadProgram(id, vmfbPath) {
-  console.log('fetching program at \'%s\'', vmfbPath);
+function loadProgramBuffer(id, programDataBuffer) {
+  const programDataView = new Int8Array(programDataBuffer);
+
+  const programDataWasmBuffer = Module._malloc(
+      programDataView.length * programDataView.BYTES_PER_ELEMENT);
+  Module.HEAP8.set(programDataView, programDataWasmBuffer);
+
+  // Note: we transfer ownership of the flatbuffer data here, so there is
+  // no need to call `Module._free(programDataWasmBuffer)` later.
+  const programState = wasmLoadProgramFn(
+      sampleState, programDataWasmBuffer, programDataBuffer.byteLength);
+
+  if (programState !== 0) {
+    postMessage({
+      'messageType': 'callResult',
+      'id': id,
+      'payload': programState,
+    });
+  } else {
+    postMessage({
+      'messageType': 'callResult',
+      'id': id,
+      'error': 'Wasm module error, check console for details',
+    });
+  }
+}
+
+function loadProgram(id, vmfbPathOrBuffer) {
+  if (vmfbPathOrBuffer instanceof ArrayBuffer) {
+    loadProgramBuffer(id, vmfbPathOrBuffer);
+    return;
+  }
 
   const fetchRequest = new XMLHttpRequest();
-
   fetchRequest.onload = function(progressEvent) {
-    console.log('XMLHttpRequest completed, passing to Wasm module');
-
-    const programDataBuffer = progressEvent.target.response;
-    const programDataView = new Int8Array(programDataBuffer);
-
-    const programDataWasmBuffer = Module._malloc(
-        programDataView.length * programDataView.BYTES_PER_ELEMENT);
-    Module.HEAP8.set(programDataView, programDataWasmBuffer);
-
-    const result =
-        wasmLoadProgramFn(programDataWasmBuffer, programDataBuffer.byteLength);
-    console.log('Result from loadProgramFn():', result);
-    Module._free(programDataWasmBuffer);
-
-    if (result !== 0) {
-      postMessage({
-        'messageType': 'loadProgramResult',
-        'id': id,
-        'error': 'Wasm module error, check console for details',
-      });
-    } else {
-      postMessage({
-        'messageType': 'loadProgramResult',
-        'id': id,
-        'payload': 'success',
-      });
-    }
+    loadProgramBuffer(id, progressEvent.target.response);
   };
-
-  fetchRequest.open('GET', vmfbPath);
+  fetchRequest.open('GET', vmfbPathOrBuffer);
   fetchRequest.responseType = 'arraybuffer';
   fetchRequest.send();
+}
+
+function unloadProgram(id, programState) {
+  wasmUnloadProgramFn(programState);
+
+  postMessage({
+    'messageType': 'callResult',
+    'id': id,
+  });
+}
+
+function callFunction(id, functionParams) {
+  const {programState, functionName, inputs} = functionParams;
+
+  let inputsJoined;
+  if (Array.isArray(inputs)) {
+    inputsJoined = inputs.join(';');
+  } else if (typeof (inputs) === 'string') {
+    inputsJoined = inputs;
+  } else {
+    postMessage({
+      'messageType': 'callResult',
+      'id': id,
+      'error': 'Expected \'inputs\' to be a String or an array of Strings',
+    });
+    return;
+  }
+
+  const returnValue =
+      wasmCallFunctionFn(programState, functionName, inputsJoined);
+
+  if (returnValue === '') {
+    postMessage({
+      'messageType': 'callResult',
+      'id': id,
+      'error': 'Wasm module error, check console for details',
+    });
+  } else {
+    postMessage({
+      'messageType': 'callResult',
+      'id': id,
+      'payload': returnValue,
+    });
+    // TODO(scotttodd): free char* buffer? Or does Emscripten handle that?
+    // Could refactor to
+    //   1) return void*
+    //   2) convert to String manually using UTF8ToString(pointer)
+    //   3) Module._free(pointer)
+  }
 }
 
 self.onmessage = function(messageEvent) {
   const {messageType, id, payload} = messageEvent.data;
 
-  console.log('worker received message:', messageEvent.data);
-
   if (messageType == 'loadProgram') {
     loadProgram(id, payload);
+  } else if (messageType == 'unloadProgram') {
+    unloadProgram(id, payload);
+  } else if (messageType == 'callFunction') {
+    callFunction(id, payload);
   }
 };
 

--- a/experimental/web/sample_dynamic/main.c
+++ b/experimental/web/sample_dynamic/main.c
@@ -7,6 +7,9 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+#include "iree/modules/hal/module.h"
 #include "iree/runtime/api.h"
 #include "iree/vm/bytecode_module.h"
 
@@ -14,16 +17,54 @@
 // Public API
 //===----------------------------------------------------------------------===//
 
-int load_program(uint8_t* vmfb_data, size_t length);
+// Opaque state for the sample, shared between multiple loaded programs.
+typedef struct iree_sample_state_t iree_sample_state_t;
+
+// Initializes the sample and returns its state.
+iree_sample_state_t* setup_sample();
+
+// Shuts down the sample and frees its state.
+// Requires that all programs first be unloaded with |unload_program|.
+void cleanup_sample(iree_sample_state_t* sample_state);
+
+// Opaque state for an individual loaded program.
+typedef struct iree_program_state_t iree_program_state_t;
+
+// Loads a program into the sample from the provided data.
+// Note: this takes ownership of |vmfb_data|.
+iree_program_state_t* load_program(iree_sample_state_t* sample_state,
+                                   uint8_t* vmfb_data, size_t length);
+
+// Unloads a program and frees its state.
+void unload_program(iree_program_state_t* program_state);
+
+// Calls a function synchronously.
+//
+// Returns a semicolon-delimited list of formatted outputs on success or the
+// empty string on failure. Note: This is in need of some real API bindings
+// that marshal structured data between C <-> JS.
+//
+// * |function_name| is the fully qualified function name, like 'module.abs'.
+// * |inputs| is a semicolon delimited list of VM scalars and buffers, as
+//   described in iree/tools/utils/vm_util and used in IREE's CLI tools.
+//   For example, the CLI `--function_input=f32=1 --function_input=f32=2`
+//   should be passed here as `f32=1;f32=2`.
+const char* call_function(iree_program_state_t* program_state,
+                          const char* function_name, const char* inputs);
 
 //===----------------------------------------------------------------------===//
 // Implementation
 //===----------------------------------------------------------------------===//
 
-// We're not really using cpuinfo here, but the linker complains about this
-// function not being defined. It actually is defined though, _if_ you patch
-// cpuinfo's CMake configuration: https://github.com/pytorch/cpuinfo/issues/34.
-void __attribute__((weak)) cpuinfo_emscripten_init(void) {}
+typedef struct iree_sample_state_t {
+  iree_runtime_instance_t* instance;
+  iree_hal_device_t* device;
+} iree_sample_state_t;
+
+typedef struct iree_program_state_t {
+  iree_runtime_session_t* session;
+  iree_vm_module_t* module;
+} iree_program_state_t;
 
 extern iree_status_t create_device_with_wasm_loader(
     iree_allocator_t host_allocator, iree_hal_device_t** out_device);
@@ -49,8 +90,8 @@ void inspect_module(iree_vm_module_t* module) {
   for (iree_host_size_t i = 0; i < module_signature.export_function_count;
        ++i) {
     iree_vm_function_t function;
-    iree_status_t status = iree_vm_module_lookup_function_by_ordinal(
-        module, IREE_VM_FUNCTION_LINKAGE_EXPORT, i, &function);
+    IREE_IGNORE_ERROR(iree_vm_module_lookup_function_by_ordinal(
+        module, IREE_VM_FUNCTION_LINKAGE_EXPORT, i, &function));
 
     iree_string_view_t function_name = iree_vm_function_name(&function);
     iree_vm_function_signature_t function_signature =
@@ -63,100 +104,313 @@ void inspect_module(iree_vm_module_t* module) {
   }
 }
 
-int load_program(uint8_t* vmfb_data, size_t length) {
-  fprintf(stdout, "load_program() received %zu bytes of data\n", length);
+iree_sample_state_t* setup_sample() {
+  iree_sample_state_t* sample_state = NULL;
+  iree_status_t status =
+      iree_allocator_malloc(iree_allocator_system(),
+                            sizeof(iree_sample_state_t), (void**)&sample_state);
 
   iree_runtime_instance_options_t instance_options;
   iree_runtime_instance_options_initialize(IREE_API_VERSION_LATEST,
                                            &instance_options);
   // Note: no call to iree_runtime_instance_options_use_all_available_drivers().
 
-  iree_runtime_instance_t* instance = NULL;
-  iree_status_t status = iree_runtime_instance_create(
-      &instance_options, iree_allocator_system(), &instance);
-
-  iree_hal_device_t* device = NULL;
   if (iree_status_is_ok(status)) {
-    status = create_device_with_wasm_loader(iree_allocator_system(), &device);
-  }
-
-  iree_runtime_session_options_t session_options;
-  iree_runtime_session_options_initialize(&session_options);
-  iree_runtime_session_t* session = NULL;
-  if (iree_status_is_ok(status)) {
-    status = iree_runtime_session_create_with_device(
-        instance, &session_options, device,
-        iree_runtime_instance_host_allocator(instance), &session);
-  }
-
-  iree_vm_module_t* program_module = NULL;
-  if (iree_status_is_ok(status)) {
-    status = iree_vm_bytecode_module_create(
-        iree_make_const_byte_span(vmfb_data, length), iree_allocator_null(),
-        iree_allocator_system(), &program_module);
+    status = iree_runtime_instance_create(
+        &instance_options, iree_allocator_system(), &sample_state->instance);
   }
 
   if (iree_status_is_ok(status)) {
-    inspect_module(program_module);
-    status = iree_runtime_session_append_module(session, program_module);
+    status = create_device_with_wasm_loader(iree_allocator_system(),
+                                            &sample_state->device);
   }
-
-  // Call the 'abs' function in the module.
-  iree_runtime_call_t call;
-  if (iree_status_is_ok(status)) {
-    status = iree_runtime_call_initialize_by_name(
-        session, iree_make_cstring_view("module.abs"), &call);
-  }
-
-  iree_hal_buffer_view_t* arg0 = NULL;
-  float arg0_data[1] = {-5.5};
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_buffer_view_allocate_buffer(
-        iree_runtime_session_device_allocator(session), /*shape=*/NULL,
-        /*shape_rank=*/0, IREE_HAL_ELEMENT_TYPE_FLOAT_32,
-        IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
-        IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-        IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER,
-        iree_make_const_byte_span((void*)arg0_data, sizeof(arg0_data)), &arg0);
-  }
-  if (iree_status_is_ok(status)) {
-    status = iree_runtime_call_inputs_push_back_buffer_view(&call, arg0);
-  }
-  iree_hal_buffer_view_release(arg0);
-
-  if (iree_status_is_ok(status)) {
-    status = iree_runtime_call_invoke(&call, /*flags=*/0);
-  }
-
-  iree_hal_buffer_view_t* ret_buffer_view = NULL;
-  if (iree_status_is_ok(status)) {
-    status = iree_runtime_call_outputs_pop_front_buffer_view(&call,
-                                                             &ret_buffer_view);
-  }
-  float result[1] = {0.0f};
-  if (iree_status_is_ok(status)) {
-    status =
-        iree_hal_buffer_read_data(iree_hal_buffer_view_buffer(ret_buffer_view),
-                                  0, result, sizeof(result));
-  }
-  iree_hal_buffer_view_release(ret_buffer_view);
-
-  if (iree_status_is_ok(status)) {
-    fprintf(stdout, "abs(%f) -> result: %f\n", arg0_data[0], result[0]);
-  }
-
-  iree_runtime_call_deinitialize(&call);
-
-  iree_vm_module_release(program_module);
-  iree_hal_device_release(device);
-  iree_runtime_session_release(session);
-  iree_runtime_instance_release(instance);
 
   if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);
     iree_status_free(status);
-    return -1;
+    cleanup_sample(sample_state);
+    return NULL;
   }
 
-  return 0;
+  return sample_state;
+}
+
+void cleanup_sample(iree_sample_state_t* sample_state) {
+  iree_hal_device_release(sample_state->device);
+  iree_runtime_instance_release(sample_state->instance);
+  free(sample_state);
+}
+
+iree_program_state_t* load_program(iree_sample_state_t* sample_state,
+                                   uint8_t* vmfb_data, size_t length) {
+  fprintf(stdout, "load_program() received %zu bytes of data\n", length);
+
+  iree_program_state_t* program_state = NULL;
+  iree_status_t status = iree_allocator_malloc(iree_allocator_system(),
+                                               sizeof(iree_program_state_t),
+                                               (void**)&program_state);
+
+  iree_runtime_session_options_t session_options;
+  iree_runtime_session_options_initialize(&session_options);
+  if (iree_status_is_ok(status)) {
+    status = iree_runtime_session_create_with_device(
+        sample_state->instance, &session_options, sample_state->device,
+        iree_runtime_instance_host_allocator(sample_state->instance),
+        &program_state->session);
+  }
+
+  if (iree_status_is_ok(status)) {
+    // Take ownership of the flatbuffer data so JavaScript doesn't need to
+    // explicitly call `Module._free()`.
+    status = iree_vm_bytecode_module_create(
+        iree_make_const_byte_span(vmfb_data, length),
+        /*flatbuffer_allocator=*/iree_allocator_system(),
+        iree_allocator_system(), &program_state->module);
+  } else {
+    // Must clean up the flatbuffer data directly.
+    iree_allocator_free(iree_allocator_system(), (void*)vmfb_data);
+  }
+
+  if (iree_status_is_ok(status)) {
+    inspect_module(program_state->module);
+    status = iree_runtime_session_append_module(program_state->session,
+                                                program_state->module);
+  }
+
+  if (!iree_status_is_ok(status)) {
+    iree_status_fprint(stderr, status);
+    iree_status_free(status);
+    unload_program(program_state);
+    return NULL;
+  }
+
+  return program_state;
+}
+
+void unload_program(iree_program_state_t* program_state) {
+  iree_vm_module_release(program_state->module);
+  iree_runtime_session_release(program_state->session);
+  free(program_state);
+}
+
+iree_status_t parse_input_into_call(iree_runtime_call_t* call,
+                                    iree_hal_allocator_t* device_allocator,
+                                    iree_string_view_t input) {
+  bool has_equal =
+      iree_string_view_find_char(input, '=', 0) != IREE_STRING_VIEW_NPOS;
+  bool has_x =
+      iree_string_view_find_char(input, 'x', 0) != IREE_STRING_VIEW_NPOS;
+  if (has_equal || has_x) {
+    // Buffer view (either just a shape or a shape=value) or buffer.
+    bool is_storage_reference =
+        iree_string_view_consume_prefix(&input, iree_make_cstring_view("&"));
+    iree_hal_buffer_view_t* buffer_view = NULL;
+    IREE_RETURN_IF_ERROR(
+        iree_hal_buffer_view_parse(input, device_allocator, &buffer_view),
+        "parsing value '%.*s'", (int)input.size, input.data);
+    if (is_storage_reference) {
+      // Storage buffer reference; just take the storage for the buffer view -
+      // it'll still have whatever contents were specified (or 0) but we'll
+      // discard the metadata.
+      iree_vm_ref_t buffer_ref =
+          iree_hal_buffer_retain_ref(iree_hal_buffer_view_buffer(buffer_view));
+      iree_hal_buffer_view_release(buffer_view);
+      return iree_vm_list_push_ref_move(call->inputs, &buffer_ref);
+    } else {
+      iree_vm_ref_t buffer_view_ref =
+          iree_hal_buffer_view_move_ref(buffer_view);
+      return iree_vm_list_push_ref_move(call->inputs, &buffer_view_ref);
+    }
+  } else {
+    // Scalar.
+    bool has_dot =
+        iree_string_view_find_char(input, '.', 0) != IREE_STRING_VIEW_NPOS;
+    iree_vm_value_t val;
+    if (has_dot) {
+      // Float.
+      val = iree_vm_value_make_f32(0.0f);
+      if (!iree_string_view_atof(input, &val.f32)) {
+        return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                "parsing value '%.*s' as f32", (int)input.size,
+                                input.data);
+      }
+    } else {
+      // Integer.
+      val = iree_vm_value_make_i32(0);
+      if (!iree_string_view_atoi_int32(input, &val.i32)) {
+        return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                "parsing value '%.*s' as i32", (int)input.size,
+                                input.data);
+      }
+    }
+    return iree_vm_list_push_value(call->inputs, &val);
+  }
+
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                          "Unhandled function input (unreachable?)");
+}
+
+iree_status_t parse_inputs_into_call(iree_runtime_call_t* call,
+                                     iree_hal_allocator_t* device_allocator,
+                                     iree_string_view_t inputs) {
+  if (inputs.size == 0) return iree_ok_status();
+
+  // Inputs are provided in a semicolon-delimited list.
+  // Split inputs from the list until no semicolons are left.
+  iree_string_view_t remaining_inputs = inputs;
+  intptr_t split_index = 0;
+  do {
+    iree_string_view_t next_input;
+    split_index = iree_string_view_split(remaining_inputs, ';', &next_input,
+                                         &remaining_inputs);
+    IREE_RETURN_IF_ERROR(
+        parse_input_into_call(call, device_allocator, next_input));
+  } while (split_index != -1);
+
+  return iree_ok_status();
+}
+
+iree_status_t print_outputs_from_call(iree_runtime_call_t* call,
+                                      iree_string_builder_t* outputs_builder) {
+  iree_vm_list_t* variants_list = iree_runtime_call_outputs(call);
+  for (iree_host_size_t i = 0; i < iree_vm_list_size(variants_list); ++i) {
+    iree_vm_variant_t variant = iree_vm_variant_empty();
+    IREE_RETURN_IF_ERROR(iree_vm_list_get_variant(variants_list, i, &variant),
+                         "variant %" PRIhsz " not present", i);
+
+    if (iree_vm_variant_is_value(variant)) {
+      switch (variant.type.value_type) {
+        case IREE_VM_VALUE_TYPE_I8: {
+          IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+              outputs_builder, "i8=%" PRIi8, variant.i8));
+          break;
+        }
+        case IREE_VM_VALUE_TYPE_I16: {
+          IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+              outputs_builder, "i16=%" PRIi16, variant.i16));
+          break;
+        }
+        case IREE_VM_VALUE_TYPE_I32: {
+          IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+              outputs_builder, "i32=%" PRIi32, variant.i32));
+          break;
+        }
+        case IREE_VM_VALUE_TYPE_I64: {
+          IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+              outputs_builder, "i64=%" PRIi64, variant.i64));
+          break;
+        }
+        case IREE_VM_VALUE_TYPE_F32: {
+          IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+              outputs_builder, "f32=%f", variant.f32));
+          break;
+        }
+        case IREE_VM_VALUE_TYPE_F64: {
+          IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+              outputs_builder, "f64=%lf", variant.f64));
+          break;
+        }
+        default: {
+          IREE_RETURN_IF_ERROR(
+              iree_string_builder_append_cstring(outputs_builder, "?"));
+          break;
+        }
+      }
+    } else if (iree_vm_variant_is_ref(variant)) {
+      if (iree_hal_buffer_view_isa(variant.ref)) {
+        iree_hal_buffer_view_t* buffer_view =
+            iree_hal_buffer_view_deref(variant.ref);
+
+        // Query total length (excluding NUL terminator).
+        iree_host_size_t result_length = 0;
+        iree_status_t status = iree_hal_buffer_view_format(
+            buffer_view, SIZE_MAX, 0, NULL, &result_length);
+        if (!iree_status_is_out_of_range(status)) return status;
+        ++result_length;  // include NUL
+
+        // Allocate scratch heap memory for the result and format into it.
+        char* result_str = NULL;
+        IREE_RETURN_IF_ERROR(iree_allocator_malloc(
+            iree_allocator_system(), result_length, (void**)&result_str));
+        IREE_RETURN_IF_ERROR(iree_hal_buffer_view_format(
+            buffer_view, SIZE_MAX, result_length, result_str, &result_length));
+        IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+            outputs_builder, "%.*s", (int)result_length, result_str));
+        iree_allocator_free(iree_allocator_system(), result_str);
+      } else {
+        IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(
+            outputs_builder, "(no printer)"));
+      }
+    } else {
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(outputs_builder, "(null)"));
+    }
+
+    if (i < iree_vm_list_size(variants_list) - 1) {
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(outputs_builder, ";"));
+    }
+  }
+
+  iree_vm_list_resize(variants_list, 0);
+
+  return iree_ok_status();
+}
+
+const char* call_function(iree_program_state_t* program_state,
+                          const char* function_name, const char* inputs) {
+  iree_status_t status = iree_ok_status();
+
+  // Fully qualify the function name. This sample only supports loading one
+  // module (i.e. 'program') per session, so we can do this.
+  iree_string_builder_t name_builder;
+  iree_string_builder_initialize(iree_allocator_system(), &name_builder);
+  if (iree_status_is_ok(status)) {
+    iree_string_view_t module_name = iree_vm_module_name(program_state->module);
+    status = iree_string_builder_append_format(&name_builder, "%.*s.%s",
+                                               (int)module_name.size,
+                                               module_name.data, function_name);
+  }
+
+  iree_runtime_call_t call;
+  if (iree_status_is_ok(status)) {
+    status = iree_runtime_call_initialize_by_name(
+        program_state->session, iree_string_builder_view(&name_builder), &call);
+  }
+  iree_string_builder_deinitialize(&name_builder);
+
+  if (iree_status_is_ok(status)) {
+    status = parse_inputs_into_call(
+        &call, iree_runtime_session_device_allocator(program_state->session),
+        iree_make_cstring_view(inputs));
+  }
+
+  // Note: Timing has ~millisecond precision on the web to mitigate timing /
+  // side-channel security threats.
+  // https://developer.mozilla.org/en-US/docs/Web/API/Performance/now#reduced_time_precision
+  iree_time_t start_time = iree_time_now();
+  if (iree_status_is_ok(status)) {
+    status = iree_runtime_call_invoke(&call, /*flags=*/0);
+  }
+  iree_time_t end_time = iree_time_now();
+  iree_time_t time_elapsed = end_time - start_time;
+  fprintf(stdout,
+          "(Approximate) time for calling '%s': %" PRId64 " nanoseconds\n",
+          function_name, time_elapsed);
+
+  iree_string_builder_t outputs_builder;
+  iree_string_builder_initialize(iree_allocator_system(), &outputs_builder);
+  if (iree_status_is_ok(status)) {
+    status = print_outputs_from_call(&call, &outputs_builder);
+  }
+
+  if (!iree_status_is_ok(status)) {
+    iree_string_builder_deinitialize(&outputs_builder);
+    iree_status_fprint(stderr, status);
+    iree_status_free(status);
+    return "";
+  }
+
+  // Note: this leaks the buffer. It's up to the caller to free it after use.
+  return iree_string_builder_buffer(&outputs_builder);
 }


### PR DESCRIPTION
Live demo: https://scotttodd.github.io/iree-llvm-sandbox/web-tools/iree-dynamic-sample/

The dynamic web sample now has a UI and supports a few different ways of loading IREE programs and specifying functions along with their arguments.

Features:

* Program path, function name, and function arguments are encoded into URL query parameters (e.g. `index.html?program=simple_abs.vmfb&function=abs&arguments=f32%3D-1.23`), for easy local iteration and settings sharing
* Drag-and-drop .vmfb files from your local machine to load them, see a bit of information about them in the console, and test calling functions on them
* Click between a few sample compiled programs with preselected inputs to try the page out without compiling on your own

Future work / other ideas:

* Populate list of function names to call based on module exported function names (except `__init`)
* Populate list of function arguments or offer better error messages based on exported function calling conventions
* Add proper JavaScript (or TypeScript?) bindings and use those to pass structured data across the JS/Wasm boundary, rather than use semicolon delimited format strings
* More complete error handling (check for Wasm support, report error messages to users, help with argument formatting, etc.)
* Integrated benchmarking

---

Implementation notes:

* `parse_input_into_call` and `print_outputs_from_call` are forked from [vm_util.cc](https://github.com/google/iree/blob/main/iree/tools/utils/vm_util.cc), with changes to use C types instead of C++ and to mesh with the rest of the sample better (e.g. output into `iree_string_builder_t` instead of `std::ostream`). These similar implementations should be reconciled IMO.