### PR TITLE
Expand HAL CTS test coverage and initialize pointers.

### DIFF
--- a/iree/hal/cts/allocator_test.h
+++ b/iree/hal/cts/allocator_test.h
@@ -75,7 +75,7 @@ TEST_P(allocator_test, AllocateBuffer) {
   iree_hal_buffer_params_t params = {0};
   params.type = IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
   params.usage = IREE_HAL_BUFFER_USAGE_TRANSFER;
-  iree_hal_buffer_t* buffer = nullptr;
+  iree_hal_buffer_t* buffer = NULL;
   IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(
       device_allocator_, params, kAllocationSize, iree_const_byte_span_empty(),
       &buffer));
@@ -98,7 +98,7 @@ TEST_P(allocator_test, AllocateEmptyBuffer) {
   iree_hal_buffer_params_t params = {0};
   params.type = IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
   params.usage = IREE_HAL_BUFFER_USAGE_TRANSFER;
-  iree_hal_buffer_t* buffer = nullptr;
+  iree_hal_buffer_t* buffer = NULL;
   IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(
       device_allocator_, params, /*allocation_size=*/0,
       iree_const_byte_span_empty(), &buffer));

--- a/iree/hal/cts/buffer_mapping_test.h
+++ b/iree/hal/cts/buffer_mapping_test.h
@@ -451,8 +451,8 @@ TEST_P(buffer_mapping_test, WriteDataSubspan) {
 }
 
 TEST_P(buffer_mapping_test, CopyData) {
-  iree_hal_buffer_t* buffer_a;
-  iree_hal_buffer_t* buffer_b;
+  iree_hal_buffer_t* buffer_a = NULL;
+  iree_hal_buffer_t* buffer_b = NULL;
   AllocateUninitializedBuffer(kDefaultAllocationSize, &buffer_a);
   AllocateUninitializedBuffer(kDefaultAllocationSize, &buffer_b);
 

--- a/iree/hal/cts/buffer_mapping_test.h
+++ b/iree/hal/cts/buffer_mapping_test.h
@@ -36,7 +36,8 @@ constexpr iree_device_size_t kDefaultAllocationSize = 1024;
 // failures may indicate issues in either the code doing the writing or the
 // code doing the reading.
 //
-// Tests for each function are organized in increasing order of complexity:
+// Where applicable, tests for each function are organized in increasing order
+// of complexity, such as:
 //   * write to full buffer
 //   * write with an offset and length
 //   * write into a subspan of a buffer
@@ -478,9 +479,69 @@ TEST_P(buffer_mapping_test, CopyData) {
   iree_hal_buffer_release(buffer_b);
 }
 
+// Maps a buffer range for reading from device -> host.
+// This is roughly what iree_hal_buffer_read_data does internally.
+TEST_P(buffer_mapping_test, MapRangeRead) {
+  iree_device_size_t buffer_size = 16;
+  iree_hal_buffer_t* buffer = NULL;
+  AllocateUninitializedBuffer(buffer_size, &buffer);
+
+  uint8_t fill_value = 0xEF;
+  IREE_ASSERT_OK(iree_hal_buffer_fill(buffer, /*byte_offset=*/0,
+                                      IREE_WHOLE_BUFFER, &fill_value,
+                                      sizeof(fill_value)));
+
+  iree_hal_buffer_mapping_t mapping;
+  IREE_ASSERT_OK(iree_hal_buffer_map_range(
+      buffer, IREE_HAL_MAPPING_MODE_SCOPED, IREE_HAL_MEMORY_ACCESS_READ,
+      /*byte_offset=*/0, /*byte_length=*/buffer_size, &mapping));
+  EXPECT_EQ(buffer, mapping.buffer);
+  EXPECT_GE(mapping.contents.data_length, (iree_host_size_t)buffer_size);
+
+  std::vector<uint8_t> reference_buffer(buffer_size);
+  std::memset(reference_buffer.data(), fill_value, buffer_size);
+  std::vector<uint8_t> mapping_data(
+      mapping.contents.data,
+      mapping.contents.data + mapping.contents.data_length);
+  EXPECT_THAT(mapping_data, ContainerEq(reference_buffer));
+
+  iree_hal_buffer_unmap_range(&mapping);
+  iree_hal_buffer_release(buffer);
+}
+
+// Maps a buffer range for writing from host -> device.
+// This is roughly what iree_hal_buffer_write_data does internally.
+TEST_P(buffer_mapping_test, MapRangeWrite) {
+  iree_device_size_t buffer_size = 16;
+  iree_hal_buffer_t* buffer = NULL;
+  AllocateUninitializedBuffer(buffer_size, &buffer);
+
+  iree_hal_buffer_mapping_t mapping;
+  IREE_ASSERT_OK(iree_hal_buffer_map_range(
+      buffer, IREE_HAL_MAPPING_MODE_SCOPED,
+      IREE_HAL_MEMORY_ACCESS_DISCARD_WRITE,
+      /*byte_offset=*/0, /*byte_length=*/buffer_size, &mapping));
+  EXPECT_EQ(buffer, mapping.buffer);
+  EXPECT_GE(mapping.contents.data_length, (iree_host_size_t)buffer_size);
+
+  // Write into the mapped memory, flush for device access, then read back.
+  uint8_t fill_value = 0x12;
+  std::memset(mapping.contents.data, fill_value, buffer_size);
+  IREE_ASSERT_OK(iree_hal_buffer_flush_range(&mapping, /*byte_offset=*/0,
+                                             /*byte_length=*/buffer_size));
+  std::vector<uint8_t> actual_data(buffer_size);
+  IREE_ASSERT_OK(iree_hal_buffer_read_data(
+      buffer, /*source_offset=*/0, actual_data.data(), actual_data.size()));
+  std::vector<uint8_t> reference_buffer(buffer_size);
+  std::memset(reference_buffer.data(), fill_value, buffer_size);
+  EXPECT_THAT(actual_data, ContainerEq(reference_buffer));
+
+  iree_hal_buffer_unmap_range(&mapping);
+  iree_hal_buffer_release(buffer);
+}
+
 // TODO(scotttodd): iree_hal_allocator_wrap_buffer
 // TODO(scotttodd): iree_hal_heap_buffer_wrap
-// TODO(scotttodd): iree_hal_buffer_map_range
 
 }  // namespace cts
 }  // namespace hal

