### PR TITLE
Splitting mobile benchmarks into CPU + GPU.

### DIFF
--- a/build_tools/buildkite/cmake/android/arm64-v8a/benchmark2.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/benchmark2.yml
@@ -23,7 +23,7 @@ steps:
 
   - wait
 
-  - label: "Benchmark on Pixel 4 (snapdragon-855, adreno-640)"
+  - label: "Benchmark CPU on Pixel 4 (snapdragon-855, adreno-640)"
     commands:
       - "git clean -fdx"
       - "buildkite-agent artifact download --step Build benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz ./"
@@ -32,18 +32,18 @@ steps:
       - "tar -xzvf benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz"
       - "tar -xzvf iree-android-tools-${BUILDKITE_BUILD_NUMBER}.tgz"
       - "tar -xzvf tracy-capture-058e8901.tgz"
-      - "python3 build_tools/benchmarks/run_benchmarks_on_android.py --pin-cpu-freq --pin-gpu-freq --normal_benchmark_tool_dir=build-android/iree/tools/ --traced_benchmark_tool_dir=build-android-trace/iree/tools/ --trace_capture_tool=tracy-capture -o benchmark-results-pixel-4-${BUILDKITE_BUILD_NUMBER}.json --capture_tarball=trace-captures-pixel-4-${BUILDKITE_BUILD_NUMBER}.tgz --verbose build-host/"
+      - "python3 build_tools/benchmarks/run_benchmarks_on_android.py --pin-cpu-freq --pin-gpu-freq --normal_benchmark_tool_dir=build-android/iree/tools/ --traced_benchmark_tool_dir=build-android-trace/iree/tools/ --trace_capture_tool=tracy-capture -o benchmark-results-pixel-4-cpu-${BUILDKITE_BUILD_NUMBER}.json --capture_tarball=trace-captures-pixel-4-cpu-${BUILDKITE_BUILD_NUMBER}.tgz --driver_filter_regex='(?!vulkan).*' --verbose build-host/"
     if: "build.pull_request.id == null || (build.pull_request.labels includes 'buildkite:benchmark')"
     agents:
       - "android-soc=snapdragon-855"
       - "android-version=12"
       - "queue=benchmark-android"
     artifact_paths:
-      - "benchmark-results-pixel-4-${BUILDKITE_BUILD_NUMBER}.json"
-      - "trace-captures-pixel-4-${BUILDKITE_BUILD_NUMBER}.tgz"
+      - "benchmark-results-pixel-4-cpu-${BUILDKITE_BUILD_NUMBER}.json"
+      - "trace-captures-pixel-4-cpu-${BUILDKITE_BUILD_NUMBER}.tgz"
     timeout_in_minutes: "60"
 
-  - label: "Benchmark on Pixel 6 Pro (google-tensor, mali-g78)"
+  - label: "Benchmark GPU on Pixel 4 (snapdragon-855, adreno-640)"
     commands:
       - "git clean -fdx"
       - "buildkite-agent artifact download --step Build benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz ./"
@@ -52,18 +52,38 @@ steps:
       - "tar -xzvf benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz"
       - "tar -xzvf iree-android-tools-${BUILDKITE_BUILD_NUMBER}.tgz"
       - "tar -xzvf tracy-capture-058e8901.tgz"
