### PR TITLE
Gardening binary size/memory consumption 🎍.

### DIFF
--- a/iree/base/status.c
+++ b/iree/base/status.c
@@ -786,7 +786,7 @@ IREE_API_EXPORT void iree_status_fprint(FILE* file, iree_status_t status) {
     fprintf(file, "%.*s\n", (int)status_buffer_length, status_buffer);
     iree_allocator_free(allocator, status_buffer);
   } else {
-    fprintf(file, "(failed to format status)\n");
+    fprintf(file, "(?)\n");
   }
   fflush(file);
 }

--- a/iree/compiler/Codegen/Common/RemoveTrivialLoops.cpp
+++ b/iree/compiler/Codegen/Common/RemoveTrivialLoops.cpp
@@ -30,6 +30,9 @@ static unsigned dimToIndex(gpu::Dimension dim) {
       return 1;
     case gpu::Dimension::z:
       return 2;
+    default:
+      llvm_unreachable("invalid dimension");
+      return 0;
   }
 }
 

--- a/iree/compiler/Codegen/Interfaces/ProcessorOpInterfaces.cpp
+++ b/iree/compiler/Codegen/Interfaces/ProcessorOpInterfaces.cpp
@@ -23,6 +23,9 @@ static unsigned dimToIndex(gpu::Dimension dim) {
       return 1;
     case gpu::Dimension::z:
       return 2;
+    default:
+      llvm_unreachable("invalid dimension");
+      return 0;
   }
 }
 

--- a/iree/hal/buffer.c
+++ b/iree/hal/buffer.c
@@ -219,11 +219,12 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_validate_memory_type(
     iree_hal_memory_type_t expected_memory_type) {
   if (IREE_UNLIKELY(
           !iree_all_bits_set(actual_memory_type, expected_memory_type))) {
+#if IREE_STATUS_MODE
     // Missing one or more bits.
     iree_bitfield_string_temp_t temp0, temp1;
-    iree_string_view_t actual_memory_type_str IREE_ATTRIBUTE_UNUSED =
+    iree_string_view_t actual_memory_type_str =
         iree_hal_memory_type_format(actual_memory_type, &temp0);
-    iree_string_view_t expected_memory_type_str IREE_ATTRIBUTE_UNUSED =
+    iree_string_view_t expected_memory_type_str =
         iree_hal_memory_type_format(expected_memory_type, &temp1);
     return iree_make_status(
         IREE_STATUS_PERMISSION_DENIED,
@@ -231,6 +232,9 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_validate_memory_type(
         "buffer has %.*s, operation requires %.*s",
         (int)actual_memory_type_str.size, actual_memory_type_str.data,
         (int)expected_memory_type_str.size, expected_memory_type_str.data);
+#else
+    return iree_status_from_code(IREE_STATUS_PERMISSION_DENIED);
+#endif  // IREE_STATUS_MODE
   }
   return iree_ok_status();
 }
@@ -250,11 +254,12 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_validate_access(
         "memory access must specify one or more of _READ or _WRITE");
   } else if (IREE_UNLIKELY(!iree_all_bits_set(allowed_memory_access,
                                               required_memory_access))) {
+#if IREE_STATUS_MODE
     // Bits must match exactly.
     iree_bitfield_string_temp_t temp0, temp1;
-    iree_string_view_t allowed_memory_access_str IREE_ATTRIBUTE_UNUSED =
+    iree_string_view_t allowed_memory_access_str =
         iree_hal_memory_access_format(allowed_memory_access, &temp0);
-    iree_string_view_t required_memory_access_str IREE_ATTRIBUTE_UNUSED =
+    iree_string_view_t required_memory_access_str =
         iree_hal_memory_access_format(required_memory_access, &temp1);
     return iree_make_status(
         IREE_STATUS_PERMISSION_DENIED,
@@ -262,6 +267,9 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_validate_access(
         "type; buffer allows %.*s, operation requires %.*s",
         (int)allowed_memory_access_str.size, allowed_memory_access_str.data,
         (int)required_memory_access_str.size, required_memory_access_str.data);
+#else
+    return iree_status_from_code(IREE_STATUS_PERMISSION_DENIED);
+#endif  // IREE_STATUS_MODE
   }
   return iree_ok_status();
 }
