### PR TITLE
Use `emitc.variable` and run canonicalizer

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -5149,7 +5149,7 @@ class ConvertVMToEmitCPass
       }
       // Remove dead basic block arguments
       if (materializations.contains(op)) {
-        assert(isa<emitc::ConstantOp>(op));
+        assert(isa<emitc::VariableOp>(op));
         assert(op->use_empty());
 
         materializations.remove(op);

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -229,7 +229,7 @@ LogicalResult convertFuncOp(IREE::VM::FuncOp funcOp,
   vmAnalysis.getValue().get().numRefArguments = numRefArgs;
 
   for (int i = 0; i < numLocalRefs; i++) {
-    auto refOp = builder.create<emitc::ConstantOp>(
+    auto refOp = builder.create<emitc::VariableOp>(
         /*location=*/loc,
         /*resultType=*/emitc::OpaqueType::get(ctx, "iree_vm_ref_t"),
         /*value=*/emitc::OpaqueAttr::get(ctx, ""));
@@ -352,7 +352,7 @@ Optional<emitc::ApplyOp> createVmTypeDefPtr(ConversionPatternRewriter &rewriter,
        {"IREE_VM_VALUE_TYPE_NONE", "IREE_VM_REF_TYPE_NULL"}},
   };
 
-  auto elementTypeOp = rewriter.create<emitc::ConstantOp>(
+  auto elementTypeOp = rewriter.create<emitc::VariableOp>(
       /*location=*/loc,
       /*resultType=*/emitc::OpaqueType::get(ctx, "iree_vm_type_def_t"),
       /*value=*/emitc::OpaqueAttr::get(ctx, ""));
@@ -774,7 +774,7 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
 
     std::string moduleStateTypeName = moduleName + "_state_t";
 
-    auto stateOp = builder.create<emitc::ConstantOp>(
+    auto stateOp = builder.create<emitc::VariableOp>(
         /*location=*/loc,
         /*resultType=*/
         emitc::PointerType::get(
@@ -1228,7 +1228,7 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
 
     std::string moduleTypeName = moduleName + "_t";
 
-    auto module = builder.create<emitc::ConstantOp>(
+    auto module = builder.create<emitc::VariableOp>(
         /*location=*/loc,
         /*resultType=*/
         emitc::PointerType::get(emitc::OpaqueType::get(ctx, moduleTypeName)),
@@ -1294,7 +1294,7 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
         /*operands=*/
         ArrayRef<Value>{module.getResult(), funcOp.getArgument(0)});
 
-    auto vmModule = builder.create<emitc::ConstantOp>(
+    auto vmModule = builder.create<emitc::VariableOp>(
         /*location=*/loc,
         /*resultType=*/emitc::OpaqueType::get(ctx, "iree_vm_module_t"),
         /*value=*/emitc::OpaqueAttr::get(ctx, ""));
@@ -2640,7 +2640,7 @@ class ImportOpConversion : public OpConversionPattern<IREE::VM::ImportOp> {
     // iree_vm_execution_result_t result;
     auto executionResult =
         rewriter
-            .create<emitc::ConstantOp>(
+            .create<emitc::VariableOp>(
                 /*location=*/loc,
                 /*resultType=*/
                 emitc::OpaqueType::get(ctx, "iree_vm_execution_result_t"),
@@ -2982,7 +2982,7 @@ class CallOpConversion : public OpConversionPattern<CallOpTy> {
           return op->emitError() << "local ref not found";
         }
 
-        auto refOp = rewriter.create<emitc::ConstantOp>(
+        auto refOp = rewriter.create<emitc::VariableOp>(
             /*location=*/loc,
             /*resultType=*/emitc::OpaqueType::get(ctx, "iree_vm_ref_t"),
             /*value=*/emitc::OpaqueAttr::get(ctx, ""));
@@ -3027,7 +3027,7 @@ class CallOpConversion : public OpConversionPattern<CallOpTy> {
         resultOperands.push_back(ref.getValue());
         updatedOperands.push_back(ref.getValue());
       } else {
-        auto resultOp = rewriter.create<emitc::ConstantOp>(
+        auto resultOp = rewriter.create<emitc::VariableOp>(
             /*location=*/loc,
             /*resultType=*/result.getType(),
             /*value=*/emitc::OpaqueAttr::get(ctx, ""));
@@ -3651,7 +3651,7 @@ class ReturnOpConversion : public OpConversionPattern<IREE::VM::ReturnOp> {
           return op->emitError() << "local ref not found";
         }
 
-        auto refOp = rewriter.create<emitc::ConstantOp>(
+        auto refOp = rewriter.create<emitc::VariableOp>(
             /*location=*/loc,
             /*resultType=*/emitc::OpaqueType::get(ctx, "iree_vm_ref_t"),
             /*value=*/emitc::OpaqueAttr::get(ctx, ""));
@@ -4225,7 +4225,7 @@ class ListAllocOpConversion
       return allocOp.emitError() << "generating iree_vm_type_def_t* failed";
     }
 
-    auto listOp = rewriter.create<emitc::ConstantOp>(
+    auto listOp = rewriter.create<emitc::VariableOp>(
         /*location=*/loc,
         /*resultType=*/
         emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_list_t")),
@@ -4329,7 +4329,7 @@ class ListGetOpConversion : public OpConversionPattern<GetOpTy> {
       return getOp.emitOpError() << "element type not handled";
     }
 
-    auto valueOp = rewriter.create<emitc::ConstantOp>(
+    auto valueOp = rewriter.create<emitc::VariableOp>(
         /*location=*/loc,
         /*resultType=*/emitc::OpaqueType::get(ctx, "iree_vm_value_t"),
         /*value=*/emitc::OpaqueAttr::get(ctx, ""));

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.cpp
@@ -54,7 +54,7 @@ EmitCTypeConverter::EmitCTypeConverter() {
     Type refType = IREE::VM::RefType::get(objectType);
 
     auto ctx = builder.getContext();
-    auto op = builder.create<emitc::ConstantOp>(
+    auto op = builder.create<emitc::VariableOp>(
         /*location=*/loc,
         /*resultType=*/refType,
         /*value=*/emitc::OpaqueAttr::get(ctx, ""));

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
@@ -30,7 +30,7 @@ vm.module @my_module {
 vm.module @my_module {
   // CHECK-LABEL: @my_module_const_ref_zero
   vm.func @const_ref_zero() {
-    // CHECK: %[[REF:.+]] = "emitc.constant"() {value = #emitc.opaque<"">} : () -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK: %[[REF:.+]] = "emitc.variable"() {value = #emitc.opaque<"">} : () -> !emitc.opaque<"iree_vm_ref_t">
     // CHECK-NEXT: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
     // CHECK-NEXT: %[[SIZE:.+]] = emitc.call "sizeof"() {args = [!emitc.opaque<"iree_vm_ref_t">]} : () -> i32
     // CHECK-NEXT: emitc.call "memset"(%[[REFPTR]], %[[SIZE]]) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, i32) -> ()

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/type_conversion.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/type_conversion.mlir
@@ -3,7 +3,7 @@
 vm.module @my_module {
   // CHECK-LABEL: @my_module_list_alloc
   vm.func @list_alloc(%arg0: i32) {
-    // CHECK: %[[REF:.+]] = "emitc.constant"() {value = #emitc.opaque<"">} : () -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK: %[[REF:.+]] = "emitc.variable"() {value = #emitc.opaque<"">} : () -> !emitc.opaque<"iree_vm_ref_t">
     // CHECK: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
     %list = vm.list.alloc %arg0 : (i32) -> !vm.list<i32>
     %list_dno = util.do_not_optimize(%list) : !vm.list<i32>
@@ -14,7 +14,7 @@ vm.module @my_module {
   // CHECK-LABEL: @my_module_list_size
   vm.func @list_size(%arg0: i32) {
     %list = vm.list.alloc %arg0 : (i32) -> !vm.list<i32>
-    // CHECK: %[[REF:.+]] = "emitc.constant"() {value = #emitc.opaque<"">} : () -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK: %[[REF:.+]] = "emitc.variable"() {value = #emitc.opaque<"">} : () -> !emitc.opaque<"iree_vm_ref_t">
     // CHECK: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
     %size = vm.list.size %list : (!vm.list<i32>) -> i32
     // CHECK: %[[SIZE:.+]] = emitc.call "iree_vm_list_size"(%{{.+}})
@@ -31,7 +31,7 @@ vm.module @my_module {
   // CHECK-LABEL: @my_module_ref
   vm.export @ref
   vm.func @ref(%arg0: i32) {
-    // CHECK: %[[REF:.+]] = "emitc.constant"() {value = #emitc.opaque<"">} : () -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK: %[[REF:.+]] = "emitc.variable"() {value = #emitc.opaque<"">} : () -> !emitc.opaque<"iree_vm_ref_t">
     // CHECK: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
     %buffer = vm.const.ref.rodata @byte_buffer : !vm.buffer
     %buffer_dno = util.do_not_optimize(%buffer) : !vm.buffer

--- a/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
+++ b/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
@@ -319,6 +319,7 @@ static LogicalResult canonicalizeModule(
   modulePasses.addPass(createConvertVMToEmitCPass());
 
   modulePasses.addPass(IREE::Util::createDropCompilerHintsPass());
+  modulePasses.addPass(mlir::createCanonicalizerPass());
 
   if (failed(passManager.run(moduleOp->getParentOfType<mlir::ModuleOp>()))) {
     return moduleOp.emitError() << "failed during transform passes";

--- a/iree/compiler/Dialect/VM/Target/C/TranslateToCpp.cpp
+++ b/iree/compiler/Dialect/VM/Target/C/TranslateToCpp.cpp
@@ -72,6 +72,14 @@ static LogicalResult printOperation(CppEmitter &emitter,
 }
 
 static LogicalResult printOperation(CppEmitter &emitter,
+                                    emitc::VariableOp variableOp) {
+  Operation *operation = variableOp.getOperation();
+  Attribute value = variableOp.value();
+
+  return printConstantOp(emitter, operation, value);
+}
+
+static LogicalResult printOperation(CppEmitter &emitter,
                                     mlir::ConstantOp constantOp) {
   Operation *operation = constantOp.getOperation();
   Attribute value = constantOp.getValueAttr();
@@ -739,7 +747,7 @@ LogicalResult CppEmitter::emitOperation(Operation &op, bool trailingSemicolon) {
       llvm::TypeSwitch<Operation *, LogicalResult>(&op)
           // EmitC ops.
           .Case<emitc::ApplyOp, emitc::CallOp, emitc::ConstantOp,
-                emitc::IncludeOp>(
+                emitc::IncludeOp, emitc::VariableOp>(
               [&](auto op) { return printOperation(*this, op); })
           // SCF ops.
           .Case<scf::ForOp, scf::IfOp, scf::YieldOp>(

--- a/iree/compiler/Dialect/VM/Target/C/test/control_flow.mlir
+++ b/iree/compiler/Dialect/VM/Target/C/test/control_flow.mlir
@@ -2,17 +2,13 @@
 
 vm.module @control_flow_module {
   vm.func @control_flow_test(%a: i32, %cond: i32) -> i32 {
-    vm.cond_br %cond, ^bb1, ^bb2
+    vm.cond_br %cond, ^bb2(%a, %a : i32, i32), ^bb1
   ^bb1:
-    vm.br ^bb3(%a: i32)
-  ^bb2:
     %b = vm.add.i32 %a, %a : i32
-    vm.br ^bb3(%b: i32)
-  ^bb3(%c: i32):
-    vm.br ^bb4(%c, %a : i32, i32)
-  ^bb4(%d : i32, %e : i32):
-    %0 = vm.add.i32 %d, %e : i32
-    vm.return %0 : i32
+    vm.br ^bb2(%b, %a : i32, i32)
+  ^bb2(%c: i32, %d: i32):
+    %e = vm.add.i32 %c, %d : i32
+    vm.return %e : i32
   }
 }
 // CHECK: static iree_status_t control_flow_module_control_flow_test(iree_vm_stack_t* v1, control_flow_module_t* v2, control_flow_module_state_t* v3, int32_t [[A:[^ ]*]], int32_t [[COND:[^ ]*]], int32_t* [[RESULT:[^ ]*]]) {
@@ -23,27 +19,22 @@ vm.module @control_flow_module {
   // CHECK-NEXT: iree_status_t [[STATUS:[^ ]*]];
   // CHECK-NEXT: int32_t [[C:[^ ]*]];
   // CHECK-NEXT: int32_t [[D:[^ ]*]];
-  // CHECK-NEXT: int32_t [[E:[^ ]*]];
   // CHECK-NEXT: [[COND_NZ]] = vm_cmp_nz_i32([[COND]]);
   // CHECK-NEXT: [[COND_BOOL]] = EMITC_CAST([[COND_NZ]], bool);
   // CHECK-NEXT: if ([[COND_BOOL]]) {
-  // CHECK-NEXT: goto [[BB1:[^ ]*]];
-  // CHECK-NEXT: } else {
+  // CHECK-NEXT: [[C]] = [[A]];
+  // CHECK-NEXT: [[D]] = [[A]];
   // CHECK-NEXT: goto [[BB2:[^ ]*]];
+  // CHECK-NEXT: } else {
+  // CHECK-NEXT: goto [[BB1:[^ ]*]];
   // CHECK-NEXT: }
   // CHECK-NEXT: [[BB1]]:
-  // CHECK-NEXT: [[C]] = [[A]];
-  // CHECK-NEXT: goto [[BB3:[^ ]*]];
-  // CHECK-NEXT: [[BB2]]:
   // CHECK-NEXT: [[B]] = vm_add_i32([[A]], [[A]]);
   // CHECK-NEXT: [[C]] = [[B]];
-  // CHECK-NEXT: goto [[BB3]];
-  // CHECK-NEXT: [[BB3]]:
-  // CHECK-NEXT: [[D]] = [[C]];
-  // CHECK-NEXT: [[E]] = [[A]];
-  // CHECK-NEXT: goto [[BB4:[^ ]*]];
-  // CHECK-NEXT: [[BB4]]:
-  // CHECK-NEXT: [[V0]] = vm_add_i32([[D]], [[E]]);
+  // CHECK-NEXT: [[D]] = [[A]];
+  // CHECK-NEXT: goto [[BB2:[^ ]*]];
+  // CHECK-NEXT: [[BB2]]:
+  // CHECK-NEXT: [[V0]] = vm_add_i32([[C]], [[D]]);
   // CHECK-NEXT: EMITC_DEREF_ASSIGN_VALUE([[RESULT]], [[V0]]);
   // CHECK-NEXT: [[STATUS]] = iree_ok_status();
   // CHECK-NEXT: return [[STATUS]];


### PR DESCRIPTION
Shrinks the `static_library_demo_c`, built in release mode, by 720 bytes. The generated header `simple_mul_emitc.h` is cropped from 3858 to 3607 lines.

Supersedes #8336.

Co-authored-by: Simon Camphausen <simon.camphausen@iml.fraunhofer.de>