### PR TITLE
Avoid overflow from repeated exponentiation of large numbers

### DIFF
--- a/integrations/tensorflow/test/python/iree_tf_tests/math/math_test.py
+++ b/integrations/tensorflow/test/python/iree_tf_tests/math/math_test.py
@@ -405,8 +405,10 @@ FUNCTIONS_TO_UNIT_TEST_SPECS = {
         tf_test_utils.unit_test_specs_from_signatures(
             signature_shapes=[[[1, 2, 2, 2], [1, 2, 2, 2]]],
             signature_dtypes=[tf.float32, tf.int32, tf.complex64],
+            # Avoid numbers <1 or large ones that will overflow
             input_generators={
-                "positive_ndarange": lambda *args: tf_utils.ndarange(*args) + 1
+                "positive_moderate_ndarange":
+                    lambda *args: tf_utils.uniform(*args, low=1.0, high=3.0)
             }),
     "real":
         tf_test_utils.unit_test_specs_from_signatures(


### PR DESCRIPTION
This causes overflow in TF when run internally with asan.