### PR TITLE
Fix out of bound access lock argument in linalg ext ops

### DIFF
--- a/iree/compiler/Codegen/Common/test/linalg_bufferize.mlir
+++ b/iree/compiler/Codegen/Common/test/linalg_bufferize.mlir
@@ -2698,3 +2698,32 @@ func @rank_reducing_no_op_subview() {
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       ins(%[[SUBVIEW]] :
 //  CHECK-SAME:       outs(%[[DEST]] :
+
+// -----
+
+// CHECK-LABEL: func @dispatch_scatter()
+func @dispatch_scatter() {
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant dense<0> : tensor<1x1xi32>
+  %cst_0 = arith.constant dense<0> : tensor<1x2xi32>
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(32) : !flow.dispatch.tensor<readonly:1xi32>
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(32) : !flow.dispatch.tensor<writeonly:1x1xi32>
+  %workgroup_size_x = hal.interface.workgroup.size[0] : index
+  %workgroup_id_x = hal.interface.workgroup.id[0] : index
+  %workgroup_count_x = hal.interface.workgroup.count[0] : index
+  %2 = affine.apply affine_map<()[s0, s1] -> (s1 * s0)>()[%workgroup_size_x, %workgroup_id_x]
+  %3 = affine.apply affine_map<()[s0, s1] -> (s1 * s0)>()[%workgroup_size_x, %workgroup_count_x]
+  scf.for %arg0 = %2 to %c1 step %3 {
+    %4 = affine.min affine_map<(d0)[s0] -> (s0, -d0 + 1)>(%arg0)[%workgroup_size_x]
+    %5 = flow.dispatch.tensor.load %0, offsets = [%arg0], sizes = [%4], strides = [1] : !flow.dispatch.tensor<readonly:1xi32> -> tensor<?xi32>
+    %6 = tensor.extract_slice %cst_0[%arg0, 0] [%4, 2] [1, 1] : tensor<1x2xi32> to tensor<?x2xi32>
+    // CHECK: iree_linalg_ext.scatter unique_indices(true) ins(%{{.*}}, %{{.*}} : memref<?xi32, #{{.*}}>, memref<?x2xi32, #{{.*}}>) outs(%{{.*}} : memref<1x1xi32>)
+    %7 = iree_linalg_ext.scatter unique_indices(true) ins(%5, %6 : tensor<?xi32>, tensor<?x2xi32>) outs(%cst : tensor<1x1xi32>) {
+    ^bb0(%arg1: i32, %arg2: i32):
+      iree_linalg_ext.yield %arg1 : i32
+    } -> tensor<1x1xi32>
+    flow.dispatch.tensor.store %7, %1, offsets = [0, 0], sizes = [1, 1], strides = [1, 1] : tensor<1x1xi32> -> !flow.dispatch.tensor<writeonly:1x1xi32>
+  }
+  return
+}

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtInterfaces.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtInterfaces.td
@@ -303,7 +303,8 @@ def LinalgExtInterface : OpInterface<"LinalgExtOp"> {
                "manually defined named Linalg op?)");
         Block &block = this->getOperation()->getRegion(0).front();
         // Init tensors have uses.
-        return !block.getArgument(bbArgNumber).use_empty();
+        return bbArgNumber < block.getNumArguments() &&
+               !block.getArgument(bbArgNumber).use_empty();
       }]
     >,
     InterfaceMethod<


### PR DESCRIPTION
linalg ext ops don't always have block argument corresponding to output
operand. For output operand payloadUsesValueFromOperand shoudl return
false.