### PR TITLE
Making it possible to pass vm dialect output through iree-translate.

### DIFF
--- a/iree/compiler/Dialect/Util/IR/UtilAttrs.cpp
+++ b/iree/compiler/Dialect/Util/IR/UtilAttrs.cpp
@@ -462,6 +462,11 @@ LogicalResult CompositeAttr::serializeToStream(llvm::support::endianness endian,
                                                llvm::raw_ostream &os) const {
   for (auto valueAttr : getValues()) {
     auto serializableAttr = valueAttr.dyn_cast<SerializableAttrInterface>();
+    if (!serializableAttr) {
+      llvm::errs() << "unable to serialize a non-serializable attribute: "
+                   << valueAttr.getType() << "\n";
+      return failure();
+    }
     if (failed(serializableAttr.serializeToStream(endian, os))) {
       return failure();
     }

--- a/iree/compiler/Dialect/VM/Analysis/test/register_allocation.mlir
+++ b/iree/compiler/Dialect/VM/Analysis/test/register_allocation.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(vm.func(test-iree-vm-register-allocation))' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(vm.func(test-iree-vm-register-allocation))" %s | FileCheck %s
 
 // CHECK-LABEL: @module
 vm.module @module {

--- a/iree/compiler/Dialect/VM/Analysis/test/value_liveness.mlir
+++ b/iree/compiler/Dialect/VM/Analysis/test/value_liveness.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(vm.func(test-iree-vm-value-liveness))' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(vm.func(test-iree-vm-value-liveness))" %s | FileCheck %s
 
 // CHECK-LABEL: @module
 vm.module @module {

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/arithmetic_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/arithmetic_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='test-iree-convert-std-to-vm' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="test-iree-convert-std-to-vm" %s | FileCheck %s
 
 // -----
 // CHECK-LABEL: @t001_addi

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/assignment_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/assignment_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='test-iree-convert-std-to-vm' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="test-iree-convert-std-to-vm" %s | FileCheck %s
 
 // -----
 // CHECK-LABEL: @t001_cmp_select

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/comparison_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/comparison_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='test-iree-convert-std-to-vm' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="test-iree-convert-std-to-vm" %s | FileCheck %s
 
 // -----
 // CHECK-LABEL: @t001_cmp_eq_i32

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/const_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/const_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='test-iree-convert-std-to-vm' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="test-iree-convert-std-to-vm" %s | FileCheck %s
 
 // -----
 // CHECK-LABEL: @t001_const.i32.nonzero

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/control_flow_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/control_flow_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='test-iree-convert-std-to-vm' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="test-iree-convert-std-to-vm" %s | FileCheck %s
 
 // -----
 // CHECK-LABEL: @t001_br

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/conversion_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/conversion_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='test-iree-convert-std-to-vm' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="test-iree-convert-std-to-vm" %s | FileCheck %s
 
 // CHECK-LABEL: @t001_bitcast_i32_f32
 module @t001_bitcast_i32_f32 {

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/func_attrs.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/func_attrs.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='test-iree-convert-std-to-vm' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="test-iree-convert-std-to-vm" %s | FileCheck %s
 
 // -----
 // CHECK-LABEL: @t001_iree_reflection

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/nesting.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/nesting.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='builtin.module(test-iree-convert-std-to-vm)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="builtin.module(test-iree-convert-std-to-vm)" %s | FileCheck %s
 
 // Note that checks are ambiguous between "module" and "vm.module" so we rely
 // on vm.module printing as `vm.module public @foo`

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/structural_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/structural_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='test-iree-convert-std-to-vm' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="test-iree-convert-std-to-vm" %s | FileCheck %s
 
 // -----
 // Checks literal specifics of structural transforms (more verbose checks

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)" %s | FileCheck %s
 
 // CHECK-LABEL: @my_module_add_i32
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops_f32.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops_f32.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)" %s | FileCheck %s
 
 // CHECK-LABEL: @my_module_add_f32
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops_i64.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)" %s | FileCheck %s
 
 // CHECK-LABEL: @my_module_add_i64
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)" %s | FileCheck %s
 
 // CHECK-LABEL: @my_module_select_i32
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops_f32.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops_f32.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)" %s | FileCheck %s
 
 // CHECK-LABEL: @my_module_select_f32
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops_i64.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)" %s | FileCheck %s
 
 // CHECK-LABEL: @my_module_select_i64
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)" %s | FileCheck %s
 
 vm.module @module {
   // CHECK-LABEL: @module_cmp_eq_i32

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops_f32.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops_f32.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)" %s | FileCheck %s
 
 vm.module @module {
   // CHECK-LABEL: @module_cmp_eq_f32o

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops_i64.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)" %s | FileCheck %s
 
 vm.module @module {
   // CHECK-LABEL: @module_cmp_eq_i64

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)" %s | FileCheck %s
 
 
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops_f32.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops_f32.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)" %s | FileCheck %s
 
 vm.module @my_module {
   // CHECK-LABEL: @my_module_const_f32_zero

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops_i64.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)" %s | FileCheck %s
 
 
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/control_flow_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/control_flow_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)" %s | FileCheck %s
 
 vm.module @my_module {
   // CHECK-LABEL: @my_module_branch_empty

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)" %s | FileCheck %s
 
 // CHECK-LABEL: @my_module_trunc
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops_f32.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops_f32.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)" %s | FileCheck %s
 
 // CHECK-LABEL: @my_module_cast
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops_i64.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)" %s | FileCheck %s
 
 // CHECK-LABEL: @my_module_trunc_i64
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/shift_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/shift_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)" %s | FileCheck %s
 
 // CHECK-LABEL: @my_module_shl_i32
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/shift_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/shift_ops_i64.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)" %s | FileCheck %s
 
 // CHECK-LABEL: @my_module_shl_i64
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/type_conversion.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/type_conversion.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)" %s | FileCheck %s
 
 vm.module @my_module {
   // CHECK-LABEL: @my_module_list_alloc

--- a/iree/compiler/Dialect/VM/IR/test/arithmetic_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/arithmetic_folding.mlir
@@ -1,6 +1,6 @@
 // Tests folding and canonicalization of arithmetic ops.
 
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(canonicalize)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(canonicalize)" %s | FileCheck %s
 
 // CHECK-LABEL: @add_i32_folds
 vm.module @add_i32_folds {

--- a/iree/compiler/Dialect/VM/IR/test/assignment_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/assignment_folding.mlir
@@ -1,6 +1,6 @@
 // Tests folding and canonicalization of assignment ops.
 
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(canonicalize)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(canonicalize)" %s | FileCheck %s
 
 // CHECK-LABEL: @select_i32_folds
 vm.module @select_i32_folds {

--- a/iree/compiler/Dialect/VM/IR/test/comparison_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/comparison_folding.mlir
@@ -1,6 +1,6 @@
 // Tests folding and canonicalization of comparison ops.
 
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(canonicalize)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(canonicalize)" %s | FileCheck %s
 
 // CHECK-LABEL: @cmp_eq_i32_folds
 vm.module @cmp_eq_i32_folds {

--- a/iree/compiler/Dialect/VM/IR/test/const_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/const_folding.mlir
@@ -1,6 +1,6 @@
 // Tests folding and canonicalization of constant ops.
 
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(cse),vm.module(canonicalize)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(cse),vm.module(canonicalize)" %s | FileCheck %s
 
 // CHECK-LABEL: @const_i32_folds
 vm.module @const_i32_folds {

--- a/iree/compiler/Dialect/VM/IR/test/control_flow_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/control_flow_folding.mlir
@@ -1,6 +1,6 @@
 // Tests folding and canonicalization of control flow ops.
 
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(canonicalize)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(canonicalize)" %s | FileCheck %s
 
 // CHECK-LABEL: @cond_br_folds
 vm.module @cond_br_folds {

--- a/iree/compiler/Dialect/VM/IR/test/conversion_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/conversion_folding.mlir
@@ -1,6 +1,6 @@
 // Tests folding and canonicalization of casting/conversion ops.
 
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(canonicalize)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(canonicalize)" %s | FileCheck %s
 
 // CHECK-LABEL: @trunc_folds
 vm.module @trunc_folds {

--- a/iree/compiler/Dialect/VM/IR/test/debug_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/debug_folding.mlir
@@ -1,6 +1,6 @@
 // Tests folding and canonicalization of debug ops.
 
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(canonicalize)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(canonicalize)" %s | FileCheck %s
 
 // CHECK-LABEL: @cond_break_folds
 vm.module @cond_break_folds {

--- a/iree/compiler/Dialect/VM/IR/test/global_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/global_folding.mlir
@@ -1,6 +1,6 @@
 // Tests folding and canonicalization of global ops.
 
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(canonicalize)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(canonicalize)" %s | FileCheck %s
 
 // CHECK-LABEL: @global_i32_folds
 vm.module @global_i32_folds {

--- a/iree/compiler/Dialect/VM/IR/test/structural_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/structural_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(canonicalize)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(canonicalize)" %s | FileCheck %s
 
 // CHECK-LABEL: @empty_initializer
 vm.module @empty_initializer {

--- a/iree/compiler/Dialect/VM/Transforms/BUILD
+++ b/iree/compiler/Dialect/VM/Transforms/BUILD
@@ -15,6 +15,7 @@ cc_library(
     srcs = [
         "Conversion.cpp",
         "DeduplicateRodata.cpp",
+        "DropEmptyModuleInitializers.cpp",
         "GlobalInitialization.cpp",
         "HoistInlinedRodata.cpp",
         "OrdinalAllocation.cpp",

--- a/iree/compiler/Dialect/VM/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Transforms/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_cc_library(
   SRCS
     "Conversion.cpp"
     "DeduplicateRodata.cpp"
+    "DropEmptyModuleInitializers.cpp"
     "GlobalInitialization.cpp"
     "HoistInlinedRodata.cpp"
     "OrdinalAllocation.cpp"

--- a/iree/compiler/Dialect/VM/Transforms/DropEmptyModuleInitializers.cpp
+++ b/iree/compiler/Dialect/VM/Transforms/DropEmptyModuleInitializers.cpp
@@ -1,0 +1,82 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/VM/IR/VMOps.h"
+#include "iree/compiler/Dialect/VM/Transforms/Passes.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassRegistry.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace VM {
+
+namespace {
+
+// Returns true if |funcOp| is empty.
+static bool isFuncEmpty(IREE::VM::FuncOp funcOp) {
+  return funcOp.empty() ||
+         (&funcOp.front() == &funcOp.back() &&
+          &funcOp.front().front() == funcOp.front().getTerminator());
+}
+
+}  // namespace
+
+class DropEmptyModuleInitializersPass
+    : public PassWrapper<DropEmptyModuleInitializersPass,
+                         OperationPass<IREE::VM::ModuleOp>> {
+ public:
+  StringRef getArgument() const override {
+    return "iree-vm-drop-empty-module-initializers";
+  }
+
+  StringRef getDescription() const override {
+    return "Drops __init/__deinit functions that have no ops.";
+  }
+
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+    SymbolTable symbolTable(moduleOp);
+
+    // Find all export ops so they are easier to remove.
+    DenseMap<StringRef, IREE::VM::ExportOp> exportOps;
+    for (auto exportOp : moduleOp.getOps<IREE::VM::ExportOp>()) {
+      exportOps[exportOp.export_name()] = exportOp;
+    }
+
+    // Check @__init:
+    auto initFuncOp = symbolTable.lookup<IREE::VM::FuncOp>("__init");
+    if (initFuncOp && isFuncEmpty(initFuncOp)) {
+      auto exportOp = exportOps[initFuncOp.getName()];
+      if (exportOp) exportOp.erase();
+      initFuncOp.erase();
+    }
+
+    // Check @__deinit:
+    auto deinitFuncOp = symbolTable.lookup<IREE::VM::FuncOp>("__deinit");
+    if (deinitFuncOp && isFuncEmpty(deinitFuncOp)) {
+      auto exportOp = exportOps[deinitFuncOp.getName()];
+      if (exportOp) exportOp.erase();
+      deinitFuncOp.erase();
+    }
+  }
+};
+
+std::unique_ptr<OperationPass<IREE::VM::ModuleOp>>
+createDropEmptyModuleInitializersPass() {
+  return std::make_unique<DropEmptyModuleInitializersPass>();
+}
+
+static PassRegistration<DropEmptyModuleInitializersPass> pass;
+
+}  // namespace VM
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp
+++ b/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp
@@ -23,6 +23,137 @@ namespace iree_compiler {
 namespace IREE {
 namespace VM {
 
+namespace {
+
+// Finds a function with |name| and returns it ready for appending.
+// The returned op builder will be set at an insertion point where new
+// operations can be added that are guaranteed to execute in the CFG. The
+// caller must insert a return op at the insertion point when done.
+static std::tuple<IREE::VM::FuncOp, OpBuilder> appendOrCreateInitFuncOp(
+    IREE::VM::ModuleOp moduleOp, StringRef name, SymbolTable &symbolTable,
+    OpBuilder &moduleBuilder) {
+  IREE::VM::FuncOp funcOp = symbolTable.lookup<IREE::VM::FuncOp>(name);
+  OpBuilder funcBuilder(moduleOp.getContext());
+  if (!funcOp) {
+    // Create a new empty function.
+    funcOp = moduleBuilder.create<IREE::VM::FuncOp>(
+        moduleBuilder.getUnknownLoc(), name,
+        moduleBuilder.getFunctionType({}, {}));
+    funcBuilder = OpBuilder::atBlockEnd(funcOp.addEntryBlock());
+    return std::make_tuple(funcOp, funcBuilder);
+  }
+
+  // Function already exists; we need to append to it. The function may have
+  // an arbitrarily complex CFG and we need to route all returns to a new
+  // block that will always execute before the initializer returns.
+
+  // Create the target block we'll be inserting into.
+  // It'll be empty and the caller must insert the terminator.
+  auto *newBlock = funcOp.addBlock();
+
+  // Find all extant return points and redirect them to the new block.
+  auto returnOps = llvm::to_vector<4>(funcOp.getOps<IREE::VM::ReturnOp>());
+  for (auto returnOp :
+       llvm::make_early_inc_range(funcOp.getOps<IREE::VM::ReturnOp>())) {
+    OpBuilder(returnOp).create<IREE::VM::BranchOp>(returnOp.getLoc(), newBlock);
+    returnOp.erase();
+  }
+
+  // Return the builder at the end of the new block.
+  funcBuilder.setInsertionPointToEnd(newBlock);
+  return std::make_tuple(funcOp, funcBuilder);
+}
+
+// Adds a vm.export for |funcOp| if there is not one already.
+static void exportFuncIfNeeded(IREE::VM::ModuleOp moduleOp,
+                               IREE::VM::FuncOp funcOp) {
+  // Check for an existing export.
+  for (auto exportOp : moduleOp.getOps<IREE::VM::ExportOp>()) {
+    if (exportOp.export_name() == funcOp.getName()) {
+      // Already has an export.
+      return;
+    }
+  }
+
+  // Functions are private, exports are public.
+  funcOp.setPrivate();
+
+  // Add vm.export if needed.
+  OpBuilder moduleBuilder(funcOp);
+  moduleBuilder.create<IREE::VM::ExportOp>(funcOp.getLoc(), funcOp);
+}
+
+// Returns true if |op| is nested within an initializer function.
+static bool isParentInitializer(Operation *op) {
+  auto initializerOp = op->getParentOfType<IREE::VM::InitializerOp>();
+  if (initializerOp) return true;
+  auto funcOp = op->getParentOfType<IREE::VM::FuncOp>();
+  return funcOp.getName() == "__init" || funcOp.getName() == "__deinit";
+}
+
+static bool isGlobalLoadOp(Operation *op) {
+  // TODO(benvanik): trait/interface to make this more generic?
+  return isa<IREE::VM::GlobalLoadI32Op>(op) ||
+         isa<IREE::VM::GlobalLoadI64Op>(op) ||
+         isa<IREE::VM::GlobalLoadF32Op>(op) ||
+         isa<IREE::VM::GlobalLoadF64Op>(op) ||
+         isa<IREE::VM::GlobalLoadRefOp>(op);
+}
+
+static bool isGlobalStoreOp(Operation *op) {
+  // TODO(benvanik): trait/interface to make this more generic?
+  return isa<IREE::VM::GlobalStoreI32Op>(op) ||
+         isa<IREE::VM::GlobalStoreI64Op>(op) ||
+         isa<IREE::VM::GlobalStoreF32Op>(op) ||
+         isa<IREE::VM::GlobalStoreF64Op>(op) ||
+         isa<IREE::VM::GlobalStoreRefOp>(op);
+}
+
+// TODO(benvanik): make this a generic pass.
+// Updates the mutability of globals based on whether they are stored outside of
+// initializers. A more sophisticated analysis is required as initializers can
+// call functions and this will miss that (but that's ok).
+static void fixupGlobalMutability(Operation *moduleOp,
+                                  SymbolTable &symbolTable) {
+  SmallVector<Operation *> deadOps;
+  for (auto &op : moduleOp->getRegion(0).front()) {
+    auto globalOp = dyn_cast<IREE::VM::VMGlobalOp>(op);
+    if (!globalOp) continue;
+    if (!cast<SymbolOpInterface>(op).isPrivate()) {
+      // May be used outside the module; treat as used and mutable.
+      globalOp.makeMutable();
+      continue;
+    }
+    auto uses = symbolTable.getSymbolUses(globalOp, moduleOp);
+    if (!uses.hasValue()) {
+      // No uses - erase the global entirely.
+      deadOps.push_back(globalOp);
+      continue;
+    }
+    bool maybeStored = false;
+    for (auto use : uses.getValue()) {
+      auto *user = use.getUser();
+      if (isa<IREE::VM::GlobalAddressOp>(user)) {
+        // Can't analyze indirect variables; assume mutated.
+        maybeStored = true;
+        break;
+      } else if (isGlobalStoreOp(user)) {
+        maybeStored = true;
+      }
+    }
+    // NOTE: we could erase globals never loaded if we know that computing
+    // their value has no side effects.
+    if (maybeStored) {
+      globalOp.makeMutable();
+    }
+  }
+  for (auto *deadOp : deadOps) {
+    deadOp->erase();
+  }
+}
+
+}  // namespace
+
 // Finds all global variables and moves their inital values/initializer calls
 // into a single function. Relies on the inliner to later make the uber function
 // better.
@@ -36,7 +167,8 @@ namespace VM {
 //
 // TODO(benvanik): combine i32 initializers to store more efficiently.
 class GlobalInitializationPass
-    : public PassWrapper<GlobalInitializationPass, OperationPass<ModuleOp>> {
+    : public PassWrapper<GlobalInitializationPass,
+                         OperationPass<IREE::VM::ModuleOp>> {
  public:
   StringRef getArgument() const override {
     return "iree-vm-global-initialization";
@@ -47,20 +179,24 @@ class GlobalInitializationPass
   }
 
   void runOnOperation() override {
+    auto moduleOp = getOperation();
+    SymbolTable symbolTable(moduleOp);
+
     // Create the __init and __deinit functions. They may be empty if there are
     // no globals but that's fine.
-    OpBuilder moduleBuilder = OpBuilder::atBlockEnd(&getOperation().getBlock());
-    moduleBuilder.setInsertionPoint(getOperation().getBlock().getTerminator());
-    auto initFuncOp =
-        moduleBuilder.create<FuncOp>(moduleBuilder.getUnknownLoc(), "__init",
-                                     moduleBuilder.getFunctionType({}, {}));
-    OpBuilder initBuilder = OpBuilder::atBlockEnd(initFuncOp.addEntryBlock());
+    OpBuilder moduleBuilder = OpBuilder::atBlockEnd(&moduleOp.getBlock());
+    moduleBuilder.setInsertionPoint(moduleOp.getBlock().getTerminator());
 
-    auto deinitFuncOp =
-        moduleBuilder.create<FuncOp>(moduleBuilder.getUnknownLoc(), "__deinit",
-                                     moduleBuilder.getFunctionType({}, {}));
-    OpBuilder deinitBuilder =
-        OpBuilder::atBlockEnd(deinitFuncOp.addEntryBlock());
+    // Find/create the init/deinit functions.
+    // We will erase them if they end up empty.
+    IREE::VM::FuncOp initFuncOp;
+    OpBuilder initBuilder(&getContext());
+    std::tie(initFuncOp, initBuilder) = appendOrCreateInitFuncOp(
+        moduleOp, "__init", symbolTable, moduleBuilder);
+    IREE::VM::FuncOp deinitFuncOp;
+    OpBuilder deinitBuilder(&getContext());
+    std::tie(deinitFuncOp, deinitBuilder) = appendOrCreateInitFuncOp(
+        moduleOp, "__deinit", symbolTable, moduleBuilder);
 
     // Build out the functions with logic from all globals.
     // Note that the initialization order here is undefined (in that it's just
@@ -69,18 +205,18 @@ class GlobalInitializationPass
     // initialization function.
     InlinerInterface inlinerInterface(&getContext());
     SmallVector<Operation *> deadOps;
-    for (auto &op : getOperation().getBlock().getOperations()) {
-      if (auto globalOp = dyn_cast<GlobalRefOp>(op)) {
+    for (auto &op : moduleOp.getBlock().getOperations()) {
+      if (auto globalOp = dyn_cast<IREE::VM::GlobalRefOp>(op)) {
         if (failed(appendRefInitialization(globalOp, initBuilder))) {
           globalOp.emitOpError() << "unable to be initialized";
           return signalPassFailure();
         }
-      } else if (auto globalOp = dyn_cast<VMGlobalOp>(op)) {
+      } else if (auto globalOp = dyn_cast<IREE::VM::VMGlobalOp>(op)) {
         if (failed(appendPrimitiveInitialization(globalOp, initBuilder))) {
           globalOp.emitOpError() << "unable to be initialized";
           return signalPassFailure();
         }
-      } else if (auto initializerOp = dyn_cast<InitializerOp>(op)) {
+      } else if (auto initializerOp = dyn_cast<IREE::VM::InitializerOp>(op)) {
         if (failed(appendInitializer(initializerOp, inlinerInterface,
                                      initBuilder))) {
           initializerOp.emitOpError() << "unable to be initialized";
@@ -94,26 +230,17 @@ class GlobalInitializationPass
       deadOp->erase();
     }
 
+    // Add returns to the initializers.
+    initBuilder.create<IREE::VM::ReturnOp>(initBuilder.getUnknownLoc());
+    deinitBuilder.create<IREE::VM::ReturnOp>(deinitBuilder.getUnknownLoc());
+
     // Correct mutability of all globals.
-    fixupGlobalMutability(getOperation());
+    fixupGlobalMutability(moduleOp, symbolTable);
 
-    initBuilder.create<ReturnOp>(initBuilder.getUnknownLoc());
-    deinitBuilder.create<ReturnOp>(deinitBuilder.getUnknownLoc());
-
-    // If we didn't need to initialize anything then we can elide the functions.
-    if (initFuncOp.getBlocks().front().getOperations().size() > 1) {
-      initFuncOp.setPrivate();
-      moduleBuilder.create<ExportOp>(moduleBuilder.getUnknownLoc(), initFuncOp);
-    } else {
-      initFuncOp.erase();
-    }
-    if (deinitFuncOp.getBlocks().front().getOperations().size() > 1) {
-      deinitFuncOp.setPrivate();
-      moduleBuilder.create<ExportOp>(moduleBuilder.getUnknownLoc(),
-                                     deinitFuncOp);
-    } else {
-      deinitFuncOp.erase();
-    }
+    // If we didn't need to initialize anything then we can elide the functions
+    // and otherwise we need to ensure they are exported.
+    exportFuncIfNeeded(moduleOp, initFuncOp);
+    exportFuncIfNeeded(moduleOp, deinitFuncOp);
   }
 
  private:
@@ -153,10 +280,10 @@ class GlobalInitializationPass
       switch (integerAttr.getType().getIntOrFloatBitWidth()) {
         case 32:
           return {success(),
-                  builder.createOrFold<ConstI32Op>(loc, integerAttr)};
+                  builder.createOrFold<IREE::VM::ConstI32Op>(loc, integerAttr)};
         case 64:
           return {success(),
-                  builder.createOrFold<ConstI64Op>(loc, integerAttr)};
+                  builder.createOrFold<IREE::VM::ConstI64Op>(loc, integerAttr)};
         default:
           return {failure(), {}};
       }
@@ -167,9 +294,11 @@ class GlobalInitializationPass
       }
       switch (floatAttr.getType().getIntOrFloatBitWidth()) {
         case 32:
-          return {success(), builder.createOrFold<ConstF32Op>(loc, floatAttr)};
+          return {success(),
+                  builder.createOrFold<IREE::VM::ConstF32Op>(loc, floatAttr)};
         case 64:
-          return {success(), builder.createOrFold<ConstF64Op>(loc, floatAttr)};
+          return {success(),
+                  builder.createOrFold<IREE::VM::ConstF64Op>(loc, floatAttr)};
         default:
           return {failure(), {}};
       }
@@ -183,10 +312,10 @@ class GlobalInitializationPass
     if (auto integerType = value.getType().dyn_cast<IntegerType>()) {
       switch (integerType.getIntOrFloatBitWidth()) {
         case 32:
-          builder.create<GlobalStoreI32Op>(loc, value, symName);
+          builder.create<IREE::VM::GlobalStoreI32Op>(loc, value, symName);
           return success();
         case 64:
-          builder.create<GlobalStoreI64Op>(loc, value, symName);
+          builder.create<IREE::VM::GlobalStoreI64Op>(loc, value, symName);
           return success();
         default:
           return failure();
@@ -194,10 +323,10 @@ class GlobalInitializationPass
     } else if (auto floatType = value.getType().dyn_cast<FloatType>()) {
       switch (floatType.getIntOrFloatBitWidth()) {
         case 32:
-          builder.create<GlobalStoreF32Op>(loc, value, symName);
+          builder.create<IREE::VM::GlobalStoreF32Op>(loc, value, symName);
           return success();
         case 64:
-          builder.create<GlobalStoreF64Op>(loc, value, symName);
+          builder.create<IREE::VM::GlobalStoreF64Op>(loc, value, symName);
           return success();
         default:
           return failure();
@@ -224,62 +353,6 @@ class GlobalInitializationPass
         /*shouldCloneInlinedRegion=*/false);
     builder.setInsertionPointToEnd(builder.getInsertionBlock());
     return result;
-  }
-
-  void fixupGlobalMutability(Operation *moduleOp) {
-    SymbolTable symbolTable(moduleOp);
-    SmallVector<Operation *> deadOps;
-    for (auto &op : moduleOp->getRegion(0).front()) {
-      auto globalOp = dyn_cast<IREE::VM::VMGlobalOp>(op);
-      if (!globalOp) continue;
-      if (!cast<SymbolOpInterface>(op).isPrivate()) {
-        // May be used outside the module; treat as used and mutable.
-        globalOp.makeMutable();
-        continue;
-      }
-      auto uses = symbolTable.getSymbolUses(globalOp, moduleOp);
-      if (!uses.hasValue()) {
-        // No uses - erase the global entirely.
-        deadOps.push_back(globalOp);
-        continue;
-      }
-      bool maybeStored = false;
-      for (auto use : uses.getValue()) {
-        if (isa<IREE::VM::GlobalAddressOp>(use.getUser())) {
-          // Can't analyze indirect variables; assume mutated.
-          maybeStored = true;
-          break;
-        } else if (isGlobalStoreOp(use.getUser())) {
-          maybeStored = true;
-        }
-      }
-      // NOTE: we could erase globals never loaded if we know that computing
-      // their value has no side effects.
-      if (maybeStored) {
-        globalOp.makeMutable();
-      }
-    }
-    for (auto *deadOp : deadOps) {
-      deadOp->erase();
-    }
-  }
-
-  bool isGlobalLoadOp(Operation *op) const {
-    // TODO(benvanik): trait/interface to make this more generic?
-    return isa<IREE::VM::GlobalLoadI32Op>(op) ||
-           isa<IREE::VM::GlobalLoadI64Op>(op) ||
-           isa<IREE::VM::GlobalLoadF32Op>(op) ||
-           isa<IREE::VM::GlobalLoadF64Op>(op) ||
-           isa<IREE::VM::GlobalLoadRefOp>(op);
-  }
-
-  bool isGlobalStoreOp(Operation *op) const {
-    // TODO(benvanik): trait/interface to make this more generic?
-    return isa<IREE::VM::GlobalStoreI32Op>(op) ||
-           isa<IREE::VM::GlobalStoreI64Op>(op) ||
-           isa<IREE::VM::GlobalStoreF32Op>(op) ||
-           isa<IREE::VM::GlobalStoreF64Op>(op) ||
-           isa<IREE::VM::GlobalStoreRefOp>(op);
   }
 };
 

--- a/iree/compiler/Dialect/VM/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/VM/Transforms/Passes.cpp
@@ -44,6 +44,12 @@ void buildVMTransformPassPipeline(OpPassManager &passManager,
   passManager.addPass(createCanonicalizerPass());
   passManager.addPass(createCSEPass());
 
+  // Now that we've inlined/canonicalized/etc the initializers we can remove
+  // them if they are empty to save a few bytes in the binary and avoid a
+  // runtime initialization call.
+  passManager.addNestedPass<IREE::VM::ModuleOp>(
+      createDropEmptyModuleInitializersPass());
+
   passManager.addPass(createSymbolDCEPass());
   if (targetOptions.optimizeForStackSize) {
     passManager.addNestedPass<IREE::VM::ModuleOp>(createSinkDefiningOpsPass());

--- a/iree/compiler/Dialect/VM/Transforms/Passes.h
+++ b/iree/compiler/Dialect/VM/Transforms/Passes.h
@@ -77,6 +77,10 @@ createOrdinalAllocationPass();
 // Optimization passes
 //===----------------------------------------------------------------------===//
 
+// Drops __init/__deinit functions that have no ops.
+std::unique_ptr<OperationPass<IREE::VM::ModuleOp>>
+createDropEmptyModuleInitializersPass();
+
 // Sinks defining ops with few uses to their use-sites to reduce the total
 // number of live registers at the cost of additional storage requirements.
 std::unique_ptr<OperationPass<IREE::VM::ModuleOp>> createSinkDefiningOpsPass();
@@ -98,6 +102,7 @@ inline void registerVMPasses() {
   createConversionPass(targetOptions);
   createHoistInlinedRodataPass();
   createDeduplicateRodataPass();
+  createDropEmptyModuleInitializersPass();
   createGlobalInitializationPass();
   createOrdinalAllocationPass();
   createSinkDefiningOpsPass();

--- a/iree/compiler/Dialect/VM/Transforms/test/BUILD
+++ b/iree/compiler/Dialect/VM/Transforms/test/BUILD
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         [
             "deduplicate_rodata.mlir",
+            "drop_empty_module_initializers.mlir",
             "global_initialization.mlir",
             "hoist_inlined_rodata.mlir",
             "ordinal_allocation.mlir",

--- a/iree/compiler/Dialect/VM/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Transforms/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "deduplicate_rodata.mlir"
+    "drop_empty_module_initializers.mlir"
     "global_initialization.mlir"
     "hoist_inlined_rodata.mlir"
     "ordinal_allocation.mlir"

--- a/iree/compiler/Dialect/VM/Transforms/test/drop_empty_module_initializers.mlir
+++ b/iree/compiler/Dialect/VM/Transforms/test/drop_empty_module_initializers.mlir
@@ -1,0 +1,43 @@
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(iree-vm-drop-empty-module-initializers)" %s | FileCheck %s
+
+// Tests an empty module is ignored.
+
+// CHECK: vm.module public @module_empty {
+// CHECK-NEXT: }
+vm.module public @module_empty {
+}
+
+// -----
+
+// Tests that an empty initializer is removed.
+
+// CHECK-LABEL: @init_empty
+vm.module @init_empty {
+  // CHECK-NOT: vm.export @__init
+  vm.export @__init
+  // CHECK-NOT: vm.func private @__init()
+  vm.func private @__init() {
+    vm.return
+  }
+}
+
+// -----
+
+// Tests that a non-empty initializer is not removed.
+
+// CHECK-LABEL: @init_nonempty
+vm.module @init_nonempty {
+  // CHECK: vm.global.ref private mutable @g0 : !vm.ref<?>
+  vm.global.ref private mutable @g0 : !vm.ref<?>
+
+  // CHECK: vm.export @__init
+  vm.export @__init
+  // CHECK-NEXT: vm.func private @__init()
+  vm.func private @__init() {
+    // CHECK-NEXT: %[[NULL:.+]] = vm.const.ref.zero
+    %null = vm.const.ref.zero : !vm.ref<?>
+    // CHECK-NEXT: vm.global.store.ref %[[NULL]], @g0
+    vm.global.store.ref %null, @g0 : !vm.ref<?>
+    vm.return
+  }
+}

--- a/iree/compiler/Dialect/VM/Transforms/test/ordinal_allocation.mlir
+++ b/iree/compiler/Dialect/VM/Transforms/test/ordinal_allocation.mlir
@@ -1,6 +1,6 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation)' %s | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(iree-vm-ordinal-allocation)" %s | FileCheck %s
 // check the parser for vm.module.ordinal_counts
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation)' %s | iree-opt | FileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="vm.module(iree-vm-ordinal-allocation)" %s | iree-opt | FileCheck %s
 
 // CHECK-LABEL: @global_address_propagation
   // CHECK-SAME: attributes {ordinal_counts = #vm.ordinal_counts<

--- a/iree/compiler/Translation/test/smoketest.mlir
+++ b/iree/compiler/Translation/test/smoketest.mlir
@@ -47,6 +47,7 @@ module @hal_usage {
 // CHECK: "full_name": "hal.command_buffer.dispatch"
 // CHECK: "exported_functions":
 // CHECK: "local_name": "hloElementwiseOps"
+// CHECK: "local_name": "__init"
 func @hloElementwiseOps(%arg0 : tensor<4xf32>) -> tensor<4xf32> {
   %0 = mhlo.add %arg0, %arg0 : tensor<4xf32>
   %1 = mhlo.subtract %0, %arg0 : tensor<4xf32>


### PR DESCRIPTION
Now a VM source listing (`-iree-vm-bytecode-source-listing=`) can be passed back to iree-translate to serialize it to binary form.