### PR TITLE
Renaming iree_hal_executable_spec_t -> .._params_t.

### DIFF
--- a/experimental/rocm/native_executable.c
+++ b/experimental/rocm/native_executable.c
@@ -46,10 +46,10 @@ static iree_hal_rocm_native_executable_t* iree_hal_rocm_native_executable_cast(
 
 iree_status_t iree_hal_rocm_native_executable_create(
     iree_hal_rocm_context_wrapper_t* context,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
   IREE_ASSERT_ARGUMENT(context);
-  IREE_ASSERT_ARGUMENT(executable_spec);
+  IREE_ASSERT_ARGUMENT(executable_params);
   IREE_ASSERT_ARGUMENT(out_executable);
   *out_executable = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -58,7 +58,7 @@ iree_status_t iree_hal_rocm_native_executable_create(
 
   // TODO: Verify the flat buffer.
   iree_ROCMExecutableDef_table_t executable_def =
-      iree_ROCMExecutableDef_as_root(executable_spec->executable_data.data);
+      iree_ROCMExecutableDef_as_root(executable_params->executable_data.data);
 
   // Create the kernel module.
   flatbuffers_string_t hsaco_image =
@@ -96,8 +96,9 @@ iree_status_t iree_hal_rocm_native_executable_create(
       executable->entry_functions[i].block_size_y = block_sizes_vec[i].y;
       executable->entry_functions[i].block_size_z = block_sizes_vec[i].z;
       executable->executable_layouts[i] =
-          executable_spec->executable_layouts[i];
-      iree_hal_executable_layout_retain(executable_spec->executable_layouts[i]);
+          executable_params->executable_layouts[i];
+      iree_hal_executable_layout_retain(
+          executable_params->executable_layouts[i]);
     }
   }
 

--- a/experimental/rocm/native_executable.h
+++ b/experimental/rocm/native_executable.h
@@ -22,7 +22,7 @@ extern "C" {
 // kernels that can be extracted along with the associated block size.
 iree_status_t iree_hal_rocm_native_executable_create(
     iree_hal_rocm_context_wrapper_t* context,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable);
 
 hipFunction_t iree_hal_rocm_native_executable_for_entry_point(

--- a/experimental/rocm/nop_executable_cache.c
+++ b/experimental/rocm/nop_executable_cache.c
@@ -72,12 +72,12 @@ static bool iree_hal_rocm_nop_executable_cache_can_prepare_format(
 
 static iree_status_t iree_hal_rocm_nop_executable_cache_prepare_executable(
     iree_hal_executable_cache_t* base_executable_cache,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
   iree_hal_rocm_nop_executable_cache_t* executable_cache =
       iree_hal_rocm_nop_executable_cache_cast(base_executable_cache);
   return iree_hal_rocm_native_executable_create(
-      executable_cache->context, executable_spec, out_executable);
+      executable_cache->context, executable_params, out_executable);
 }
 
 static const iree_hal_executable_cache_vtable_t

--- a/iree/hal/cts/command_buffer_dispatch_test.h
+++ b/iree/hal/cts/command_buffer_dispatch_test.h
@@ -37,18 +37,18 @@ class command_buffer_dispatch_test : public CtsTestBase {
         device_, /*push_constants=*/0, /*set_layout_count=*/1,
         &descriptor_set_layout_, &executable_layout_));
 
-    iree_hal_executable_spec_t executable_spec;
-    executable_spec.caching_mode =
+    iree_hal_executable_params_t executable_params;
+    executable_params.caching_mode =
         IREE_HAL_EXECUTABLE_CACHING_MODE_ALIAS_PROVIDED_DATA;
-    executable_spec.executable_format =
+    executable_params.executable_format =
         iree_make_cstring_view(get_test_executable_format());
-    executable_spec.executable_data = get_test_executable_data(
+    executable_params.executable_data = get_test_executable_data(
         iree_make_cstring_view("command_buffer_dispatch_test.bin"));
-    executable_spec.executable_layout_count = 1;
-    executable_spec.executable_layouts = &executable_layout_;
+    executable_params.executable_layout_count = 1;
+    executable_params.executable_layouts = &executable_layout_;
 
     IREE_ASSERT_OK(iree_hal_executable_cache_prepare_executable(
-        executable_cache_, &executable_spec, &executable_));
+        executable_cache_, &executable_params, &executable_));
   }
 
   void CleanupExecutable() {

--- a/iree/hal/cts/executable_cache_test.h
+++ b/iree/hal/cts/executable_cache_test.h
@@ -59,19 +59,19 @@ TEST_P(executable_cache_test, PrepareExecutable) {
       device_, /*push_constants=*/0, /*set_layout_count=*/1,
       &descriptor_set_layout, &executable_layout));
 
-  iree_hal_executable_spec_t executable_spec;
-  executable_spec.caching_mode =
+  iree_hal_executable_params_t executable_params;
+  executable_params.caching_mode =
       IREE_HAL_EXECUTABLE_CACHING_MODE_ALIAS_PROVIDED_DATA;
-  executable_spec.executable_format =
+  executable_params.executable_format =
       iree_make_cstring_view(get_test_executable_format());
-  executable_spec.executable_data = get_test_executable_data(
+  executable_params.executable_data = get_test_executable_data(
       iree_make_cstring_view("executable_cache_test.bin"));
-  executable_spec.executable_layout_count = 1;
-  executable_spec.executable_layouts = &executable_layout;
+  executable_params.executable_layout_count = 1;
+  executable_params.executable_layouts = &executable_layout;
 
   iree_hal_executable_t* executable;
   IREE_ASSERT_OK(iree_hal_executable_cache_prepare_executable(
-      executable_cache, &executable_spec, &executable));
+      executable_cache, &executable_params, &executable));
 
   iree_hal_executable_release(executable);
   iree_hal_executable_layout_release(executable_layout);