--- a/iree/hal/cts/command_buffer_dispatch_test.h
+++ b/iree/hal/cts/command_buffer_dispatch_test.h
@@ -67,7 +67,7 @@ class command_buffer_dispatch_test : public CtsTestBase {
 TEST_P(command_buffer_dispatch_test, DispatchAbs) {
   PrepareAbsExecutable();
 
-  iree_hal_command_buffer_t* command_buffer;
+  iree_hal_command_buffer_t* command_buffer = NULL;
   IREE_ASSERT_OK(iree_hal_command_buffer_create(
       device_,
       IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT |

--- a/iree/hal/cts/command_buffer_test.h
+++ b/iree/hal/cts/command_buffer_test.h
@@ -47,10 +47,10 @@ class command_buffer_test : public CtsTestBase {
                                          iree_device_size_t fill_length,
                                          const void* pattern,
                                          iree_host_size_t pattern_length) {
-    iree_hal_buffer_t* device_buffer;
+    iree_hal_buffer_t* device_buffer = NULL;
     CreateZeroedDeviceBuffer(buffer_size, &device_buffer);
 
-    iree_hal_command_buffer_t* command_buffer;
+    iree_hal_command_buffer_t* command_buffer = NULL;
     IREE_CHECK_OK(iree_hal_command_buffer_create(
         device_, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
         IREE_HAL_COMMAND_CATEGORY_ANY, IREE_HAL_QUEUE_AFFINITY_ANY,
@@ -80,7 +80,7 @@ class command_buffer_test : public CtsTestBase {
 };
 
 TEST_P(command_buffer_test, Create) {
-  iree_hal_command_buffer_t* command_buffer;
+  iree_hal_command_buffer_t* command_buffer = NULL;
   IREE_ASSERT_OK(iree_hal_command_buffer_create(
       device_, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
       IREE_HAL_COMMAND_CATEGORY_DISPATCH, IREE_HAL_QUEUE_AFFINITY_ANY,
@@ -94,7 +94,7 @@ TEST_P(command_buffer_test, Create) {
 }
 
 TEST_P(command_buffer_test, BeginEnd) {
-  iree_hal_command_buffer_t* command_buffer;
+  iree_hal_command_buffer_t* command_buffer = NULL;
   IREE_ASSERT_OK(iree_hal_command_buffer_create(
       device_, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
       IREE_HAL_COMMAND_CATEGORY_DISPATCH, IREE_HAL_QUEUE_AFFINITY_ANY,
@@ -107,7 +107,7 @@ TEST_P(command_buffer_test, BeginEnd) {
 }
 
 TEST_P(command_buffer_test, SubmitEmpty) {
-  iree_hal_command_buffer_t* command_buffer;
+  iree_hal_command_buffer_t* command_buffer = NULL;
   IREE_ASSERT_OK(iree_hal_command_buffer_create(
       device_, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
       IREE_HAL_COMMAND_CATEGORY_DISPATCH, IREE_HAL_QUEUE_AFFINITY_ANY,
@@ -123,7 +123,7 @@ TEST_P(command_buffer_test, SubmitEmpty) {
 }
 
 TEST_P(command_buffer_test, CopyWholeBuffer) {
-  iree_hal_command_buffer_t* command_buffer;
+  iree_hal_command_buffer_t* command_buffer = NULL;
   IREE_ASSERT_OK(iree_hal_command_buffer_create(
       device_, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
       IREE_HAL_COMMAND_CATEGORY_TRANSFER, IREE_HAL_QUEUE_AFFINITY_ANY,
@@ -425,10 +425,10 @@ TEST_P(command_buffer_test, UpdateBufferWholeBuffer) {
                                      0xA1, 0xA2, 0xA3, 0xA4,  //
                                      0xA5, 0xA6, 0xA7, 0xA8};
 
-  iree_hal_buffer_t* device_buffer;
+  iree_hal_buffer_t* device_buffer = NULL;
   CreateZeroedDeviceBuffer(target_buffer_size, &device_buffer);
 
-  iree_hal_command_buffer_t* command_buffer;
+  iree_hal_command_buffer_t* command_buffer = NULL;
   IREE_CHECK_OK(iree_hal_command_buffer_create(
       device_, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
       IREE_HAL_COMMAND_CATEGORY_ANY, IREE_HAL_QUEUE_AFFINITY_ANY,
@@ -461,10 +461,10 @@ TEST_P(command_buffer_test, UpdateBufferWithOffsets) {
                                      0xA1, 0xA2, 0xA3, 0xA4,  //
                                      0xA5, 0xA6, 0xA7, 0xA8};
 
-  iree_hal_buffer_t* device_buffer;
+  iree_hal_buffer_t* device_buffer = NULL;
   CreateZeroedDeviceBuffer(target_buffer_size, &device_buffer);
 
-  iree_hal_command_buffer_t* command_buffer;
+  iree_hal_command_buffer_t* command_buffer = NULL;
   IREE_CHECK_OK(iree_hal_command_buffer_create(
       device_, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
       IREE_HAL_COMMAND_CATEGORY_ANY, IREE_HAL_QUEUE_AFFINITY_ANY,
@@ -501,7 +501,7 @@ TEST_P(command_buffer_test, UpdateBufferSubspan) {
                                      0xA1, 0xA2, 0xA3, 0xA4,  //
                                      0xA5, 0xA6, 0xA7, 0xA8};
 
-  iree_hal_buffer_t* device_buffer;
+  iree_hal_buffer_t* device_buffer = NULL;
   CreateZeroedDeviceBuffer(target_buffer_size, &device_buffer);
 
   // Create a subspan.
@@ -510,7 +510,7 @@ TEST_P(command_buffer_test, UpdateBufferSubspan) {
   IREE_ASSERT_OK(iree_hal_buffer_subspan(device_buffer, /*byte_offset=*/4,
                                          subspan_length, &buffer_subspan));
 
-  iree_hal_command_buffer_t* command_buffer;
+  iree_hal_command_buffer_t* command_buffer = NULL;
   IREE_CHECK_OK(iree_hal_command_buffer_create(
       device_, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
       IREE_HAL_COMMAND_CATEGORY_ANY, IREE_HAL_QUEUE_AFFINITY_ANY,

--- a/iree/hal/cts/cts_test_base.h
+++ b/iree/hal/cts/cts_test_base.h
@@ -44,7 +44,7 @@ class CtsTestBase : public ::testing::TestWithParam<std::string> {
 
     // Get driver with the given name and create its default device.
     // Skip drivers that are (gracefully) unavailable, fail if creation fails.
-    iree_hal_driver_t* driver;
+    iree_hal_driver_t* driver = NULL;
     iree_status_t status = TryGetDriver(driver_name, &driver);
     if (iree_status_is_unavailable(status)) {
       iree_status_free(status);
@@ -56,7 +56,7 @@ class CtsTestBase : public ::testing::TestWithParam<std::string> {
     IREE_ASSERT_OK(status);
     driver_ = driver;
 
-    iree_hal_device_t* device;
+    iree_hal_device_t* device = NULL;
     status = iree_hal_driver_create_default_device(
         driver_, iree_allocator_system(), &device);
     if (iree_status_is_unavailable(status)) {

--- a/iree/hal/cts/descriptor_set_layout_test.h
+++ b/iree/hal/cts/descriptor_set_layout_test.h
@@ -22,7 +22,7 @@ class descriptor_set_layout_test : public CtsTestBase {};
 // Note: bindingCount == 0 is valid in VkDescriptorSetLayoutCreateInfo:
 // https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorSetLayoutCreateInfo.html
 TEST_P(descriptor_set_layout_test, CreateWithNoBindings) {
-  iree_hal_descriptor_set_layout_t* descriptor_set_layout;
+  iree_hal_descriptor_set_layout_t* descriptor_set_layout = NULL;
   IREE_ASSERT_OK(iree_hal_descriptor_set_layout_create(
       device_, IREE_HAL_DESCRIPTOR_SET_LAYOUT_USAGE_TYPE_IMMUTABLE,
       /*binding_count=*/0,
@@ -31,7 +31,7 @@ TEST_P(descriptor_set_layout_test, CreateWithNoBindings) {
 }
 
 TEST_P(descriptor_set_layout_test, CreateWithOneBinding) {
-  iree_hal_descriptor_set_layout_t* descriptor_set_layout;
+  iree_hal_descriptor_set_layout_t* descriptor_set_layout = NULL;
   iree_hal_descriptor_set_layout_binding_t descriptor_set_layout_bindings[] = {
       {/*binding=*/0, /*type=*/IREE_HAL_DESCRIPTOR_TYPE_STORAGE_BUFFER},
   };
@@ -43,7 +43,7 @@ TEST_P(descriptor_set_layout_test, CreateWithOneBinding) {
 }
 
 TEST_P(descriptor_set_layout_test, CreateWithTwoBindings) {
-  iree_hal_descriptor_set_layout_t* descriptor_set_layout;
+  iree_hal_descriptor_set_layout_t* descriptor_set_layout = NULL;
   iree_hal_descriptor_set_layout_binding_t descriptor_set_layout_bindings[] = {
       {/*binding=*/0, /*type=*/IREE_HAL_DESCRIPTOR_TYPE_STORAGE_BUFFER},
       {/*binding=*/1, /*type=*/IREE_HAL_DESCRIPTOR_TYPE_STORAGE_BUFFER},
@@ -56,7 +56,7 @@ TEST_P(descriptor_set_layout_test, CreateWithTwoBindings) {
 }
 
 TEST_P(descriptor_set_layout_test, CreateWithPushDescriptorType) {
-  iree_hal_descriptor_set_layout_t* descriptor_set_layout;
+  iree_hal_descriptor_set_layout_t* descriptor_set_layout = NULL;
   iree_hal_descriptor_set_layout_binding_t descriptor_set_layout_bindings[] = {
       {/*binding=*/0, /*type=*/IREE_HAL_DESCRIPTOR_TYPE_STORAGE_BUFFER},
       {/*binding=*/1, /*type=*/IREE_HAL_DESCRIPTOR_TYPE_STORAGE_BUFFER},

--- a/iree/hal/cts/descriptor_set_test.h
+++ b/iree/hal/cts/descriptor_set_test.h
@@ -20,7 +20,7 @@ namespace cts {
 class descriptor_set_test : public CtsTestBase {};
 
 TEST_P(descriptor_set_test, CreateWithTwoBindings) {
-  iree_hal_descriptor_set_layout_t* descriptor_set_layout;
+  iree_hal_descriptor_set_layout_t* descriptor_set_layout = NULL;
   iree_hal_descriptor_set_layout_binding_t descriptor_set_layout_bindings[] = {
       {/*binding=*/0, /*type=*/IREE_HAL_DESCRIPTOR_TYPE_STORAGE_BUFFER},
       {/*binding=*/1, /*type=*/IREE_HAL_DESCRIPTOR_TYPE_STORAGE_BUFFER},
@@ -34,8 +34,7 @@ TEST_P(descriptor_set_test, CreateWithTwoBindings) {
       {/*binding=*/0, /*buffer=*/NULL, /*offset=*/0, /*length=*/0},
       {/*binding=*/1, /*buffer=*/NULL, /*offset=*/0, /*length=*/0},
   };
-
-  iree_hal_descriptor_set_t* descriptor_set;
+  iree_hal_descriptor_set_t* descriptor_set = NULL;
   IREE_ASSERT_OK(iree_hal_descriptor_set_create(
       device_, descriptor_set_layout, IREE_ARRAYSIZE(descriptor_set_bindings),
       descriptor_set_bindings, &descriptor_set));

--- a/iree/hal/cts/descriptor_set_test.h
+++ b/iree/hal/cts/descriptor_set_test.h
@@ -19,6 +19,25 @@ namespace cts {
 
 class descriptor_set_test : public CtsTestBase {};
 
+TEST_P(descriptor_set_test, CreateWithNoBindings) {
+  iree_hal_descriptor_set_layout_t* descriptor_set_layout = NULL;
+  IREE_ASSERT_OK(iree_hal_descriptor_set_layout_create(
+      device_, IREE_HAL_DESCRIPTOR_SET_LAYOUT_USAGE_TYPE_IMMUTABLE,
+      /*binding_count=*/0,
+      /*bindings=*/NULL, &descriptor_set_layout));
+
+  iree_hal_descriptor_set_t* descriptor_set = NULL;
+  IREE_ASSERT_OK(iree_hal_descriptor_set_create(
+      device_, descriptor_set_layout, /*binding_count=*/0,
+      /*bindings=*/NULL, &descriptor_set));
+
+  // The descriptor set struct is an opaque handle. We can't test for much more
+  // than successful creation.
+
+  iree_hal_descriptor_set_release(descriptor_set);
+  iree_hal_descriptor_set_layout_release(descriptor_set_layout);
+}
+
 TEST_P(descriptor_set_test, CreateWithTwoBindings) {
   iree_hal_descriptor_set_layout_t* descriptor_set_layout = NULL;
   iree_hal_descriptor_set_layout_binding_t descriptor_set_layout_bindings[] = {
@@ -38,6 +57,9 @@ TEST_P(descriptor_set_test, CreateWithTwoBindings) {
   IREE_ASSERT_OK(iree_hal_descriptor_set_create(
       device_, descriptor_set_layout, IREE_ARRAYSIZE(descriptor_set_bindings),
       descriptor_set_bindings, &descriptor_set));
+
+  // The descriptor set struct is an opaque handle. We can't test for much more
+  // than successful creation.
 
   iree_hal_descriptor_set_release(descriptor_set);
   iree_hal_descriptor_set_layout_release(descriptor_set_layout);

--- a/iree/hal/cts/driver_test.h
+++ b/iree/hal/cts/driver_test.h
@@ -23,7 +23,7 @@ namespace cts {
 class driver_test : public CtsTestBase {};
 
 TEST_P(driver_test, QueryAndCreateAvailableDevices) {
-  iree_hal_device_info_t* device_infos;
+  iree_hal_device_info_t* device_infos = NULL;
   iree_host_size_t device_info_count;
   IREE_ASSERT_OK(iree_hal_driver_query_available_devices(
       driver_, iree_allocator_system(), &device_infos, &device_info_count));

--- a/iree/hal/cts/event_test.h
+++ b/iree/hal/cts/event_test.h
@@ -22,16 +22,16 @@ namespace cts {
 class event_test : public CtsTestBase {};
 
 TEST_P(event_test, Create) {
-  iree_hal_event_t* event;
+  iree_hal_event_t* event = NULL;
   IREE_ASSERT_OK(iree_hal_event_create(device_, &event));
   iree_hal_event_release(event);
 }
 
 TEST_P(event_test, SignalAndReset) {
-  iree_hal_event_t* event;
+  iree_hal_event_t* event = NULL;
   IREE_ASSERT_OK(iree_hal_event_create(device_, &event));
 
-  iree_hal_command_buffer_t* command_buffer;
+  iree_hal_command_buffer_t* command_buffer = NULL;
   IREE_ASSERT_OK(iree_hal_command_buffer_create(
       device_, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
       IREE_HAL_COMMAND_CATEGORY_DISPATCH, IREE_HAL_QUEUE_AFFINITY_ANY,
@@ -52,11 +52,11 @@ TEST_P(event_test, SignalAndReset) {
 }
 
 TEST_P(event_test, SubmitWithChainedCommandBuffers) {
-  iree_hal_event_t* event;
+  iree_hal_event_t* event = NULL;
   IREE_ASSERT_OK(iree_hal_event_create(device_, &event));
 
-  iree_hal_command_buffer_t* command_buffer_1;
-  iree_hal_command_buffer_t* command_buffer_2;
+  iree_hal_command_buffer_t* command_buffer_1 = NULL;
+  iree_hal_command_buffer_t* command_buffer_2 = NULL;
   IREE_ASSERT_OK(iree_hal_command_buffer_create(
       device_, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
       IREE_HAL_COMMAND_CATEGORY_DISPATCH, IREE_HAL_QUEUE_AFFINITY_ANY,

--- a/iree/hal/cts/executable_cache_test.h
+++ b/iree/hal/cts/executable_cache_test.h
@@ -21,7 +21,7 @@ namespace cts {
 class executable_cache_test : public CtsTestBase {};
 
 TEST_P(executable_cache_test, Create) {
-  iree_hal_executable_cache_t* executable_cache;
+  iree_hal_executable_cache_t* executable_cache = NULL;
   IREE_ASSERT_OK(iree_hal_executable_cache_create(
       device_, iree_make_cstring_view("default"), &executable_cache));
 
@@ -29,7 +29,7 @@ TEST_P(executable_cache_test, Create) {
 }
 
 TEST_P(executable_cache_test, CantPrepareUnknownFormat) {
-  iree_hal_executable_cache_t* executable_cache;
+  iree_hal_executable_cache_t* executable_cache = NULL;
   IREE_ASSERT_OK(iree_hal_executable_cache_create(
       device_, iree_make_cstring_view("default"), &executable_cache));
 
@@ -40,12 +40,12 @@ TEST_P(executable_cache_test, CantPrepareUnknownFormat) {
 }
 
 TEST_P(executable_cache_test, PrepareExecutable) {
-  iree_hal_executable_cache_t* executable_cache;
+  iree_hal_executable_cache_t* executable_cache = NULL;
   IREE_ASSERT_OK(iree_hal_executable_cache_create(
       device_, iree_make_cstring_view("default"), &executable_cache));
 
   // Note: this layout must match the testdata executable.
-  iree_hal_descriptor_set_layout_t* descriptor_set_layout;
+  iree_hal_descriptor_set_layout_t* descriptor_set_layout = NULL;
   iree_hal_descriptor_set_layout_binding_t descriptor_set_layout_bindings[] = {
       {0, IREE_HAL_DESCRIPTOR_TYPE_STORAGE_BUFFER},
       {1, IREE_HAL_DESCRIPTOR_TYPE_STORAGE_BUFFER},
@@ -69,7 +69,7 @@ TEST_P(executable_cache_test, PrepareExecutable) {
   executable_spec.executable_layout_count = 1;
   executable_spec.executable_layouts = &executable_layout;
 
-  iree_hal_executable_t* executable;
+  iree_hal_executable_t* executable = NULL;
   IREE_ASSERT_OK(iree_hal_executable_cache_prepare_executable(
       executable_cache, &executable_spec, &executable));
 

--- a/iree/hal/cts/executable_layout_test.h
+++ b/iree/hal/cts/executable_layout_test.h
@@ -20,7 +20,7 @@ namespace cts {
 class executable_layout_test : public CtsTestBase {};
 
 TEST_P(executable_layout_test, CreateWithNoLayouts) {
-  iree_hal_executable_layout_t* executable_layout;
+  iree_hal_executable_layout_t* executable_layout = NULL;
   IREE_ASSERT_OK(iree_hal_executable_layout_create(
       device_, /*push_constants=*/0, /*set_layout_count=*/0, NULL,
       &executable_layout));
@@ -29,7 +29,7 @@ TEST_P(executable_layout_test, CreateWithNoLayouts) {
 }
 
 TEST_P(executable_layout_test, CreateWithPushConstants) {
-  iree_hal_executable_layout_t* executable_layout;
+  iree_hal_executable_layout_t* executable_layout = NULL;
   // Note: The Vulkan maxPushConstantsSize limit must be at least 128 bytes:
   // https://www.khronos.org/registry/vulkan/specs/1.2/html/vkspec.html#limits-minmax
   IREE_ASSERT_OK(iree_hal_executable_layout_create(
@@ -40,7 +40,7 @@ TEST_P(executable_layout_test, CreateWithPushConstants) {
 }
 
 TEST_P(executable_layout_test, CreateWithOneLayout) {
-  iree_hal_descriptor_set_layout_t* descriptor_set_layout;
+  iree_hal_descriptor_set_layout_t* descriptor_set_layout = NULL;
   iree_hal_descriptor_set_layout_binding_t descriptor_set_layout_bindings[] = {
       {/*binding=*/0, /*type=*/IREE_HAL_DESCRIPTOR_TYPE_STORAGE_BUFFER},
       {/*binding=*/1, /*type=*/IREE_HAL_DESCRIPTOR_TYPE_STORAGE_BUFFER},
@@ -50,7 +50,7 @@ TEST_P(executable_layout_test, CreateWithOneLayout) {
       IREE_ARRAYSIZE(descriptor_set_layout_bindings),
       descriptor_set_layout_bindings, &descriptor_set_layout));
 
-  iree_hal_executable_layout_t* executable_layout;
+  iree_hal_executable_layout_t* executable_layout = NULL;
   IREE_ASSERT_OK(iree_hal_executable_layout_create(
       device_, /*push_constants=*/0, /*set_layout_count=*/1,
       &descriptor_set_layout, &executable_layout));
@@ -60,7 +60,7 @@ TEST_P(executable_layout_test, CreateWithOneLayout) {
 }
 
 TEST_P(executable_layout_test, CreateWithTwoLayouts) {
-  iree_hal_descriptor_set_layout_t* descriptor_set_layouts[2];
+  iree_hal_descriptor_set_layout_t* descriptor_set_layouts[2] = {NULL};
   iree_hal_descriptor_set_layout_binding_t layout_bindings_0[] = {
       {/*binding=*/0, /*type=*/IREE_HAL_DESCRIPTOR_TYPE_STORAGE_BUFFER},
       {/*binding=*/1, /*type=*/IREE_HAL_DESCRIPTOR_TYPE_STORAGE_BUFFER},
@@ -80,7 +80,7 @@ TEST_P(executable_layout_test, CreateWithTwoLayouts) {
       IREE_ARRAYSIZE(layout_bindings_1), layout_bindings_1,
       &descriptor_set_layouts[1]));
 
-  iree_hal_executable_layout_t* executable_layout;
+  iree_hal_executable_layout_t* executable_layout = NULL;
   IREE_ASSERT_OK(iree_hal_executable_layout_create(
       device_, /*push_constants=*/0, IREE_ARRAYSIZE(descriptor_set_layouts),
       descriptor_set_layouts, &executable_layout));

--- a/iree/hal/cts/semaphore_submission_test.h
+++ b/iree/hal/cts/semaphore_submission_test.h
@@ -29,7 +29,7 @@ TEST_P(semaphore_submission_test, SubmitWithNoCommandBuffers) {
   submission_batch.wait_semaphores.payload_values = NULL;
   submission_batch.command_buffer_count = 0;
   submission_batch.command_buffers = NULL;
-  iree_hal_semaphore_t* signal_semaphore;
+  iree_hal_semaphore_t* signal_semaphore = NULL;
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &signal_semaphore));
   iree_hal_semaphore_t* signal_semaphore_ptrs[] = {signal_semaphore};
   submission_batch.signal_semaphores.count =
@@ -49,7 +49,7 @@ TEST_P(semaphore_submission_test, SubmitWithNoCommandBuffers) {
 }
 
 TEST_P(semaphore_submission_test, SubmitAndSignal) {
-  iree_hal_command_buffer_t* command_buffer;
+  iree_hal_command_buffer_t* command_buffer = NULL;
   IREE_ASSERT_OK(iree_hal_command_buffer_create(
       device_, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
       IREE_HAL_COMMAND_CATEGORY_DISPATCH, IREE_HAL_QUEUE_AFFINITY_ANY,
@@ -65,7 +65,7 @@ TEST_P(semaphore_submission_test, SubmitAndSignal) {
   submission_batch.wait_semaphores.payload_values = NULL;
   submission_batch.command_buffer_count = 1;
   submission_batch.command_buffers = &command_buffer;
-  iree_hal_semaphore_t* signal_semaphore;
+  iree_hal_semaphore_t* signal_semaphore = NULL;
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &signal_semaphore));
   iree_hal_semaphore_t* signal_semaphore_ptrs[] = {signal_semaphore};
   submission_batch.signal_semaphores.count =
@@ -87,7 +87,7 @@ TEST_P(semaphore_submission_test, SubmitAndSignal) {
 
 TEST_P(semaphore_submission_test, SubmitWithWait) {
   // Empty command buffer.
-  iree_hal_command_buffer_t* command_buffer;
+  iree_hal_command_buffer_t* command_buffer = NULL;
   IREE_ASSERT_OK(iree_hal_command_buffer_create(
       device_, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
       IREE_HAL_COMMAND_CATEGORY_DISPATCH, IREE_HAL_QUEUE_AFFINITY_ANY,
@@ -97,8 +97,8 @@ TEST_P(semaphore_submission_test, SubmitWithWait) {
 
   // One wait and one signal semaphore.
   iree_hal_submission_batch_t submission_batch;
-  iree_hal_semaphore_t* wait_semaphore;
-  iree_hal_semaphore_t* signal_semaphore;
+  iree_hal_semaphore_t* wait_semaphore = NULL;
+  iree_hal_semaphore_t* signal_semaphore = NULL;
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &wait_semaphore));
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 100ull, &signal_semaphore));
   iree_hal_semaphore_t* wait_semaphore_ptrs[] = {wait_semaphore};
@@ -136,7 +136,7 @@ TEST_P(semaphore_submission_test, SubmitWithWait) {
 }
 
 TEST_P(semaphore_submission_test, SubmitWithMultipleSemaphores) {
-  iree_hal_command_buffer_t* command_buffer;
+  iree_hal_command_buffer_t* command_buffer = NULL;
   IREE_ASSERT_OK(iree_hal_command_buffer_create(
       device_, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
       IREE_HAL_COMMAND_CATEGORY_DISPATCH, IREE_HAL_QUEUE_AFFINITY_ANY,
@@ -146,10 +146,10 @@ TEST_P(semaphore_submission_test, SubmitWithMultipleSemaphores) {
   IREE_ASSERT_OK(iree_hal_command_buffer_end(command_buffer));
 
   iree_hal_submission_batch_t submission_batch;
-  iree_hal_semaphore_t* wait_semaphore_1;
-  iree_hal_semaphore_t* wait_semaphore_2;
-  iree_hal_semaphore_t* signal_semaphore_1;
-  iree_hal_semaphore_t* signal_semaphore_2;
+  iree_hal_semaphore_t* wait_semaphore_1 = NULL;
+  iree_hal_semaphore_t* wait_semaphore_2 = NULL;
+  iree_hal_semaphore_t* signal_semaphore_1 = NULL;
+  iree_hal_semaphore_t* signal_semaphore_2 = NULL;
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &wait_semaphore_1));
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &wait_semaphore_2));
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &signal_semaphore_1));

--- a/iree/hal/cts/semaphore_test.h
+++ b/iree/hal/cts/semaphore_test.h
@@ -24,7 +24,7 @@ class semaphore_test : public CtsTestBase {};
 
 // Tests that a semaphore that is unused properly cleans itself up.
 TEST_P(semaphore_test, NoOp) {
-  iree_hal_semaphore_t* semaphore;
+  iree_hal_semaphore_t* semaphore = NULL;
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 123ull, &semaphore));
 
   uint64_t value;
@@ -36,7 +36,7 @@ TEST_P(semaphore_test, NoOp) {
 
 // Tests that a semaphore will accept new values as it is signaled.
 TEST_P(semaphore_test, NormalSignaling) {
-  iree_hal_semaphore_t* semaphore;
+  iree_hal_semaphore_t* semaphore = NULL;
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 2ull, &semaphore));
 
   uint64_t value;
@@ -58,7 +58,7 @@ TEST_P(semaphore_test, NormalSignaling) {
 
 // Tests semaphore failure handling.
 TEST_P(semaphore_test, Failure) {
-  iree_hal_semaphore_t* semaphore;
+  iree_hal_semaphore_t* semaphore = NULL;
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 2ull, &semaphore));
 
   IREE_ASSERT_OK(iree_hal_semaphore_signal(semaphore, 3ull));
@@ -97,7 +97,7 @@ TEST_P(semaphore_test, EmptyWait) {
 // Tests waiting on a semaphore that has already been signaled.
 // **Never completes when using SwiftShader**
 TEST_P(semaphore_test, DISABLED_WaitAlreadySignaled) {
-  iree_hal_semaphore_t* semaphore;
+  iree_hal_semaphore_t* semaphore = NULL;
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 2ull, &semaphore));
 
   // Test both previous and current values.
@@ -116,7 +116,7 @@ TEST_P(semaphore_test, DISABLED_WaitAlreadySignaled) {
 
 // Tests waiting on a semaphore that has not been signaled.
 TEST_P(semaphore_test, WaitUnsignaled) {
-  iree_hal_semaphore_t* semaphore;
+  iree_hal_semaphore_t* semaphore = NULL;
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 2ull, &semaphore));
 
   // NOTE: we don't actually block here because otherwise we'd lock up.
@@ -133,8 +133,8 @@ TEST_P(semaphore_test, WaitUnsignaled) {
 
 // Tests IREE_HAL_WAIT_MODE_ALL when not all are signaled.
 TEST_P(semaphore_test, WaitAllButNotAllSignaled) {
-  iree_hal_semaphore_t* semaphore_a;
-  iree_hal_semaphore_t* semaphore_b;
+  iree_hal_semaphore_t* semaphore_a = NULL;
+  iree_hal_semaphore_t* semaphore_b = NULL;
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &semaphore_a));
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 1ull, &semaphore_b));
 
@@ -158,8 +158,8 @@ TEST_P(semaphore_test, WaitAllButNotAllSignaled) {
 
 // Tests IREE_HAL_WAIT_MODE_ALL when all are signaled.
 TEST_P(semaphore_test, WaitAllAndAllSignaled) {
-  iree_hal_semaphore_t* semaphore_a;
-  iree_hal_semaphore_t* semaphore_b;
+  iree_hal_semaphore_t* semaphore_a = NULL;
+  iree_hal_semaphore_t* semaphore_b = NULL;
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 1ull, &semaphore_a));
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 1ull, &semaphore_b));
 
@@ -184,8 +184,8 @@ TEST_P(semaphore_test, WaitAllAndAllSignaled) {
 // Tests IREE_HAL_WAIT_MODE_ANY.
 // **Fails using timeline semaphore emulation**
 TEST_P(semaphore_test, DISABLED_WaitAny) {
-  iree_hal_semaphore_t* semaphore_a;
-  iree_hal_semaphore_t* semaphore_b;
+  iree_hal_semaphore_t* semaphore_a = NULL;
+  iree_hal_semaphore_t* semaphore_b = NULL;
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &semaphore_a));
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 1ull, &semaphore_b));
 
@@ -207,8 +207,8 @@ TEST_P(semaphore_test, DISABLED_WaitAny) {
 // Tests threading behavior by ping-ponging between the test main thread and
 // a little thread.
 TEST_P(semaphore_test, PingPong) {
-  iree_hal_semaphore_t* a2b;
-  iree_hal_semaphore_t* b2a;
+  iree_hal_semaphore_t* a2b = NULL;
+  iree_hal_semaphore_t* b2a = NULL;
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &a2b));
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &b2a));
   std::thread thread([&]() {


### PR DESCRIPTION
I tried to set up coverage reporting to help guide this work, but gave up after trying a few different versions of gcc/clang and still getting version mismatches between tools with unhelpful error messages >_>