### PR TITLE
TSan instrumentation of module code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,29 @@ option(IREE_ENABLE_LLD "Use lld when linking" OFF)
 option(IREE_ENABLE_ASAN "Enable address sanitizer" OFF)
 option(IREE_ENABLE_MSAN "Enable memory sanitizer" OFF)
 option(IREE_ENABLE_TSAN "Enable thread sanitizer" OFF)
+option(IREE_BYTECODE_MODULE_ENABLE_TSAN "Enable thread sanitizer in IREE modules in tests" OFF)
+
+# STREQUAL feels wrong here - we don't care about the exact true-value used,
+# ON or TRUE or something else. But we haven't been able to think of a less bad
+# alternative. https://github.com/google/iree/pull/8474#discussion_r840790062
+if(NOT IREE_ENABLE_TSAN STREQUAL IREE_BYTECODE_MODULE_ENABLE_TSAN)
+  message(SEND_ERROR
+      "IREE_ENABLE_TSAN and IREE_BYTECODE_MODULE_ENABLE_TSAN must be "
+      "simultaneously ON or OFF. "
+      "A discrepancy between the two would cause tests to crash as IREE "
+      "runtime code (controlled by IREE_ENABLE_TSAN) calls into test IREE "
+      "modules (controlled by IREE_BYTECODE_MODULE_ENABLE_TSAN)")
+endif()
+
+if(IREE_BYTECODE_MODULE_ENABLE_TSAN)
+  if(NOT IREE_BYTECODE_MODULE_FORCE_SYSTEM_DYLIB_LINKER)
+    message(SEND_ERROR
+        "When IREE_BYTECODE_MODULE_ENABLE_TSAN is ON, "
+        "IREE_BYTECODE_MODULE_FORCE_SYSTEM_DYLIB_LINKER must also be ON. "
+        "TSAN instrumentation is not currently supported in embedded modules.")
+  endif()
+endif()
+
 option(IREE_ENABLE_CCACHE "Use ccache if installed to speed up rebuilds." OFF)
 
 if(${IREE_ENABLE_CCACHE})

--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -116,8 +116,15 @@ function(iree_bytecode_module)
     # Note: -iree-llvm-system-linker-path is left unspecified.
   endif()
 
-  if (IREE_BYTECODE_MODULE_FORCE_SYSTEM_DYLIB_LINKER)
+  if(IREE_BYTECODE_MODULE_FORCE_SYSTEM_DYLIB_LINKER)
     list(APPEND _ARGS "-iree-llvm-link-embedded=false")
+  endif()
+
+  # Support testing in TSan build dirs. Unlike other sanitizers, TSan is an
+  # ABI break: when the host code is built with TSan, the module must be too,
+  # otherwise we get crashes calling module code.
+  if(IREE_BYTECODE_MODULE_ENABLE_TSAN)
+    list(APPEND _ARGS "-iree-llvm-sanitize=thread")
   endif()
 
   # Depending on the binary instead of the target here given we might not have

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp
@@ -284,6 +284,12 @@ class LLVMAOTTargetBackend final : public TargetBackend {
           function.addFnAttr(llvm::Attribute::SanitizeAddress);
         }
       } break;
