### PR TITLE
Fixing check-test leaks (ASan)

### DIFF
--- a/iree/modules/check/check_test.cc
+++ b/iree/modules/check/check_test.cc
@@ -183,8 +183,7 @@ class CheckTest : public ::testing::Test {
                             iree_allocator_system(), &inputs_));
     for (auto& arg : args) {
       iree_vm_ref_t arg_ref = iree_hal_buffer_view_move_ref(arg.get());
-      IREE_RETURN_IF_ERROR(
-          iree_vm_list_push_ref_retain(inputs_.get(), &arg_ref));
+      IREE_RETURN_IF_ERROR(iree_vm_list_push_ref_move(inputs_.get(), &arg_ref));
     }
     return Invoke(function_name);
   }
@@ -237,7 +236,6 @@ TEST_F(CheckTest, ExpectAllTrueSuccess) {
   ASSERT_NO_FATAL_FAILURE(
       CreateInt32BufferView(contents, shape, &input_buffer_view));
   IREE_ASSERT_OK(Invoke("expect_all_true", {input_buffer_view}));
-  iree_hal_buffer_view_release(input_buffer_view.get());
 }
 
 TEST_F(CheckTest, ExpectAllTrue3DTrueSuccess) {
@@ -247,7 +245,6 @@ TEST_F(CheckTest, ExpectAllTrue3DTrueSuccess) {
   ASSERT_NO_FATAL_FAILURE(
       CreateInt32BufferView(contents, shape, &input_buffer_view));
   IREE_ASSERT_OK(Invoke("expect_all_true", {input_buffer_view}));
-  iree_hal_buffer_view_release(input_buffer_view.get());
 }
 
 TEST_F(CheckTest, ExpectAllTrueFailure) {
@@ -258,7 +255,6 @@ TEST_F(CheckTest, ExpectAllTrueFailure) {
       CreateInt32BufferView(contents, shape, &input_buffer_view));
   EXPECT_NONFATAL_FAILURE(
       IREE_ASSERT_OK(Invoke("expect_all_true", {input_buffer_view})), "0");
-  iree_hal_buffer_view_release(input_buffer_view.get());
 }
 
 TEST_F(CheckTest, ExpectAllTrueSingleElementFailure) {
@@ -270,7 +266,6 @@ TEST_F(CheckTest, ExpectAllTrueSingleElementFailure) {
   EXPECT_NONFATAL_FAILURE(
       IREE_ASSERT_OK(Invoke("expect_all_true", {input_buffer_view})),
       "1, 2, 3, 0, 4");
-  iree_hal_buffer_view_release(input_buffer_view.get());
 }
 
 TEST_F(CheckTest, ExpectAllTrue3DSingleElementFailure) {
@@ -282,7 +277,6 @@ TEST_F(CheckTest, ExpectAllTrue3DSingleElementFailure) {
   EXPECT_NONFATAL_FAILURE(
       IREE_ASSERT_OK(Invoke("expect_all_true", {input_buffer_view})),
       "1, 2, 3, 4, 5, 6, 0, 8");
-  iree_hal_buffer_view_release(input_buffer_view.get());
 }
 
 TEST_F(CheckTest, ExpectEqSameBufferSuccess) {
@@ -292,8 +286,6 @@ TEST_F(CheckTest, ExpectEqSameBufferSuccess) {
   ASSERT_NO_FATAL_FAILURE(
       CreateInt32BufferView(contents, shape, &input_buffer_view));
   IREE_ASSERT_OK(Invoke("expect_eq", {input_buffer_view, input_buffer_view}));
-  iree_hal_buffer_view_release(input_buffer_view.get());
-  iree_hal_buffer_view_release(input_buffer_view.get());
 }
 
 TEST_F(CheckTest, ExpectEqIdenticalBufferSuccess) {
@@ -304,8 +296,6 @@ TEST_F(CheckTest, ExpectEqIdenticalBufferSuccess) {
   ASSERT_NO_FATAL_FAILURE(CreateInt32BufferView(contents, shape, &lhs));
   ASSERT_NO_FATAL_FAILURE(CreateInt32BufferView(contents, shape, &rhs));
   IREE_ASSERT_OK(Invoke("expect_eq", {lhs, rhs}));
-  iree_hal_buffer_view_release(lhs.get());
-  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectEqIdentical3DBufferSuccess) {
@@ -316,8 +306,6 @@ TEST_F(CheckTest, ExpectEqIdentical3DBufferSuccess) {
   ASSERT_NO_FATAL_FAILURE(CreateInt32BufferView(contents, shape, &lhs));
   ASSERT_NO_FATAL_FAILURE(CreateInt32BufferView(contents, shape, &rhs));
   IREE_ASSERT_OK(Invoke("expect_eq", {lhs, rhs}));
-  iree_hal_buffer_view_release(lhs.get());
-  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectEqDifferentShapeFailure) {
@@ -330,8 +318,6 @@ TEST_F(CheckTest, ExpectEqDifferentShapeFailure) {
   ASSERT_NO_FATAL_FAILURE(CreateInt32BufferView(contents, rhs_shape, &rhs));
   EXPECT_NONFATAL_FAILURE(IREE_ASSERT_OK(Invoke("expect_eq", {lhs, rhs})),
                           "Shapes do not match");
-  iree_hal_buffer_view_release(lhs.get());
-  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectEqDifferentElementTypeFailure) {
@@ -344,8 +330,6 @@ TEST_F(CheckTest, ExpectEqDifferentElementTypeFailure) {
   ASSERT_NO_FATAL_FAILURE(CreateFloat32BufferView(rhs_contents, shape, &rhs));
   EXPECT_NONFATAL_FAILURE(IREE_ASSERT_OK(Invoke("expect_eq", {lhs, rhs})),
                           "Element types do not match");
-  iree_hal_buffer_view_release(lhs.get());
-  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectEqDifferentContentsFailure) {
@@ -358,8 +342,6 @@ TEST_F(CheckTest, ExpectEqDifferentContentsFailure) {
   ASSERT_NO_FATAL_FAILURE(CreateInt32BufferView(rhs_contents, shape, &rhs));
   EXPECT_NONFATAL_FAILURE(IREE_ASSERT_OK(Invoke("expect_eq", {lhs, rhs})),
                           "Contents does not match");
-  iree_hal_buffer_view_release(lhs.get());
-  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectEqDifferentEverythingFullMessageFailure) {
@@ -380,8 +362,6 @@ TEST_F(CheckTest, ExpectEqDifferentEverythingFullMessageFailure) {
       "    2x3xi32=[1 2 3][4 5 6]\n"
       "  rhs:\n"
       "    2x2xf32=[1 2][3 42]");
-  iree_hal_buffer_view_release(lhs.get());
-  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectEqDifferentContents3DFullMessageFailure) {
@@ -399,8 +379,6 @@ TEST_F(CheckTest, ExpectEqDifferentContents3DFullMessageFailure) {
       "    2x2x2xi32=[[1 2][3 4]][[5 6][7 8]]\n"
       "  rhs:\n"
       "    2x2x2xi32=[[1 2][3 42]][[5 6][7 8]]");
-  iree_hal_buffer_view_release(lhs.get());
-  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqSameBufferSuccess) {
@@ -411,8 +389,6 @@ TEST_F(CheckTest, ExpectAlmostEqSameBufferSuccess) {
       CreateFloat32BufferView(contents, shape, &input_buffer_view));
   IREE_ASSERT_OK(
       Invoke("expect_almost_eq", {input_buffer_view, input_buffer_view}));
-  iree_hal_buffer_view_release(input_buffer_view.get());
-  iree_hal_buffer_view_release(input_buffer_view.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqIdenticalBufferSuccess) {
@@ -423,8 +399,6 @@ TEST_F(CheckTest, ExpectAlmostEqIdenticalBufferSuccess) {
   ASSERT_NO_FATAL_FAILURE(CreateFloat32BufferView(contents, shape, &lhs));
   ASSERT_NO_FATAL_FAILURE(CreateFloat32BufferView(contents, shape, &rhs));
   IREE_ASSERT_OK(Invoke("expect_almost_eq", {lhs, rhs}));
-  iree_hal_buffer_view_release(lhs.get());
-  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqNearIdenticalBufferSuccess) {
@@ -436,8 +410,6 @@ TEST_F(CheckTest, ExpectAlmostEqNearIdenticalBufferSuccess) {
   ASSERT_NO_FATAL_FAILURE(CreateFloat32BufferView(lhs_contents, shape, &lhs));
   ASSERT_NO_FATAL_FAILURE(CreateFloat32BufferView(rhs_contents, shape, &rhs));
   IREE_ASSERT_OK(Invoke("expect_almost_eq", {lhs, rhs}));
-  iree_hal_buffer_view_release(lhs.get());
-  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqIdentical3DBufferSuccess) {
@@ -448,8 +420,6 @@ TEST_F(CheckTest, ExpectAlmostEqIdentical3DBufferSuccess) {
   ASSERT_NO_FATAL_FAILURE(CreateFloat32BufferView(contents, shape, &lhs));
   ASSERT_NO_FATAL_FAILURE(CreateFloat32BufferView(contents, shape, &rhs));
   IREE_ASSERT_OK(Invoke("expect_almost_eq", {lhs, rhs}));
-  iree_hal_buffer_view_release(lhs.get());
-  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqDifferentShapeFailure) {
@@ -463,8 +433,6 @@ TEST_F(CheckTest, ExpectAlmostEqDifferentShapeFailure) {
   EXPECT_NONFATAL_FAILURE(
       IREE_ASSERT_OK(Invoke("expect_almost_eq", {lhs, rhs})),
       "Shapes do not match");
-  iree_hal_buffer_view_release(lhs.get());
-  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqSmallerLhsElementCountFailure) {
@@ -481,8 +449,6 @@ TEST_F(CheckTest, ExpectAlmostEqSmallerLhsElementCountFailure) {
   EXPECT_NONFATAL_FAILURE(
       IREE_ASSERT_OK(Invoke("expect_almost_eq", {smaller, bigger})),
       "Shapes do not match");
-  iree_hal_buffer_view_release(smaller.get());
-  iree_hal_buffer_view_release(bigger.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqSmallerRhsElementCountFailure) {
@@ -499,8 +465,6 @@ TEST_F(CheckTest, ExpectAlmostEqSmallerRhsElementCountFailure) {
   EXPECT_NONFATAL_FAILURE(
       IREE_ASSERT_OK(Invoke("expect_almost_eq", {bigger, smaller})),
       "Shapes do not match");
-  iree_hal_buffer_view_release(smaller.get());
-  iree_hal_buffer_view_release(bigger.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqDifferentElementTypeFailure) {
@@ -514,8 +478,6 @@ TEST_F(CheckTest, ExpectAlmostEqDifferentElementTypeFailure) {
   EXPECT_NONFATAL_FAILURE(
       IREE_ASSERT_OK(Invoke("expect_almost_eq", {lhs, rhs})),
       "Element types do not match");
-  iree_hal_buffer_view_release(lhs.get());
-  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqDifferentContentsFailure) {
@@ -529,8 +491,6 @@ TEST_F(CheckTest, ExpectAlmostEqDifferentContentsFailure) {
   EXPECT_NONFATAL_FAILURE(
       IREE_ASSERT_OK(Invoke("expect_almost_eq", {lhs, rhs})),
       "Contents does not match");
-  iree_hal_buffer_view_release(lhs.get());
-  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqDifferentEverythingFullMessageFailure) {
@@ -554,8 +514,6 @@ TEST_F(CheckTest, ExpectAlmostEqDifferentEverythingFullMessageFailure) {
       "    2x3xf64=[1 2 3][4 5 6]\n"
       "  rhs:\n"
       "    2x2xf32=[1 2][3 42]");
-  iree_hal_buffer_view_release(lhs.get());
-  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqDifferentContents3DFullMessageFailure) {
@@ -573,8 +531,6 @@ TEST_F(CheckTest, ExpectAlmostEqDifferentContents3DFullMessageFailure) {
       "    2x2x2xf32=[[1 2][3 4]][[5 6][7 8]]\n"
       "  rhs:\n"
       "    2x2x2xf32=[[1 2][3 42]][[5 6][7 8]]");
-  iree_hal_buffer_view_release(lhs.get());
-  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqIdenticalBufferF16Success) {
@@ -585,8 +541,6 @@ TEST_F(CheckTest, ExpectAlmostEqIdenticalBufferF16Success) {
   ASSERT_NO_FATAL_FAILURE(CreateFloat16BufferView(contents, shape, &lhs));
   ASSERT_NO_FATAL_FAILURE(CreateFloat16BufferView(contents, shape, &rhs));
   IREE_ASSERT_OK(Invoke("expect_almost_eq", {lhs, rhs}));
-  iree_hal_buffer_view_release(lhs.get());
-  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqNearIdenticalBufferF16Success) {
@@ -602,8 +556,6 @@ TEST_F(CheckTest, ExpectAlmostEqNearIdenticalBufferF16Success) {
   ASSERT_NO_FATAL_FAILURE(CreateFloat16BufferView(lhs_contents, shape, &lhs));
   ASSERT_NO_FATAL_FAILURE(CreateFloat16BufferView(rhs_contents, shape, &rhs));
   IREE_ASSERT_OK(Invoke("expect_almost_eq", {lhs, rhs}));
-  iree_hal_buffer_view_release(lhs.get());
-  iree_hal_buffer_view_release(rhs.get());
 }
 
 TEST_F(CheckTest, ExpectAlmostEqDifferentContentsF16Failure) {
@@ -617,8 +569,6 @@ TEST_F(CheckTest, ExpectAlmostEqDifferentContentsF16Failure) {
   EXPECT_NONFATAL_FAILURE(
       IREE_ASSERT_OK(Invoke("expect_almost_eq", {lhs, rhs})),
       "Contents does not match");
-  iree_hal_buffer_view_release(lhs.get());
-  iree_hal_buffer_view_release(rhs.get());
 }
 }  // namespace
 }  // namespace iree


### PR DESCRIPTION
This is a follow-up from PR #8450 where I naively fixed ASan failures by ad-hoc refcount decrements without undertanding the root issue. This fixes the root issue as explained by @benvanik.

closes #8458.