--- a/iree/hal/cuda/native_executable.c
+++ b/iree/hal/cuda/native_executable.c
@@ -47,10 +47,10 @@ static iree_hal_cuda_native_executable_t* iree_hal_cuda_native_executable_cast(
 
 iree_status_t iree_hal_cuda_native_executable_create(
     iree_hal_cuda_context_wrapper_t* context,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
   IREE_ASSERT_ARGUMENT(context);
-  IREE_ASSERT_ARGUMENT(executable_spec);
+  IREE_ASSERT_ARGUMENT(executable_params);
   IREE_ASSERT_ARGUMENT(out_executable);
   *out_executable = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -59,7 +59,7 @@ iree_status_t iree_hal_cuda_native_executable_create(
 
   // TODO: Verify the flat buffer.
   iree_CUDAExecutableDef_table_t executable_def =
-      iree_CUDAExecutableDef_as_root(executable_spec->executable_data.data);
+      iree_CUDAExecutableDef_as_root(executable_params->executable_data.data);
 
   // Create the kernel module.
   flatbuffers_string_t ptx_image =
@@ -108,8 +108,9 @@ iree_status_t iree_hal_cuda_native_executable_create(
       executable->entry_functions[i].shared_memory_size =
           shared_memory_sizes[i];
       executable->executable_layouts[i] =
-          executable_spec->executable_layouts[i];
-      iree_hal_executable_layout_retain(executable_spec->executable_layouts[i]);
+          executable_params->executable_layouts[i];
+      iree_hal_executable_layout_retain(
+          executable_params->executable_layouts[i]);
     }
   }
 

--- a/iree/hal/cuda/native_executable.h
+++ b/iree/hal/cuda/native_executable.h
@@ -22,7 +22,7 @@ extern "C" {
 // kernels that can be extracted along with the associated block size.
 iree_status_t iree_hal_cuda_native_executable_create(
     iree_hal_cuda_context_wrapper_t* context,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable);
 
 CUfunction iree_hal_cuda_native_executable_for_entry_point(

--- a/iree/hal/cuda/nop_executable_cache.c
+++ b/iree/hal/cuda/nop_executable_cache.c
@@ -72,12 +72,12 @@ static bool iree_hal_cuda_nop_executable_cache_can_prepare_format(
 
 static iree_status_t iree_hal_cuda_nop_executable_cache_prepare_executable(
     iree_hal_executable_cache_t* base_executable_cache,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
   iree_hal_cuda_nop_executable_cache_t* executable_cache =
       iree_hal_cuda_nop_executable_cache_cast(base_executable_cache);
   return iree_hal_cuda_native_executable_create(
-      executable_cache->context, executable_spec, out_executable);
+      executable_cache->context, executable_params, out_executable);
 }
 
 static const iree_hal_executable_cache_vtable_t

--- a/iree/hal/executable_cache.c
+++ b/iree/hal/executable_cache.c
@@ -14,9 +14,10 @@
 #include "iree/hal/device.h"
 #include "iree/hal/resource.h"
 
-void iree_hal_executable_spec_initialize(iree_hal_executable_spec_t* out_spec) {
-  memset(out_spec, 0, sizeof(*out_spec));
-  out_spec->caching_mode =
+void iree_hal_executable_params_initialize(
+    iree_hal_executable_params_t* out_executable_params) {
+  memset(out_executable_params, 0, sizeof(*out_executable_params));
+  out_executable_params->caching_mode =
       IREE_HAL_EXECUTABLE_CACHING_MODE_ALLOW_PERSISTENT_CACHING |
       IREE_HAL_EXECUTABLE_CACHING_MODE_ALLOW_OPTIMIZATION;
 }
@@ -52,17 +53,17 @@ IREE_API_EXPORT bool iree_hal_executable_cache_can_prepare_format(
 
 IREE_API_EXPORT iree_status_t iree_hal_executable_cache_prepare_executable(
     iree_hal_executable_cache_t* executable_cache,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
   IREE_ASSERT_ARGUMENT(executable_cache);
-  IREE_ASSERT_ARGUMENT(executable_spec);
-  IREE_ASSERT_ARGUMENT(!executable_spec->executable_layout_count ||
-                       executable_spec->executable_layouts);
+  IREE_ASSERT_ARGUMENT(executable_params);
+  IREE_ASSERT_ARGUMENT(!executable_params->executable_layout_count ||
+                       executable_params->executable_layouts);
   IREE_ASSERT_ARGUMENT(out_executable);
   *out_executable = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
   iree_status_t status = _VTABLE_DISPATCH(executable_cache, prepare_executable)(
-      executable_cache, executable_spec, out_executable);
+      executable_cache, executable_params, out_executable);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/iree/hal/executable_cache.h
+++ b/iree/hal/executable_cache.h
@@ -72,7 +72,7 @@ enum iree_hal_executable_caching_mode_bits_t {
 typedef uint32_t iree_hal_executable_caching_mode_t;
 
 // Defines an executable compilation specification.
-typedef struct iree_hal_executable_spec_t {
+typedef struct iree_hal_executable_params_t {
   // Specifies what caching the executable cache is allowed to perform and
   // (if supported) which transformations on the executable contents are
   // allowed.
@@ -98,11 +98,12 @@ typedef struct iree_hal_executable_spec_t {
   // executable layout objects.
   iree_host_size_t executable_layout_count;
   iree_hal_executable_layout_t* const* executable_layouts;
-} iree_hal_executable_spec_t;
+} iree_hal_executable_params_t;
 
-// Initializes |out_spec| to the default values for normal executables. Callers
-// must override the fields as required.
-void iree_hal_executable_spec_initialize(iree_hal_executable_spec_t* out_spec);
+// Initializes |out_executable_params| to the default values for normal
+// executables. Callers must override the fields as required.
+void iree_hal_executable_params_initialize(
+    iree_hal_executable_params_t* out_executable_params);
 
 //===----------------------------------------------------------------------===//
 // iree_hal_executable_cache_t
@@ -148,7 +149,7 @@ IREE_API_EXPORT bool iree_hal_executable_cache_can_prepare_format(
     iree_hal_executable_caching_mode_t caching_mode,
     iree_string_view_t executable_format);
 
-// Prepares the executable defined by |executable_spec| for use.
+// Prepares the executable defined by |executable_params| for use.
 // The provided |executable_data| (in a format defined by |executable_format|)
 // will be used to either lookup a previously prepared executable in the cache
 // or prepare a new one.
@@ -163,7 +164,7 @@ IREE_API_EXPORT bool iree_hal_executable_cache_can_prepare_format(
 // executables - and calls will block until preparation completes.
 IREE_API_EXPORT iree_status_t iree_hal_executable_cache_prepare_executable(
     iree_hal_executable_cache_t* executable_cache,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable);
 
 //===----------------------------------------------------------------------===//
@@ -180,7 +181,7 @@ typedef struct iree_hal_executable_cache_vtable_t {
 
   iree_status_t(IREE_API_PTR* prepare_executable)(
       iree_hal_executable_cache_t* executable_cache,
-      const iree_hal_executable_spec_t* executable_spec,
+      const iree_hal_executable_params_t* executable_params,
       iree_hal_executable_t** out_executable);
 } iree_hal_executable_cache_vtable_t;
 IREE_HAL_ASSERT_VTABLE_LAYOUT(iree_hal_executable_cache_vtable_t);

--- a/iree/hal/local/executable_library_benchmark.c
+++ b/iree/hal/local/executable_library_benchmark.c
@@ -216,31 +216,31 @@ static iree_status_t iree_hal_executable_library_run(
   // Setup the specification used to perform the executable load.
   // This information is normally used to select the appropriate loader but in
   // this benchmark we only have a single one.
-  iree_hal_executable_spec_t executable_spec;
-  iree_hal_executable_spec_initialize(&executable_spec);
-  executable_spec.caching_mode =
+  iree_hal_executable_params_t executable_params;
+  iree_hal_executable_params_initialize(&executable_params);
+  executable_params.caching_mode =
       IREE_HAL_EXECUTABLE_CACHING_MODE_ALLOW_OPTIMIZATION |
       IREE_HAL_EXECUTABLE_CACHING_MODE_ALIAS_PROVIDED_DATA |
       IREE_HAL_EXECUTABLE_CACHING_MODE_DISABLE_VERIFICATION;
-  executable_spec.executable_format =
+  executable_params.executable_format =
       iree_make_cstring_view(FLAG_executable_format);
 
   // Load the executable data.
   IREE_RETURN_IF_ERROR(iree_file_read_contents(
       FLAG_executable_file, host_allocator,
-      (iree_byte_span_t*)&executable_spec.executable_data));
+      (iree_byte_span_t*)&executable_params.executable_data));
 
   // Setup the layouts defining how each entry point is interpreted.
   // NOTE: we know for the embedded library loader that this is not required.
   // Other loaders may need it in which case it'll have to be provided.
-  executable_spec.executable_layout_count = 0;
-  executable_spec.executable_layouts = NULL;
+  executable_params.executable_layout_count = 0;
+  executable_params.executable_layouts = NULL;
 
   // Perform the load, which will fail if the executable cannot be loaded or
   // there was an issue with the layouts.
   iree_hal_executable_t* executable = NULL;
   IREE_RETURN_IF_ERROR(iree_hal_executable_loader_try_load(
-      executable_loader, &executable_spec, &executable));
+      executable_loader, &executable_params, &executable));
   iree_hal_local_executable_t* local_executable =
       iree_hal_local_executable_cast(executable);
 
@@ -331,7 +331,7 @@ static iree_status_t iree_hal_executable_library_run(
 
   // Unload.
   iree_allocator_free(host_allocator,
-                      (void*)executable_spec.executable_data.data);
+                      (void*)executable_params.executable_data.data);
   iree_hal_executable_release(executable);
   iree_hal_executable_loader_release(executable_loader);
 

--- a/iree/hal/local/executable_loader.c
+++ b/iree/hal/local/executable_loader.c
@@ -86,15 +86,15 @@ bool iree_hal_query_any_executable_loader_support(
 
 iree_status_t iree_hal_executable_loader_try_load(
     iree_hal_executable_loader_t* executable_loader,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
   IREE_ASSERT_ARGUMENT(executable_loader);
-  IREE_ASSERT_ARGUMENT(executable_spec);
-  IREE_ASSERT_ARGUMENT(!executable_spec->executable_layout_count ||
-                       executable_spec->executable_layouts);
-  IREE_ASSERT_ARGUMENT(!executable_spec->executable_data.data_length ||
-                       executable_spec->executable_data.data);
+  IREE_ASSERT_ARGUMENT(executable_params);
+  IREE_ASSERT_ARGUMENT(!executable_params->executable_layout_count ||
+                       executable_params->executable_layouts);
+  IREE_ASSERT_ARGUMENT(!executable_params->executable_data.data_length ||
+                       executable_params->executable_data.data);
   IREE_ASSERT_ARGUMENT(out_executable);
-  return executable_loader->vtable->try_load(executable_loader, executable_spec,
-                                             out_executable);
+  return executable_loader->vtable->try_load(executable_loader,
+                                             executable_params, out_executable);
 }

--- a/iree/hal/local/executable_loader.h
+++ b/iree/hal/local/executable_loader.h
@@ -121,7 +121,7 @@ bool iree_hal_query_any_executable_loader_support(
 // given format.
 iree_status_t iree_hal_executable_loader_try_load(
     iree_hal_executable_loader_t* executable_loader,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable);
 
 //===----------------------------------------------------------------------===//
@@ -138,7 +138,7 @@ typedef struct iree_hal_executable_loader_vtable_t {
 
   iree_status_t(IREE_API_PTR* try_load)(
       iree_hal_executable_loader_t* executable_loader,
-      const iree_hal_executable_spec_t* executable_spec,
+      const iree_hal_executable_params_t* executable_params,
       iree_hal_executable_t** out_executable);
 } iree_hal_executable_loader_vtable_t;
 

--- a/iree/hal/local/loaders/embedded_library_loader.c
+++ b/iree/hal/local/loaders/embedded_library_loader.c
@@ -322,7 +322,7 @@ static bool iree_hal_embedded_library_loader_query_support(
 
 static iree_status_t iree_hal_embedded_library_loader_try_load(
     iree_hal_executable_loader_t* base_executable_loader,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
   iree_hal_embedded_library_loader_t* executable_loader =
       (iree_hal_embedded_library_loader_t*)base_executable_loader;
@@ -330,9 +330,9 @@ static iree_status_t iree_hal_embedded_library_loader_try_load(
 
   // Perform the load of the ELF and wrap it in an executable handle.
   iree_status_t status = iree_hal_elf_executable_create(
-      executable_spec->caching_mode, executable_spec->executable_data,
-      executable_spec->executable_layout_count,
-      executable_spec->executable_layouts,
+      executable_params->caching_mode, executable_params->executable_data,
+      executable_params->executable_layout_count,
+      executable_params->executable_layouts,
       base_executable_loader->import_provider,
       executable_loader->host_allocator, out_executable);
 

--- a/iree/hal/local/loaders/static_library_loader.c
+++ b/iree/hal/local/loaders/static_library_loader.c
@@ -255,15 +255,15 @@ static bool iree_hal_static_library_loader_query_support(
 
 static iree_status_t iree_hal_static_library_loader_try_load(
     iree_hal_executable_loader_t* base_executable_loader,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
   iree_hal_static_library_loader_t* executable_loader =
       (iree_hal_static_library_loader_t*)base_executable_loader;
 
   // The executable data is just the name of the library.
-  iree_string_view_t library_name =
-      iree_make_string_view((const char*)executable_spec->executable_data.data,
-                            executable_spec->executable_data.data_length);
+  iree_string_view_t library_name = iree_make_string_view(
+      (const char*)executable_params->executable_data.data,
+      executable_params->executable_data.data_length);
 
   // Linear scan of the registered libraries; there's usually only one per
   // module (aka source model) and as such it's a small list and probably not
@@ -277,8 +277,8 @@ static iree_status_t iree_hal_static_library_loader_try_load(
                                iree_make_cstring_view(header->name))) {
       return iree_hal_static_executable_create(
           executable_loader->libraries[i],
-          executable_spec->executable_layout_count,
-          executable_spec->executable_layouts,
+          executable_params->executable_layout_count,
+          executable_params->executable_layouts,
           base_executable_loader->import_provider,
           executable_loader->host_allocator, out_executable);
     }

--- a/iree/hal/local/loaders/static_library_loader.h
+++ b/iree/hal/local/loaders/static_library_loader.h
@@ -27,8 +27,8 @@ extern "C" {
 //
 // The name defined on each library will be used to lookup the executables and
 // must match with the names used during compilation exactly. The
-// iree_hal_executable_spec_t used to reference the executables will contain the
-// library name and be used to lookup the library in the list.
+// iree_hal_executable_params_t used to reference the executables will contain
+// the library name and be used to lookup the library in the list.
 //
 // Multiple static library loaders can be registered in cases when several
 // independent sets of libraries are linked in however duplicate names both

--- a/iree/hal/local/loaders/system_library_loader.c
+++ b/iree/hal/local/loaders/system_library_loader.c
@@ -438,7 +438,7 @@ static bool iree_hal_system_library_loader_query_support(
 
 static iree_status_t iree_hal_system_library_loader_try_load(
     iree_hal_executable_loader_t* base_executable_loader,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
   iree_hal_system_library_loader_t* executable_loader =
       (iree_hal_system_library_loader_t*)base_executable_loader;
@@ -447,9 +447,9 @@ static iree_status_t iree_hal_system_library_loader_try_load(
   // Perform the load (and requisite disgusting hackery).
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_system_executable_create(
-              executable_spec->executable_data,
-              executable_spec->executable_layout_count,
-              executable_spec->executable_layouts,
+              executable_params->executable_data,
+              executable_params->executable_layout_count,
+              executable_params->executable_layouts,
               base_executable_loader->import_provider,
               executable_loader->host_allocator, out_executable));
 

--- a/iree/hal/local/local_executable_cache.c
+++ b/iree/hal/local/local_executable_cache.c
@@ -97,14 +97,14 @@ static bool iree_hal_local_executable_cache_can_prepare_format(
 
 static iree_status_t iree_hal_local_executable_cache_prepare_executable(
     iree_hal_executable_cache_t* base_executable_cache,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
   iree_hal_local_executable_cache_t* executable_cache =
       iree_hal_local_executable_cache_cast(base_executable_cache);
   for (iree_host_size_t i = 0; i < executable_cache->loader_count; ++i) {
     if (!iree_hal_executable_loader_query_support(
-            executable_cache->loaders[i], executable_spec->caching_mode,
-            executable_spec->executable_format)) {
+            executable_cache->loaders[i], executable_params->caching_mode,
+            executable_params->executable_format)) {
       // Loader definitely can't handle the executable; no use trying so skip.
       continue;
     }
@@ -112,7 +112,7 @@ static iree_status_t iree_hal_local_executable_cache_prepare_executable(
     // supported then the try will fail with IREE_STATUS_CANCELLED and we should
     // continue trying other loaders.
     iree_status_t status = iree_hal_executable_loader_try_load(
-        executable_cache->loaders[i], executable_spec, out_executable);
+        executable_cache->loaders[i], executable_params, out_executable);
     if (iree_status_is_ok(status)) {
       // Executable was successfully loaded.
       return status;
@@ -125,8 +125,8 @@ static iree_status_t iree_hal_local_executable_cache_prepare_executable(
   return iree_make_status(
       IREE_STATUS_NOT_FOUND,
       "no executable loader registered for the given executable format '%.*s'",
-      (int)executable_spec->executable_format.size,
-      executable_spec->executable_format.data);
+      (int)executable_params->executable_format.size,
+      executable_params->executable_format.data);
 }
 
 static const iree_hal_executable_cache_vtable_t

--- a/iree/hal/vulkan/native_executable.cc
+++ b/iree/hal/vulkan/native_executable.cc
@@ -213,10 +213,10 @@ iree_hal_vulkan_native_executable_cast(iree_hal_executable_t* base_value) {
 iree_status_t iree_hal_vulkan_native_executable_create(
     iree::hal::vulkan::VkDeviceHandle* logical_device,
     VkPipelineCache pipeline_cache,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
   IREE_ASSERT_ARGUMENT(logical_device);
-  IREE_ASSERT_ARGUMENT(executable_spec);
+  IREE_ASSERT_ARGUMENT(executable_params);
   IREE_ASSERT_ARGUMENT(out_executable);
   *out_executable = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -224,10 +224,10 @@ iree_status_t iree_hal_vulkan_native_executable_create(
   // Verify and fetch the executable flatbuffer wrapper.
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_spirv_executable_flatbuffer_verify(
-              executable_spec->executable_data,
-              executable_spec->executable_layout_count));
+              executable_params->executable_data,
+              executable_params->executable_layout_count));
   iree_SpirVExecutableDef_table_t executable_def =
-      iree_SpirVExecutableDef_as_root(executable_spec->executable_data.data);
+      iree_SpirVExecutableDef_as_root(executable_params->executable_data.data);
 
   // Create the shader module.
   flatbuffers_uint32_vec_t code_vec =
@@ -263,9 +263,10 @@ iree_status_t iree_hal_vulkan_native_executable_create(
   }
   if (iree_status_is_ok(status)) {
     status = iree_hal_vulkan_create_pipelines(
-        logical_device, pipeline_cache, executable_spec->caching_mode,
-        executable_def, shader_module, executable_spec->executable_layout_count,
-        executable_spec->executable_layouts, executable->entry_point_count,
+        logical_device, pipeline_cache, executable_params->caching_mode,
+        executable_def, shader_module,
+        executable_params->executable_layout_count,
+        executable_params->executable_layouts, executable->entry_point_count,
         executable->entry_points);
   }
   iree_hal_vulkan_destroy_shader_module(logical_device, shader_module);

--- a/iree/hal/vulkan/native_executable.h
+++ b/iree/hal/vulkan/native_executable.h
@@ -31,7 +31,7 @@ typedef struct iree_hal_vulkan_source_location_t {
 iree_status_t iree_hal_vulkan_native_executable_create(
     iree::hal::vulkan::VkDeviceHandle* logical_device,
     VkPipelineCache pipeline_cache,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable);
 
 // Returns the source location for the given entry point. May be empty if not

--- a/iree/hal/vulkan/nop_executable_cache.cc
+++ b/iree/hal/vulkan/nop_executable_cache.cc
@@ -80,13 +80,13 @@ static bool iree_hal_vulkan_nop_executable_cache_can_prepare_format(
 
 static iree_status_t iree_hal_vulkan_nop_executable_cache_prepare_executable(
     iree_hal_executable_cache_t* base_executable_cache,
-    const iree_hal_executable_spec_t* executable_spec,
+    const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
   iree_hal_vulkan_nop_executable_cache_t* executable_cache =
       iree_hal_vulkan_nop_executable_cache_cast(base_executable_cache);
   return iree_hal_vulkan_native_executable_create(
       executable_cache->logical_device,
-      /*pipeline_cache=*/VK_NULL_HANDLE, executable_spec, out_executable);
+      /*pipeline_cache=*/VK_NULL_HANDLE, executable_params, out_executable);
 }
 
 namespace {

--- a/iree/modules/hal/module.c
+++ b/iree/modules/hal/module.c
@@ -1219,19 +1219,19 @@ IREE_VM_ABI_EXPORT(iree_hal_module_executable_create,  //
 
   iree_hal_executable_t* executable = NULL;
   if (iree_status_is_ok(status)) {
-    iree_hal_executable_spec_t spec;
-    iree_hal_executable_spec_initialize(&spec);
-    spec.caching_mode |=
+    iree_hal_executable_params_t executable_params;
+    iree_hal_executable_params_initialize(&executable_params);
+    executable_params.caching_mode |=
         executable_data->access == IREE_VM_BUFFER_ACCESS_ORIGIN_MODULE
             ? IREE_HAL_EXECUTABLE_CACHING_MODE_ALIAS_PROVIDED_DATA
             : 0;
-    spec.executable_format = executable_format_str;
-    spec.executable_data = iree_make_const_byte_span(
+    executable_params.executable_format = executable_format_str;
+    executable_params.executable_data = iree_make_const_byte_span(
         executable_data->data.data, executable_data->data.data_length);
-    spec.executable_layout_count = executable_layout_count;
-    spec.executable_layouts = executable_layouts;
+    executable_params.executable_layout_count = executable_layout_count;
+    executable_params.executable_layouts = executable_layouts;
     status = iree_hal_executable_cache_prepare_executable(
-        state->executable_cache, &spec, &executable);
+        state->executable_cache, &executable_params, &executable);
   }
 
   iree_allocator_free(state->host_allocator, executable_layouts);


### PR DESCRIPTION
Matches the style of other parameter structs.