### PR TITLE
Do not adapt Linalg ops when the input is from ReadOnly tensors.

### DIFF
--- a/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
+++ b/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
@@ -311,8 +311,7 @@ static LogicalResult duplicateInitTensorOps(OpBuilder &b,
   return success();
 }
 
-namespace {
-SmallVector<NamedAttribute> PruneAttributeList(linalg::GenericOp op) {
+static SmallVector<NamedAttribute> PruneAttributeList(linalg::GenericOp op) {
   auto opAttributes = op.getAttributeNames();
   llvm::StringSet<> elidedAttrs;
   elidedAttrs.insert(opAttributes.begin(), opAttributes.end());
@@ -324,6 +323,26 @@ SmallVector<NamedAttribute> PruneAttributeList(linalg::GenericOp op) {
   return preservedAttrs;
 }
 
+static bool isFromReadOnlyTensor(Value v) {
+  return TypeSwitch<Operation *, bool>(v.getDefiningOp())
+      .Case<arith::ConstantOp>(
+          [&](arith::ConstantOp constantOp) { return true; })
+      .Case<tensor::CollapseShapeOp, tensor::ExpandShapeOp>(
+          [&](auto op) { return isFromReadOnlyTensor(op.src()); })
+      .Case<tensor::ExtractSliceOp>([&](tensor::ExtractSliceOp sliceOp) {
+        return isFromReadOnlyTensor(sliceOp.source());
+      })
+      .Case<IREE::Flow::DispatchTensorLoadOp>(
+          [&](IREE::Flow::DispatchTensorLoadOp loadOp) {
+            return loadOp.source()
+                       .getType()
+                       .cast<IREE::Flow::DispatchTensorType>()
+                       .getAccess() == IREE::Flow::TensorAccess::ReadOnly;
+          })
+      .Default([&](Operation *op) { return false; });
+}
+
+namespace {
 /// Adapts Linalg ops input operand to output operand. This is required for not
 /// creating extra alloca ops. For more details, see
 /// https://github.com/google/iree/issues/8303
@@ -346,7 +365,7 @@ struct AdaptLinalgInputOperandToOutputOperand
     SmallVector<Value> newOperands;
     SmallVector<AffineMap> maps;
     for (auto in : op.getInputOperands()) {
-      if (!operand &&
+      if (!operand && !isFromReadOnlyTensor(in->get()) &&
           op.getTiedIndexingMap(in) == op.getTiedIndexingMap(outputOperand) &&
           in->get().getType() == outputOperand->get().getType()) {
         operand = in;

--- a/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
+++ b/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
@@ -329,12 +329,8 @@ static bool isFromReadOnlyTensor(Value v) {
           [&](arith::ConstantOp constantOp) { return true; })
       .Case<tensor::CollapseShapeOp, tensor::ExpandShapeOp>(
           [&](auto op) { return isFromReadOnlyTensor(op.src()); })
-      .Case<tensor::ExtractSliceOp>([&](tensor::ExtractSliceOp sliceOp) {
-        return isFromReadOnlyTensor(sliceOp.source());
-      })
-      .Case<tensor::CastOp>([&](tensor::CastOp castOp) {
-        return isFromReadOnlyTensor(castOp.source());
-      })
+      .Case<tensor::CastOp, tensor::ExtractSliceOp>(
+          [&](auto op) { return isFromReadOnlyTensor(op.source()); })
       .Case<IREE::Flow::DispatchTensorLoadOp>(
           [&](IREE::Flow::DispatchTensorLoadOp loadOp) {
             return loadOp.source()

--- a/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
+++ b/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
@@ -332,6 +332,9 @@ static bool isFromReadOnlyTensor(Value v) {
       .Case<tensor::ExtractSliceOp>([&](tensor::ExtractSliceOp sliceOp) {
         return isFromReadOnlyTensor(sliceOp.source());
       })
+      .Case<tensor::CastOp>([&](tensor::CastOp castOp) {
+        return isFromReadOnlyTensor(castOp.source());
+      })
       .Case<IREE::Flow::DispatchTensorLoadOp>(
           [&](IREE::Flow::DispatchTensorLoadOp loadOp) {
             return loadOp.source()

--- a/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
+++ b/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
@@ -360,7 +360,9 @@ struct AdaptLinalgInputOperandToOutputOperand
     auto outputOperand = op.getOutputOperand(0);
     if (op.payloadUsesValueFromOperand(outputOperand)) return failure();
 
-    // Find an input operand that has the same indexing map and type.
+    // Find an input operand which meets:
+    //   1. It has the same indexing map and type.
+    //   2. It is not from a readonly tensor.
     OpOperand *operand = nullptr;
     SmallVector<Value> newOperands;
     SmallVector<AffineMap> maps;


### PR DESCRIPTION
This is a post-fix for https://github.com/google/iree/commit/36fb4d3ee02790e23f909872cbbf231ac93a3538

Verified that there are no alloca ops in mobilenet_v3 model with the PR.