### PR TITLE
Don't call allowUnregisteredDialects from passes

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/ConvertLinalgTensorOps.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/ConvertLinalgTensorOps.cpp
@@ -133,7 +133,6 @@ struct ConvertLinalgTensorOpsPass
   void runOnOperation() override {
     auto funcOp = getOperation();
     MLIRContext *context = funcOp->getContext();
-    context->allowUnregisteredDialects(true);
     RewritePatternSet patterns(&getContext());
     if (runBeforeDispatchRegionFormation) {
       patterns.insert<

--- a/iree/compiler/Dialect/Flow/Transforms/ConvertToFlow.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/ConvertToFlow.cpp
@@ -106,7 +106,6 @@ struct ConvertToFlowBeforeDispatchFormation
   void runOnOperation() override {
     auto funcOp = getOperation();
     MLIRContext *context = funcOp->getContext();
-    context->allowUnregisteredDialects(true);
     RewritePatternSet patterns(&getContext());
 
     patterns
@@ -134,7 +133,6 @@ struct ConvertToFlowAfterDispatchFormation
   void runOnOperation() override {
     auto funcOp = getOperation();
     MLIRContext *context = funcOp->getContext();
-    context->allowUnregisteredDialects(true);
     RewritePatternSet patterns(&getContext());
 
     patterns.insert<LinalgFillToFlowTensorSplat>(context);

--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -959,10 +959,7 @@ LogicalResult createDispatchRegionsFromRootOps(mlir::Operation *funcOp) {
 
 void DispatchLinalgOnTensorsPass::runOnOperation() {
   auto funcOp = llvm::cast<FunctionOpInterface>(getOperation());
-
   MLIRContext *context = funcOp->getContext();
-  context->allowUnregisteredDialects(true);
-
   unsigned numRoots = decideFusableLinalgOps(funcOp);
 
   LLVM_DEBUG({


### PR DESCRIPTION
Motivation: these calls were data races, as pass code runs on multiple
threads concurrently on the same MLIRContext instance. This was reported
by TSan and prevented even completing a build of the tests with TSan.

This just drops those allowUnregisteredDialects calls... I expected that
to cause failures that I would then have to fix by adding dependent
dialects, but I don't see any failure ?! As if these
allowUnregisteredDialects calls were not actually necessary.

There remains one call to allowUnregisteredDialects in
  iree/tools/iree_translate_lib.cc
but it is performed on a newly constructed MLIRContext so it's not going
to run afoul of the assertion being added in
https://reviews.llvm.org/D112021 .