@@ -270,11 +278,12 @@ IREE_API_EXPORT iree_status_t
 iree_hal_buffer_validate_usage(iree_hal_buffer_usage_t allowed_usage,
                                iree_hal_buffer_usage_t required_usage) {
   if (IREE_UNLIKELY(!iree_all_bits_set(allowed_usage, required_usage))) {
+#if IREE_STATUS_MODE
     // Missing one or more bits.
     iree_bitfield_string_temp_t temp0, temp1;
-    iree_string_view_t allowed_usage_str IREE_ATTRIBUTE_UNUSED =
+    iree_string_view_t allowed_usage_str =
         iree_hal_buffer_usage_format(allowed_usage, &temp0);
-    iree_string_view_t required_usage_str IREE_ATTRIBUTE_UNUSED =
+    iree_string_view_t required_usage_str =
         iree_hal_buffer_usage_format(required_usage, &temp1);
     return iree_make_status(
         IREE_STATUS_PERMISSION_DENIED,
@@ -282,6 +291,9 @@ iree_hal_buffer_validate_usage(iree_hal_buffer_usage_t allowed_usage,
         "buffer allows %.*s, operation requires %.*s",
         (int)allowed_usage_str.size, allowed_usage_str.data,
         (int)required_usage_str.size, required_usage_str.data);
+#else
+    return iree_status_from_code(IREE_STATUS_PERMISSION_DENIED);
+#endif  // IREE_STATUS_MODE
   }
   return iree_ok_status();
 }

--- a/iree/hal/command_buffer_validation.c
+++ b/iree/hal/command_buffer_validation.c
@@ -35,10 +35,11 @@ static iree_status_t iree_hal_command_buffer_validate_categories(
     iree_hal_command_category_t required_categories) {
   if (!iree_all_bits_set(command_buffer->allowed_categories,
                          required_categories)) {
+#if IREE_STATUS_MODE
     iree_bitfield_string_temp_t temp0, temp1;
-    iree_string_view_t required_categories_str IREE_ATTRIBUTE_UNUSED =
+    iree_string_view_t required_categories_str =
         iree_hal_command_category_format(required_categories, &temp0);
-    iree_string_view_t allowed_categories_str IREE_ATTRIBUTE_UNUSED =
+    iree_string_view_t allowed_categories_str =
         iree_hal_command_category_format(command_buffer->allowed_categories,
                                          &temp1);
     return iree_make_status(
@@ -47,6 +48,9 @@ static iree_status_t iree_hal_command_buffer_validate_categories(
         "%.*s",
         (int)required_categories_str.size, required_categories_str.data,
         (int)allowed_categories_str.size, allowed_categories_str.data);
+#else
+    return iree_status_from_code(IREE_STATUS_FAILED_PRECONDITION);
+#endif  // IREE_STATUS_MODE
   }
   return iree_ok_status();
 }
@@ -65,12 +69,12 @@ static iree_status_t iree_hal_command_buffer_validate_buffer_compatibility(
           },
           iree_hal_buffer_allocation_size(buffer));
   if (!iree_all_bits_set(allowed_compatibility, required_compatibility)) {
+#if IREE_STATUS_MODE
     // Buffer cannot be used on the queue for the given usage.
     iree_bitfield_string_temp_t temp0, temp1;
-    iree_string_view_t allowed_usage_str IREE_ATTRIBUTE_UNUSED =
-        iree_hal_buffer_usage_format(iree_hal_buffer_allowed_usage(buffer),
-                                     &temp0);
-    iree_string_view_t intended_usage_str IREE_ATTRIBUTE_UNUSED =
+    iree_string_view_t allowed_usage_str = iree_hal_buffer_usage_format(
+        iree_hal_buffer_allowed_usage(buffer), &temp0);
+    iree_string_view_t intended_usage_str =
         iree_hal_buffer_usage_format(intended_usage, &temp1);
     return iree_make_status(
         IREE_STATUS_PERMISSION_DENIED,
@@ -79,6 +83,9 @@ static iree_status_t iree_hal_command_buffer_validate_buffer_compatibility(
         "mismatch)",
         (int)allowed_usage_str.size, allowed_usage_str.data,
         (int)intended_usage_str.size, intended_usage_str.data);
+#else
+    return iree_status_from_code(IREE_STATUS_PERMISSION_DENIED);
+#endif  // IREE_STATUS_MODE
   }
   return iree_ok_status();
 }
@@ -315,19 +322,21 @@ iree_status_t iree_hal_command_buffer_copy_buffer_validation(
                         IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE) &&
       !iree_any_bit_set(iree_hal_buffer_memory_type(target_buffer),
                         IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE)) {
+#if IREE_STATUS_MODE
     iree_bitfield_string_temp_t temp0, temp1;
-    iree_string_view_t source_memory_type_str IREE_ATTRIBUTE_UNUSED =
-        iree_hal_memory_type_format(iree_hal_buffer_memory_type(source_buffer),
-                                    &temp0);
-    iree_string_view_t target_memory_type_str IREE_ATTRIBUTE_UNUSED =
-        iree_hal_memory_type_format(iree_hal_buffer_memory_type(target_buffer),
-                                    &temp1);
+    iree_string_view_t source_memory_type_str = iree_hal_memory_type_format(
+        iree_hal_buffer_memory_type(source_buffer), &temp0);
+    iree_string_view_t target_memory_type_str = iree_hal_memory_type_format(
+        iree_hal_buffer_memory_type(target_buffer), &temp1);
     return iree_make_status(
         IREE_STATUS_PERMISSION_DENIED,
         "at least one buffer must be device-visible for a copy; "
         "source_buffer=%.*s, target_buffer=%.*s",
         (int)source_memory_type_str.size, source_memory_type_str.data,
         (int)target_memory_type_str.size, target_memory_type_str.data);
+#else
+    return iree_status_from_code(IREE_STATUS_PERMISSION_DENIED);
+#endif  // IREE_STATUS_MODE
   }
 
   // Check for overlap - just like memcpy we don't handle that.

