### PR TITLE
Enable Vulkan benchmarking on Moto Edge X30

### DIFF
--- a/build_tools/buildkite/cmake/android/arm64-v8a/benchmark2.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/benchmark2.yml
@@ -63,6 +63,26 @@ steps:
       - "trace-captures-galaxy-pixel6-pro-${BUILDKITE_BUILD_NUMBER}.tgz"
     timeout_in_minutes: "60"
 
+  - label: "Benchmark on Moto Edge X30 (snapdragon-8gen1, adreno-730)"
+    commands:
+      - "git clean -fdx"
+      - "buildkite-agent artifact download --step Build benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz ./"
+      - "buildkite-agent artifact download --step Build iree-android-tools-${BUILDKITE_BUILD_NUMBER}.tgz ./"
+      - "wget https://storage.googleapis.com/iree-shared-files/tracy-capture-058e8901.tgz"
+      - "tar -xzvf benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz"
+      - "tar -xzvf iree-android-tools-${BUILDKITE_BUILD_NUMBER}.tgz"
+      - "tar -xzvf tracy-capture-058e8901.tgz"
+      - "python3 build_tools/benchmarks/run_benchmarks_on_android.py --pin-cpu-freq --pin-gpu-freq --normal_benchmark_tool_dir=build-android/iree/tools/ --traced_benchmark_tool_dir=build-android-trace/iree/tools/ --trace_capture_tool=tracy-capture -o benchmark-results-galaxy-moto-edge-x30-${BUILDKITE_BUILD_NUMBER}.json --capture_tarball=trace-captures-galaxy-moto-edge-x30-${BUILDKITE_BUILD_NUMBER}.tgz --driver_filter_regex='vulkan' --verbose build-host/"
+    if: "build.pull_request.id == null || (build.pull_request.labels includes 'buildkite:benchmark')"
+    agents:
+      - "android-soc=snapdragon-8gen1"
+      - "android-version=12"
+      - "queue=benchmark-android"
+    artifact_paths:
+      - "benchmark-results-galaxy-moto-edge-x30-${BUILDKITE_BUILD_NUMBER}.json"
+      - "trace-captures-galaxy-moto-edge-x30-${BUILDKITE_BUILD_NUMBER}.tgz"
+    timeout_in_minutes: "60"
+
   - wait
 
   - label: "Comment benchmark results on pull request"


### PR DESCRIPTION
Another step before landing #8018, which would disable
benchmarking on Pixel 4. This makes sure we have another
device tracking Adreno GPU performance.