### PR TITLE
Flatten tuples when generating ABI signatures.

### DIFF
--- a/integrations/tensorflow/iree_tf_compiler/MHLO/test/emit_default_iree_abi.mlir
+++ b/integrations/tensorflow/iree_tf_compiler/MHLO/test/emit_default_iree_abi.mlir
@@ -5,3 +5,11 @@
 func @valid(%arg0: tensor<2x3xf32>, %arg1: tensor<3xf32>) -> (tensor<3xf32>, tensor<2x3xf32>) {
   return %arg1, %arg0 : tensor<3xf32>, tensor<2x3xf32>
 }
+
+// -----
+
+// CHECK-LABEL: func @tupled
+// CHECK-SAME{LITERAL}: iree.abi = "{\22a\22:[[\22ndarray\22,\22f32\22,1,3],[\22ndarray\22,\22f32\22,2,2,3]],\22r\22:[[\22ndarray\22,\22f32\22,1,3],[\22ndarray\22,\22f32\22,2,2,3]],\22v\22:1}"
+func @tupled(%arg0: tuple<tensor<3xf32>, tensor<2x3xf32>>) -> tuple<tensor<3xf32>, tensor<2x3xf32>> {
+  return %arg0 : tuple<tensor<3xf32>, tensor<2x3xf32>>
+}


### PR DESCRIPTION
This fixes some legacy Jax integration tests which were relying on this
behavior.