### PR TITLE
Fix missing test deps after https://github.com/google/iree/pull/8423

### DIFF
--- a/build_tools/cmake/build_android.sh
+++ b/build_tools/cmake/build_android.sh
@@ -78,4 +78,11 @@ cd build-android
   -DIREE_BUILD_COMPILER=OFF \
   -DIREE_BUILD_TESTS=ON \
   -DIREE_BUILD_SAMPLES=OFF
+
+echo "Building all for device"
+echo "------------"
 "${CMAKE_BIN}" --build . -- -k 0
+
+echo "Building test deps for device"
+echo "------------------"
+"$CMAKE_BIN" --build . --target iree-test-deps -- -k 0

--- a/build_tools/kokoro/gcp_ubuntu/cmake/android/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/android/build.sh
@@ -103,4 +103,11 @@ cd build-android
   -DIREE_BUILD_COMPILER=OFF \
   -DIREE_BUILD_TESTS=ON \
   -DIREE_BUILD_SAMPLES=OFF
+
+echo "Building all for device"
+echo "------------"
 "${CMAKE_BIN}" --build . -- -k 0
+
+echo "Building test deps for device"
+echo "------------------"
+"$CMAKE_BIN" --build . --target iree-test-deps -- -k 0

--- a/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-turing/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-turing/build.sh
@@ -63,8 +63,16 @@ CMAKE_ARGS=(
   "-DIREE_HAL_DRIVER_CUDA=ON"
 )
 
+echo "Configuring CMake"
 "$CMAKE_BIN" "${CMAKE_ARGS[@]?}" "$@" ..
+
+echo "Building all"
+echo "------------"
 "$CMAKE_BIN" --build . -- -k 0
+
+echo "Building test deps"
+echo "------------------"
+"$CMAKE_BIN" --build . --target iree-test-deps -- -k 0
 
 cd ${ROOT_DIR?}
 


### PR DESCRIPTION
Should fix `iree/gcp_ubuntu/cmake/linux/x86-turing/main[default]` and `iree/iree-android-arm64-v8a` by adding `"$CMAKE_BIN" --build . --target iree-test-deps -- -k 0` steps to each. 