### PR TITLE
Revert "Add a pattern to adapt linalg.generic inputs to outputs."

### DIFF
--- a/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
+++ b/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
@@ -26,7 +26,6 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/EquivalenceClasses.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -39,7 +38,6 @@
 #include "mlir/IR/Value.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
 
 namespace mlir {
@@ -51,10 +49,6 @@ class ConvertToDestinationPassingStylePass
           ConvertToDestinationPassingStylePass> {
  public:
   ConvertToDestinationPassingStylePass() = default;
-
-  void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<linalg::LinalgDialect>();
-  }
   void runOnOperation() override;
 };
 }  // namespace
@@ -311,85 +305,9 @@ static LogicalResult duplicateInitTensorOps(OpBuilder &b,
   return success();
 }
 
-namespace {
-SmallVector<NamedAttribute> PruneAttributeList(linalg::GenericOp op) {
-  auto opAttributes = op.getAttributeNames();
-  llvm::StringSet<> elidedAttrs;
-  elidedAttrs.insert(opAttributes.begin(), opAttributes.end());
-  SmallVector<NamedAttribute> preservedAttrs;
-  for (auto attr : op->getAttrs()) {
-    if (elidedAttrs.count(attr.getName())) continue;
-    preservedAttrs.push_back(attr);
-  }
-  return preservedAttrs;
-}
-
-/// Adapts Linalg ops input operand to output operand. This is required for not
-/// creating extra alloca ops. For more details, see
-/// https://github.com/google/iree/issues/8303
-struct AdaptLinalgInputOperandToOutputOperand
-    : public OpRewritePattern<linalg::GenericOp> {
-  using OpRewritePattern<linalg::GenericOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(linalg::GenericOp op,
-                                PatternRewriter &rewriter) const override {
-    // All the loops should be parallel loops.
-    if (op.getNumLoops() != op.getNumParallelLoops()) return failure();
-    // There is only one result tensor.
-    if (op->getNumResults() != 1) return failure();
-    // The output tensor is unused in the body computation.
-    auto outputOperand = op.getOutputOperand(0);
-    if (op.payloadUsesValueFromOperand(outputOperand)) return failure();
-
-    // Find an input operand that has the same indexing map and type.
-    OpOperand *operand = nullptr;
-    SmallVector<Value> newOperands;
-    SmallVector<AffineMap> maps;
-    for (auto in : op.getInputOperands()) {
-      if (!operand &&
-          op.getTiedIndexingMap(in) == op.getTiedIndexingMap(outputOperand) &&
-          in->get().getType() == outputOperand->get().getType()) {
-        operand = in;
-      } else {
-        newOperands.push_back(in->get());
-        maps.push_back(op.getTiedIndexingMap(in));
-      }
-    }
-    if (!operand) return failure();
-    maps.push_back(op.getTiedIndexingMap(operand));
-
-    Location loc = op.getLoc();
-    SmallVector<StringRef> iterTypes(op.getNumLoops(),
-                                     getParallelIteratorTypeName());
-    auto newOp = rewriter.create<linalg::GenericOp>(
-        loc, op.getResultTypes(), newOperands, operand->get(), maps, iterTypes,
-        /*bodyBuild=*/nullptr, PruneAttributeList(op));
-    rewriter.inlineRegionBefore(op.region(), newOp.region(),
-                                newOp.region().begin());
-
-    // Repair the payload entry block.
-    Block &payload = newOp.region().front();
-    payload.getArgument(operand->getOperandNumber())
-        .replaceAllUsesWith(payload.getArgument(op.getNumInputs()));
-    payload.eraseArgument(operand->getOperandNumber());
-
-    rewriter.replaceOp(op, newOp.getResults());
-    return success();
-  }
-};
-}  // namespace
-
 void ConvertToDestinationPassingStylePass::runOnOperation() {
   FuncOp funcOp = getOperation();
   MLIRContext *context = &getContext();
-
-  {
-    RewritePatternSet patterns(context);
-    patterns.insert<AdaptLinalgInputOperandToOutputOperand>(context);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
-      return signalPassFailure();
-    }
-  }
 
   OpBuilder b(context);
   SmallVector<linalg::InitTensorOp> initTensorOps;

