### PR TITLE
Add missing build step to RISC-V building from source docs.

### DIFF
--- a/docs/website/docs/building-from-source/riscv.md
+++ b/docs/website/docs/building-from-source/riscv.md
@@ -81,6 +81,7 @@ cmake -GNinja -B ../iree-build-riscv/ \
   -DIREE_BUILD_COMPILER=OFF \
   -DRISCV_TOOLCHAIN_ROOT=${RISCV_TOOLCHAIN_ROOT} \
   .
+cmake --build ../iree-build-riscv/
 ```
 
 ## Running IREE bytecode modules on the RISC-V system


### PR DESCRIPTION
Fixes https://github.com/google/iree/issues/8493 (unless there are further questions there)

This matches the other docs, such as https://google.github.io/iree/building-from-source/android/#target-configuration