-      - "python3 build_tools/benchmarks/run_benchmarks_on_android.py --pin-cpu-freq --pin-gpu-freq --normal_benchmark_tool_dir=build-android/iree/tools/ --traced_benchmark_tool_dir=build-android-trace/iree/tools/ --trace_capture_tool=tracy-capture -o benchmark-results-galaxy-pixel6-pro-${BUILDKITE_BUILD_NUMBER}.json --capture_tarball=trace-captures-galaxy-pixel6-pro-${BUILDKITE_BUILD_NUMBER}.tgz --verbose build-host/"
+      - "python3 build_tools/benchmarks/run_benchmarks_on_android.py --pin-cpu-freq --pin-gpu-freq --normal_benchmark_tool_dir=build-android/iree/tools/ --traced_benchmark_tool_dir=build-android-trace/iree/tools/ --trace_capture_tool=tracy-capture -o benchmark-results-pixel-4-gpu-${BUILDKITE_BUILD_NUMBER}.json --capture_tarball=trace-captures-pixel-4-gpu-${BUILDKITE_BUILD_NUMBER}.tgz --driver_filter_regex='vulkan' --verbose build-host/"
+    if: "build.pull_request.id == null || (build.pull_request.labels includes 'buildkite:benchmark')"
+    agents:
+      - "android-soc=snapdragon-855"
+      - "android-version=12"
+      - "queue=benchmark-android"
+    artifact_paths:
+      - "benchmark-results-pixel-4-gpu-${BUILDKITE_BUILD_NUMBER}.json"
+      - "trace-captures-pixel-4-gpu-${BUILDKITE_BUILD_NUMBER}.tgz"
+    timeout_in_minutes: "60"
+
+  - label: "Benchmark CPU on Pixel 6 Pro (google-tensor, mali-g78)"
+    commands:
+      - "git clean -fdx"
+      - "buildkite-agent artifact download --step Build benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz ./"
+      - "buildkite-agent artifact download --step Build iree-android-tools-${BUILDKITE_BUILD_NUMBER}.tgz ./"
+      - "wget https://storage.googleapis.com/iree-shared-files/tracy-capture-058e8901.tgz"
+      - "tar -xzvf benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz"
+      - "tar -xzvf iree-android-tools-${BUILDKITE_BUILD_NUMBER}.tgz"
+      - "tar -xzvf tracy-capture-058e8901.tgz"
+      - "python3 build_tools/benchmarks/run_benchmarks_on_android.py --pin-cpu-freq --pin-gpu-freq --normal_benchmark_tool_dir=build-android/iree/tools/ --traced_benchmark_tool_dir=build-android-trace/iree/tools/ --trace_capture_tool=tracy-capture -o benchmark-results-galaxy-pixel6-pro-cpu-${BUILDKITE_BUILD_NUMBER}.json --capture_tarball=trace-captures-galaxy-pixel6-pro-cpu-${BUILDKITE_BUILD_NUMBER}.tgz --driver_filter_regex='(?!vulkan).*' --verbose build-host/"
     if: "build.pull_request.id == null || (build.pull_request.labels includes 'buildkite:benchmark')"
     agents:
       - "android-soc=google-tensor"
       - "android-version=12"
       - "queue=benchmark-android"
     artifact_paths:
-      - "benchmark-results-galaxy-pixel6-pro-${BUILDKITE_BUILD_NUMBER}.json"
-      - "trace-captures-galaxy-pixel6-pro-${BUILDKITE_BUILD_NUMBER}.tgz"
+      - "benchmark-results-galaxy-pixel6-pro-cpu-${BUILDKITE_BUILD_NUMBER}.json"
+      - "trace-captures-galaxy-pixel6-pro-cpu-${BUILDKITE_BUILD_NUMBER}.tgz"
     timeout_in_minutes: "60"
 
-  - label: "Benchmark on Moto Edge X30 (snapdragon-8gen1, adreno-730)"
+  - label: "Benchmark GPU on Pixel 6 Pro (google-tensor, mali-g78)"
     commands:
       - "git clean -fdx"
       - "buildkite-agent artifact download --step Build benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz ./"
@@ -72,15 +92,35 @@ steps:
       - "tar -xzvf benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz"
       - "tar -xzvf iree-android-tools-${BUILDKITE_BUILD_NUMBER}.tgz"
       - "tar -xzvf tracy-capture-058e8901.tgz"
