### PR TITLE
Remove iree-mlir-lsp-server from `all` target.

### DIFF
--- a/build_tools/cmake/iree_cc_binary.cmake
+++ b/build_tools/cmake/iree_cc_binary.cmake
@@ -49,9 +49,9 @@ include(CMakeParseArguments)
 function(iree_cc_binary)
   cmake_parse_arguments(
     _RULE
-    "HOSTONLY;TESTONLY"
+    "EXCLUDE_FROM_ALL;HOSTONLY;TESTONLY"
     "NAME"
-    "SRCS;COPTS;DEFINES;EXCLUDE_FROM_ALL;LINKOPTS;DATA;DEPS"
+    "SRCS;COPTS;DEFINES;LINKOPTS;DATA;DEPS"
     ${ARGN}
   )
 
@@ -134,7 +134,7 @@ function(iree_cc_binary)
   set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD ${IREE_CXX_STANDARD})
   set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
 
-  if (${_RULE_EXCLUDE_FROM_ALL})
+  if(_RULE_EXCLUDE_FROM_ALL)
     set_property(TARGET ${_NAME} PROPERTY EXCLUDE_FROM_ALL ON)
     install(TARGETS ${_NAME}
             RENAME ${_RULE_NAME}

--- a/build_tools/cmake/iree_cc_binary.cmake
+++ b/build_tools/cmake/iree_cc_binary.cmake
@@ -51,7 +51,7 @@ function(iree_cc_binary)
     _RULE
     "HOSTONLY;TESTONLY"
     "NAME"
-    "SRCS;COPTS;DEFINES;LINKOPTS;DATA;DEPS"
+    "SRCS;COPTS;DEFINES;EXCLUDE_FROM_ALL;LINKOPTS;DATA;DEPS"
     ${ARGN}
   )
 
@@ -134,8 +134,17 @@ function(iree_cc_binary)
   set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD ${IREE_CXX_STANDARD})
   set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
 
-  install(TARGETS ${_NAME}
-          RENAME ${_RULE_NAME}
-          COMPONENT ${_RULE_NAME}
-          RUNTIME DESTINATION bin)
+  if (${_RULE_EXCLUDE_FROM_ALL})
+    set_property(TARGET ${_NAME} PROPERTY EXCLUDE_FROM_ALL ON)
+    install(TARGETS ${_NAME}
+            RENAME ${_RULE_NAME}
+            COMPONENT ${_RULE_NAME}
+            RUNTIME DESTINATION bin
+            EXCLUDE_FROM_ALL)
+  else()
+    install(TARGETS ${_NAME}
+      RENAME ${_RULE_NAME}
+      COMPONENT ${_RULE_NAME}
+      RUNTIME DESTINATION bin)
+  endif()
 endfunction()

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -440,7 +440,7 @@ if(${IREE_BUILD_COMPILER})
     PUBLIC
     EXCLUDE_FROM_ALL
   )
-  
+
   iree_cc_binary(
     NAME
       iree-run-mlir

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -438,10 +438,9 @@ if(${IREE_BUILD_COMPILER})
       MLIRLspServerLib
       MLIRSupport
     PUBLIC
+    EXCLUDE_FROM_ALL
   )
-  set_target_properties(iree_tools_iree-mlir-lsp-server
-    PROPERTIES EXCLUDE_FROM_ALL ON)
-
+  
   iree_cc_binary(
     NAME
       iree-run-mlir

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -439,6 +439,8 @@ if(${IREE_BUILD_COMPILER})
       MLIRSupport
     PUBLIC
   )
+  set_target_properties(iree_tools_iree-mlir-lsp-server
+    PROPERTIES EXCLUDE_FROM_ALL ON)
 
   iree_cc_binary(
     NAME


### PR DESCRIPTION
This binary takes a long time to compile, and only needs to be
compiled rarely.