### PR TITLE
Adding an executable environment and plumbing through processor information.

### DIFF
--- a/experimental/rocm/native_executable.c
+++ b/experimental/rocm/native_executable.c
@@ -46,10 +46,10 @@ static iree_hal_rocm_native_executable_t* iree_hal_rocm_native_executable_cast(
 
 iree_status_t iree_hal_rocm_native_executable_create(
     iree_hal_rocm_context_wrapper_t* context,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
   IREE_ASSERT_ARGUMENT(context);
-  IREE_ASSERT_ARGUMENT(executable_spec);
+  IREE_ASSERT_ARGUMENT(executable_params);
   IREE_ASSERT_ARGUMENT(out_executable);
   *out_executable = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -58,7 +58,7 @@ iree_status_t iree_hal_rocm_native_executable_create(
 
   // TODO: Verify the flat buffer.
   iree_ROCMExecutableDef_table_t executable_def =
-      iree_ROCMExecutableDef_as_root(executable_spec->executable_data.data);
+      iree_ROCMExecutableDef_as_root(executable_params->executable_data.data);
 
   // Create the kernel module.
   flatbuffers_string_t hsaco_image =
@@ -96,8 +96,9 @@ iree_status_t iree_hal_rocm_native_executable_create(
       executable->entry_functions[i].block_size_y = block_sizes_vec[i].y;
       executable->entry_functions[i].block_size_z = block_sizes_vec[i].z;
       executable->executable_layouts[i] =
-          executable_spec->executable_layouts[i];
-      iree_hal_executable_layout_retain(executable_spec->executable_layouts[i]);
+          executable_params->executable_layouts[i];
+      iree_hal_executable_layout_retain(
+          executable_params->executable_layouts[i]);
     }
   }
 

--- a/experimental/rocm/native_executable.h
+++ b/experimental/rocm/native_executable.h
@@ -22,7 +22,7 @@ extern "C" {
 // kernels that can be extracted along with the associated block size.
 iree_status_t iree_hal_rocm_native_executable_create(
     iree_hal_rocm_context_wrapper_t* context,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable);
 
 hipFunction_t iree_hal_rocm_native_executable_for_entry_point(

--- a/experimental/rocm/nop_executable_cache.c
+++ b/experimental/rocm/nop_executable_cache.c
@@ -72,12 +72,12 @@ static bool iree_hal_rocm_nop_executable_cache_can_prepare_format(
 
 static iree_status_t iree_hal_rocm_nop_executable_cache_prepare_executable(
     iree_hal_executable_cache_t* base_executable_cache,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
   iree_hal_rocm_nop_executable_cache_t* executable_cache =
       iree_hal_rocm_nop_executable_cache_cast(base_executable_cache);
   return iree_hal_rocm_native_executable_create(
-      executable_cache->context, executable_spec, out_executable);
+      executable_cache->context, executable_params, out_executable);
 }
 
 static const iree_hal_executable_cache_vtable_t

--- a/experimental/web/sample_static/device_multithreaded.c
+++ b/experimental/web/sample_static/device_multithreaded.c
@@ -16,13 +16,10 @@ iree_status_t create_device_with_static_loader(iree_allocator_t host_allocator,
   iree_hal_task_device_params_t params;
   iree_hal_task_device_params_initialize(&params);
 
-  // Load the statically embedded library.
-  const iree_hal_executable_library_header_t** static_library =
-      mnist_linked_llvm_library_query(
-          IREE_HAL_EXECUTABLE_LIBRARY_LATEST_VERSION,
-          /*reserved=*/NULL);
-  const iree_hal_executable_library_header_t** libraries[1] = {static_library};
-
+  // Register the statically linked executable library.
+  const iree_hal_executable_library_query_fn_t* libraries[] = {
+      mnist_linked_llvm_library_query,
+  };
   iree_hal_executable_loader_t* library_loader = NULL;
   iree_status_t status = iree_hal_static_library_loader_create(
       IREE_ARRAYSIZE(libraries), libraries,

--- a/experimental/web/sample_static/device_sync.c
+++ b/experimental/web/sample_static/device_sync.c
@@ -13,13 +13,10 @@ iree_status_t create_device_with_static_loader(iree_allocator_t host_allocator,
   iree_hal_sync_device_params_t params;
   iree_hal_sync_device_params_initialize(&params);
 
-  // Load the statically embedded library.
-  const iree_hal_executable_library_header_t** static_library =
-      mnist_linked_llvm_library_query(
-          IREE_HAL_EXECUTABLE_LIBRARY_LATEST_VERSION,
-          /*reserved=*/NULL);
-  const iree_hal_executable_library_header_t** libraries[1] = {static_library};
-
+  // Register the statically linked executable library.
+  const iree_hal_executable_library_query_fn_t* libraries[] = {
+      mnist_linked_llvm_library_query,
+  };
   iree_hal_executable_loader_t* library_loader = NULL;
   iree_status_t status = iree_hal_static_library_loader_create(
       IREE_ARRAYSIZE(libraries), libraries,

--- a/iree/base/internal/BUILD
+++ b/iree/base/internal/BUILD
@@ -103,6 +103,16 @@ cc_test(
 )
 
 cc_library(
+    name = "cpu",
+    srcs = ["cpu.c"],
+    hdrs = ["cpu.h"],
+    deps = [
+        "//iree/base",
+        "//iree/base:core_headers",
+    ],
+)
+
+cc_library(
     name = "dynamic_library",
     srcs = [
         "dynamic_library_posix.c",

--- a/iree/base/internal/BUILD
+++ b/iree/base/internal/BUILD
@@ -287,6 +287,7 @@ cc_library(
     ],
     deps = [
         ":internal",
+        "//build_tools:default_linkopts",
         "//iree/base",
         "//iree/base:core_headers",
         "//iree/base:tracing",

--- a/iree/base/internal/CMakeLists.txt
+++ b/iree/base/internal/CMakeLists.txt
@@ -94,6 +94,19 @@ iree_cc_test(
 
 iree_cc_library(
   NAME
+    cpu
+  HDRS
+    "cpu.h"
+  SRCS
+    "cpu.c"
+  DEPS
+    iree::base
+    iree::base::core_headers
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
     dynamic_library
   HDRS
     "dynamic_library.h"

--- a/iree/base/internal/cpu.c
+++ b/iree/base/internal/cpu.c
@@ -1,0 +1,65 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/base/internal/cpu.h"
+
+#include "iree/base/target_platform.h"
+
+//===----------------------------------------------------------------------===//
+// iree_cpu_*
+//===----------------------------------------------------------------------===//
+
+#if defined(IREE_PLATFORM_ANDROID) || defined(IREE_PLATFORM_EMSCRIPTEN) || \
+    defined(IREE_PLATFORM_LINUX)
+
+#include <sched.h>
+
+extern __attribute__((weak)) int sched_getcpu(void) {
+  // TODO(benvanik): emulate with syscall/vdso/etc.
+  errno = ENOSYS;
+  return -1;
+}
+
+iree_cpu_processor_id_t iree_cpu_query_processor_id(void) {
+  // This path is relatively portable and should work on linux/bsd/etc-likes.
+  // We may want to use getcpu when available so that we can get the group ID.
+  // https://man7.org/linux/man-pages/man3/sched_getcpu.3.html
+  //
+  // libc implementations can use vDSO and other fun stuff to make this really
+  // cheap: http://git.musl-libc.org/cgit/musl/tree/src/sched/sched_getcpu.c
+  int id = sched_getcpu();
+  return id != -1 ? id : 0;
+}
+
+#elif defined(IREE_PLATFORM_WINDOWS)
+
+iree_cpu_processor_id_t iree_cpu_query_processor_id(void) {
+  PROCESSOR_NUMBER pn;
+  GetCurrentProcessorNumberEx(&pn);
+  return 64 * pn.Group + pn.Number;
+}
+
+#else
+
+// No implementation.
+// We could allow an iree/base/config.h override to externalize this.
+iree_cpu_processor_id_t iree_cpu_query_processor_id(void) { return 0; }
+
+#endif  // IREE_PLATFORM_*
+
+void iree_cpu_requery_processor_id(iree_cpu_processor_tag_t* IREE_RESTRICT tag,
+                                   iree_cpu_processor_id_t* IREE_RESTRICT
+                                       processor_id) {
+  IREE_ASSERT_ARGUMENT(tag);
+  IREE_ASSERT_ARGUMENT(processor_id);
+
+  // TODO(benvanik): set a frequency for this and use a coarse timer
+  // (CLOCK_MONOTONIC_COARSE) to do a ~4-10Hz refresh. We can store the last
+  // query time and the last processor ID in the tag and only perform the query
+  // if it has changed.
+
+  *processor_id = iree_cpu_query_processor_id();
+}

--- a/iree/base/internal/cpu.h
+++ b/iree/base/internal/cpu.h
@@ -1,0 +1,40 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BASE_INTERNAL_CPU_H_
+#define IREE_BASE_INTERNAL_CPU_H_
+
+#include <stddef.h>
+
+#include "iree/base/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// iree_cpu_*
+//===----------------------------------------------------------------------===//
+
+typedef uint32_t iree_cpu_processor_id_t;
+typedef uint32_t iree_cpu_processor_tag_t;
+
+// Returns the ID of the logical processor executing this code.
+iree_cpu_processor_id_t iree_cpu_query_processor_id(void);
+
+// Returns the ID of the logical processor executing this code, using |tag| to
+// memoize the query in cases where it does not change frequently.
+// |tag| must be initialized to 0 on first call and may be reset to 0 by the
+// caller at any time to invalidate the cached result.
+void iree_cpu_requery_processor_id(iree_cpu_processor_tag_t* IREE_RESTRICT tag,
+                                   iree_cpu_processor_id_t* IREE_RESTRICT
+                                       processor_id);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_BASE_INTERNAL_ARENA_H_

--- a/iree/compiler/Dialect/HAL/Target/LLVM/StaticLibraryGenerator.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/StaticLibraryGenerator.cpp
@@ -54,7 +54,8 @@ static void generateQueryFunction(llvm::raw_ostream &os,
                                   const std::string &query_function_name) {
   os << "const iree_hal_executable_library_header_t**\n"
      << query_function_name << "(\n"
-     << "iree_hal_executable_library_version_t max_version, void* reserved);\n";
+     << "iree_hal_executable_library_version_t max_version, const "
+        "iree_hal_executable_environment_v0_t* environment);\n";
 }
 
 static void generateSuffix(llvm::raw_ostream &os,

--- a/iree/hal/cts/command_buffer_dispatch_test.h
+++ b/iree/hal/cts/command_buffer_dispatch_test.h
@@ -37,18 +37,18 @@ class command_buffer_dispatch_test : public CtsTestBase {
         device_, /*push_constants=*/0, /*set_layout_count=*/1,
         &descriptor_set_layout_, &executable_layout_));
 
-    iree_hal_executable_spec_t executable_spec;
-    executable_spec.caching_mode =
+    iree_hal_executable_params_t executable_params;
+    executable_params.caching_mode =
         IREE_HAL_EXECUTABLE_CACHING_MODE_ALIAS_PROVIDED_DATA;
-    executable_spec.executable_format =
+    executable_params.executable_format =
         iree_make_cstring_view(get_test_executable_format());
-    executable_spec.executable_data = get_test_executable_data(
+    executable_params.executable_data = get_test_executable_data(
         iree_make_cstring_view("command_buffer_dispatch_test.bin"));
-    executable_spec.executable_layout_count = 1;
-    executable_spec.executable_layouts = &executable_layout_;
+    executable_params.executable_layout_count = 1;
+    executable_params.executable_layouts = &executable_layout_;
 
     IREE_ASSERT_OK(iree_hal_executable_cache_prepare_executable(
-        executable_cache_, &executable_spec, &executable_));
+        executable_cache_, &executable_params, &executable_));
   }
 
   void CleanupExecutable() {

--- a/iree/hal/cts/executable_cache_test.h
+++ b/iree/hal/cts/executable_cache_test.h
@@ -59,19 +59,19 @@ TEST_P(executable_cache_test, PrepareExecutable) {
       device_, /*push_constants=*/0, /*set_layout_count=*/1,
       &descriptor_set_layout, &executable_layout));
 
-  iree_hal_executable_spec_t executable_spec;
-  executable_spec.caching_mode =
+  iree_hal_executable_params_t executable_params;
+  executable_params.caching_mode =
       IREE_HAL_EXECUTABLE_CACHING_MODE_ALIAS_PROVIDED_DATA;
-  executable_spec.executable_format =
+  executable_params.executable_format =
       iree_make_cstring_view(get_test_executable_format());
-  executable_spec.executable_data = get_test_executable_data(
+  executable_params.executable_data = get_test_executable_data(
       iree_make_cstring_view("executable_cache_test.bin"));
-  executable_spec.executable_layout_count = 1;
-  executable_spec.executable_layouts = &executable_layout;
+  executable_params.executable_layout_count = 1;
+  executable_params.executable_layouts = &executable_layout;
 
   iree_hal_executable_t* executable = NULL;
   IREE_ASSERT_OK(iree_hal_executable_cache_prepare_executable(
-      executable_cache, &executable_spec, &executable));
+      executable_cache, &executable_params, &executable));
 
   iree_hal_executable_release(executable);
   iree_hal_executable_layout_release(executable_layout);

--- a/iree/hal/cuda/native_executable.c
+++ b/iree/hal/cuda/native_executable.c
@@ -47,10 +47,10 @@ static iree_hal_cuda_native_executable_t* iree_hal_cuda_native_executable_cast(
 
 iree_status_t iree_hal_cuda_native_executable_create(
     iree_hal_cuda_context_wrapper_t* context,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
   IREE_ASSERT_ARGUMENT(context);
-  IREE_ASSERT_ARGUMENT(executable_spec);
+  IREE_ASSERT_ARGUMENT(executable_params);
   IREE_ASSERT_ARGUMENT(out_executable);
   *out_executable = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -59,7 +59,7 @@ iree_status_t iree_hal_cuda_native_executable_create(
 
   // TODO: Verify the flat buffer.
   iree_CUDAExecutableDef_table_t executable_def =
-      iree_CUDAExecutableDef_as_root(executable_spec->executable_data.data);
+      iree_CUDAExecutableDef_as_root(executable_params->executable_data.data);
 
   // Create the kernel module.
   flatbuffers_string_t ptx_image =
@@ -108,8 +108,9 @@ iree_status_t iree_hal_cuda_native_executable_create(
       executable->entry_functions[i].shared_memory_size =
           shared_memory_sizes[i];
       executable->executable_layouts[i] =
-          executable_spec->executable_layouts[i];
-      iree_hal_executable_layout_retain(executable_spec->executable_layouts[i]);
+          executable_params->executable_layouts[i];
+      iree_hal_executable_layout_retain(
+          executable_params->executable_layouts[i]);
     }
   }
 

--- a/iree/hal/cuda/native_executable.h
+++ b/iree/hal/cuda/native_executable.h
@@ -22,7 +22,7 @@ extern "C" {
 // kernels that can be extracted along with the associated block size.
 iree_status_t iree_hal_cuda_native_executable_create(
     iree_hal_cuda_context_wrapper_t* context,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable);
 
 CUfunction iree_hal_cuda_native_executable_for_entry_point(

--- a/iree/hal/cuda/nop_executable_cache.c
+++ b/iree/hal/cuda/nop_executable_cache.c
@@ -72,12 +72,12 @@ static bool iree_hal_cuda_nop_executable_cache_can_prepare_format(
 
 static iree_status_t iree_hal_cuda_nop_executable_cache_prepare_executable(
     iree_hal_executable_cache_t* base_executable_cache,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
   iree_hal_cuda_nop_executable_cache_t* executable_cache =
       iree_hal_cuda_nop_executable_cache_cast(base_executable_cache);
   return iree_hal_cuda_native_executable_create(
-      executable_cache->context, executable_spec, out_executable);
+      executable_cache->context, executable_params, out_executable);
 }
 
 static const iree_hal_executable_cache_vtable_t

--- a/iree/hal/executable_cache.c
+++ b/iree/hal/executable_cache.c
@@ -14,9 +14,10 @@
 #include "iree/hal/device.h"
 #include "iree/hal/resource.h"
 
-void iree_hal_executable_spec_initialize(iree_hal_executable_spec_t* out_spec) {
-  memset(out_spec, 0, sizeof(*out_spec));
-  out_spec->caching_mode =
+void iree_hal_executable_params_initialize(
+    iree_hal_executable_params_t* out_executable_params) {
+  memset(out_executable_params, 0, sizeof(*out_executable_params));
+  out_executable_params->caching_mode =
       IREE_HAL_EXECUTABLE_CACHING_MODE_ALLOW_PERSISTENT_CACHING |
       IREE_HAL_EXECUTABLE_CACHING_MODE_ALLOW_OPTIMIZATION;
 }
@@ -52,17 +53,17 @@ IREE_API_EXPORT bool iree_hal_executable_cache_can_prepare_format(
 
 IREE_API_EXPORT iree_status_t iree_hal_executable_cache_prepare_executable(
     iree_hal_executable_cache_t* executable_cache,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
   IREE_ASSERT_ARGUMENT(executable_cache);
-  IREE_ASSERT_ARGUMENT(executable_spec);
-  IREE_ASSERT_ARGUMENT(!executable_spec->executable_layout_count ||
-                       executable_spec->executable_layouts);
+  IREE_ASSERT_ARGUMENT(executable_params);
+  IREE_ASSERT_ARGUMENT(!executable_params->executable_layout_count ||
+                       executable_params->executable_layouts);
   IREE_ASSERT_ARGUMENT(out_executable);
   *out_executable = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
   iree_status_t status = _VTABLE_DISPATCH(executable_cache, prepare_executable)(
-      executable_cache, executable_spec, out_executable);
+      executable_cache, executable_params, out_executable);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/iree/hal/executable_cache.h
+++ b/iree/hal/executable_cache.h
@@ -72,7 +72,7 @@ enum iree_hal_executable_caching_mode_bits_t {
 typedef uint32_t iree_hal_executable_caching_mode_t;
 
 // Defines an executable compilation specification.
-typedef struct iree_hal_executable_spec_t {
+typedef struct iree_hal_executable_params_t {
   // Specifies what caching the executable cache is allowed to perform and
   // (if supported) which transformations on the executable contents are
   // allowed.
@@ -98,11 +98,12 @@ typedef struct iree_hal_executable_spec_t {
   // executable layout objects.
   iree_host_size_t executable_layout_count;
   iree_hal_executable_layout_t* const* executable_layouts;
-} iree_hal_executable_spec_t;
+} iree_hal_executable_params_t;
 
-// Initializes |out_spec| to the default values for normal executables. Callers
-// must override the fields as required.
-void iree_hal_executable_spec_initialize(iree_hal_executable_spec_t* out_spec);
+// Initializes |out_executable_params| to the default values for normal
+// executables. Callers must override the fields as required.
+void iree_hal_executable_params_initialize(
+    iree_hal_executable_params_t* out_executable_params);
 
 //===----------------------------------------------------------------------===//
 // iree_hal_executable_cache_t
@@ -148,7 +149,7 @@ IREE_API_EXPORT bool iree_hal_executable_cache_can_prepare_format(
     iree_hal_executable_caching_mode_t caching_mode,
     iree_string_view_t executable_format);
 
-// Prepares the executable defined by |executable_spec| for use.
+// Prepares the executable defined by |executable_params| for use.
 // The provided |executable_data| (in a format defined by |executable_format|)
 // will be used to either lookup a previously prepared executable in the cache
 // or prepare a new one.
@@ -163,7 +164,7 @@ IREE_API_EXPORT bool iree_hal_executable_cache_can_prepare_format(
 // executables - and calls will block until preparation completes.
 IREE_API_EXPORT iree_status_t iree_hal_executable_cache_prepare_executable(
     iree_hal_executable_cache_t* executable_cache,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable);
 
 //===----------------------------------------------------------------------===//
@@ -180,7 +181,7 @@ typedef struct iree_hal_executable_cache_vtable_t {
 
   iree_status_t(IREE_API_PTR* prepare_executable)(
       iree_hal_executable_cache_t* executable_cache,
-      const iree_hal_executable_spec_t* executable_spec,
+      const iree_hal_executable_params_t* executable_params,
       iree_hal_executable_t** out_executable);
 } iree_hal_executable_cache_vtable_t;
 IREE_HAL_ASSERT_VTABLE_LAYOUT(iree_hal_executable_cache_vtable_t);

--- a/iree/hal/local/BUILD
+++ b/iree/hal/local/BUILD
@@ -17,6 +17,19 @@ package(
 )
 
 cc_library(
+    name = "executable_environment",
+    srcs = ["executable_environment.c"],
+    hdrs = ["executable_environment.h"],
+    deps = [
+        ":executable_library",
+        "//iree/base",
+        "//iree/base:tracing",
+        "//iree/base/internal:cpu",
+        "//iree/hal",
+    ],
+)
+
+cc_library(
     name = "executable_library",
     hdrs = ["executable_library.h"],
 )
@@ -25,6 +38,7 @@ cc_binary_benchmark(
     name = "executable_library_benchmark",
     srcs = ["executable_library_benchmark.c"],
     deps = [
+        ":executable_environment",
         ":executable_library",
         ":local",
         "//iree/base",
@@ -44,9 +58,10 @@ cc_test(
         "executable_library_test.c",
     ],
     deps = [
+        ":executable_environment",
+        ":executable_library",
         "//iree/base",
         "//iree/base:core_headers",
-        "//iree/hal/local:executable_library",
     ],
 )
 
@@ -71,6 +86,7 @@ cc_library(
         "local_executable_layout.h",
     ],
     deps = [
+        ":executable_environment",
         ":executable_library",
         "//iree/base",
         "//iree/base:core_headers",
@@ -145,6 +161,7 @@ cc_library(
         "task_semaphore.h",
     ],
     deps = [
+        ":executable_environment",
         ":executable_library",
         ":local",
         "//iree/base",

--- a/iree/hal/local/CMakeLists.txt
+++ b/iree/hal/local/CMakeLists.txt
@@ -12,6 +12,22 @@ iree_add_all_subdirs()
 
 iree_cc_library(
   NAME
+    executable_environment
+  HDRS
+    "executable_environment.h"
+  SRCS
+    "executable_environment.c"
+  DEPS
+    ::executable_library
+    iree::base
+    iree::base::internal::cpu
+    iree::base::tracing
+    iree::hal
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
     executable_library
   HDRS
     "executable_library.h"
@@ -24,6 +40,7 @@ iree_cc_binary_benchmark(
   SRCS
     "executable_library_benchmark.c"
   DEPS
+    ::executable_environment
     ::executable_library
     ::local
     iree::base
@@ -43,9 +60,10 @@ iree_cc_test(
     "executable_library_demo.h"
     "executable_library_test.c"
   DEPS
+    ::executable_environment
+    ::executable_library
     iree::base
     iree::base::core_headers
-    iree::hal::local::executable_library
 )
 
 iree_cc_library(
@@ -68,6 +86,7 @@ iree_cc_library(
     "local_executable_cache.c"
     "local_executable_layout.c"
   DEPS
+    ::executable_environment
     ::executable_library
     iree::base
     iree::base::core_headers
@@ -131,6 +150,7 @@ iree_cc_library(
     "task_queue_state.c"
     "task_semaphore.c"
   DEPS
+    ::executable_environment
     ::executable_library
     ::local
     iree::base

--- a/iree/hal/local/elf/BUILD
+++ b/iree/hal/local/elf/BUILD
@@ -41,6 +41,7 @@ cc_binary(
         ":elf_module",
         "//iree/base",
         "//iree/base:core_headers",
+        "//iree/hal/local:executable_environment",
         "//iree/hal/local:executable_library",
         "//iree/hal/local/elf/testdata:elementwise_mul",
     ],

--- a/iree/hal/local/elf/CMakeLists.txt
+++ b/iree/hal/local/elf/CMakeLists.txt
@@ -37,6 +37,7 @@ iree_cc_binary(
     iree::base
     iree::base::core_headers
     iree::hal::local::elf::testdata::elementwise_mul
+    iree::hal::local::executable_environment
     iree::hal::local::executable_library
 )
 

--- a/iree/hal/local/executable_environment.c
+++ b/iree/hal/local/executable_environment.c
@@ -1,0 +1,40 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/local/executable_environment.h"
+
+#include "iree/base/tracing.h"
+
+//===----------------------------------------------------------------------===//
+// iree_hal_processor_*_t
+//===----------------------------------------------------------------------===//
+
+void iree_hal_processor_query(iree_allocator_t temp_allocator,
+                              iree_hal_processor_v0_t* out_processor) {
+  IREE_ASSERT_ARGUMENT(out_processor);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  memset(out_processor, 0, sizeof(*out_processor));
+
+  // TODO(benvanik): define processor features we want to query for each arch.
+  // This needs to be baked into the executable library API and made consistent
+  // with the compiler side producing the executables that access it.
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_executable_environment_*_t
+//===----------------------------------------------------------------------===//
+
+void iree_hal_executable_environment_initialize(
+    iree_allocator_t temp_allocator,
+    iree_hal_executable_environment_v0_t* out_environment) {
+  IREE_ASSERT_ARGUMENT(out_environment);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  memset(out_environment, 0, sizeof(*out_environment));
+  iree_hal_processor_query(temp_allocator, &out_environment->processor);
+  IREE_TRACE_ZONE_END(z0);
+}

--- a/iree/hal/local/executable_environment.h
+++ b/iree/hal/local/executable_environment.h
@@ -1,0 +1,47 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_LOCAL_EXECUTABLE_ENVIRONMENT_H_
+#define IREE_HAL_LOCAL_EXECUTABLE_ENVIRONMENT_H_
+
+#include <stdint.h>
+
+#include "iree/base/api.h"
+#include "iree/base/internal/cpu.h"
+#include "iree/hal/api.h"
+#include "iree/hal/local/executable_library.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// iree_hal_processor_*_t
+//===----------------------------------------------------------------------===//
+
+// Queries the current processor information and writes it to |out_processor|.
+// |temp_allocator| may be used for temporary allocations required while
+// querying. If the processor cannot be queried then |out_processor| will be
+// zeroed.
+void iree_hal_processor_query(iree_allocator_t temp_allocator,
+                              iree_hal_processor_v0_t* out_processor);
+
+//===----------------------------------------------------------------------===//
+// iree_hal_executable_environment_*_t
+//===----------------------------------------------------------------------===//
+
+// Initializes |out_environment| to the default empty environment.
+// No imports will be available unless overridden during loading.
+// |temp_allocator| may be used for temporary allocations during initialization.
+void iree_hal_executable_environment_initialize(
+    iree_allocator_t temp_allocator,
+    iree_hal_executable_environment_v0_t* out_environment);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_LOCAL_EXECUTABLE_ENVIRONMENT_H_

--- a/iree/hal/local/executable_library_benchmark.c
+++ b/iree/hal/local/executable_library_benchmark.c
@@ -300,8 +300,7 @@ static iree_status_t iree_hal_executable_library_run(
       .binding_count = dispatch_params.binding_count,
       .binding_ptrs = binding_ptrs,
       .binding_lengths = binding_lengths,
-      .import_thunk = NULL,  // not yet implemented
-      .imports = NULL,       // not yet implemented
+      .environment = &local_executable->environment,
   };
 
   // Execute benchmark the workgroup invocation.

--- a/iree/hal/local/executable_library_benchmark.c
+++ b/iree/hal/local/executable_library_benchmark.c
@@ -216,31 +216,31 @@ static iree_status_t iree_hal_executable_library_run(
   // Setup the specification used to perform the executable load.
   // This information is normally used to select the appropriate loader but in
   // this benchmark we only have a single one.
-  iree_hal_executable_spec_t executable_spec;
-  iree_hal_executable_spec_initialize(&executable_spec);
-  executable_spec.caching_mode =
+  iree_hal_executable_params_t executable_params;
+  iree_hal_executable_params_initialize(&executable_params);
+  executable_params.caching_mode =
       IREE_HAL_EXECUTABLE_CACHING_MODE_ALLOW_OPTIMIZATION |
       IREE_HAL_EXECUTABLE_CACHING_MODE_ALIAS_PROVIDED_DATA |
       IREE_HAL_EXECUTABLE_CACHING_MODE_DISABLE_VERIFICATION;
-  executable_spec.executable_format =
+  executable_params.executable_format =
       iree_make_cstring_view(FLAG_executable_format);
 
   // Load the executable data.
   IREE_RETURN_IF_ERROR(iree_file_read_contents(
       FLAG_executable_file, host_allocator,
-      (iree_byte_span_t*)&executable_spec.executable_data));
+      (iree_byte_span_t*)&executable_params.executable_data));
 
   // Setup the layouts defining how each entry point is interpreted.
   // NOTE: we know for the embedded library loader that this is not required.
   // Other loaders may need it in which case it'll have to be provided.
-  executable_spec.executable_layout_count = 0;
-  executable_spec.executable_layouts = NULL;
+  executable_params.executable_layout_count = 0;
+  executable_params.executable_layouts = NULL;
 
   // Perform the load, which will fail if the executable cannot be loaded or
   // there was an issue with the layouts.
   iree_hal_executable_t* executable = NULL;
   IREE_RETURN_IF_ERROR(iree_hal_executable_loader_try_load(
-      executable_loader, &executable_spec, &executable));
+      executable_loader, &executable_params, &executable));
   iree_hal_local_executable_t* local_executable =
       iree_hal_local_executable_cast(executable);
 
@@ -331,7 +331,7 @@ static iree_status_t iree_hal_executable_library_run(
 
   // Unload.
   iree_allocator_free(host_allocator,
-                      (void*)executable_spec.executable_data.data);
+                      (void*)executable_params.executable_data.data);
   iree_hal_executable_release(executable);
   iree_hal_executable_loader_release(executable_loader);
 

--- a/iree/hal/local/executable_library_demo.c
+++ b/iree/hal/local/executable_library_demo.c
@@ -105,7 +105,8 @@ static const iree_hal_executable_library_v0_t library = {
 // example, an executable may want to swap out a few entry points to an
 // architecture-specific version.
 const iree_hal_executable_library_header_t** demo_executable_library_query(
-    iree_hal_executable_library_version_t max_version, void* reserved) {
+    iree_hal_executable_library_version_t max_version,
+    const iree_hal_executable_environment_v0_t* environment) {
   return max_version <= 0
              ? (const iree_hal_executable_library_header_t**)&library
              : NULL;

--- a/iree/hal/local/executable_library_demo.h
+++ b/iree/hal/local/executable_library_demo.h
@@ -43,7 +43,8 @@ typedef union {
 //       bindings: 0
 //
 const iree_hal_executable_library_header_t** demo_executable_library_query(
-    iree_hal_executable_library_version_t max_version, void* reserved);
+    iree_hal_executable_library_version_t max_version,
+    const iree_hal_executable_environment_v0_t* environment);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/iree/hal/local/executable_library_test.c
+++ b/iree/hal/local/executable_library_test.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include "iree/base/api.h"
+#include "iree/hal/local/executable_environment.h"
 #include "iree/hal/local/executable_library_demo.h"
 
 // Demonstration of the HAL-side of the iree_hal_executable_library_t ABI.
@@ -27,6 +28,11 @@
 //
 // See iree/hal/local/executable_library.h for more information.
 int main(int argc, char** argv) {
+  // Default environment.
+  iree_hal_executable_environment_v0_t environment;
+  iree_hal_executable_environment_initialize(iree_allocator_system(),
+                                             &environment);
+
   // Query the library header at the requested version.
   // The query call in this example is going into the handwritten demo code
   // but could be targeted at generated files or runtime-loaded shared objects.
@@ -35,7 +41,7 @@ int main(int argc, char** argv) {
     const iree_hal_executable_library_v0_t* v0;
   } library;
   library.header = demo_executable_library_query(
-      IREE_HAL_EXECUTABLE_LIBRARY_LATEST_VERSION, /*reserved=*/NULL);
+      IREE_HAL_EXECUTABLE_LIBRARY_LATEST_VERSION, &environment);
   const iree_hal_executable_library_header_t* header = *library.header;
   IREE_ASSERT_NE(header, NULL, "version may not have matched");
   IREE_ASSERT_LE(
@@ -82,8 +88,8 @@ int main(int argc, char** argv) {
       .binding_count = IREE_ARRAYSIZE(binding_ptrs),
       .binding_ptrs = binding_ptrs,
       .binding_lengths = binding_lengths,
-      .import_thunk = NULL,  // not yet implemented
-      .imports = NULL,       // not yet implemented
+      .processor_id = iree_cpu_query_processor_id(),
+      .environment = &environment,
   };
   for (uint32_t z = 0; z < dispatch_state.workgroup_count.z; ++z) {
     for (uint32_t y = 0; y < dispatch_state.workgroup_count.y; ++y) {

--- a/iree/hal/local/executable_loader.c
+++ b/iree/hal/local/executable_loader.c
@@ -86,15 +86,15 @@ bool iree_hal_query_any_executable_loader_support(
 
 iree_status_t iree_hal_executable_loader_try_load(
     iree_hal_executable_loader_t* executable_loader,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
   IREE_ASSERT_ARGUMENT(executable_loader);
-  IREE_ASSERT_ARGUMENT(executable_spec);
-  IREE_ASSERT_ARGUMENT(!executable_spec->executable_layout_count ||
-                       executable_spec->executable_layouts);
-  IREE_ASSERT_ARGUMENT(!executable_spec->executable_data.data_length ||
-                       executable_spec->executable_data.data);
+  IREE_ASSERT_ARGUMENT(executable_params);
+  IREE_ASSERT_ARGUMENT(!executable_params->executable_layout_count ||
+                       executable_params->executable_layouts);
+  IREE_ASSERT_ARGUMENT(!executable_params->executable_data.data_length ||
+                       executable_params->executable_data.data);
   IREE_ASSERT_ARGUMENT(out_executable);
-  return executable_loader->vtable->try_load(executable_loader, executable_spec,
-                                             out_executable);
+  return executable_loader->vtable->try_load(executable_loader,
+                                             executable_params, out_executable);
 }

--- a/iree/hal/local/executable_loader.c
+++ b/iree/hal/local/executable_loader.c
@@ -6,8 +6,6 @@
 
 #include "iree/hal/local/executable_loader.h"
 
-#include "iree/base/api.h"
-
 iree_status_t iree_hal_executable_import_provider_resolve(
     const iree_hal_executable_import_provider_t import_provider,
     iree_string_view_t symbol_name, void** out_fn_ptr) {

--- a/iree/hal/local/executable_loader.h
+++ b/iree/hal/local/executable_loader.h
@@ -121,7 +121,7 @@ bool iree_hal_query_any_executable_loader_support(
 // given format.
 iree_status_t iree_hal_executable_loader_try_load(
     iree_hal_executable_loader_t* executable_loader,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable);
 
 //===----------------------------------------------------------------------===//
@@ -138,7 +138,7 @@ typedef struct iree_hal_executable_loader_vtable_t {
 
   iree_status_t(IREE_API_PTR* try_load)(
       iree_hal_executable_loader_t* executable_loader,
-      const iree_hal_executable_spec_t* executable_spec,
+      const iree_hal_executable_params_t* executable_params,
       iree_hal_executable_t** out_executable);
 } iree_hal_executable_loader_vtable_t;
 

--- a/iree/hal/local/executable_loader.h
+++ b/iree/hal/local/executable_loader.h
@@ -107,12 +107,12 @@ bool iree_hal_query_any_executable_loader_support(
     iree_hal_executable_caching_mode_t caching_mode,
     iree_string_view_t executable_format);
 
-// Tries loading the |executable_data| provided in the given
-// |executable_format|. May fail even if the executable is valid if it requires
-// features not supported by the current host or runtime (such as available
-// architectures, imports, etc).
+// Tries loading the executable data provided in the given format.
+// May fail even if the executable is valid if it requires features not
+// supported by the current host or runtime (such as available architectures,
+// imports, etc).
 //
-// Depending on loader ability the |caching_mode| is used to enable certain
+// Depending on loader ability the caching_mode is used to enable certain
 // features such as instrumented profiling. Not all formats support these
 // features and cooperation of both the compiler producing the executables and
 // the runtime loader and system are required.

--- a/iree/hal/local/loaders/BUILD
+++ b/iree/hal/local/loaders/BUILD
@@ -45,6 +45,7 @@ cc_library(
         "//iree/base:tracing",
         "//iree/hal",
         "//iree/hal/local",
+        "//iree/hal/local:executable_environment",
         "//iree/hal/local:executable_library",
     ],
 )

--- a/iree/hal/local/loaders/CMakeLists.txt
+++ b/iree/hal/local/loaders/CMakeLists.txt
@@ -42,6 +42,7 @@ iree_cc_library(
     iree::base::tracing
     iree::hal
     iree::hal::local
+    iree::hal::local::executable_environment
     iree::hal::local::executable_library
   DEFINES
     "IREE_HAL_HAVE_STATIC_LIBRARY_LOADER=1"

--- a/iree/hal/local/loaders/embedded_library_loader.c
+++ b/iree/hal/local/loaders/embedded_library_loader.c
@@ -53,7 +53,7 @@ static iree_status_t iree_hal_elf_executable_query_library(
   executable->library.header =
       (const iree_hal_executable_library_header_t**)iree_elf_call_p_ip(
           query_fn, IREE_HAL_EXECUTABLE_LIBRARY_LATEST_VERSION,
-          /*reserved=*/NULL);
+          &executable->base.environment);
   if (!executable->library.header) {
     return iree_make_status(
         IREE_STATUS_FAILED_PRECONDITION,
@@ -98,15 +98,16 @@ static iree_status_t iree_hal_elf_executable_resolve_imports(
 
   // All calls from the loaded ELF route through our thunk function so that we
   // can adapt to ABI differences.
-  executable->base.import_thunk =
+  executable->base.environment.import_thunk =
       (iree_hal_executable_import_thunk_v0_t)iree_elf_thunk_i_p;
 
   // Allocate storage for the imports.
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_allocator_malloc(
-              executable->base.host_allocator,
-              import_table->count * sizeof(*executable->base.imports),
-              (void**)&executable->base.imports));
+      z0,
+      iree_allocator_malloc(
+          executable->base.host_allocator,
+          import_table->count * sizeof(*executable->base.environment.imports),
+          (void**)&executable->base.environment.imports));
 
   // Try to resolve each import.
   // NOTE: imports are sorted alphabetically and if we cared we could use this
@@ -117,7 +118,7 @@ static iree_status_t iree_hal_elf_executable_resolve_imports(
         z0,
         iree_hal_executable_import_provider_resolve(
             import_provider, iree_make_cstring_view(import_table->symbols[i]),
-            (void**)&executable->base.imports[i]));
+            (void**)&executable->base.environment.imports[i]));
   }
 
   IREE_TRACE_ZONE_END(z0);
@@ -198,8 +199,9 @@ static void iree_hal_elf_executable_destroy(
 
   iree_elf_module_deinitialize(&executable->module);
 
-  if (executable->base.imports != NULL) {
-    iree_allocator_free(host_allocator, (void*)executable->base.imports);
+  if (executable->base.environment.imports != NULL) {
+    iree_allocator_free(host_allocator,
+                        (void*)executable->base.environment.imports);
   }
 
   iree_hal_local_executable_deinitialize(

--- a/iree/hal/local/loaders/embedded_library_loader.c
+++ b/iree/hal/local/loaders/embedded_library_loader.c
@@ -322,7 +322,7 @@ static bool iree_hal_embedded_library_loader_query_support(
 
 static iree_status_t iree_hal_embedded_library_loader_try_load(
     iree_hal_executable_loader_t* base_executable_loader,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
   iree_hal_embedded_library_loader_t* executable_loader =
       (iree_hal_embedded_library_loader_t*)base_executable_loader;
@@ -330,9 +330,9 @@ static iree_status_t iree_hal_embedded_library_loader_try_load(
 
   // Perform the load of the ELF and wrap it in an executable handle.
   iree_status_t status = iree_hal_elf_executable_create(
-      executable_spec->caching_mode, executable_spec->executable_data,
-      executable_spec->executable_layout_count,
-      executable_spec->executable_layouts,
+      executable_params->caching_mode, executable_params->executable_data,
+      executable_params->executable_layout_count,
+      executable_params->executable_layouts,
       base_executable_loader->import_provider,
       executable_loader->host_allocator, out_executable);
 

--- a/iree/hal/local/loaders/static_library_loader.c
+++ b/iree/hal/local/loaders/static_library_loader.c
@@ -255,15 +255,15 @@ static bool iree_hal_static_library_loader_query_support(
 
 static iree_status_t iree_hal_static_library_loader_try_load(
     iree_hal_executable_loader_t* base_executable_loader,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
   iree_hal_static_library_loader_t* executable_loader =
       (iree_hal_static_library_loader_t*)base_executable_loader;
 
   // The executable data is just the name of the library.
-  iree_string_view_t library_name =
-      iree_make_string_view((const char*)executable_spec->executable_data.data,
-                            executable_spec->executable_data.data_length);
+  iree_string_view_t library_name = iree_make_string_view(
+      (const char*)executable_params->executable_data.data,
+      executable_params->executable_data.data_length);
 
   // Linear scan of the registered libraries; there's usually only one per
   // module (aka source model) and as such it's a small list and probably not
@@ -277,8 +277,8 @@ static iree_status_t iree_hal_static_library_loader_try_load(
                                iree_make_cstring_view(header->name))) {
       return iree_hal_static_executable_create(
           executable_loader->libraries[i],
-          executable_spec->executable_layout_count,
-          executable_spec->executable_layouts,
+          executable_params->executable_layout_count,
+          executable_params->executable_layouts,
           base_executable_loader->import_provider,
           executable_loader->host_allocator, out_executable);
     }

--- a/iree/hal/local/loaders/static_library_loader.h
+++ b/iree/hal/local/loaders/static_library_loader.h
@@ -35,7 +35,7 @@ extern "C" {
 // within and across loaders will result in undefined behavior.
 iree_status_t iree_hal_static_library_loader_create(
     iree_host_size_t library_count,
-    const iree_hal_executable_library_header_t** const* libraries,
+    const iree_hal_executable_library_query_fn_t* library_query_fns,
     iree_hal_executable_import_provider_t import_provider,
     iree_allocator_t host_allocator,
     iree_hal_executable_loader_t** out_executable_loader);

--- a/iree/hal/local/loaders/static_library_loader.h
+++ b/iree/hal/local/loaders/static_library_loader.h
@@ -27,8 +27,8 @@ extern "C" {
 //
 // The name defined on each library will be used to lookup the executables and
 // must match with the names used during compilation exactly. The
-// iree_hal_executable_spec_t used to reference the executables will contain the
-// library name and be used to lookup the library in the list.
+// iree_hal_executable_params_t used to reference the executables will contain
+// the library name and be used to lookup the library in the list.
 //
 // Multiple static library loaders can be registered in cases when several
 // independent sets of libraries are linked in however duplicate names both

--- a/iree/hal/local/loaders/system_library_loader.c
+++ b/iree/hal/local/loaders/system_library_loader.c
@@ -438,7 +438,7 @@ static bool iree_hal_system_library_loader_query_support(
 
 static iree_status_t iree_hal_system_library_loader_try_load(
     iree_hal_executable_loader_t* base_executable_loader,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
   iree_hal_system_library_loader_t* executable_loader =
       (iree_hal_system_library_loader_t*)base_executable_loader;
@@ -447,9 +447,9 @@ static iree_status_t iree_hal_system_library_loader_try_load(
   // Perform the load (and requisite disgusting hackery).
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_system_executable_create(
-              executable_spec->executable_data,
-              executable_spec->executable_layout_count,
-              executable_spec->executable_layouts,
+              executable_params->executable_data,
+              executable_params->executable_layout_count,
+              executable_params->executable_layouts,
               base_executable_loader->import_provider,
               executable_loader->host_allocator, out_executable));
 

--- a/iree/hal/local/loaders/system_library_loader.c
+++ b/iree/hal/local/loaders/system_library_loader.c
@@ -147,7 +147,8 @@ static iree_status_t iree_hal_system_executable_query_library(
 
   // Query for a compatible version of the library.
   executable->library.header =
-      query_fn(IREE_HAL_EXECUTABLE_LIBRARY_LATEST_VERSION, /*reserved=*/NULL);
+      query_fn(IREE_HAL_EXECUTABLE_LIBRARY_LATEST_VERSION,
+               &executable->base.environment);
   if (!executable->library.header) {
     return iree_make_status(
         IREE_STATUS_FAILED_PRECONDITION,
@@ -209,14 +210,16 @@ static iree_status_t iree_hal_system_executable_resolve_imports(
   IREE_TRACE_ZONE_BEGIN(z0);
 
   // Pass all imports right through.
-  executable->base.import_thunk = iree_hal_system_executable_import_thunk_v0;
+  executable->base.environment.import_thunk =
+      iree_hal_system_executable_import_thunk_v0;
 
   // Allocate storage for the imports.
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_allocator_malloc(
-              executable->base.host_allocator,
-              import_table->count * sizeof(*executable->base.imports),
-              (void**)&executable->base.imports));
+      z0,
+      iree_allocator_malloc(
+          executable->base.host_allocator,
+          import_table->count * sizeof(*executable->base.environment.imports),
+          (void**)&executable->base.environment.imports));
 
   // Try to resolve each import.
   // NOTE: imports are sorted alphabetically and if we cared we could use this
@@ -227,7 +230,7 @@ static iree_status_t iree_hal_system_executable_resolve_imports(
         z0,
         iree_hal_executable_import_provider_resolve(
             import_provider, iree_make_cstring_view(import_table->symbols[i]),
-            (void**)&executable->base.imports[i]));
+            (void**)&executable->base.environment.imports[i]));
   }
 
   IREE_TRACE_ZONE_END(z0);
@@ -301,6 +304,11 @@ static void iree_hal_system_executable_destroy(
   IREE_TRACE_ZONE_BEGIN(z0);
 
   iree_dynamic_library_release(executable->handle);
+
+  if (executable->base.environment.imports != NULL) {
+    iree_allocator_free(host_allocator,
+                        (void*)executable->base.environment.imports);
+  }
 
   iree_hal_local_executable_deinitialize(
       (iree_hal_local_executable_t*)base_executable);

--- a/iree/hal/local/local_executable.c
+++ b/iree/hal/local/local_executable.c
@@ -7,6 +7,7 @@
 #include "iree/hal/local/local_executable.h"
 
 #include "iree/base/tracing.h"
+#include "iree/hal/local/executable_environment.h"
 
 void iree_hal_local_executable_initialize(
     const iree_hal_local_executable_vtable_t* vtable,
@@ -29,9 +30,9 @@ void iree_hal_local_executable_initialize(
   // Function attributes are optional and populated by the parent type.
   out_base_executable->dispatch_attrs = NULL;
 
-  // Imports will be provided by the parent type, if needed.
-  out_base_executable->import_thunk = NULL;
-  out_base_executable->imports = NULL;
+  // Default environment with no imports assigned.
+  iree_hal_executable_environment_initialize(host_allocator,
+                                             &out_base_executable->environment);
 }
 
 void iree_hal_local_executable_deinitialize(

--- a/iree/hal/local/local_executable.h
+++ b/iree/hal/local/local_executable.h
@@ -28,12 +28,8 @@ typedef struct iree_hal_local_executable_t {
   // of memory required by the function.
   const iree_hal_executable_dispatch_attrs_v0_t* dispatch_attrs;
 
-  // Thunk function for calling imports. All calls must be made through this.
-  iree_hal_executable_import_thunk_v0_t import_thunk;
-  // Optional imported functions available for use within the executable.
-  // Contains one entry per imported function. If an import was marked as weak
-  // then the corresponding entry may be NULL.
-  const iree_hal_executable_import_v0_t* imports;
+  // Execution environment.
+  iree_hal_executable_environment_v0_t environment;
 } iree_hal_local_executable_t;
 
 typedef struct iree_hal_local_executable_vtable_t {

--- a/iree/hal/local/local_executable_cache.c
+++ b/iree/hal/local/local_executable_cache.c
@@ -97,14 +97,14 @@ static bool iree_hal_local_executable_cache_can_prepare_format(
 
 static iree_status_t iree_hal_local_executable_cache_prepare_executable(
     iree_hal_executable_cache_t* base_executable_cache,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
   iree_hal_local_executable_cache_t* executable_cache =
       iree_hal_local_executable_cache_cast(base_executable_cache);
   for (iree_host_size_t i = 0; i < executable_cache->loader_count; ++i) {
     if (!iree_hal_executable_loader_query_support(
-            executable_cache->loaders[i], executable_spec->caching_mode,
-            executable_spec->executable_format)) {
+            executable_cache->loaders[i], executable_params->caching_mode,
+            executable_params->executable_format)) {
       // Loader definitely can't handle the executable; no use trying so skip.
       continue;
     }
@@ -112,7 +112,7 @@ static iree_status_t iree_hal_local_executable_cache_prepare_executable(
     // supported then the try will fail with IREE_STATUS_CANCELLED and we should
     // continue trying other loaders.
     iree_status_t status = iree_hal_executable_loader_try_load(
-        executable_cache->loaders[i], executable_spec, out_executable);
+        executable_cache->loaders[i], executable_params, out_executable);
     if (iree_status_is_ok(status)) {
       // Executable was successfully loaded.
       return status;
@@ -125,8 +125,8 @@ static iree_status_t iree_hal_local_executable_cache_prepare_executable(
   return iree_make_status(
       IREE_STATUS_NOT_FOUND,
       "no executable loader registered for the given executable format '%.*s'",
-      (int)executable_spec->executable_format.size,
-      executable_spec->executable_format.data);
+      (int)executable_params->executable_format.size,
+      executable_params->executable_format.data);
 }
 
 static const iree_hal_executable_cache_vtable_t

--- a/iree/hal/local/task_command_buffer.c
+++ b/iree/hal/local/task_command_buffer.c
@@ -13,6 +13,7 @@
 
 #include "iree/base/api.h"
 #include "iree/base/tracing.h"
+#include "iree/hal/local/executable_environment.h"
 #include "iree/hal/local/executable_library.h"
 #include "iree/hal/local/local_descriptor_set_layout.h"
 #include "iree/hal/local/local_executable.h"
@@ -838,11 +839,8 @@ static iree_status_t iree_hal_cmd_dispatch_tile(
   state.binding_lengths = (size_t*)cmd_ptr;
   cmd_ptr += cmd->binding_count * sizeof(*state.binding_lengths);
 
-  // When we support imports we can populate those here based on what the
-  // executable declared (as each executable may import a unique set of
-  // functions).
-  state.import_thunk = cmd->executable->import_thunk;
-  state.imports = cmd->executable->imports;
+  state.processor_id = tile_context->processor_id;
+  state.environment = &cmd->executable->environment;
 
   iree_status_t status = iree_hal_local_executable_issue_call(
       cmd->executable, cmd->ordinal, &state,

--- a/iree/hal/vulkan/native_executable.cc
+++ b/iree/hal/vulkan/native_executable.cc
@@ -213,10 +213,10 @@ iree_hal_vulkan_native_executable_cast(iree_hal_executable_t* base_value) {
 iree_status_t iree_hal_vulkan_native_executable_create(
     iree::hal::vulkan::VkDeviceHandle* logical_device,
     VkPipelineCache pipeline_cache,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
   IREE_ASSERT_ARGUMENT(logical_device);
-  IREE_ASSERT_ARGUMENT(executable_spec);
+  IREE_ASSERT_ARGUMENT(executable_params);
   IREE_ASSERT_ARGUMENT(out_executable);
   *out_executable = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -224,10 +224,10 @@ iree_status_t iree_hal_vulkan_native_executable_create(
   // Verify and fetch the executable flatbuffer wrapper.
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_spirv_executable_flatbuffer_verify(
-              executable_spec->executable_data,
-              executable_spec->executable_layout_count));
+              executable_params->executable_data,
+              executable_params->executable_layout_count));
   iree_SpirVExecutableDef_table_t executable_def =
-      iree_SpirVExecutableDef_as_root(executable_spec->executable_data.data);
+      iree_SpirVExecutableDef_as_root(executable_params->executable_data.data);
 
   // Create the shader module.
   flatbuffers_uint32_vec_t code_vec =
@@ -263,9 +263,10 @@ iree_status_t iree_hal_vulkan_native_executable_create(
   }
   if (iree_status_is_ok(status)) {
     status = iree_hal_vulkan_create_pipelines(
-        logical_device, pipeline_cache, executable_spec->caching_mode,
-        executable_def, shader_module, executable_spec->executable_layout_count,
-        executable_spec->executable_layouts, executable->entry_point_count,
+        logical_device, pipeline_cache, executable_params->caching_mode,
+        executable_def, shader_module,
+        executable_params->executable_layout_count,
+        executable_params->executable_layouts, executable->entry_point_count,
         executable->entry_points);
   }
   iree_hal_vulkan_destroy_shader_module(logical_device, shader_module);

--- a/iree/hal/vulkan/native_executable.h
+++ b/iree/hal/vulkan/native_executable.h
@@ -31,7 +31,7 @@ typedef struct iree_hal_vulkan_source_location_t {
 iree_status_t iree_hal_vulkan_native_executable_create(
     iree::hal::vulkan::VkDeviceHandle* logical_device,
     VkPipelineCache pipeline_cache,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable);
 
 // Returns the source location for the given entry point. May be empty if not

--- a/iree/hal/vulkan/nop_executable_cache.cc
+++ b/iree/hal/vulkan/nop_executable_cache.cc
@@ -80,13 +80,13 @@ static bool iree_hal_vulkan_nop_executable_cache_can_prepare_format(
 
 static iree_status_t iree_hal_vulkan_nop_executable_cache_prepare_executable(
     iree_hal_executable_cache_t* base_executable_cache,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
   iree_hal_vulkan_nop_executable_cache_t* executable_cache =
       iree_hal_vulkan_nop_executable_cache_cast(base_executable_cache);
   return iree_hal_vulkan_native_executable_create(
       executable_cache->logical_device,
-      /*pipeline_cache=*/VK_NULL_HANDLE, executable_spec, out_executable);
+      /*pipeline_cache=*/VK_NULL_HANDLE, executable_params, out_executable);
 }
 
 namespace {

--- a/iree/modules/hal/module.c
+++ b/iree/modules/hal/module.c
@@ -1219,19 +1219,19 @@ IREE_VM_ABI_EXPORT(iree_hal_module_executable_create,  //
 
   iree_hal_executable_t* executable = NULL;
   if (iree_status_is_ok(status)) {
-    iree_hal_executable_spec_t spec;
-    iree_hal_executable_spec_initialize(&spec);
-    spec.caching_mode |=
+    iree_hal_executable_params_t executable_params;
+    iree_hal_executable_params_initialize(&executable_params);
+    executable_params.caching_mode |=
         executable_data->access == IREE_VM_BUFFER_ACCESS_ORIGIN_MODULE
             ? IREE_HAL_EXECUTABLE_CACHING_MODE_ALIAS_PROVIDED_DATA
             : 0;
-    spec.executable_format = executable_format_str;
-    spec.executable_data = iree_make_const_byte_span(
+    executable_params.executable_format = executable_format_str;
+    executable_params.executable_data = iree_make_const_byte_span(
         executable_data->data.data, executable_data->data.data_length);
-    spec.executable_layout_count = executable_layout_count;
-    spec.executable_layouts = executable_layouts;
+    executable_params.executable_layout_count = executable_layout_count;
+    executable_params.executable_layouts = executable_layouts;
     status = iree_hal_executable_cache_prepare_executable(
-        state->executable_cache, &spec, &executable);
+        state->executable_cache, &executable_params, &executable);
   }
 
   iree_allocator_free(state->host_allocator, executable_layouts);

--- a/iree/task/BUILD
+++ b/iree/task/BUILD
@@ -73,6 +73,7 @@ cc_library(
         "//iree/base:tracing",
         "//iree/base/internal",
         "//iree/base/internal:atomic_slist",
+        "//iree/base/internal:cpu",
         "//iree/base/internal:event_pool",
         "//iree/base/internal:fpu_state",
         "//iree/base/internal:prng",

--- a/iree/task/CMakeLists.txt
+++ b/iree/task/CMakeLists.txt
@@ -68,6 +68,7 @@ iree_cc_library(
     iree::base::core_headers
     iree::base::internal
     iree::base::internal::atomic_slist
+    iree::base::internal::cpu
     iree::base::internal::event_pool
     iree::base::internal::fpu_state
     iree::base::internal::prng

--- a/iree/task/task.c
+++ b/iree/task/task.c
@@ -706,7 +706,8 @@ iree_task_dispatch_shard_t* iree_task_dispatch_shard_allocate(
 }
 
 void iree_task_dispatch_shard_execute(
-    iree_task_dispatch_shard_t* task, iree_byte_span_t worker_local_memory,
+    iree_task_dispatch_shard_t* task, iree_cpu_processor_id_t processor_id,
+    iree_byte_span_t worker_local_memory,
     iree_task_submission_t* pending_submission) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
@@ -750,6 +751,9 @@ void iree_task_dispatch_shard_execute(
   iree_task_dispatch_statistics_t shard_statistics;
   memset(&shard_statistics, 0, sizeof(shard_statistics));
   tile_context.statistics = &shard_statistics;
+
+  // Hint as to which processor we are running on.
+  tile_context.processor_id = processor_id;
 
   // Loop over all tiles until they are all processed.
   const uint32_t tile_count = dispatch_task->tile_count;

--- a/iree/task/task.h
+++ b/iree/task/task.h
@@ -14,6 +14,7 @@
 #include "iree/base/api.h"
 #include "iree/base/internal/atomic_slist.h"
 #include "iree/base/internal/atomics.h"
+#include "iree/base/internal/cpu.h"
 #include "iree/base/internal/synchronization.h"
 #include "iree/task/affinity_set.h"
 
@@ -539,8 +540,9 @@ typedef iree_alignas(iree_max_align_t) struct {
   // Shared statistics counters for the dispatch shard.
   iree_task_dispatch_statistics_t* statistics;
 
-  // TODO(benvanik): cpuid uarch.
-  // TODO(benvanik): per-tile coroutine storage.
+  // Opaque ID of the processor executing the tile.
+  // May be slightly out of date or 0 if the processor could not be queried.
+  iree_cpu_processor_id_t processor_id;
 } iree_task_tile_context_t;
 
 typedef struct iree_task_dispatch_t iree_task_dispatch_t;

--- a/iree/task/task_impl.h
+++ b/iree/task/task_impl.h
@@ -111,13 +111,18 @@ iree_task_dispatch_shard_t* iree_task_dispatch_shard_allocate(
 // May block the caller for an indeterminate amount of time and should only be
 // called from threads owned by or donated to the executor.
 //
+// |processor_id| is a guess as to which logical processor the shard is
+// executing on. It may be out of date or 0 if the processor could not be
+// queried.
+//
 // |worker_local_memory| is a block of memory exclusively available to the shard
 // during execution. Contents are undefined both before and after execution.
 //
 // Errors are propagated to the parent scope and the dispatch will fail once
 // all shards have completed.
 void iree_task_dispatch_shard_execute(
-    iree_task_dispatch_shard_t* task, iree_byte_span_t worker_local_memory,
+    iree_task_dispatch_shard_t* task, iree_cpu_processor_id_t processor_id,
+    iree_byte_span_t worker_local_memory,
     iree_task_submission_t* pending_submission);
 
 #ifdef __cplusplus

--- a/iree/task/worker.h
+++ b/iree/task/worker.h
@@ -110,6 +110,15 @@ typedef struct iree_task_worker_t {
   // remain valid so that the executor can query its state.
   iree_thread_t* thread;
 
+  // Guess at the current processor ID.
+  // This is updated infrequently as it can be semi-expensive to determine
+  // (on some platforms at least 1 syscall involved). We always update it upon
+  // waking as idle waits are the most likely place the worker will be migrated
+  // across processors.
+  iree_cpu_processor_id_t processor_id;
+  // An opaque tag used to reduce the cost of processor ID queries.
+  iree_cpu_processor_tag_t processor_tag;
+
   // Destructive interference padding between the mailbox and local task queue
   // to ensure that the worker - who is pounding on local_task_queue - doesn't
   // contend with submissions or coordinators dropping new tasks in the mailbox.


### PR DESCRIPTION
This adds an `iree_hal_executable_environment_*_t` struct to wrap up the existing import table, a new processor info struct, and a new reserved spot for specialization constants.

An "executable environment" is now provided to executables as they are loaded as well as on each dispatch invocation. On initial query the executable code can use the optional processor information, import functions, and executable-level specialization constants to decide which implementation of functions to use by switching the pointers returned in the library table. There may be future work around that area to support different concurrently specialized versions of the same library but for today our usage doesn't trigger that issue. Dispatch functions receive the same processor information, imports, and constants and can be used to enable per-invocation specialization (switch paths based on the current processor microarchitecture when in a heterogenous system, use a runtime-derived executable-level constant computed by the host code such as workgroup sizes, etc).

The general equivalence to regular software is that flags provided to clang become HAL configurations in iree-translate, runtime queries done once to switch between implementations compiled in become specialization constants, and queries done per invocation become the environment/processor info. This design gives us the same capabilities normal software has while preserving our intra-architecture artifact portability and forward compatibility along with the ability to separate host and device (running in enclaves, on remote devices, etc).

Isolation is being maintained between the internal parts of the runtime that only need be source compatible (such as how to query the current processor ordinal via a platform/arch-specific impl) and those that bridge into the compiler. The executable library structs are part of the public stable ABI for the executables and once we go stable will only be able to be appended or versioned coarsely. By construction it's not possible to load an executable compiled for any other major architecture than the one doing the loading so each can have its own data format and there's no need to normalize all the various architectural quirks - instead the runtime is just passing data from some function that produces the data to the executable using it by memcpy. Beyond keeping things simple this also allows the runtime to be architecture-agnostic with respect to out-of-tree ISA's/OS'/bare-metal HAL's/etc; there's no enum of architectures or list of features in the runtime that needs to change beyond custom data query functions that can be overlaid into the build.

The processor data itself is represented as a set of opaque uint64_t fields. One could just store the architectural info registers right in the data, though of all the thousands of bits there are only a handful we care about and we can append to the set as we need it. A benefit of the arch registers would be that the runtime does not need to be updated to run models using newer features, but that's risky (it may mean the kernel or hosting code doesn't support it - like trying to use avx512 in an app compiled for avx2). The arch registers may not always be available to query either (sandboxing/fingerprinting avoidance), and having something that was robust to partial information is important. Another example use of the fields is a bitmap indicating which logical processors are running on a little core in a big.LITTLE setup such that testing per-invocation which code path should be used becomes `(processor.data[CORE_TYPE_FIELD] >> processor_id) & 1`. All other information about cache topology and such can come through specialization constants queried from the host side as that's what needs to adjust workgroup parameters anyway. The first few bits we add will likely be those from `iree/tools/utils/cpu_features.h`.

Note that the intent here is that executables we produce from the compiler always run on some baseline; unless a user is hyper optimizing for size the additional fallback paths would at most double the small executable size but realistically only increase it a marginal amount: not every dispatch is going to use all of the conditional features and need to be duplicated. There's going to need to be some compiler infra to make that happen, though (plumbing in MLIR through to LLVM's function multi-versioning), so today we're probably stuck with whatever the user specifies to the compiler :(

Progress on #5417. Follow-on PRs will fold in the `iree/tools/utils/cpu_features.h` work though there will need to be some discussion about how to represent it. Prepares for #8469.
Work remains to wire up the ability to specify the specialization constants in the compiler/runtime HAL layers; what's here is just the plumbing for CPU.