-      - "python3 build_tools/benchmarks/run_benchmarks_on_android.py --pin-cpu-freq --pin-gpu-freq --normal_benchmark_tool_dir=build-android/iree/tools/ --traced_benchmark_tool_dir=build-android-trace/iree/tools/ --trace_capture_tool=tracy-capture -o benchmark-results-galaxy-moto-edge-x30-${BUILDKITE_BUILD_NUMBER}.json --capture_tarball=trace-captures-galaxy-moto-edge-x30-${BUILDKITE_BUILD_NUMBER}.tgz --driver_filter_regex='vulkan' --verbose build-host/"
+      - "python3 build_tools/benchmarks/run_benchmarks_on_android.py --pin-cpu-freq --pin-gpu-freq --normal_benchmark_tool_dir=build-android/iree/tools/ --traced_benchmark_tool_dir=build-android-trace/iree/tools/ --trace_capture_tool=tracy-capture -o benchmark-results-galaxy-pixel6-pro-gpu-${BUILDKITE_BUILD_NUMBER}.json --capture_tarball=trace-captures-galaxy-pixel6-pro-gpu-${BUILDKITE_BUILD_NUMBER}.tgz --driver_filter_regex='vulkan' --verbose build-host/"
+    if: "build.pull_request.id == null || (build.pull_request.labels includes 'buildkite:benchmark')"
+    agents:
+      - "android-soc=google-tensor"
+      - "android-version=12"
+      - "queue=benchmark-android"
+    artifact_paths:
+      - "benchmark-results-galaxy-pixel6-pro-gpu-${BUILDKITE_BUILD_NUMBER}.json"
+      - "trace-captures-galaxy-pixel6-pro-gpu-${BUILDKITE_BUILD_NUMBER}.tgz"
+    timeout_in_minutes: "60"
+
+  - label: "Benchmark GPU on Moto Edge X30 (snapdragon-8gen1, adreno-730)"
+    commands:
+      - "git clean -fdx"
+      - "buildkite-agent artifact download --step Build benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz ./"
+      - "buildkite-agent artifact download --step Build iree-android-tools-${BUILDKITE_BUILD_NUMBER}.tgz ./"
+      - "wget https://storage.googleapis.com/iree-shared-files/tracy-capture-058e8901.tgz"
+      - "tar -xzvf benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz"
+      - "tar -xzvf iree-android-tools-${BUILDKITE_BUILD_NUMBER}.tgz"
+      - "tar -xzvf tracy-capture-058e8901.tgz"
+      - "python3 build_tools/benchmarks/run_benchmarks_on_android.py --pin-cpu-freq --pin-gpu-freq --normal_benchmark_tool_dir=build-android/iree/tools/ --traced_benchmark_tool_dir=build-android-trace/iree/tools/ --trace_capture_tool=tracy-capture -o benchmark-results-galaxy-moto-edge-x30-gpu-${BUILDKITE_BUILD_NUMBER}.json --capture_tarball=trace-captures-galaxy-moto-edge-x30-gpu-${BUILDKITE_BUILD_NUMBER}.tgz --driver_filter_regex='vulkan' --verbose build-host/"
     if: "build.pull_request.id == null || (build.pull_request.labels includes 'buildkite:benchmark')"
     agents:
       - "android-soc=snapdragon-8gen1"
       - "android-version=12"
       - "queue=benchmark-android"
     artifact_paths:
-      - "benchmark-results-galaxy-moto-edge-x30-${BUILDKITE_BUILD_NUMBER}.json"
-      - "trace-captures-galaxy-moto-edge-x30-${BUILDKITE_BUILD_NUMBER}.tgz"
+      - "benchmark-results-galaxy-moto-edge-x30-gpu-${BUILDKITE_BUILD_NUMBER}.json"
+      - "trace-captures-galaxy-moto-edge-x30-gpu-${BUILDKITE_BUILD_NUMBER}.tgz"
     timeout_in_minutes: "60"
 
   - wait


### PR DESCRIPTION
The goal is to reduce latency by using multiple devices.
Each configuration still fetches the artifacts for all of them and that
takes a decent chunk of time - we could split them up in
build_android_benchmark.sh to make that better.