### PR TITLE
Fix ASan test failures on linux/x86/CPU

### DIFF
--- a/bindings/tflite/interpreter.c
+++ b/bindings/tflite/interpreter.c
@@ -426,8 +426,8 @@ TFL_CAPI_EXPORT extern void TfLiteInterpreterDelete(
   iree_vm_context_release(interpreter->context);
   iree_vm_module_release(interpreter->hal_module);
   iree_vm_module_release(interpreter->user_module);
+  iree_hal_driver_release(interpreter->driver);
   iree_vm_instance_release(interpreter->instance);
-  iree_hal_driver_release((iree_hal_driver_t*)interpreter->driver);
 
   _TfLiteModelRelease(interpreter->model);
   iree_allocator_free(interpreter->allocator, interpreter);

--- a/bindings/tflite/interpreter.c
+++ b/bindings/tflite/interpreter.c
@@ -427,6 +427,7 @@ TFL_CAPI_EXPORT extern void TfLiteInterpreterDelete(
   iree_vm_module_release(interpreter->hal_module);
   iree_vm_module_release(interpreter->user_module);
   iree_vm_instance_release(interpreter->instance);
+  iree_hal_driver_release((iree_hal_driver_t*)interpreter->driver);
 
   _TfLiteModelRelease(interpreter->model);
   iree_allocator_free(interpreter->allocator, interpreter);

--- a/bindings/tflite/model.c
+++ b/bindings/tflite/model.c
@@ -123,6 +123,7 @@ TFL_CAPI_EXPORT extern TfLiteModel* TfLiteModelCreate(const void* model_data,
   status =
       _TfLiteModelInitializeModule(model_data, model_size, allocator, model);
   if (!iree_status_is_ok(iree_status_consume_code(status))) {
+    iree_allocator_free(allocator, model);
     IREE_TRACE_ZONE_END(z0);
     return NULL;
   }

--- a/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader-asan/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader-asan/build.sh
@@ -105,9 +105,6 @@ label_exclude_regex="($(IFS="|" ; echo "${label_exclude_args[*]?}"))"
 # These tests currently have asan failures
 # TODO(#5715): Fix these
 declare -a excluded_tests=(
-  "iree/base/internal/file_io_test"
-  "bindings/tflite/smoke_test"
-  "iree/modules/check/check_test"
   "iree/samples/simple_embedding/simple_embedding_vulkan_test"
 )
 

--- a/iree/base/internal/file_io_test.cc
+++ b/iree/base/internal/file_io_test.cc
@@ -49,7 +49,9 @@ TEST(FileIO, ReadWriteContents) {
   auto path = GetUniquePath(kUniqueName);
 
   // File must not exist.
-  IREE_EXPECT_STATUS_IS(IREE_STATUS_NOT_FOUND, iree_file_exists(path.c_str()));
+  iree_status_t status = iree_file_exists(path.c_str());
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_NOT_FOUND, status);
+  iree_status_free(status);
 
   // Generate file contents.
   auto write_contents = GetUniqueContents(kUniqueName);

--- a/iree/modules/check/check_test.cc
+++ b/iree/modules/check/check_test.cc
@@ -237,6 +237,7 @@ TEST_F(CheckTest, ExpectAllTrueSuccess) {
   ASSERT_NO_FATAL_FAILURE(
       CreateInt32BufferView(contents, shape, &input_buffer_view));
   IREE_ASSERT_OK(Invoke("expect_all_true", {input_buffer_view}));
+  iree_hal_buffer_view_release(input_buffer_view.get());
 }
 
 TEST_F(CheckTest, ExpectAllTrue3DTrueSuccess) {
@@ -246,6 +247,7 @@ TEST_F(CheckTest, ExpectAllTrue3DTrueSuccess) {
   ASSERT_NO_FATAL_FAILURE(
       CreateInt32BufferView(contents, shape, &input_buffer_view));
   IREE_ASSERT_OK(Invoke("expect_all_true", {input_buffer_view}));
+  iree_hal_buffer_view_release(input_buffer_view.get());
 }
 
 TEST_F(CheckTest, ExpectAllTrueFailure) {
@@ -256,6 +258,7 @@ TEST_F(CheckTest, ExpectAllTrueFailure) {
       CreateInt32BufferView(contents, shape, &input_buffer_view));
   EXPECT_NONFATAL_FAILURE(
       IREE_ASSERT_OK(Invoke("expect_all_true", {input_buffer_view})), "0");
+  iree_hal_buffer_view_release(input_buffer_view.get());
 }
 
 TEST_F(CheckTest, ExpectAllTrueSingleElementFailure) {
@@ -267,6 +270,7 @@ TEST_F(CheckTest, ExpectAllTrueSingleElementFailure) {
   EXPECT_NONFATAL_FAILURE(
       IREE_ASSERT_OK(Invoke("expect_all_true", {input_buffer_view})),
       "1, 2, 3, 0, 4");
+  iree_hal_buffer_view_release(input_buffer_view.get());
 }
 
 TEST_F(CheckTest, ExpectAllTrue3DSingleElementFailure) {
@@ -278,6 +282,7 @@ TEST_F(CheckTest, ExpectAllTrue3DSingleElementFailure) {
   EXPECT_NONFATAL_FAILURE(
       IREE_ASSERT_OK(Invoke("expect_all_true", {input_buffer_view})),
       "1, 2, 3, 4, 5, 6, 0, 8");
+  iree_hal_buffer_view_release(input_buffer_view.get());
 }
 
 TEST_F(CheckTest, ExpectEqSameBufferSuccess) {
@@ -287,6 +292,8 @@ TEST_F(CheckTest, ExpectEqSameBufferSuccess) {
   ASSERT_NO_FATAL_FAILURE(
       CreateInt32BufferView(contents, shape, &input_buffer_view));
   IREE_ASSERT_OK(Invoke("expect_eq", {input_buffer_view, input_buffer_view}));
+  iree_hal_buffer_view_release(input_buffer_view.get());
+  iree_hal_buffer_view_release(input_buffer_view.get());
 }
 
 TEST_F(CheckTest, ExpectEqIdenticalBufferSuccess) {
@@ -297,6 +304,8 @@ TEST_F(CheckTest, ExpectEqIdenticalBufferSuccess) {
   ASSERT_NO_FATAL_FAILURE(CreateInt32BufferView(contents, shape, &lhs));
   ASSERT_NO_FATAL_FAILURE(CreateInt32BufferView(contents, shape, &rhs));
   IREE_ASSERT_OK(Invoke("expect_eq", {lhs, rhs}));
+  iree_hal_buffer_view_release(lhs.get());
+  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectEqIdentical3DBufferSuccess) {
@@ -307,6 +316,8 @@ TEST_F(CheckTest, ExpectEqIdentical3DBufferSuccess) {
   ASSERT_NO_FATAL_FAILURE(CreateInt32BufferView(contents, shape, &lhs));
   ASSERT_NO_FATAL_FAILURE(CreateInt32BufferView(contents, shape, &rhs));
   IREE_ASSERT_OK(Invoke("expect_eq", {lhs, rhs}));
+  iree_hal_buffer_view_release(lhs.get());
+  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectEqDifferentShapeFailure) {
@@ -319,6 +330,8 @@ TEST_F(CheckTest, ExpectEqDifferentShapeFailure) {
   ASSERT_NO_FATAL_FAILURE(CreateInt32BufferView(contents, rhs_shape, &rhs));
   EXPECT_NONFATAL_FAILURE(IREE_ASSERT_OK(Invoke("expect_eq", {lhs, rhs})),
                           "Shapes do not match");
+  iree_hal_buffer_view_release(lhs.get());
+  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectEqDifferentElementTypeFailure) {
@@ -331,6 +344,8 @@ TEST_F(CheckTest, ExpectEqDifferentElementTypeFailure) {
   ASSERT_NO_FATAL_FAILURE(CreateFloat32BufferView(rhs_contents, shape, &rhs));
   EXPECT_NONFATAL_FAILURE(IREE_ASSERT_OK(Invoke("expect_eq", {lhs, rhs})),
                           "Element types do not match");
+  iree_hal_buffer_view_release(lhs.get());
+  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectEqDifferentContentsFailure) {
@@ -343,6 +358,8 @@ TEST_F(CheckTest, ExpectEqDifferentContentsFailure) {
   ASSERT_NO_FATAL_FAILURE(CreateInt32BufferView(rhs_contents, shape, &rhs));
   EXPECT_NONFATAL_FAILURE(IREE_ASSERT_OK(Invoke("expect_eq", {lhs, rhs})),
                           "Contents does not match");
+  iree_hal_buffer_view_release(lhs.get());
+  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectEqDifferentEverythingFullMessageFailure) {
@@ -363,6 +380,8 @@ TEST_F(CheckTest, ExpectEqDifferentEverythingFullMessageFailure) {
       "    2x3xi32=[1 2 3][4 5 6]\n"
       "  rhs:\n"
       "    2x2xf32=[1 2][3 42]");
+  iree_hal_buffer_view_release(lhs.get());
+  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectEqDifferentContents3DFullMessageFailure) {
@@ -380,6 +399,8 @@ TEST_F(CheckTest, ExpectEqDifferentContents3DFullMessageFailure) {
       "    2x2x2xi32=[[1 2][3 4]][[5 6][7 8]]\n"
       "  rhs:\n"
       "    2x2x2xi32=[[1 2][3 42]][[5 6][7 8]]");
+  iree_hal_buffer_view_release(lhs.get());
+  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqSameBufferSuccess) {
@@ -390,6 +411,8 @@ TEST_F(CheckTest, ExpectAlmostEqSameBufferSuccess) {
       CreateFloat32BufferView(contents, shape, &input_buffer_view));
   IREE_ASSERT_OK(
       Invoke("expect_almost_eq", {input_buffer_view, input_buffer_view}));
+  iree_hal_buffer_view_release(input_buffer_view.get());
+  iree_hal_buffer_view_release(input_buffer_view.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqIdenticalBufferSuccess) {
@@ -400,6 +423,8 @@ TEST_F(CheckTest, ExpectAlmostEqIdenticalBufferSuccess) {
   ASSERT_NO_FATAL_FAILURE(CreateFloat32BufferView(contents, shape, &lhs));
   ASSERT_NO_FATAL_FAILURE(CreateFloat32BufferView(contents, shape, &rhs));
   IREE_ASSERT_OK(Invoke("expect_almost_eq", {lhs, rhs}));
+  iree_hal_buffer_view_release(lhs.get());
+  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqNearIdenticalBufferSuccess) {
@@ -411,6 +436,8 @@ TEST_F(CheckTest, ExpectAlmostEqNearIdenticalBufferSuccess) {
   ASSERT_NO_FATAL_FAILURE(CreateFloat32BufferView(lhs_contents, shape, &lhs));
   ASSERT_NO_FATAL_FAILURE(CreateFloat32BufferView(rhs_contents, shape, &rhs));
   IREE_ASSERT_OK(Invoke("expect_almost_eq", {lhs, rhs}));
+  iree_hal_buffer_view_release(lhs.get());
+  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqIdentical3DBufferSuccess) {
@@ -421,6 +448,8 @@ TEST_F(CheckTest, ExpectAlmostEqIdentical3DBufferSuccess) {
   ASSERT_NO_FATAL_FAILURE(CreateFloat32BufferView(contents, shape, &lhs));
   ASSERT_NO_FATAL_FAILURE(CreateFloat32BufferView(contents, shape, &rhs));
   IREE_ASSERT_OK(Invoke("expect_almost_eq", {lhs, rhs}));
+  iree_hal_buffer_view_release(lhs.get());
+  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqDifferentShapeFailure) {
@@ -434,6 +463,8 @@ TEST_F(CheckTest, ExpectAlmostEqDifferentShapeFailure) {
   EXPECT_NONFATAL_FAILURE(
       IREE_ASSERT_OK(Invoke("expect_almost_eq", {lhs, rhs})),
       "Shapes do not match");
+  iree_hal_buffer_view_release(lhs.get());
+  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqSmallerLhsElementCountFailure) {
@@ -450,6 +481,8 @@ TEST_F(CheckTest, ExpectAlmostEqSmallerLhsElementCountFailure) {
   EXPECT_NONFATAL_FAILURE(
       IREE_ASSERT_OK(Invoke("expect_almost_eq", {smaller, bigger})),
       "Shapes do not match");
+  iree_hal_buffer_view_release(smaller.get());
+  iree_hal_buffer_view_release(bigger.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqSmallerRhsElementCountFailure) {
@@ -466,6 +499,8 @@ TEST_F(CheckTest, ExpectAlmostEqSmallerRhsElementCountFailure) {
   EXPECT_NONFATAL_FAILURE(
       IREE_ASSERT_OK(Invoke("expect_almost_eq", {bigger, smaller})),
       "Shapes do not match");
+  iree_hal_buffer_view_release(smaller.get());
+  iree_hal_buffer_view_release(bigger.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqDifferentElementTypeFailure) {
@@ -479,6 +514,8 @@ TEST_F(CheckTest, ExpectAlmostEqDifferentElementTypeFailure) {
   EXPECT_NONFATAL_FAILURE(
       IREE_ASSERT_OK(Invoke("expect_almost_eq", {lhs, rhs})),
       "Element types do not match");
+  iree_hal_buffer_view_release(lhs.get());
+  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqDifferentContentsFailure) {
@@ -492,6 +529,8 @@ TEST_F(CheckTest, ExpectAlmostEqDifferentContentsFailure) {
   EXPECT_NONFATAL_FAILURE(
       IREE_ASSERT_OK(Invoke("expect_almost_eq", {lhs, rhs})),
       "Contents does not match");
+  iree_hal_buffer_view_release(lhs.get());
+  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqDifferentEverythingFullMessageFailure) {
@@ -515,6 +554,8 @@ TEST_F(CheckTest, ExpectAlmostEqDifferentEverythingFullMessageFailure) {
       "    2x3xf64=[1 2 3][4 5 6]\n"
       "  rhs:\n"
       "    2x2xf32=[1 2][3 42]");
+  iree_hal_buffer_view_release(lhs.get());
+  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqDifferentContents3DFullMessageFailure) {
@@ -532,6 +573,8 @@ TEST_F(CheckTest, ExpectAlmostEqDifferentContents3DFullMessageFailure) {
       "    2x2x2xf32=[[1 2][3 4]][[5 6][7 8]]\n"
       "  rhs:\n"
       "    2x2x2xf32=[[1 2][3 42]][[5 6][7 8]]");
+  iree_hal_buffer_view_release(lhs.get());
+  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqIdenticalBufferF16Success) {
@@ -542,6 +585,8 @@ TEST_F(CheckTest, ExpectAlmostEqIdenticalBufferF16Success) {
   ASSERT_NO_FATAL_FAILURE(CreateFloat16BufferView(contents, shape, &lhs));
   ASSERT_NO_FATAL_FAILURE(CreateFloat16BufferView(contents, shape, &rhs));
   IREE_ASSERT_OK(Invoke("expect_almost_eq", {lhs, rhs}));
+  iree_hal_buffer_view_release(lhs.get());
+  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqNearIdenticalBufferF16Success) {
@@ -557,6 +602,8 @@ TEST_F(CheckTest, ExpectAlmostEqNearIdenticalBufferF16Success) {
   ASSERT_NO_FATAL_FAILURE(CreateFloat16BufferView(lhs_contents, shape, &lhs));
   ASSERT_NO_FATAL_FAILURE(CreateFloat16BufferView(rhs_contents, shape, &rhs));
   IREE_ASSERT_OK(Invoke("expect_almost_eq", {lhs, rhs}));
+  iree_hal_buffer_view_release(lhs.get());
+  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqDifferentContentsF16Failure) {
@@ -570,6 +617,8 @@ TEST_F(CheckTest, ExpectAlmostEqDifferentContentsF16Failure) {
   EXPECT_NONFATAL_FAILURE(
       IREE_ASSERT_OK(Invoke("expect_almost_eq", {lhs, rhs})),
       "Contents does not match");
+  iree_hal_buffer_view_release(lhs.get());
+  iree_hal_buffer_view_release(rhs.get());
 }
 }  // namespace
 }  // namespace iree


### PR DESCRIPTION
This gives us clean test runs with ASan. There were failures in the
following tests (all were memory leaks reported by LSan, which is folded
into ASan).

```
10 - iree/base/internal/file_io_test (Failed)
53 - iree/modules/check/check_test (Failed)
629 - bindings/tflite/smoke_test (Failed)
```

There was one leak in a non-error path, `TfLiteInterpreter` leaked its `driver`.
There was also one leak in an error path: when the model is invalid, `TfLiteModelCreate` returned `NULL` but still leaked the model it had already internally allocated.
There were additional test-only leaks.

Fixes some of https://github.com/google/iree/issues/5715