--- a/iree/runtime/demo/BUILD
+++ b/iree/runtime/demo/BUILD
@@ -17,6 +17,22 @@ package(
 # Hello World!
 #===------------------------------------------------------------------------===#
 
+cc_binary(
+    name = "hello_world_file",
+    srcs = ["hello_world_explained.c"],
+    defines = [
+        # Load data from a file passed on the command line.
+        "IREE_RUNTIME_DEMO_LOAD_FILE_FROM_COMMAND_LINE_ARG",
+    ],
+    deps = [
+        "//iree/runtime",
+    ],
+)
+
+# TODO(benvanik): native_test that passes the file as a flag. Right now we
+# can't specify data through native_test, though, so this isn't possible to
+# automate.
+
 iree_cmake_extra_content(
     content = """
 if (NOT ${IREE_HAL_DRIVER_VMVX} OR NOT ${IREE_TARGET_BACKEND_VMVX})
@@ -43,22 +59,6 @@ native_test(
     name = "hello_world_embedded_test",
     src = ":hello_world_embedded",
 )
-
-cc_binary(
-    name = "hello_world_file",
-    srcs = ["hello_world_explained.c"],
-    defines = [
-        # Load data from a file passed on the command line.
-        "IREE_RUNTIME_DEMO_LOAD_FILE_FROM_COMMAND_LINE_ARG",
-    ],
-    deps = [
-        "//iree/runtime",
-    ],
-)
-
-# TODO(benvanik): native_test that passes the file as a flag. Right now we
-# can't specify data through native_test, though, so this isn't possible to
-# automate.
 
 cc_binary(
     name = "hello_world_terse",

--- a/iree/runtime/demo/CMakeLists.txt
+++ b/iree/runtime/demo/CMakeLists.txt
@@ -1,3 +1,17 @@
+# NOTE: not using bazel-to-cmake here because of the runtime unified rule.
+# We should figure out how to make bazel/cmake consistent with that.
+
+iree_cc_binary(
+  NAME
+    hello_world_file
+  SRCS
+    "hello_world_explained.c"
+  DEFINES
+    "IREE_RUNTIME_DEMO_LOAD_FILE_FROM_COMMAND_LINE_ARG"
+  DEPS
+    iree::runtime::unified
+)
+
 if (NOT ${IREE_HAL_DRIVER_VMVX} OR NOT ${IREE_TARGET_BACKEND_VMVX})
   return()
 endif()
@@ -19,17 +33,6 @@ iree_native_test(
     "hello_world_embedded_test"
   SRC
     ::hello_world_embedded
-)
-
-iree_cc_binary(
-  NAME
-    hello_world_file
-  SRCS
-    "hello_world_explained.c"
-  DEFINES
-    "IREE_RUNTIME_DEMO_LOAD_FILE_FROM_COMMAND_LINE_ARG"
-  DEPS
-    iree::runtime::unified
 )
 
 iree_cc_binary(

--- a/iree/vm/stack.c
+++ b/iree/vm/stack.c
@@ -417,9 +417,9 @@ IREE_API_EXPORT iree_status_t iree_vm_stack_function_enter(
 
   iree_vm_stack_frame_t* callee_frame = &frame_header->frame;
   callee_frame->function = *function;
-  callee_frame->depth = caller_frame ? caller_frame->depth + 1 : 0;
   callee_frame->module_state = module_state;
   callee_frame->pc = 0;
+  callee_frame->depth = caller_frame ? caller_frame->depth + 1 : 0;
 
   stack->frame_storage_size = new_top;
   stack->top = frame_header;

--- a/iree/vm/stack.h
+++ b/iree/vm/stack.h
@@ -75,11 +75,6 @@ typedef struct iree_vm_stack_frame_t {
   // Function that the stack frame is within.
   iree_vm_function_t function;
 
-  // Depth of the frame within the stack.
-  // As stack frame pointers are not stable this can be used instead to detect
-  // stack enter/leave balance issues.
-  int32_t depth;
-
   // Cached module state pointer for the module containing |function|.
   // This removes the need to lookup the module state when control returns to
   // the function during continuation or from a return instruction.
@@ -90,6 +85,11 @@ typedef struct iree_vm_stack_frame_t {
   // offset (such as in the case of VM bytecode), a block identifier (compiled
   // code), etc.
   iree_vm_source_offset_t pc;
+
+  // Depth of the frame within the stack.
+  // As stack frame pointers are not stable this can be used instead to detect
+  // stack enter/leave balance issues.
+  int32_t depth;
 
   IREE_TRACE(iree_zone_id_t trace_zone;)
 } iree_vm_stack_frame_t;


### PR DESCRIPTION
Minor tweaks found while digging into binary sizes with SizeBench.