### PR TITLE
Save one canonicalization pass in TOSA input conversion

### DIFF
--- a/iree/compiler/InputConversion/TOSA/Passes.cpp
+++ b/iree/compiler/InputConversion/TOSA/Passes.cpp
@@ -48,8 +48,6 @@ void buildTOSAInputConversionPassPipeline(OpPassManager &passManager) {
   passManager.addNestedPass<FuncOp>(tosa::createTosaToStandard());
 
   passManager.addNestedPass<FuncOp>(IREE::Flow::createStripSignednessPass());
-  passManager.addNestedPass<FuncOp>(mlir::createCanonicalizerPass());
-
   passManager.addNestedPass<FuncOp>(createLinalgQuantizedMatmulToMatmulPass());
   passManager.addNestedPass<FuncOp>(mlir::createCanonicalizerPass());
 


### PR DESCRIPTION
This saves one run of canonicalization and it also fixes a performance
regression for PoseNet on Mali GPUs.