### PR TITLE
e2e matmul testing for compilation infos on gpu

### DIFF
--- a/build_tools/bazel/iree_trace_runner_test.bzl
+++ b/build_tools/bazel/iree_trace_runner_test.bzl
@@ -228,6 +228,9 @@ def iree_generated_trace_runner_test(
     processed_opt_flags = [flag.replace("#pass_options_variant#", "") for flag in opt_flags]
     processsed_compiler_flags = [flag.replace("#pass_options_variant#", "") for flag in compiler_flags]
     for backend, driver in target_backends_and_drivers:
+        # CUDA backend/driver not supported by Bazel build.
+        if backend == "cuda" or driver == "cuda":
+            continue
         suite_entry_name = "_".join([name, backend, driver])
         iree_single_backend_generated_trace_runner_test(
             name = suite_entry_name,

--- a/iree/test/e2e/regression/BUILD
+++ b/iree/test/e2e/regression/BUILD
@@ -132,6 +132,7 @@ py_binary(
     generator_args = [
         "--lhs_rhs_type=%s" % lhs_rhs_type,
         "--shapes=small",
+        "--compilation_info=none",
     ],
     target_backends_and_drivers = [
         ("dylib-llvm-aot", "dylib"),
@@ -153,6 +154,7 @@ py_binary(
     generator_args = [
         "--lhs_rhs_type=%s" % lhs_rhs_type,
         "--shapes=small",
+        "--compilation_info=none",
     ],
     target_backends_and_drivers = [
         ("dylib-llvm-aot", "dylib"),
@@ -177,6 +179,7 @@ py_binary(
     generator_args = [
         "--lhs_rhs_type=%s" % lhs_rhs_type,
         "--shapes=large",
+        "--compilation_info=none",
     ],
     target_backends_and_drivers = [
         ("dylib-llvm-aot", "dylib"),
@@ -205,6 +208,7 @@ py_binary(
     generator_args = [
         "--lhs_rhs_type=%s" % lhs_rhs_type,
         "--shapes=%s" % size,
+        "--compilation_info=none",
     ],
     target_backends_and_drivers = [
         ("dylib-llvm-aot", "dylib"),
@@ -220,4 +224,32 @@ py_binary(
     "f32",
 ] for size in [
     "small",
+]]
+
+[iree_generated_trace_runner_test(
+    name = "e2e_matmul_direct_f32_gpu_large_%s" % compilation_info,
+    generator = ":generate_e2e_matmul_tests",
+    generator_args = [
+        "--lhs_rhs_type=f32",
+        "--shapes=gpu_large",
+        "--compilation_info=%s" % compilation_info,
+    ],
+    tags = [
+        # CUDA cuInit fails with sanitizer on.
+        "noasan",
+        "nomsan",
+        "notsan",
+        "noubsan",
+        "requires-gpu-nvidia",
+        "driver=cuda",
+        "nokokoro",
+        "manual",
+    ],
+    target_backends_and_drivers = [
+        ("cuda", "cuda"),
+    ],
+    trace_runner = "//iree/tools:iree-e2e-matmul-test",
+) for compilation_info in [
+    "LLVMGPUMatmulSimt",
+    "LLVMGPUMatmulTensorCore",
 ]]

--- a/iree/test/e2e/regression/BUILD
+++ b/iree/test/e2e/regression/BUILD
@@ -132,7 +132,6 @@ py_binary(
     generator_args = [
         "--lhs_rhs_type=%s" % lhs_rhs_type,
         "--shapes=small",
-        "--compilation_info=none",
     ],
     target_backends_and_drivers = [
         ("dylib-llvm-aot", "dylib"),
@@ -154,7 +153,6 @@ py_binary(
     generator_args = [
         "--lhs_rhs_type=%s" % lhs_rhs_type,
         "--shapes=small",
-        "--compilation_info=none",
     ],
     target_backends_and_drivers = [
         ("dylib-llvm-aot", "dylib"),
@@ -179,7 +177,6 @@ py_binary(
     generator_args = [
         "--lhs_rhs_type=%s" % lhs_rhs_type,
         "--shapes=large",
-        "--compilation_info=none",
     ],
     target_backends_and_drivers = [
         ("dylib-llvm-aot", "dylib"),
@@ -208,7 +205,6 @@ py_binary(
     generator_args = [
         "--lhs_rhs_type=%s" % lhs_rhs_type,
         "--shapes=%s" % size,
-        "--compilation_info=none",
     ],
     target_backends_and_drivers = [
         ("dylib-llvm-aot", "dylib"),
@@ -241,9 +237,6 @@ py_binary(
         "notsan",
         "noubsan",
         "requires-gpu-nvidia",
-        "driver=cuda",
-        "nokokoro",
-        "manual",
     ],
     target_backends_and_drivers = [
         ("cuda", "cuda"),
@@ -251,5 +244,4 @@ py_binary(
     trace_runner = "//iree/tools:iree-e2e-matmul-test",
 ) for compilation_info in [
     "LLVMGPUMatmulSimt",
-    "LLVMGPUMatmulTensorCore",
 ]]

--- a/iree/test/e2e/regression/CMakeLists.txt
+++ b/iree/test/e2e/regression/CMakeLists.txt
@@ -145,7 +145,6 @@ iree_generated_trace_runner_test(
   GENERATOR_ARGS
     "--lhs_rhs_type=i8"
     "--shapes=small"
-    "--compilation_info=none"
   TRACE_RUNNER
     iree_tools_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -164,7 +163,6 @@ iree_generated_trace_runner_test(
   GENERATOR_ARGS
     "--lhs_rhs_type=f32"
     "--shapes=small"
-    "--compilation_info=none"
   TRACE_RUNNER
     iree_tools_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -183,7 +181,6 @@ iree_generated_trace_runner_test(
   GENERATOR_ARGS
     "--lhs_rhs_type=i8"
     "--shapes=small"
-    "--compilation_info=none"
   TRACE_RUNNER
     iree_tools_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -206,7 +203,6 @@ iree_generated_trace_runner_test(
   GENERATOR_ARGS
     "--lhs_rhs_type=f32"
     "--shapes=small"
-    "--compilation_info=none"
   TRACE_RUNNER
     iree_tools_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -227,7 +223,6 @@ iree_generated_trace_runner_test(
   GENERATOR_ARGS
     "--lhs_rhs_type=i8"
     "--shapes=large"
-    "--compilation_info=none"
   TRACE_RUNNER
     iree_tools_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -250,7 +245,6 @@ iree_generated_trace_runner_test(
   GENERATOR_ARGS
     "--lhs_rhs_type=f32"
     "--shapes=large"
-    "--compilation_info=none"
   TRACE_RUNNER
     iree_tools_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -271,7 +265,6 @@ iree_generated_trace_runner_test(
   GENERATOR_ARGS
     "--lhs_rhs_type=i8"
     "--shapes=small"
-    "--compilation_info=none"
   TRACE_RUNNER
     iree_tools_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -295,7 +288,6 @@ iree_generated_trace_runner_test(
   GENERATOR_ARGS
     "--lhs_rhs_type=f32"
     "--shapes=small"
-    "--compilation_info=none"
   TRACE_RUNNER
     iree_tools_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -330,35 +322,6 @@ iree_generated_trace_runner_test(
     "notsan"
     "noubsan"
     "requires-gpu-nvidia"
-    "driver=cuda"
-    "nokokoro"
-    "manual"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_direct_f32_gpu_large_LLVMGPUMatmulTensorCore
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f32"
-    "--shapes=gpu_large"
-    "--compilation_info=LLVMGPUMatmulTensorCore"
-  TRACE_RUNNER
-    iree_tools_iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "cuda"
-  DRIVERS
-    "cuda"
-  LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
-    "requires-gpu-nvidia"
-    "driver=cuda"
-    "nokokoro"
-    "manual"
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/iree/test/e2e/regression/CMakeLists.txt
+++ b/iree/test/e2e/regression/CMakeLists.txt
@@ -145,6 +145,7 @@ iree_generated_trace_runner_test(
   GENERATOR_ARGS
     "--lhs_rhs_type=i8"
     "--shapes=small"
+    "--compilation_info=none"
   TRACE_RUNNER
     iree_tools_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -163,6 +164,7 @@ iree_generated_trace_runner_test(
   GENERATOR_ARGS
     "--lhs_rhs_type=f32"
     "--shapes=small"
+    "--compilation_info=none"
   TRACE_RUNNER
     iree_tools_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -181,6 +183,7 @@ iree_generated_trace_runner_test(
   GENERATOR_ARGS
     "--lhs_rhs_type=i8"
     "--shapes=small"
+    "--compilation_info=none"
   TRACE_RUNNER
     iree_tools_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -203,6 +206,7 @@ iree_generated_trace_runner_test(
   GENERATOR_ARGS
     "--lhs_rhs_type=f32"
     "--shapes=small"
+    "--compilation_info=none"
   TRACE_RUNNER
     iree_tools_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -223,6 +227,7 @@ iree_generated_trace_runner_test(
   GENERATOR_ARGS
     "--lhs_rhs_type=i8"
     "--shapes=large"
+    "--compilation_info=none"
   TRACE_RUNNER
     iree_tools_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -245,6 +250,7 @@ iree_generated_trace_runner_test(
   GENERATOR_ARGS
     "--lhs_rhs_type=f32"
     "--shapes=large"
+    "--compilation_info=none"
   TRACE_RUNNER
     iree_tools_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -265,6 +271,7 @@ iree_generated_trace_runner_test(
   GENERATOR_ARGS
     "--lhs_rhs_type=i8"
     "--shapes=small"
+    "--compilation_info=none"
   TRACE_RUNNER
     iree_tools_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -288,6 +295,7 @@ iree_generated_trace_runner_test(
   GENERATOR_ARGS
     "--lhs_rhs_type=f32"
     "--shapes=small"
+    "--compilation_info=none"
   TRACE_RUNNER
     iree_tools_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -299,6 +307,58 @@ iree_generated_trace_runner_test(
     "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_direct_f32_gpu_large_LLVMGPUMatmulSimt
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--shapes=gpu_large"
+    "--compilation_info=LLVMGPUMatmulSimt"
+  TRACE_RUNNER
+    iree_tools_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "cuda"
+  DRIVERS
+    "cuda"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-nvidia"
+    "driver=cuda"
+    "nokokoro"
+    "manual"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_direct_f32_gpu_large_LLVMGPUMatmulTensorCore
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--shapes=gpu_large"
+    "--compilation_info=LLVMGPUMatmulTensorCore"
+  TRACE_RUNNER
+    iree_tools_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "cuda"
+  DRIVERS
+    "cuda"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-nvidia"
+    "driver=cuda"
+    "nokokoro"
+    "manual"
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/iree/test/e2e/regression/generate_e2e_matmul_tests.py
+++ b/iree/test/e2e/regression/generate_e2e_matmul_tests.py
@@ -32,6 +32,16 @@ class MatrixElemTypeId(enum.Enum):
 class ShapesId(enum.Enum):
   SMALL = "small"
   LARGE = "large"
+  GPU_LARGE = "gpu_large"
+
+
+# Enumerates of the collections of compilation info that we can generate tests
+# for. The values are the accepted values for the --compilation_info= flag.
+@enum.unique
+class CompilationInfoId(enum.Enum):
+  NONE = "none"
+  LLVMGPUMatmulSimt = "LLVMGPUMatmulSimt"
+  LLVMGPUMatmulTensorCore = "LLVMGPUMatmulTensorCore"
 
 
 # Enumerates ways to construct MLIR tensor types.
@@ -68,6 +78,24 @@ class TestGenerator:
   rhs: MatrixGenerator
   acc: MatrixGenerator
   dynamicity: Dynamicity
+
+
+# Describes how to construct compilation info for the testcase.
+@dataclasses.dataclass
+class CompilationInfo:
+  # Lowering Config
+  tile_sizes: typing.List[int]
+  native_vector_size: typing.List[int]
+  # Translation Info
+  dispatch_lowering_pass_pipeline: str
+  workload_per_wg: typing.List[int]
+  # Compilation info
+  workgroup_size: typing.List[int]
+
+  # Prints the workgroup size as 'index' types
+  def workgroup_size_str(self):
+    return "[" + ", ".join([f"{size} : index" for size in self.workgroup_size
+                           ]) + "]"
 
 
 # Returns the list of TestShape's to use for the collection of shapes
@@ -144,6 +172,8 @@ def get_test_shapes(shapes_id: ShapesId):
         # running on fewer backends/drivers or with fewer generators
         # (see get_test_generators).
     ]
+  if shapes_id == ShapesId.GPU_LARGE:
+    return [TestShape(m=512, k=512, n=512)]
   raise ValueError(shapes_id)
 
 
@@ -200,7 +230,56 @@ def get_test_generators(shapes_id: ShapesId):
                       acc=MatrixGenerator.RANDOM,
                       dynamicity=Dynamicity.STATIC),
     ]
+  if shapes_id == ShapesId.GPU_LARGE:
+    return [
+        TestGenerator(lhs=MatrixGenerator.IDENTITY,
+                      rhs=MatrixGenerator.IDENTITY,
+                      acc=MatrixGenerator.ZERO,
+                      dynamicity=Dynamicity.STATIC),
+        TestGenerator(lhs=MatrixGenerator.RANDOM,
+                      rhs=MatrixGenerator.RANDOM,
+                      acc=MatrixGenerator.RANDOM,
+                      dynamicity=Dynamicity.STATIC),
+    ]
   raise ValueError(shapes_id)
+
+
+@dataclasses.dataclass
+class TileWorkgroupSizePair:
+  tile_size: typing.List[int]
+  workgroup_size: typing.List[int]
+
+
+# Returns the list of CompilationInfo's to use for the CompilationInfoId.
+def get_test_compilation_infos(
+    compilation_info_id: CompilationInfoId) -> typing.List[CompilationInfo]:
+  if compilation_info_id == CompilationInfoId.LLVMGPUMatmulSimt:
+    tile_workgroup_size_pairs = [
+        TileWorkgroupSizePair([32, 128, 32], [32, 8, 1]),
+        TileWorkgroupSizePair([128, 64, 8], [16, 8, 1]),
+        TileWorkgroupSizePair([16, 256, 32], [64, 2, 1]),
+        TileWorkgroupSizePair([8, 32, 32], [8, 8, 1]),
+        TileWorkgroupSizePair([8, 128, 4], [32, 1, 1]),
+        TileWorkgroupSizePair([16, 64, 4], [16, 2, 1]),
+        TileWorkgroupSizePair([1, 128, 8], [32, 1, 1]),
+    ]
+  elif compilation_info_id == CompilationInfoId.LLVMGPUMatmulTensorCore:
+    tile_workgroup_size_pairs = [
+        TileWorkgroupSizePair([32, 32, 16], [64, 2, 1]),
+    ]
+
+  compilation_infos = []
+  for tile_workgroup_size_pair in tile_workgroup_size_pairs:
+    compilation_infos.append(
+        CompilationInfo(
+            tile_sizes=tile_workgroup_size_pair.tile_size,
+            native_vector_size=[],
+            dispatch_lowering_pass_pipeline=compilation_info_id.value,
+            workload_per_wg=[
+                a for a in reversed(tile_workgroup_size_pair.tile_size[0:2])
+            ],
+            workgroup_size=tile_workgroup_size_pair.workgroup_size))
+  return compilation_infos
 
 
 # Intentionally fixed seed! We want full reproducibility here, both across runs
@@ -305,9 +384,11 @@ def generate_shapes(shape: TestShape, dynamicity: Dynamicity):
 
 # Helper for generate_function.
 # Generates a name for a test function in the generated MLIR code.
-def generate_function_name(lhs_rhs_type: MatrixElemTypeId,
-                           acc_type: MatrixElemTypeId,
-                           shapes: TestInputMatricesShapes):
+def generate_function_name(
+    lhs_rhs_type: MatrixElemTypeId,
+    acc_type: MatrixElemTypeId,
+    shapes: TestInputMatricesShapes,
+    compilation_info: typing.Optional[CompilationInfo] = None):
   input_t = lhs_rhs_type.value
   acc_t = acc_type.value
   lhs_m = int_or_DYN(shapes.lhs_rows)
@@ -316,7 +397,15 @@ def generate_function_name(lhs_rhs_type: MatrixElemTypeId,
   rhs_n = int_or_DYN(shapes.rhs_cols)
   acc_m = int_or_DYN(shapes.acc_rows)
   acc_n = int_or_DYN(shapes.acc_cols)
-  return f"matmul_{lhs_m}x{lhs_k}x{input_t}_times_{rhs_k}x{rhs_n}x{input_t}_into_{acc_m}x{acc_n}x{acc_t}"
+
+  info = ""
+  if compilation_info:
+    tile_workgroup_key = "_".join([
+        str(a) for a in compilation_info.tile_sizes
+    ]) + "_" + "_".join([str(a) for a in compilation_info.workgroup_size])
+    info = f"_for_{compilation_info.dispatch_lowering_pass_pipeline}_{tile_workgroup_key}"
+
+  return f"matmul_{lhs_m}x{lhs_k}x{input_t}_times_{rhs_k}x{rhs_n}x{input_t}_into_{acc_m}x{acc_n}x{acc_t}{info}"
 
 
 # Represents a generated test function.
@@ -329,11 +418,15 @@ class MLIRFunction:
 # Generates a test function in the generated MLIR code.
 # The generated function will take the same arguments as linalg.matmul and
 # will just call linalg.matmul with them, returning its result.
-def generate_function(lhs_rhs_type: MatrixElemTypeId,
-                      acc_type: MatrixElemTypeId, shape: TestShape,
-                      dynamicity: Dynamicity):
+def generate_function(
+    lhs_rhs_type: MatrixElemTypeId,
+    acc_type: MatrixElemTypeId,
+    shape: TestShape,
+    dynamicity: Dynamicity,
+    compilation_info: typing.Optional[CompilationInfo] = None):
   shapes = generate_shapes(shape, dynamicity)
-  func_name = generate_function_name(lhs_rhs_type, acc_type, shapes)
+  func_name = generate_function_name(lhs_rhs_type, acc_type, shapes,
+                                     compilation_info)
   lhs_m = int_or_question_mark(shapes.lhs_rows)
   lhs_k = int_or_question_mark(shapes.lhs_cols)
   rhs_k = int_or_question_mark(shapes.rhs_rows)
@@ -343,9 +436,23 @@ def generate_function(lhs_rhs_type: MatrixElemTypeId,
   lhs_tensor_type = f"tensor<{lhs_m}x{lhs_k}x{lhs_rhs_type.value}>"
   rhs_tensor_type = f"tensor<{rhs_k}x{rhs_n}x{lhs_rhs_type.value}>"
   acc_tensor_type = f"tensor<{acc_m}x{acc_n}x{acc_type.value}>"
-  func_definition = (
+
+  # Compilation info is optional; prints empty string by default.
+  func_definition = ""
+  compilation_info_attr = ""
+  if compilation_info:
+    compilation_info_string = (
+        f"#compilation{generate_function.compilation_index} = #iree_codegen.compilation.info<\n"
+        f"  #iree_codegen.lowering.config<tile_sizes = [{compilation_info.tile_sizes}], native_vector_size = {compilation_info.native_vector_size}>,\n"
+        f"  #iree_codegen.translation.info<\"{compilation_info.dispatch_lowering_pass_pipeline}\", workload_per_wg = {compilation_info.workload_per_wg}>,\n"
+        f"  workgroup_size = {compilation_info.workgroup_size_str()}>\n")
+    compilation_info_attr = f"{{compilation.info = #compilation{generate_function.compilation_index}}} "
+    func_definition = func_definition + compilation_info_string
+    generate_function.compilation_index += 1
+
+  func_definition = func_definition + (
       f"func @{func_name}(%lhs: {lhs_tensor_type}, %rhs: {rhs_tensor_type}, %acc: {acc_tensor_type}) -> {acc_tensor_type} {{\n"
-      f"  %result = linalg.matmul ins(%lhs, %rhs: {lhs_tensor_type}, {rhs_tensor_type}) outs(%acc: {acc_tensor_type}) -> {acc_tensor_type}\n"
+      f"  %result = linalg.matmul {compilation_info_attr}ins(%lhs, %rhs: {lhs_tensor_type}, {rhs_tensor_type}) outs(%acc: {acc_tensor_type}) -> {acc_tensor_type}\n"
       f"  return %result: {acc_tensor_type}\n"
       f"}}\n")
   return MLIRFunction(
@@ -353,6 +460,8 @@ def generate_function(lhs_rhs_type: MatrixElemTypeId,
       definition=func_definition,
   )
 
+# Counter for producing unique complation info attrs
+generate_function.compilation_index = 0
 
 # Intentionally fixed seed! We want full reproducibility here, both across runs
 # and across machines.
@@ -414,8 +523,8 @@ def generate_trace(func_name: str, lhs_rhs_type: MatrixElemTypeId,
 
 
 # Generates all output files' contents as strings.
-def generate(lhs_rhs_type: MatrixElemTypeId, acc_type: MatrixElemTypeId,
-             shapes_id: ShapesId):
+def generate_default(lhs_rhs_type: MatrixElemTypeId, acc_type: MatrixElemTypeId,
+                     shapes_id: ShapesId):
   function_definitions = {}
   traces = []
   for shape in get_test_shapes(shapes_id):
@@ -431,6 +540,31 @@ def generate(lhs_rhs_type: MatrixElemTypeId, acc_type: MatrixElemTypeId,
         function_definitions[function.name] = function.definition
       traces.append(
           generate_trace(function.name, lhs_rhs_type, acc_type, shape, gen))
+  return (function_definitions, traces)
+
+
+# Generates all output files' contents as strings.
+def generate_gpu(lhs_rhs_type: MatrixElemTypeId, acc_type: MatrixElemTypeId,
+                 shapes_id: ShapesId, compilation_info_id: CompilationInfoId):
+  function_definitions = {}
+  traces = []
+
+  for compilation_info in get_test_compilation_infos(compilation_info_id):
+    for shape in get_test_shapes(shapes_id):
+      for gen in get_test_generators(shapes_id):
+
+        function = generate_function(lhs_rhs_type, acc_type, shape,
+                                     gen.dynamicity, compilation_info)
+        # Different testcases may differ only by runtime parameters but
+        # share the same code. For example, dynamic-shapes testcases
+        # share the same code involing tensor<?x?xf32> even though the runtime
+        # value in the trace are different. That's why we append conditionally
+        # to traces, but unconditionally to function_definitions.
+        if function.name not in function_definitions:
+          function_definitions[function.name] = function.definition
+        traces.append(
+            generate_trace(function.name, lhs_rhs_type, acc_type, shape, gen))
+
   return (function_definitions, traces)
 
 
@@ -454,6 +588,13 @@ def parse_arguments():
                       choices=[s.value for s in ShapesId],
                       help="Collection of matrix shapes to test",
                       required=True)
+  parser.add_argument("--compilation_info",
+                      type=str,
+                      choices=[i.value for i in CompilationInfoId],
+                      help="Collection of compilation info setups to test",
+                      default="none",
+                      required=True)
+
   parser.add_argument(
       "--module_path",
       type=str,
@@ -533,7 +674,15 @@ def main(args):
   lhs_rhs_type = MatrixElemTypeId(args.lhs_rhs_type)
   acc_type = infer_acc_type(lhs_rhs_type)
   shapes_id = ShapesId(args.shapes)
-  (function_definitions, traces) = generate(lhs_rhs_type, acc_type, shapes_id)
+  compilation_info_id = CompilationInfoId(args.compilation_info)
+  if compilation_info_id == CompilationInfoId.LLVMGPUMatmulSimt or compilation_info_id == CompilationInfoId.LLVMGPUMatmulTensorCore:
+    (function_definitions, traces) = generate_gpu(lhs_rhs_type, acc_type,
+                                                  shapes_id,
+                                                  compilation_info_id)
+  else:
+    (function_definitions, traces) = generate_default(lhs_rhs_type, acc_type,
+                                                      shapes_id)
+
   write_code_file(function_definitions, args.output_code)
   write_trace_file(traces, args.output_trace, args.module_path,
                    args.requirements)


### PR DESCRIPTION
Integrates e2e matmul testing for GPUs; intended to test the compilation verifiers for `LLVMGPUMatmulSimt` and `LLVMGPUMatmulTensorCore` pass pipelines. 

Changes mainly to `generate_e2e_matmul_tests.py`: In order to support GPU testing apart from CPU:
* `ShapesId::GPU_LARGE` option to `--shapes` for gpu shapes
* `--compilation_info` allows to specify the compiling pass pipeline for generated test cases and compilation infos

GPU tests make use of additional compilation info attrs added during generation. These are committed with other tests (`--compilation_info=none`)