### PR TITLE
Force embedded ELF linking off when targeting WebAssembly.

### DIFF
--- a/experimental/web/sample_dynamic/README.md
+++ b/experimental/web/sample_dynamic/README.md
@@ -24,10 +24,9 @@ to compile the runtime into WebAssembly and JavaScript files.
 
 Any supported IREE program, such as
 [simple_abs.mlir](../../../iree/samples/models/simple_abs.mlir), is compiled using
-the "system library" linking mode (i.e. `--iree-llvm-link-embedded=false`).
-This creates a shared object (typically .so/.dll, .wasm in this case). When the
-runtime attempts to load this file using `dlopen()` and `dlsym()`, Emscripten
-makes use of its
+the "system library" linking mode. This creates a shared object (typically
+.so/.dll, .wasm in this case). When the runtime attempts to load this file
+using `dlopen()` and `dlsym()`, Emscripten makes use of its
 [runtime dynamic linking support](https://emscripten.org/docs/compiling/Dynamic-Linking.html#runtime-dynamic-linking-with-dlopen)
 to instantiate a new `WebAssembly.Instance` which shares memory with the main
 runtime then resolve each export provided by the new Wasm module.

--- a/experimental/web/sample_dynamic/build_sample.sh
+++ b/experimental/web/sample_dynamic/build_sample.sh
@@ -44,7 +44,6 @@ translate_sample() {
     --iree-hal-target-backends=llvm \
     --iree-llvm-target-triple=wasm32-unknown-emscripten \
     --iree-llvm-target-cpu-features=+atomics,+bulk-memory,+simd128 \
-    --iree-llvm-link-embedded=false \
     --o ${BINARY_DIR}/$1.vmfb
 }
 

--- a/experimental/web/sample_dynamic/index.html
+++ b/experimental/web/sample_dynamic/index.html
@@ -146,11 +146,10 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     </p>
 
     <textarea type="text" readonly spellcheck="false"
-    class="form-control" style="width:600px; height:110px; font-family: monospace;">
+    class="form-control" style="width:610px; height:90px; resize:none; font-family: monospace;">
 --iree-hal-target-backends=llvm \
 --iree-llvm-target-triple=wasm32-unknown-emscripten \
---iree-llvm-target-cpu-features=+atomics,+bulk-memory,+simd128 \
---iree-llvm-link-embedded=false \</textarea>
+--iree-llvm-target-cpu-features=+atomics,+bulk-memory,+simd128 \</textarea>
 
   </div>
 

--- a/experimental/web/sample_dynamic/iree_api.js
+++ b/experimental/web/sample_dynamic/iree_api.js
@@ -77,7 +77,6 @@ function ireeInitializeWorker() {
 // configuration, such as with these flags:
 //     --iree-hal-target-backends=llvm
 //     --iree-llvm-target-triple=wasm32-unknown-emscripten
-//     --iree-llvm-link-embedded=false
 //
 // Resolves with an opaque pointer to the program state on success.
 function ireeLoadProgram(vmfbPathOrBuffer) {

--- a/experimental/web/sample_static/build_sample.sh
+++ b/experimental/web/sample_static/build_sample.sh
@@ -45,7 +45,6 @@ ${TRANSLATE_TOOL?} ${INPUT_PATH} \
   --iree-hal-target-backends=llvm \
   --iree-llvm-target-triple=wasm32-unknown-unknown \
   --iree-llvm-target-cpu-features=+simd128 \
-  --iree-llvm-link-embedded=false \
   --iree-llvm-link-static \
   --iree-llvm-static-library-output-path=${BINARY_DIR}/${INPUT_NAME}_static.o \
   --o ${BINARY_DIR}/${INPUT_NAME}.vmfb

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.h
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.h
@@ -49,6 +49,8 @@ struct LLVMTargetOptions {
   std::string embeddedLinkerPath;
 
   // Build for the IREE embedded platform-agnostic ELF loader.
+  // Note: this is ignored for target machines that do not support the ELF
+  // loader, such as WebAssembly.
   bool linkEmbedded = true;
 
   // Link any required runtime libraries into the produced binaries statically.


### PR DESCRIPTION
One less sharp edge to worry about when using Wasm :D