+      case SanitizerKind::kThread: {
+        libraryBuilder.setSanitizerKind(LibraryBuilder::SanitizerKind::THREAD);
+        for (auto &function : llvmModule->getFunctionList()) {
+          function.addFnAttr(llvm::Attribute::SanitizeThread);
+        }
+      } break;
     }
     auto align16 = llvm::Attribute::getWithAlignment(context, llvm::Align(16));
     for (auto entryPointOp :

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp
@@ -109,7 +109,9 @@ LLVMTargetOptions getLLVMTargetOptionsFromFlags() {
       "iree-llvm-sanitize", llvm::cl::desc("Apply LLVM sanitize feature"),
       llvm::cl::init(SanitizerKind::kNone),
       llvm::cl::values(clEnumValN(SanitizerKind::kAddress, "address",
-                                  "Address sanitizer support")));
+                                  "Address sanitizer support"),
+                       clEnumValN(SanitizerKind::kThread, "thread",
+                                  "Thread sanitizer support")));
   targetOptions.sanitizerKind = clSanitizerKind;
 
   static llvm::cl::opt<std::string> clTargetABI(

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.h
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.h
@@ -20,6 +20,7 @@ namespace HAL {
 enum class SanitizerKind {
   kNone = 0,
   kAddress,
+  kThread,
 };
 
 struct LLVMTargetOptions {

--- a/iree/hal/local/loaders/system_library_loader.c
+++ b/iree/hal/local/loaders/system_library_loader.c
@@ -179,6 +179,18 @@ static iree_status_t iree_hal_system_executable_query_library(
           "runtime is not compiled with it enabled; add -fsanitize=address to "
           "the runtime compilation options");
 #endif  // IREE_SANITIZER_ADDRESS
+#if defined(IREE_SANITIZER_THREAD)
+    case IREE_HAL_EXECUTABLE_LIBRARY_SANITIZER_THREAD:
+      // TSAN is compiled into the host and we can load this library.
+      break;
+#else
+    case IREE_HAL_EXECUTABLE_LIBRARY_SANITIZER_THREAD:
+      return iree_make_status(
+          IREE_STATUS_UNAVAILABLE,
+          "executable library is compiled with TSAN support but the host "
+          "runtime is not compiled with it enabled; add -fsanitize=thread to "
+          "the runtime compilation options");
+#endif  // IREE_SANITIZER_THREAD
     default:
       return iree_make_status(
           IREE_STATUS_UNAVAILABLE,


### PR DESCRIPTION
This implements TSan instrumentation in the IREE compiler, and adds a `IREE_BYTECODE_MODULE_ENABLE_TSAN` flag, which when set causes `iree_bytecode_module` to enable TSan instrumentation. 

When `IREE_BUILD_TESTS` is on, we enforce early that `IREE_ENABLE_TSAN` and `IREE_BYTECODE_MODULE_ENABLE_TSAN` agree, as we would otherwise get test crashes anyway.

`IREE_BYTECODE_MODULE_ENABLE_TSAN` also requires `IREE_BYTECODE_MODULE_FORCE_SYSTEM_DYLIB_LINKER` to be set. That too is enforced early.

Putting all that together, with this PR, the incantation to build tests with TSan is:
```
cmake \
  -DIREE_BUILD_TESTS=ON \
  -DIREE_ENABLE_TSAN=ON \
  -DIREE_BYTECODE_MODULE_ENABLE_TSAN=ON \
  -DIREE_BYTECODE_MODULE_FORCE_SYSTEM_DYLIB_LINKER=ON \
   ...other flags...

cmake --build .
cmake --build . --target iree-test-deps
```

So clearly this isn't optimal in the sense of minimizing required typing to enable TSan, but at least this is optimizing "options that do one clear thing each" and "reuse existing cmake logic (`IREE_BYTECODE_MODULE_FORCE_SYSTEM_DYLIB_LINKER`).

This PR is ending up simpler than anticipated because
* We used to have trouble with `iree_bytecode_module` setting the system-linker-path but that was fixed in #8591
* We used to have to handle switching to the system-linker as opposed to embedded-linker, but the cmake infra for that (`IREE_BYTECODE_MODULE_FORCE_SYSTEM_DYLIB_LINKER`) was added in #8659 .
* We used to run into lots of trouble with TSan apparently not supporting vectors with more than 16 elements, I first tackled that using LLVM Scalarizer pass but ran into a [bug](https://github.com/llvm/llvm-project/issues/54469), then I wrote another approach using VectorUnrollPatterns ([diff here](https://gist.github.com/bjacob/b0d967327ab53574d99d8ff9875f582c)), but in the end I noticed that none of this seemed to be needed anymore --- I want to believe that that's because something was changed in LLVM but I haven't been able to pinpoint it. Anyway, if we run into issues where some vector load/stores of more than 16 elements are not tsan-instrumented, we can revive that diff.