### PR TITLE
Improve and log error message for tflite bindings model init.

### DIFF
--- a/bindings/tflite/model.c
+++ b/bindings/tflite/model.c
@@ -59,7 +59,8 @@ static iree_status_t _TfLiteModelInitializeModule(const void* flatbuffer_data,
       iree_vm_module_lookup_function_by_name(
           model->module, IREE_VM_FUNCTION_LINKAGE_EXPORT,
           iree_make_cstring_view("_tflite_main"), &model->exports._main),
-      "unable to find '_tflite_main' export in module");
+      "unable to find '_tflite_main' export in module, ensure the "
+      "`-iree-tflite-bindings-support` flag was set when compiling your model");
 
   // Get the input and output counts of the function; this is useful for being
   // able to preallocate storage when creating interpreters.
@@ -122,7 +123,9 @@ TFL_CAPI_EXPORT extern TfLiteModel* TfLiteModelCreate(const void* model_data,
 
   status =
       _TfLiteModelInitializeModule(model_data, model_size, allocator, model);
-  if (!iree_status_is_ok(iree_status_consume_code(status))) {
+  if (!iree_status_is_ok(status)) {
+    iree_status_fprint(stderr, status);
+    iree_status_free(status);
     iree_allocator_free(allocator, model);
     IREE_TRACE_ZONE_END(z0);
     return NULL;

--- a/bindings/tflite/model.c
+++ b/bindings/tflite/model.c
@@ -59,8 +59,8 @@ static iree_status_t _TfLiteModelInitializeModule(const void* flatbuffer_data,
       iree_vm_module_lookup_function_by_name(
           model->module, IREE_VM_FUNCTION_LINKAGE_EXPORT,
           iree_make_cstring_view("_tflite_main"), &model->exports._main),
-      "unable to find '_tflite_main' export in module, ensure the "
-      "`-iree-tflite-bindings-support` flag was set when compiling your model");
+      "unable to find '_tflite_main' export in module, module must be compiled "
+      "with tflite bindings support");
 
   // Get the input and output counts of the function; this is useful for being
   // able to preallocate storage when creating interpreters.


### PR DESCRIPTION
This should help with issues like https://github.com/google/iree/issues/8412

I also noticed a lot of `IREE_TRACE_MESSAGE` use in https://github.com/google/iree/blob/main/bindings/tflite/model.c, which only logs to Tracy. Those could be turned in to `IREE_LOG` or `IREE_DLOG` (or we could add a macro that does both).