### PR TITLE
Remove features=+dotprod from fp32 benchmarks (i8-only feature)

### DIFF
--- a/benchmarks/TFLite/CMakeLists.txt
+++ b/benchmarks/TFLite/CMakeLists.txt
@@ -381,7 +381,7 @@ iree_benchmark_suite(
     "CPU-ARM64-v8A"
   TRANSLATION_FLAGS
     ${ANDROID_CPU_TRANSLATION_FLAGS}
-    "--iree-flow-mmt4d-target-options=arch=aarch64 features=+dotprod"
+    "--iree-flow-mmt4d-target-options=arch=aarch64"
   BENCHMARK_TOOL
     iree-benchmark-module
   DRIVER
@@ -410,7 +410,7 @@ iree_benchmark_suite(
     "CPU-ARM64-v8A"
   TRANSLATION_FLAGS
     ${ANDROID_CPU_TRANSLATION_FLAGS}
-    "--iree-flow-mmt4d-target-options=arch=aarch64 features=+dotprod"
+    "--iree-flow-mmt4d-target-options=arch=aarch64"
   BENCHMARK_TOOL
     iree-benchmark-module
   DRIVER
@@ -439,7 +439,7 @@ iree_benchmark_suite(
 #     "CPU-ARM64-v8A"
 #   TRANSLATION_FLAGS
 #     ${ANDROID_CPU_TRANSLATION_FLAGS}
-#     "--iree-flow-mmt4d-target-options=arch=aarch64 features=+dotprod"
+#     "--iree-flow-mmt4d-target-options=arch=aarch64"
 #   BENCHMARK_TOOL
 #     iree-benchmark-module
 #   DRIVER
@@ -466,7 +466,7 @@ iree_benchmark_suite(
 #     "CPU-ARM64-v8A"
 #   TRANSLATION_FLAGS
 #     ${ANDROID_CPU_TRANSLATION_FLAGS}
-#     "--iree-flow-mmt4d-target-options=arch=aarch64 features=+dotprod"
+#     "--iree-flow-mmt4d-target-options=arch=aarch64"
 #   BENCHMARK_TOOL
 #     iree-benchmark-module
 #   DRIVER
@@ -493,7 +493,7 @@ iree_benchmark_suite(
     "CPU-ARM64-v8A"
   TRANSLATION_FLAGS
     ${ANDROID_CPU_TRANSLATION_FLAGS}
-    "--iree-flow-mmt4d-target-options=arch=aarch64 features=+dotprod"
+    "--iree-flow-mmt4d-target-options=arch=aarch64"
   BENCHMARK_TOOL
     iree-benchmark-module
   DRIVER


### PR DESCRIPTION
Also, just adding this to the mmt4d flag without correspondingly
enabling it in the compiler backend via
`-iree-llvm-target-cpu-features=+dotprod` would have not have produced the
intended effect.