### PR TITLE
Expose One-Shot Bufferize debug options

### DIFF
--- a/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -100,7 +100,8 @@ void IREEComprehensiveBufferizePass::runOnOperation() {
   options.allocationFn = allocationFn;
   options.deallocationFn = deallocationFn;
   options.memCpyFn = memCpyFn;
-  options.testAnalysisOnly = false;
+  options.testAnalysisOnly = testAnalysisOnly;
+  options.printConflicts = printConflicts;
   options.alwaysAliasingWithDest = false;
   addPostAnalysisTransformations(options);
 

--- a/iree/compiler/Codegen/Passes.td
+++ b/iree/compiler/Codegen/Passes.td
@@ -69,6 +69,14 @@ def IREEComprehensiveBufferize :
     Pass<"iree-codegen-iree-comprehensive-bufferize", "ModuleOp"> {
   let summary = "Convert from to Linalg ops on tensors to buffers";
   let constructor = "mlir::iree_compiler::createIREEComprehensiveBufferizePass()";
+  let options = [
+    Option<"testAnalysisOnly", "test-analysis-only", "bool",
+            /*default=*/"false",
+           "Only runs inplaceability analysis (for testing purposes only)">,
+    Option<"printConflicts", "print-conflicts", "bool",
+            /*default=*/"false",
+           "Annotates IR with RaW conflicts. Requires test-analysis-only.">,
+  ];
 }
 
 def OptimizeVectorTransfer :


### PR DESCRIPTION
Exposing two debug flags in the bufferization pass. This should speed up debugging. To get debug output run:

```
iree/tools/iree-opt iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir --iree-codegen-iree-comprehensive-bufferize="test-analysis-only print-conflicts"
```

This will show you which OpOperands were decided to bufferize out-of-place and what caused the conflict. If there is no conflict annotation, it means that the tensor is not writable, thus a copy must be created (e.g., when specifying a tensor with `readonly`).