--- a/iree/compiler/Codegen/Common/test/convert_to_destination_passing_style.mlir
+++ b/iree/compiler/Codegen/Common/test/convert_to_destination_passing_style.mlir
@@ -192,10 +192,12 @@ func @reshape_fused_source() {
 //      CHECK: func @reshape_fused_source()
 //  CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
 //  CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
+//      CHECK:   %[[TARGET:.+]] = flow.dispatch.tensor.load %[[RET0]]
 //      CHECK:   %[[SOURCE:.+]] = flow.dispatch.tensor.load %[[ARG0]]
 //      CHECK:   %[[RESHAPE:.+]] = tensor.expand_shape %[[SOURCE]]
 //      CHECK:   %[[GENERIC:.+]] = linalg.generic
-// CHECK-SAME:       outs(%[[RESHAPE]]
+// CHECK-SAME:       ins(%[[RESHAPE]]
+// CHECK-SAME:       outs(%[[TARGET]]
 //      CHECK:   flow.dispatch.tensor.store %[[GENERIC]], %[[RET0]]
 
 // -----
@@ -227,11 +229,13 @@ func @reshape_fused_source_and_copyout() {
 //      CHECK: func @reshape_fused_source_and_copyout()
 //  CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
 //  CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
+//  CHECK-DAG:   %[[TARGET:.+]] = flow.dispatch.tensor.load %[[RET0]]
 //  CHECK-DAG:   %[[RET1:.+]] = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer)
 //      CHECK:   %[[SOURCE:.+]] = flow.dispatch.tensor.load %[[ARG0]]
 //      CHECK:   %[[RESHAPE:.+]] = tensor.expand_shape %[[SOURCE]]
 //      CHECK:   %[[GENERIC:.+]] = linalg.generic
-// CHECK-SAME:       outs(%[[RESHAPE]]
+// CHECK-SAME:       ins(%[[RESHAPE]]
+// CHECK-SAME:       outs(%[[TARGET]]
 //      CHECK:   flow.dispatch.tensor.store %[[GENERIC]], %[[RET0]]
 //      CHECK:   flow.dispatch.tensor.store %[[RESHAPE]], %[[RET1]]
 
@@ -263,8 +267,11 @@ func @reshape_fused_target() {
 //  CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
 //  CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
 //  CHECK-DAG:   %[[SOURCE:.+]] = flow.dispatch.tensor.load %[[ARG0]]
+//  CHECK-DAG:   %[[TARGET:.+]] = flow.dispatch.tensor.load %[[RET0]]
+//  CHECK-DAG:   %[[RESHAPE_EXPAND:.+]] = tensor.expand_shape %[[TARGET]] {{\[}}[0, 1]{{\]}}
 //      CHECK:   %[[GENERIC:.+]] = linalg.generic
-// CHECK-SAME:       outs(%[[SOURCE]]
+// CHECK-SAME:       ins(%[[SOURCE]]
+// CHECK-SAME:       outs(%[[RESHAPE_EXPAND]]
 //      CHECK:   %[[RESHAPE_COLLAPSE:.+]] = tensor.collapse_shape %[[GENERIC]] {{\[}}[0, 1]{{\]}}
 //      CHECK:   flow.dispatch.tensor.store %[[RESHAPE_COLLAPSE]], %[[RET0]]
 
@@ -456,11 +463,14 @@ func @unused_ins_operand() {
 //   CHECK-DAG:   %[[IN:.+]] = hal.interface.binding.subspan set(0) binding(0)
 //   CHECK-DAG:   %[[OUT:.+]] = hal.interface.binding.subspan set(0) binding(2)
 //   CHECK-DAG:   %[[IN_VIEW:.+]] = flow.dispatch.tensor.load %[[IN]]
+//   CHECK-DAG:   %[[OUT_VIEW:.+]] = flow.dispatch.tensor.load %[[OUT]]
 //   CHECK-DAG:   %[[INIT:.+]] = linalg.init_tensor
 //       CHECK:   linalg.generic
-//  CHECK-SAME:       ins(%[[INIT]]
-//  CHECK-SAME:       outs(%[[IN_VIEW]]
+//  CHECK-SAME:       ins(%[[IN_VIEW]], %[[INIT]]
+//  CHECK-SAME:       outs(%[[OUT_VIEW]]
+
 // -----
+
 func @three_init_tensor_uses() {
   %c6400 = arith.constant 6400 : index
   %c64 = arith.constant 64 : index
@@ -513,53 +523,7 @@ func @three_init_tensor_uses() {
 //       CHECK:   %[[LOAD:.+]] = flow.dispatch.tensor.load %[[OUTPUT]]
 //   CHECK-NOT:   linalg.init_tensor
 //       CHECK:   linalg.fill(%{{.+}}, %[[LOAD]])
-//       CHECK:   %[[MATMUL:.+]] = linalg.matmul
-//       CHECK:   %[[GENERIC:.+]] = linalg.generic
-//  CHECK-SAME:       outs(%[[MATMUL]] :
 //       CHECK:   linalg.generic
-//  CHECK-SAME:       outs(%[[GENERIC]] :
-
-// -----
-
-func @fill_matmul_exp() {
-  %cst = arith.constant 0.000000e+00 : f32
-  %c0 = arith.constant 0 : index
-  %c33 = arith.constant 33 : index
-  %c49 = arith.constant 49 : index
-  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(32) : !flow.dispatch.tensor<readonly:33x16xf32>
-  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(32) : !flow.dispatch.tensor<readonly:16x49xf32>
-  %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(32) : !flow.dispatch.tensor<writeonly:33x49xf32>
-  %workgroup_id_x = hal.interface.workgroup.id[0] : index
-  %workgroup_count_x = hal.interface.workgroup.count[0] : index
-  %workgroup_id_y = hal.interface.workgroup.id[1] : index
-  %workgroup_count_y = hal.interface.workgroup.count[1] : index
-  %3 = affine.apply affine_map<()[s0] -> (s0 * 16)>()[%workgroup_id_y]
-  %4 = affine.apply affine_map<()[s0] -> (s0 * 16)>()[%workgroup_count_y]
-  scf.for %arg0 = %3 to %c33 step %4 {
-    %5 = affine.apply affine_map<()[s0] -> (s0 * 16)>()[%workgroup_id_x]
-    %6 = affine.apply affine_map<()[s0] -> (s0 * 16)>()[%workgroup_count_x]
-    scf.for %arg1 = %5 to %c49 step %6 {
-      %7 = affine.min affine_map<(d0) -> (16, -d0 + 33)>(%arg0)
-      %8 = affine.min affine_map<(d0) -> (16, -d0 + 49)>(%arg1)
-      %9 = linalg.init_tensor [%7, %8] : tensor<?x?xf32>
-      %10 = affine.min affine_map<(d0) -> (-d0 + 33, 16)>(%arg0)
-      %11 = flow.dispatch.tensor.load %0, offsets = [%arg0, 0], sizes = [%10, 16], strides = [1, 1] : !flow.dispatch.tensor<readonly:33x16xf32> -> tensor<?x16xf32>
-      %12 = affine.min affine_map<(d0) -> (-d0 + 49, 16)>(%arg1)
-      %13 = flow.dispatch.tensor.load %1, offsets = [0, %arg1], sizes = [16, %12], strides = [1, 1] : !flow.dispatch.tensor<readonly:16x49xf32> -> tensor<16x?xf32>
-      %14 = linalg.init_tensor [%10, %12] : tensor<?x?xf32>
-      %15 = linalg.fill(%cst, %14) : f32, tensor<?x?xf32> -> tensor<?x?xf32>
-      %16 = linalg.matmul {lowering.config = #iree_codegen.lowering.config<tile_sizes = [[], [8, 0, 0], [0, 0, 16]], native_vector_size = []>} ins(%11, %13 : tensor<?x16xf32>, tensor<16x?xf32>) outs(%15 : tensor<?x?xf32>) -> tensor<?x?xf32>
-      %17 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%16 : tensor<?x?xf32>) outs(%9 : tensor<?x?xf32>) {
-      ^bb0(%arg2: f32, %arg3: f32):
-        %18 = math.exp %arg2 : f32
-        linalg.yield %18 : f32
-      } -> tensor<?x?xf32>
-      flow.dispatch.tensor.store %17, %2, offsets = [%arg0, %arg1], sizes = [%7, %8], strides = [1, 1] : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:33x49xf32>
-    }
-  }
-  return
-}
-// CHECK-LABEL: func @fill_matmul_exp()
-//       CHECK:   %[[MATMUL:.+]] = linalg.matmul
+//  CHECK-SAME:       outs(%[[LOAD]] :
 //       CHECK:   linalg.generic
-//  CHECK-SAME:       outs(%[[MATMUL]]
+//  CHECK-SAME:       outs(%[[LOAD]] :


### PR DESCRIPTION
Reverts google/iree#8440

This PR introduces other memref.alloca op issues. The memref.alloca ops are created even in simple input IR. E.g.,

```mlir
func @add() -> tensor<33x49xf32> {
  %lhs = util.unfoldable_constant dense<1.0> : tensor<33x49xf32>
  %rhs = util.unfoldable_constant dense<0.5> : tensor<33x49xf32>
  %0 = mhlo.add %lhs, %rhs : tensor<33x49xf32>
  return %0 : tensor<33x49xf32>
}
```

Since we have https://github.com/google/iree/commit/da06cc91a85b1317a3c5cf6b890386364094fa3a checked in, we can try to vectorize all the operations to avoid the issue.