### PR TITLE
Add postsubmit failure alerts to a few buildkite pipelines.

### DIFF
--- a/build_tools/buildkite/cmake/build_configurations.yml
+++ b/build_tools/buildkite/cmake/build_configurations.yml
@@ -65,3 +65,8 @@ steps:
       IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
     agents:
       - "queue=build"
+
+# Notify rotation on postsubmit failures.
+notify:
+  - email: "bdi-build-cop+buildkite@grotations.appspotmail.com"
+    if: "build.state == 'failed' && build.pull_request.id == null"

--- a/build_tools/buildkite/samples.yml
+++ b/build_tools/buildkite/samples.yml
@@ -20,3 +20,8 @@ steps:
       IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
     agents:
       - "queue=build"
+
+# Notify rotation on postsubmit failures.
+notify:
+  - email: "bdi-build-cop+buildkite@grotations.appspotmail.com"
+    if: "build.state == 'failed' && build.pull_request.id == null"


### PR DESCRIPTION
Docs: https://buildkite.com/docs/pipelines/notifications

Referenced
https://github.com/google/iree/blob/6348e9e16b7fbc5ea8c8287efca31828504e0fe5/build_tools/buildkite/cmake/android/arm64-v8a/pipeline.yml#L53-L55
and
https://github.com/google/iree/blob/6348e9e16b7fbc5ea8c8287efca31828504e0fe5/build_tools/buildkite/cmake/android/arm64-v8a/benchmark2.yml#L74-L76

(#testinprod)