### PR TITLE
[CUDA] Fix thread tile size calculation for unaligned cases

### DIFF
--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
@@ -87,7 +87,8 @@ static SmallVector<Value, 4> calculateDistributedTileSize(
   for (unsigned depth : partitionedLoops) {
     if (depth >= blockTileSize.size()) continue;
     tileSizesVal[depth] = builder.create<arith::ConstantIndexOp>(
-        operation->getLoc(), blockTileSize[depth] / distributedDim[idIdx++]);
+        operation->getLoc(),
+        llvm::divideCeil(blockTileSize[depth], distributedDim[idIdx++]));
     if (idIdx == kNumMaxParallelDims) break;
   }
   return tileSizesVal;


### PR DESCRIPTION
This prevent skipping tiling for cases where the workgroup tile size is
smaller than workgroup size.