### PR TITLE
[spirv] Invoke GLSL canonicalization in the pipeline

### DIFF
--- a/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -127,6 +127,7 @@ static void addSPIRVLoweringPasses(OpPassManager &pm) {
   spirvPM.addPass(spirv::createLowerABIAttributesPass());
   spirvPM.addPass(createCanonicalizerPass());
   spirvPM.addPass(createCSEPass());
+  spirvPM.addPass(spirv::createCanonicalizeGLSLPass());
   spirvPM.addPass(spirv::createUpdateVersionCapabilityExtensionPass());
 }
 


### PR DESCRIPTION
This helps to clean up IRs by using certain ops from GLSL
extended instruction set.