### PR TITLE
Cleanup `LoweringConfigAttr`, `TranslationInfoAttr` and `CompilationInfoAttr`

### DIFF
--- a/iree/compiler/Codegen/Common/test/convert_to_destination_passing_style.mlir
+++ b/iree/compiler/Codegen/Common/test/convert_to_destination_passing_style.mlir
@@ -443,7 +443,7 @@ func @unused_ins_operand() {
         %25 = flow.dispatch.tensor.load %12, offsets = [%arg0, %arg1, %arg2], sizes = [%22, %23, %24], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:?x?x?xi32>{%6, %7, %8} -> tensor<?x?x?xi32>
         %26 = linalg.init_tensor [%22, %23] : tensor<?x?xi32>
         %27 = linalg.init_tensor [%22, %23, %24] : tensor<?x?x?xi32>
-        %28 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%25, %26 : tensor<?x?x?xi32>, tensor<?x?xi32>) outs(%27 : tensor<?x?x?xi32>) attrs =  {lowering.config = #iree_codegen.lowering.config<tile_sizes = [[], [1, 4, 4]], native_vector_size = [1, 4, 4]>} {
+        %28 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%25, %26 : tensor<?x?x?xi32>, tensor<?x?xi32>) outs(%27 : tensor<?x?x?xi32>) attrs =  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[], [1, 4, 4]], native_vector_size = [1, 4, 4]>} {
         ^bb0(%arg3: i32, %arg4: i32, %arg5: i32):  // no predecessors
           %29 = arith.index_cast %arg3 : i32 to index
           %30 = linalg.index 0 : index
@@ -498,7 +498,7 @@ func @three_init_tensor_uses() {
       %9 = flow.dispatch.tensor.load %0, offsets = [%arg0, 0], sizes = [64, 64], strides = [1, 1] : !flow.dispatch.tensor<readonly:6400x64xf32> -> tensor<64x64xf32>
       %10 = flow.dispatch.tensor.load %1, offsets = [0, %arg1], sizes = [64, 64], strides = [1, 1] : !flow.dispatch.tensor<readonly:64x64xf32> -> tensor<64x64xf32>
       %11 = linalg.fill(%cst_1, %7) : f32, tensor<64x64xf32> -> tensor<64x64xf32>
-      %12 = linalg.matmul {lowering.config = #iree_codegen.lowering.config<tile_sizes = [[64, 64, 0], [8, 32, 0], [0, 0, 16]], native_vector_size = []>} ins(%9, %10 : tensor<64x64xf32>, tensor<64x64xf32>) outs(%11 : tensor<64x64xf32>) -> tensor<64x64xf32>
+      %12 = linalg.matmul {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 0], [8, 32, 0], [0, 0, 16]]>} ins(%9, %10 : tensor<64x64xf32>, tensor<64x64xf32>) outs(%11 : tensor<64x64xf32>) -> tensor<64x64xf32>
       %13 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%8, %12 : tensor<64xf32>, tensor<64x64xf32>) outs(%7 : tensor<64x64xf32>) {
       ^bb0(%arg2: f32, %arg3: f32, %arg4: f32):
         %15 = arith.addf %arg2, %arg3 : f32
@@ -558,7 +558,7 @@ func @fill_matmul_exp() {
       %13 = flow.dispatch.tensor.load %1, offsets = [0, %arg1], sizes = [16, %12], strides = [1, 1] : !flow.dispatch.tensor<readonly:16x49xf32> -> tensor<16x?xf32>
       %14 = linalg.init_tensor [%10, %12] : tensor<?x?xf32>
       %15 = linalg.fill(%cst, %14) : f32, tensor<?x?xf32> -> tensor<?x?xf32>
-      %16 = linalg.matmul {lowering.config = #iree_codegen.lowering.config<tile_sizes = [[], [8, 0, 0], [0, 0, 16]], native_vector_size = []>} ins(%11, %13 : tensor<?x16xf32>, tensor<16x?xf32>) outs(%15 : tensor<?x?xf32>) -> tensor<?x?xf32>
+      %16 = linalg.matmul ins(%11, %13 : tensor<?x16xf32>, tensor<16x?xf32>) outs(%15 : tensor<?x?xf32>) -> tensor<?x?xf32>
       %17 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%16 : tensor<?x?xf32>) outs(%9 : tensor<?x?xf32>) {
       ^bb0(%arg2: f32, %arg3: f32):
         %18 = math.exp %arg2 : f32

--- a/iree/compiler/Codegen/Common/test/linalg_bufferize.mlir
+++ b/iree/compiler/Codegen/Common/test/linalg_bufferize.mlir
@@ -1756,9 +1756,9 @@ func @multi_result_reduce() {
     %7 = flow.dispatch.tensor.load %0, offsets = [0, %arg0], sizes = [%d0, %6], strides = [1, 1] : !flow.dispatch.tensor<readonly:?x?xi32>{%d0, %d1} -> tensor<?x?xi32>
     %9 = flow.dispatch.tensor.load %1, offsets = [0, %arg0], sizes = [%d0, %6], strides = [1, 1] : !flow.dispatch.tensor<readonly:?x?xi32>{%d0, %d1} -> tensor<?x?xi32>
     %13 = linalg.init_tensor [%6] : tensor<?xi32>
-    %14 = linalg.fill(%c-2147483648_i32, %13) {__internal_linalg_transform__ = "workgroup", lowering.config = {tileSizes = [[128]]}} : i32, tensor<?xi32> -> tensor<?xi32>
-    %17 = linalg.fill(%c0_i32, %13) {__internal_linalg_transform__ = "workgroup", lowering.config = {tileSizes = [[128]]}} : i32, tensor<?xi32> -> tensor<?xi32>
-    %18:2 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d1, d0)>, affine_map<(d0, d1) -> (d1, d0)>, affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%7, %9 : tensor<?x?xi32>, tensor<?x?xi32>) outs(%14, %17 : tensor<?xi32>, tensor<?xi32>) attrs =  {__internal_linalg_transform__ = "workgroup", lowering.config = {tileSizes = [[128]]}} {
+    %14 = linalg.fill(%c-2147483648_i32, %13) {__internal_linalg_transform__ = "workgroup", lowering_config = {tileSizes = [[128]]}} : i32, tensor<?xi32> -> tensor<?xi32>
+    %17 = linalg.fill(%c0_i32, %13) {__internal_linalg_transform__ = "workgroup", lowering_config = {tileSizes = [[128]]}} : i32, tensor<?xi32> -> tensor<?xi32>
+    %18:2 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d1, d0)>, affine_map<(d0, d1) -> (d1, d0)>, affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%7, %9 : tensor<?x?xi32>, tensor<?x?xi32>) outs(%14, %17 : tensor<?xi32>, tensor<?xi32>) attrs =  {__internal_linalg_transform__ = "workgroup", lowering_config = {tileSizes = [[128]]}} {
     ^bb0(%arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32):  // no predecessors
       %19 = arith.cmpi sge, %arg1, %arg3 : i32
       %20 = arith.select %19, %arg1, %arg3 : i32
@@ -1843,7 +1843,7 @@ func @l1_tiled_matmul_no_fill() {
             %23 = tensor.dim %arg7, %c1 : tensor<?x?xf32>
             %24 = affine.min #map6(%23, %arg4)
             %25 = tensor.extract_slice %arg7[%arg2, %arg4] [%22, %24] [1, 1] : tensor<?x?xf32> to tensor<?x?xf32>
-            %26 = linalg.matmul {__internal_linalg_transform__ = "workgroup_l1_tile", lowering.config = #config1} ins(%18, %20 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%25 : tensor<?x?xf32>) -> tensor<?x?xf32>
+            %26 = linalg.matmul {__internal_linalg_transform__ = "workgroup_l1_tile", lowering_config = #config1} ins(%18, %20 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%25 : tensor<?x?xf32>) -> tensor<?x?xf32>
             %27 = tensor.insert_slice %26 into %arg7[%arg2, %arg4] [%22, %24] [1, 1] : tensor<?x?xf32> into tensor<?x?xf32>
             scf.yield %27 : tensor<?x?xf32>
           }
@@ -1940,7 +1940,7 @@ func @l1_tiled_matmul_no_fill_readwrite() {
             %23 = tensor.dim %arg7, %c1 : tensor<?x?xf32>
             %24 = affine.min #map6(%23, %arg4)
             %25 = tensor.extract_slice %arg7[%arg2, %arg4] [%22, %24] [1, 1] : tensor<?x?xf32> to tensor<?x?xf32>
-            %26 = linalg.matmul {__internal_linalg_transform__ = "workgroup_l1_tile", lowering.config = #config1} ins(%18, %20 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%25 : tensor<?x?xf32>) -> tensor<?x?xf32>
+            %26 = linalg.matmul {__internal_linalg_transform__ = "workgroup_l1_tile", lowering_config = #config1} ins(%18, %20 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%25 : tensor<?x?xf32>) -> tensor<?x?xf32>
             %27 = tensor.insert_slice %26 into %arg7[%arg2, %arg4] [%22, %24] [1, 1] : tensor<?x?xf32> into tensor<?x?xf32>
             scf.yield %27 : tensor<?x?xf32>
           }
@@ -2020,7 +2020,7 @@ func @l1_tiled_matmul() {
       %9 = affine.min #map2(%arg1)
       %10 = flow.dispatch.tensor.load %1, offsets = [0, %arg1], sizes = [144, %9], strides = [1, 1] : !flow.dispatch.tensor<readonly:144x370xf32> -> tensor<144x?xf32>
       %11 = linalg.init_tensor [%7, %9] : tensor<?x?xf32>
-      %12 = linalg.fill(%cst, %11) {__internal_linalg_transform__ = "workgroup", lowering.config = #config0} : f32, tensor<?x?xf32> -> tensor<?x?xf32>
+      %12 = linalg.fill(%cst, %11) {__internal_linalg_transform__ = "workgroup", lowering_config = #config0} : f32, tensor<?x?xf32> -> tensor<?x?xf32>
       %13 = scf.for %arg2 = %c0 to %c250 step %c32 iter_args(%arg3 = %12) -> (tensor<?x?xf32>) {
         %14 = scf.for %arg4 = %c0 to %c370 step %c32 iter_args(%arg5 = %arg3) -> (tensor<?x?xf32>) {
           %15 = scf.for %arg6 = %c0 to %c144 step %c24 iter_args(%arg7 = %arg5) -> (tensor<?x?xf32>) {
@@ -2034,7 +2034,7 @@ func @l1_tiled_matmul() {
             %23 = tensor.dim %arg7, %c1 : tensor<?x?xf32>
             %24 = affine.min #map6(%23, %arg4)
             %25 = tensor.extract_slice %arg7[%arg2, %arg4] [%22, %24] [1, 1] : tensor<?x?xf32> to tensor<?x?xf32>
-            %26 = linalg.matmul {__internal_linalg_transform__ = "workgroup_l1_tile", lowering.config = #config1} ins(%18, %20 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%25 : tensor<?x?xf32>) -> tensor<?x?xf32>
+            %26 = linalg.matmul {__internal_linalg_transform__ = "workgroup_l1_tile", lowering_config = #config1} ins(%18, %20 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%25 : tensor<?x?xf32>) -> tensor<?x?xf32>
             %27 = tensor.insert_slice %26 into %arg7[%arg2, %arg4] [%22, %24] [1, 1] : tensor<?x?xf32> into tensor<?x?xf32>
             scf.yield %27 : tensor<?x?xf32>
           }
@@ -2324,7 +2324,7 @@ func @multi_level_tile_fuse() {
               %31 = affine.apply affine_map<(d0, d1) -> (d0 + d1)>(%arg8, %arg4)
               %32 = tensor.extract_slice %15[0, %31] [%k, %30] [1, 1] : tensor<?x?xf32> to tensor<?x?xf32>
               %33 = tensor.extract_slice %arg9[%arg6, %arg8] [%27, %30] [1, 1] : tensor<?x?xf32> to tensor<?x?xf32>
-              %34 = linalg.matmul {__internal_linalg_transform__ = "vectorize", lowering.config = {nativeVectorSize = [4, 4, 4], tileSizes = [[], [4, 4, 4], [4, 4, 4]]}} ins(%29, %32 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%33 : tensor<?x?xf32>) -> tensor<?x?xf32>
+              %34 = linalg.matmul {__internal_linalg_transform__ = "vectorize", lowering_config = {nativeVectorSize = [4, 4, 4], tileSizes = [[], [4, 4, 4], [4, 4, 4]]}} ins(%29, %32 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%33 : tensor<?x?xf32>) -> tensor<?x?xf32>
               %35 = tensor.insert_slice %34 into %arg9[%arg6, %arg8] [%27, %30] [1, 1] : tensor<?x?xf32> into tensor<?x?xf32>
               scf.yield %35 : tensor<?x?xf32>
             }

--- a/iree/compiler/Codegen/Common/test/remove_trivial_loops.mlir
+++ b/iree/compiler/Codegen/Common/test/remove_trivial_loops.mlir
@@ -54,11 +54,11 @@ hal.executable private @dispatch_0  {
 ]>
 
 // CHECK-LABEL: func @workgroup_tile_loop()
-#translation = #iree_codegen.translation.info<"LLVMGPUDistribute", workload_per_wg = [32]>
+#translation = #iree_codegen.translation_info<LLVMGPUDistribute, workload_per_wg = [32]>
 hal.executable private @workgroup_tile_loop  {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
     hal.executable.entry_point @workgroup_tile_loop layout(#executable_layout) {
-      translation.info = #translation
+      translation_info = #translation
     }
     builtin.module {
       builtin.func @workgroup_tile_loop() {
@@ -88,11 +88,11 @@ hal.executable private @workgroup_tile_loop  {
 ]>
 
 // CHECK-LABEL: func @workgroup_tile_loop_negative()
-#translation = #iree_codegen.translation.info<"LLVMGPUDistribute", workload_per_wg = [16]>
+#translation = #iree_codegen.translation_info<LLVMGPUDistribute, workload_per_wg = [16]>
 hal.executable private @workgroup_tile_loop_negative  {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
     hal.executable.entry_point @workgroup_tile_loop_negative layout(#executable_layout)  {
-      translation.info = #translation
+      translation_info = #translation
     }
     builtin.module {
       builtin.func @workgroup_tile_loop_negative() {
@@ -124,11 +124,11 @@ hal.executable private @workgroup_tile_loop_negative  {
 // CHECK-LABEL: func @both_workgroup_and_workitem()
 //   CHECK-NOT:   scf.for
 //       CHECK:   gpu.barrier
-#translation = #iree_codegen.translation.info<"LLVMGPUDistribute", workload_per_wg = [32, 8, 1]>
+#translation = #iree_codegen.translation_info<LLVMGPUDistribute, workload_per_wg = [32, 8, 1]>
 hal.executable private @both_workgroup_and_workitem  {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
     hal.executable.entry_point @both_workgroup_and_workitem layout(#executable_layout)  {
-      translation.info = #translation,
+      translation_info = #translation,
       workgroup_size = [8: index, 2: index, 1: index]
     }
     builtin.module {

--- a/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
+++ b/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt -pass-pipeline='hal.executable(hal.executable.variant(builtin.module(builtin.func(iree-codegen-tile-and-distribute-to-workgroups)))), canonicalize, cse' -split-input-file %s | FileCheck %s
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[64, 64, 0], [16, 4, 64], [4, 4, 4]], native_vector_size = [4, 4, 4]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 0], [16, 4, 64], [4, 4, 4]], native_vector_size = [4, 4, 4]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -14,10 +14,10 @@
   native_vector_size = 16 : index,
   target_triple = "aarch64-unknown-unknown-eabi-elf"
 }>
-#translation = #iree_codegen.translation.info<"CPUTileFuseAndVectorize", workload_per_wg = []>
+#translation = #iree_codegen.translation_info<CPUTileFuseAndVectorize>
 hal.executable private @matmul_tensors {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_arm_64_ {
-    hal.executable.entry_point public @matmul_tensors layout(#executable_layout) {translation.info = #translation}
+    hal.executable.entry_point public @matmul_tensors layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func @matmul_tensors() {
         %0 = hal.interface.constant.load[0] : index
@@ -37,7 +37,7 @@ hal.executable private @matmul_tensors {
             : !flow.dispatch.tensor<readonly:?x?xf32>{%2, %1} -> tensor<?x?xf32>
         %9 = flow.dispatch.tensor.load %5, offsets = [0, 0], sizes = [%0, %1], strides = [1, 1]
             : !flow.dispatch.tensor<readonly:?x?xf32>{%0, %1} -> tensor<?x?xf32>
-        %10 = linalg.matmul {lowering.config = #config}
+        %10 = linalg.matmul {lowering_config = #config}
             ins(%7, %8 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%9 : tensor<?x?xf32>) -> tensor<?x?xf32>
         flow.dispatch.tensor.store %10, %6, offsets = [0, 0], sizes = [%0, %1], strides = [1, 1]
             : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:?x?xf32>{%0, %1}
@@ -49,9 +49,9 @@ hal.executable private @matmul_tensors {
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 * 64)>
 //  CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0)[s0] -> (64, -d0 + s0)>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUTileFuseAndVectorize", workload_per_wg = [64, 64]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUTileFuseAndVectorize, workload_per_wg = [64, 64]>
 //      CHECK: hal.executable.entry_point public @matmul_tensors
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:   (%[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[ARG2:[a-zA-Z0-9_]+]]: index)
@@ -93,7 +93,7 @@ hal.executable private @matmul_tensors {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[64, 64], [1, 4], [0, 0]], native_vector_size = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[64, 64], [1, 4], [0, 0]]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -108,10 +108,10 @@ hal.executable private @matmul_tensors {
 }>
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d1)>
-#translation = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+#translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @add {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @add layout(#executable_layout) {translation.info = #translation}
+    hal.executable.entry_point public @add layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func @add() {
         %0 = hal.interface.constant.load[0] : index
@@ -130,7 +130,7 @@ hal.executable private @add {
         %8 = linalg.generic {
             indexing_maps = [#map0, #map1, #map0], iterator_types = ["parallel", "parallel"]}
             ins(%5, %6 : tensor<?x?xf32>, tensor<?xf32>) outs(%7 : tensor<?x?xf32>)
-            attrs =  {lowering.config = #config} {
+            attrs =  {lowering_config = #config} {
         ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
           %9 = arith.addf %arg0, %arg1 : f32
           linalg.yield %9 : f32
@@ -143,10 +143,10 @@ hal.executable private @add {
   }
 }
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = [64, 64]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert, workload_per_wg = [64, 64]>
 //      CHECK: hal.executable private @add
 //      CHECK: hal.executable.entry_point public @add
-// CHECK-SAME:  translation.info = #[[TRANSLATION]]
+// CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
@@ -162,7 +162,7 @@ hal.executable private @add {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[0, 64, 64, 64], [1, 1, 1, 4], [0, 0, 0, 0]], native_vector_size = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[0, 64, 64, 64], [1, 1, 1, 4], [0, 0, 0, 0]]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -176,10 +176,10 @@ hal.executable private @add {
   native_vector_size = 16 : index,
   target_triple = "x86_64-unknown-linux-gnu"}>
 #map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
-#translation = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+#translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @add4D {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @add4D layout(#executable_layout) {translation.info = #translation}
+    hal.executable.entry_point public @add4D layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func @add4D() {
         %0 = hal.interface.constant.load[0] : index
@@ -199,7 +199,7 @@ hal.executable private @add4D {
         %9 = linalg.init_tensor [%0, %1, %2, %3] : tensor<?x?x?x?xf32>
         %10 = linalg.generic {
             indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
-            ins(%7, %8 : tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>) outs(%9 : tensor<?x?x?x?xf32>) attrs =  {lowering.config = #config} {
+            ins(%7, %8 : tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>) outs(%9 : tensor<?x?x?x?xf32>) attrs =  {lowering_config = #config} {
         ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
           %11 = arith.addf %arg0, %arg1 : f32
           linalg.yield %11 : f32
@@ -212,9 +212,9 @@ hal.executable private @add4D {
   }
 }
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = [64, 64, 64]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert, workload_per_wg = [64, 64, 64]>
 //      CHECK: hal.executable.entry_point public @add4D
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:   (%[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[ARG2:[a-zA-Z0-9_]+]]: index)
@@ -232,7 +232,7 @@ hal.executable private @add4D {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[1, 64, 64, 0], [1, 16, 4, 64], [1, 4, 4, 4]], native_vector_size = [1, 4, 4, 4]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[1, 64, 64, 0], [1, 16, 4, 64], [1, 4, 4, 4]], native_vector_size = [1, 4, 4, 4]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -244,10 +244,10 @@ hal.executable private @add4D {
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 16 : index,
   target_triple = "aarch64-unknown-unknown-eabi-elf"}>
-#translation = #iree_codegen.translation.info<"CPUTileFuseAndVectorize", workload_per_wg = []>
+#translation = #iree_codegen.translation_info<CPUTileFuseAndVectorize>
 hal.executable private @batch_matmul_tensors {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_arm_64_ {
-    hal.executable.entry_point public @batch_matmul_tensors layout(#executable_layout) {translation.info = #translation}
+    hal.executable.entry_point public @batch_matmul_tensors layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func @batch_matmul_tensors() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -267,7 +267,7 @@ hal.executable private @batch_matmul_tensors {
             : !flow.dispatch.tensor<readonly:?x?x?xf32>{%0, %3, %2} -> tensor<?x?x?xf32>
         %9 = linalg.init_tensor [%0, %1, %2] : tensor<?x?x?xf32>
         %10 = linalg.fill(%cst, %9) : f32, tensor<?x?x?xf32> -> tensor<?x?x?xf32>
-        %11 = linalg.batch_matmul {lowering.config = #config}
+        %11 = linalg.batch_matmul {lowering_config = #config}
             ins(%7, %8 : tensor<?x?x?xf32>, tensor<?x?x?xf32>) outs(%10 : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
         flow.dispatch.tensor.store %11, %6, offsets = [0, 0, 0], sizes = [%0, %1, %2], strides = [1, 1, 1]
             : tensor<?x?x?xf32> -> !flow.dispatch.tensor<writeonly:?x?x?xf32>{%0, %1, %2}
@@ -277,7 +277,7 @@ hal.executable private @batch_matmul_tensors {
   }
 }
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUTileFuseAndVectorize", workload_per_wg = [64, 64, 1]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUTileFuseAndVectorize, workload_per_wg = [64, 64, 1]>
 //      CHECK: hal.executable.entry_point public @batch_matmul_tensors
 // CHECK-NEXT:   (%[[ARG0:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: index
@@ -296,7 +296,7 @@ hal.executable private @batch_matmul_tensors {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[32, 16, 0], [16, 8, 0], [0, 0, 2]], native_vector_size = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[32, 16, 0], [16, 8, 0], [0, 0, 2]]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -305,10 +305,10 @@ hal.executable private @batch_matmul_tensors {
   ]>
 ]>
 #executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm", "system-elf-x86_64">
-#translation = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+#translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @preset_config_matmul_tensors {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @preset_config layout(#executable_layout) {translation.info = #translation}
+    hal.executable.entry_point public @preset_config layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func @preset_config() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -324,7 +324,7 @@ hal.executable private @preset_config_matmul_tensors {
             : !flow.dispatch.tensor<readonly:256x512xf32> -> tensor<256x512xf32>
         %5 = linalg.init_tensor [128, 512] : tensor<128x512xf32>
         %6 = linalg.fill(%cst, %5) : f32, tensor<128x512xf32> -> tensor<128x512xf32>
-        %7 = linalg.matmul {lowering.config = #config}
+        %7 = linalg.matmul {lowering_config = #config}
             ins(%3, %4 : tensor<128x256xf32>, tensor<256x512xf32>) outs(%6 : tensor<128x512xf32>) -> tensor<128x512xf32>
         flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [128, 512], strides = [1, 1]
             : tensor<128x512xf32> -> !flow.dispatch.tensor<writeonly:128x512xf32>
@@ -337,7 +337,7 @@ hal.executable private @preset_config_matmul_tensors {
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 32)>
 //  CHECK-DAG: #[[MAP2:.+]] = affine_map<()[s0] -> (s0 * 32)>
 //  CHECK-DAG: #[[MAP3:.+]] = affine_map<()[s0] -> (s0 * 16)>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = [16, 32]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert, workload_per_wg = [16, 32]>
 //      CHECK: hal.executable.entry_point public @preset_config
 // CHECK-NEXT:   (%[[ARG0:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: index
@@ -360,7 +360,7 @@ hal.executable private @preset_config_matmul_tensors {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[64, 64]], native_vector_size = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[64, 64]]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -368,10 +368,10 @@ hal.executable private @preset_config_matmul_tensors {
   ]>
 ]>
 #executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm", "system-elf-x86_64">
-#translation = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = []>
+#translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable public @tensor_insert {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @tensor_insert_slice layout(#executable_layout) {translation.info = #translation}
+    hal.executable.entry_point public @tensor_insert_slice layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func @tensor_insert_slice() {
         %0 = hal.interface.constant.load[0] : index
@@ -388,7 +388,7 @@ hal.executable public @tensor_insert {
             : !flow.dispatch.tensor<readonly:?x?xi32>{%0, %1} -> tensor<?x?xi32>
         %9 = flow.dispatch.tensor.load %7, offsets = [0, 0], sizes = [%0, %1], strides = [1, 1]
             : !flow.dispatch.tensor<readwrite:?x?xi32>{%2, %3} -> tensor<?x?xi32>
-        %10 = tensor.insert_slice %8 into %9[%4, %5] [%0, %1] [1, 1] {lowering.config = #config} : tensor<?x?xi32> into tensor<?x?xi32>
+        %10 = tensor.insert_slice %8 into %9[%4, %5] [%0, %1] [1, 1] {lowering_config = #config} : tensor<?x?xi32> into tensor<?x?xi32>
         flow.dispatch.tensor.store %10, %7, offsets = [0, 0], sizes = [%2, %3], strides = [1, 1]
             : tensor<?x?xi32> -> !flow.dispatch.tensor<readwrite:?x?xi32>{%2, %3}
         return
@@ -400,9 +400,9 @@ hal.executable public @tensor_insert {
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 * 64)>
 //  CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0)[s0] -> (64, -d0 + s0)>
 //  CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0)[s0] -> (d0 + s0)>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = [64, 64]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault, workload_per_wg = [64, 64]>
 //      CHECK: hal.executable.entry_point public @tensor_insert
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:   (%[[ARG0:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]: index)
@@ -438,7 +438,7 @@ hal.executable public @tensor_insert {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[64, 64]], native_vector_size = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[64, 64]]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -446,10 +446,10 @@ hal.executable public @tensor_insert {
   ]>
 ]>
 #executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm", "system-elf-x86_64">
-#translation = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = []>
+#translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable public @extract_slice {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @extract_slice layout(#executable_layout) {translation.info = #translation}
+    hal.executable.entry_point public @extract_slice layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func @extract_slice() {
         %0 = hal.interface.constant.load[0] : index
@@ -464,7 +464,7 @@ hal.executable public @extract_slice {
             : !flow.dispatch.tensor<writeonly:?x?xi32>{%2, %3}
         %8 = flow.dispatch.tensor.load %6, offsets = [0, 0], sizes = [%0, %1], strides = [1, 1]
             : !flow.dispatch.tensor<readonly:?x?xi32>{%0, %1} -> tensor<?x?xi32>
-        %9 = tensor.extract_slice %8[%4, %5] [%2, %3] [1, 1] {lowering.config = #config} : tensor<?x?xi32> to tensor<?x?xi32>
+        %9 = tensor.extract_slice %8[%4, %5] [%2, %3] [1, 1] {lowering_config = #config} : tensor<?x?xi32> to tensor<?x?xi32>
         flow.dispatch.tensor.store %9, %7, offsets = [0, 0], sizes = [%2, %3], strides = [1, 1]
             : tensor<?x?xi32> -> !flow.dispatch.tensor<writeonly:?x?xi32>{%2, %3}
         return
@@ -476,9 +476,9 @@ hal.executable public @extract_slice {
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 * 64)>
 //  CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0)[s0] -> (64, -d0 + s0)>
 //  CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0)[s0] -> (d0 + s0)>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = [64, 64]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault, workload_per_wg = [64, 64]>
 //      CHECK: hal.executable.entry_point public @extract_slice
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:   (%[[ARG0:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]: index)
@@ -514,7 +514,7 @@ hal.executable public @extract_slice {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[64]], native_vector_size = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[64]]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -522,10 +522,10 @@ hal.executable public @extract_slice {
   ]>
 ]>
 #executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm", "system-elf-x86_64">
-#translation = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = []>
+#translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @static_1d_fft_stage2 {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @static_1d_fft_stage2 layout(#executable_layout) {translation.info = #translation}
+    hal.executable.entry_point public @static_1d_fft_stage2 layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func @static_1d_fft_stage2() {
         %c2 = arith.constant 2 : index
@@ -539,7 +539,7 @@ hal.executable private @static_1d_fft_stage2 {
             : !flow.dispatch.tensor<readwrite:32xf32> -> tensor<32xf32>
         %3 = flow.dispatch.tensor.load %1, offsets = [0], sizes = [32], strides = [1]
             : !flow.dispatch.tensor<readwrite:32xf32> -> tensor<32xf32>
-        %4:2 = iree_linalg_ext.fft {__internal_linalg_transform__ = "workgroup", lowering.config = #config}
+        %4:2 = iree_linalg_ext.fft {__internal_linalg_transform__ = "workgroup", lowering_config = #config}
             ins(%c2, %cst, %cst_0 : index, tensor<2xf32>, tensor<2xf32>) outs(%2, %3 : tensor<32xf32>, tensor<32xf32>) : tensor<32xf32>, tensor<32xf32>
         flow.dispatch.tensor.store %4#0, %0, offsets = [0], sizes = [32], strides = [1]
             : tensor<32xf32> -> !flow.dispatch.tensor<readwrite:32xf32>
@@ -551,10 +551,10 @@ hal.executable private @static_1d_fft_stage2 {
   }
 }
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = [64]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault, workload_per_wg = [64]>
 //      CHECK: hal.executable private @static_1d_fft_stage2
 //      CHECK: hal.executable.entry_point public @static_1d_fft_stage2
-// CHECK-SAME:  translation.info = #[[TRANSLATION]]
+// CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
@@ -569,7 +569,7 @@ hal.executable private @static_1d_fft_stage2 {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[64, 64, 64]], native_vector_size = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 64]]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -577,10 +577,10 @@ hal.executable private @static_1d_fft_stage2 {
   ]>
 ]>
 #executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm", "system-elf-x86_64">
-#translation = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = []>
+#translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @static_3d_fft_stage3 {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @static_3d_fft_stage3 layout(#executable_layout) {translation.info = #translation}
+    hal.executable.entry_point public @static_3d_fft_stage3 layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func @static_3d_fft_stage3() {
         %c3 = arith.constant 3 : index
@@ -590,7 +590,7 @@ hal.executable private @static_3d_fft_stage3 {
         %1 = bufferization.to_memref %cst : memref<4xf32>
         %2 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<64x128x32xf32>
         %3 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<64x128x32xf32>
-        iree_linalg_ext.fft {lowering.config = #config}
+        iree_linalg_ext.fft {lowering_config = #config}
             ins(%c3, %1, %0 : index, memref<4xf32>, memref<4xf32>) outs(%2, %3 : memref<64x128x32xf32>, memref<64x128x32xf32>)
         return
       }
@@ -598,10 +598,10 @@ hal.executable private @static_3d_fft_stage3 {
   }
 }
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = [64, 64, 64]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault, workload_per_wg = [64, 64, 64]>
 //      CHECK: hal.executable private @static_3d_fft_stage3
 //      CHECK: hal.executable.entry_point public @static_3d_fft_stage3
-// CHECK-SAME:  translation.info = #[[TRANSLATION]]
+// CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
@@ -620,7 +620,7 @@ hal.executable private @static_3d_fft_stage3 {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[64, 64, 0], [1, 4, 0], [0, 0, 4]], native_vector_size = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 0], [1, 4, 0], [0, 0, 4]]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -633,10 +633,10 @@ hal.executable private @static_3d_fft_stage3 {
 #map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map2 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map3 = affine_map<(d0, d1, d2) -> (d0, d1)>
-#translation = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+#translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @outs_fusion {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @outs_fusion_fn layout(#executable_layout) {translation.info = #translation}
+    hal.executable.entry_point public @outs_fusion_fn layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func @outs_fusion_fn() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -661,7 +661,7 @@ hal.executable private @outs_fusion {
             : !flow.dispatch.tensor<readonly:?x?xf32>{%2, %1} -> tensor<?x?xf32>
         %10 = linalg.generic {
             indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "reduction"]}
-            ins(%8, %9 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%7 : tensor<?x?xf32>) attrs =  {lowering.config = #config} {
+            ins(%8, %9 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%7 : tensor<?x?xf32>) attrs =  {lowering_config = #config} {
         ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
           %11 = arith.mulf %arg0, %arg1 : f32
           linalg.yield %11 : f32
@@ -685,7 +685,7 @@ hal.executable private @outs_fusion {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[0, 64, 64, 64, 0, 0, 0]], native_vector_size = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[0, 64, 64, 64, 0, 0, 0]]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -697,10 +697,10 @@ hal.executable private @outs_fusion {
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 16 : index,
   target_triple = "x86_64-unknown-linux-gnu"}>
-#translation = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = []>
+#translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @conv {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @conv layout(#executable_layout) {translation.info = #translation}
+    hal.executable.entry_point public @conv layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func @conv() {
         %0 = hal.interface.constant.load[0] : index
@@ -724,7 +724,7 @@ hal.executable private @conv {
             : !flow.dispatch.tensor<readonly:?x?x?x?xf32>{%4, %5, %3, %6} -> tensor<?x?x?x?xf32>
         %14 = flow.dispatch.tensor.load %11, offsets = [0, 0, 0, 0], sizes = [%0, %7, %8, %6], strides = [1, 1, 1, 1]
             : !flow.dispatch.tensor<readwrite:?x?x?x?xf32>{%0, %7, %8, %6} -> tensor<?x?x?x?xf32>
-        %15 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, lowering.config = #config, strides = dense<1> : tensor<2xi64>}
+        %15 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, lowering_config = #config, strides = dense<1> : tensor<2xi64>}
             ins(%12, %13 : tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>) outs(%14 : tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
         flow.dispatch.tensor.store %15, %11, offsets = [0, 0, 0, 0], sizes = [%0, %7, %8, %6], strides = [1, 1, 1, 1]
             : tensor<?x?x?x?xf32> -> !flow.dispatch.tensor<readwrite:?x?x?x?xf32>{%0, %7, %8, %6}
@@ -734,10 +734,10 @@ hal.executable private @conv {
   }
 }
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = [64, 64, 64]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault, workload_per_wg = [64, 64, 64]>
 //      CHECK: hal.executable private @conv
 //      CHECK: hal.executable.entry_point public @conv
-// CHECK-SAME:  translation.info = #[[TRANSLATION]]
+// CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
@@ -757,7 +757,7 @@ hal.executable private @conv {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[0, 20, 40, 48, 0, 0]], native_vector_size = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[0, 20, 40, 48, 0, 0]]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -769,10 +769,10 @@ hal.executable private @conv {
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 16 : index,
   target_triple = "x86_64-unknown-linux-gnu"}>
-#translation = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = []>
+#translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @conv_static {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @conv_static layout(#executable_layout) {translation.info = #translation}
+    hal.executable.entry_point public @conv_static layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func @conv_static() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -788,7 +788,7 @@ hal.executable private @conv_static {
             : !flow.dispatch.tensor<readonly:3x3x96xf32> -> tensor<3x3x96xf32>
         %5 = linalg.init_tensor [1, 80, 80, 96] : tensor<1x80x80x96xf32>
         %6 = linalg.fill(%cst, %5) : f32, tensor<1x80x80x96xf32> -> tensor<1x80x80x96xf32>
-        %7 = linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, lowering.config = #config, strides = dense<2> : tensor<2xi64>}
+        %7 = linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, lowering_config = #config, strides = dense<2> : tensor<2xi64>}
             ins(%3, %4 : tensor<1x161x161x96xf32>, tensor<3x3x96xf32>) outs(%6 : tensor<1x80x80x96xf32>) -> tensor<1x80x80x96xf32>
         flow.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [1, 80, 80, 96], strides = [1, 1, 1, 1]
             : tensor<1x80x80x96xf32> -> !flow.dispatch.tensor<writeonly:1x80x80x96xf32>
@@ -800,10 +800,10 @@ hal.executable private @conv_static {
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 48)>
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 40)>
 //  CHECK-DAG: #[[MAP2:.+]] = affine_map<()[s0] -> (s0 ceildiv 20)>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = [48, 40, 20]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault, workload_per_wg = [48, 40, 20]>
 //      CHECK: hal.executable private @conv_static
 //      CHECK: hal.executable.entry_point public @conv_static
-// CHECK-SAME:  translation.info = #[[TRANSLATION]]
+// CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
@@ -823,7 +823,7 @@ hal.executable private @conv_static {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[16, 32], [16, 16], [0, 0]], native_vector_size = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[16, 32], [16, 16], [0, 0]]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -836,10 +836,10 @@ hal.executable private @conv_static {
   target_triple = "x86_64-pc-linux-gnu"}>
 #map0 = affine_map<(d0, d1) -> (d1, d0)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>
-#translation = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+#translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @generic_static {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @generic_static layout(#executable_layout) {translation.info = #translation}
+    hal.executable.entry_point public @generic_static layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func @generic_static() {
         %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
@@ -851,7 +851,7 @@ hal.executable private @generic_static {
         %3 = linalg.init_tensor [16, 96] : tensor<16x96xf32>
         %4 = linalg.generic {
             indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel"]}
-            ins(%2 : tensor<96x16xf32>) outs(%3 : tensor<16x96xf32>) attrs =  {lowering.config = #config} {
+            ins(%2 : tensor<96x16xf32>) outs(%3 : tensor<16x96xf32>) attrs =  {lowering_config = #config} {
         ^bb0(%arg0: f32, %arg1: f32):
           linalg.yield %arg0 : f32
         } -> tensor<16x96xf32>
@@ -864,10 +864,10 @@ hal.executable private @generic_static {
 }
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 32)>
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 16)>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = [32, 16]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert, workload_per_wg = [32, 16]>
 //      CHECK: hal.executable private @generic_static
 //      CHECK: hal.executable.entry_point public @generic_static
-// CHECK-SAME:  translation.info = #[[TRANSLATION]]
+// CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
@@ -883,7 +883,7 @@ hal.executable private @generic_static {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[28, 8, 0], [4, 4, 60], [4, 4, 4]], native_vector_size = [4, 4, 4]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[28, 8, 0], [4, 4, 60], [4, 4, 4]], native_vector_size = [4, 4, 4]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -895,10 +895,10 @@ hal.executable private @generic_static {
   data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
   native_vector_size = 16 : index,
   target_triple = "aarch64-none-linux-android30"}>
-#translation = #iree_codegen.translation.info<"CPUTileFuseAndVectorize", workload_per_wg = []>
+#translation = #iree_codegen.translation_info<CPUTileFuseAndVectorize>
 hal.executable private @matmul_static {
   hal.executable.variant public @system_elf_arm_64, target = #executable_target_system_elf_arm_64_ {
-    hal.executable.entry_point public @matmul_static layout(#executable_layout) {translation.info = #translation}
+    hal.executable.entry_point public @matmul_static layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func @matmul_static() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -914,7 +914,7 @@ hal.executable private @matmul_static {
             : !flow.dispatch.tensor<readonly:240x40xf32> -> tensor<240x40xf32>
         %5 = linalg.init_tensor [196, 40] : tensor<196x40xf32>
         %6 = linalg.fill(%cst, %5) : f32, tensor<196x40xf32> -> tensor<196x40xf32>
-        %7 = linalg.matmul {lowering.config = #config}
+        %7 = linalg.matmul {lowering_config = #config}
             ins(%3, %4 : tensor<196x240xf32>, tensor<240x40xf32>) outs(%6 : tensor<196x40xf32>) -> tensor<196x40xf32>
         flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [196, 40], strides = [1, 1]
             : tensor<196x40xf32> -> !flow.dispatch.tensor<writeonly:196x40xf32>
@@ -925,10 +925,10 @@ hal.executable private @matmul_static {
 }
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 8)>
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 28)>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUTileFuseAndVectorize", workload_per_wg = [8, 28]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUTileFuseAndVectorize, workload_per_wg = [8, 28]>
 //      CHECK: hal.executable private @matmul_static
 //      CHECK: hal.executable.entry_point public @matmul_static
-// CHECK-SAME:  translation.info = #[[TRANSLATION]]
+// CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
@@ -939,7 +939,7 @@ hal.executable private @matmul_static {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[0, 1, 7, 64, 0, 0]], native_vector_size = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[0, 1, 7, 64, 0, 0]]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -951,10 +951,10 @@ hal.executable private @matmul_static {
   data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
   native_vector_size = 16 : index,
   target_triple = "aarch64-none-linux-android30"}>
-#translation = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = []>
+#translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @restrict_num_workgroups {
   hal.executable.variant public @system_elf_arm_64, target = #executable_target_system_elf_arm_64_ {
-    hal.executable.entry_point public @restrict_num_workgroups layout(#executable_layout) {translation.info = #translation}
+    hal.executable.entry_point public @restrict_num_workgroups layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func @restrict_num_workgroups() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -970,7 +970,7 @@ hal.executable private @restrict_num_workgroups {
             : !flow.dispatch.tensor<readonly:5x5x576xf32> -> tensor<5x5x576xf32>
         %5 = linalg.init_tensor [1, 7, 7, 576] : tensor<1x7x7x576xf32>
         %6 = linalg.fill(%cst, %5) : f32, tensor<1x7x7x576xf32> -> tensor<1x7x7x576xf32>
-        %7 = linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, lowering.config = #config, strides = dense<1> : tensor<2xi64>}
+        %7 = linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, lowering_config = #config, strides = dense<1> : tensor<2xi64>}
             ins(%3, %4 : tensor<1x11x11x576xf32>, tensor<5x5x576xf32>) outs(%6 : tensor<1x7x7x576xf32>) -> tensor<1x7x7x576xf32>
         flow.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [1, 7, 7, 576], strides = [1, 1, 1, 1]
             : tensor<1x7x7x576xf32> -> !flow.dispatch.tensor<writeonly:1x7x7x576xf32>
@@ -981,10 +981,10 @@ hal.executable private @restrict_num_workgroups {
 }
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 7)>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = [64, 7, 1]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault, workload_per_wg = [64, 7, 1]>
 //      CHECK: hal.executable private @restrict_num_workgroups
 //      CHECK: hal.executable.entry_point public @restrict_num_workgroups
-// CHECK-SAME:  translation.info = #[[TRANSLATION]]
+// CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
@@ -994,7 +994,7 @@ hal.executable private @restrict_num_workgroups {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[4, 0, 0], [4, 0, 0], [0, 1, 4]], native_vector_size = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[4, 0, 0], [4, 0, 0], [0, 1, 4]]>
 #executable_layout = #hal.executable.layout<push_constants = 4, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -1009,10 +1009,10 @@ hal.executable private @restrict_num_workgroups {
 #map0 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d0)>
 #map2 = affine_map<(d0) -> (d0)>
-#translation = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+#translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @reduction {
   hal.executable.variant public @reduction, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @reduction ordinal(0) layout(#executable_layout) {translation.info = #translation}
+    hal.executable.entry_point public @reduction ordinal(0) layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func @reduction(%arg0 : !flow.dispatch.tensor<readonly:7x7x2048xf32>,
           %arg1 : !flow.dispatch.tensor<writeonly:7xf32>) {
@@ -1024,7 +1024,7 @@ hal.executable private @reduction {
         %2 = linalg.fill(%cst, %1) : f32, tensor<7xf32> -> tensor<7xf32>
         %3 = linalg.generic {
             indexing_maps = [#map0, #map1], iterator_types = ["parallel", "reduction", "reduction"]}
-            ins(%0 : tensor<7x7x2048xf32>) outs(%2 : tensor<7xf32>) attrs =  {lowering.config = #config} {
+            ins(%0 : tensor<7x7x2048xf32>) outs(%2 : tensor<7xf32>) attrs =  {lowering_config = #config} {
         ^bb0(%arg2: f32, %arg3: f32):
           %5 = arith.addf %arg2, %arg3 : f32
           linalg.yield %5 : f32
@@ -1044,10 +1044,10 @@ hal.executable private @reduction {
   }
 }
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 4)>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = [4]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert, workload_per_wg = [4]>
 //      CHECK: hal.executable private @reduction
 //      CHECK: hal.executable.entry_point public @reduction
-// CHECK-SAME:  translation.info = #[[TRANSLATION]]
+// CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
@@ -1067,7 +1067,7 @@ hal.executable private @reduction {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[64, 0, 0], [8, 0, 0], [0, 0, 16]], native_vector_size = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[64, 0, 0], [8, 0, 0], [0, 0, 16]]>
 #executable_layout = #hal.executable.layout<push_constants = 4, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -1079,10 +1079,10 @@ hal.executable private @reduction {
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 16 : index,
   target_triple = "x86_64-unknown-unknown-eabi-elf"}>
-#translation = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+#translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @gemm_unit_N {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @gemm_unit_N ordinal(0) layout(#executable_layout) {translation.info = #translation}
+    hal.executable.entry_point public @gemm_unit_N ordinal(0) layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func @gemm_unit_N() {
         %c0 = arith.constant 0 : index
@@ -1100,7 +1100,7 @@ hal.executable private @gemm_unit_N {
             : !flow.dispatch.tensor<readonly:?x?xf32>{%0, %1} -> tensor<?x?xf32>
         %7 = flow.dispatch.tensor.load %4, offsets = [0, 0], sizes = [%0, 1], strides = [1, 1]
             : !flow.dispatch.tensor<readwrite:?x1xf32>{%0} -> tensor<?x1xf32>
-        %8 = linalg.matmul {lowering.config = #config}
+        %8 = linalg.matmul {lowering_config = #config}
             ins(%6, %5 : tensor<?x?xf32>, tensor<?x1xf32>) outs(%7 : tensor<?x1xf32>) -> tensor<?x1xf32>
         flow.dispatch.tensor.store %8, %4, offsets = [0, 0], sizes = [%0, 1], strides = [1, 1]
             : tensor<?x1xf32> -> !flow.dispatch.tensor<readwrite:?x1xf32>{%0}
@@ -1111,10 +1111,10 @@ hal.executable private @gemm_unit_N {
 }
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 * 64)>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = [64]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert, workload_per_wg = [64]>
 //      CHECK: hal.executable private @gemm_unit_N
 //      CHECK: hal.executable.entry_point public @gemm_unit_N
-// CHECK-SAME:  translation.info = #[[TRANSLATION]]
+// CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
@@ -1134,7 +1134,7 @@ hal.executable private @gemm_unit_N {
 // CHECK-SAME:         offsets = [%[[IV0]], 0]
 
 // -----
-#config = #iree_codegen.lowering.config<tile_sizes = [[0, 0, 0], [0, 0, 0], [0, 0, 16]], native_vector_size = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[0, 0, 0], [0, 0, 0], [0, 0, 16]]>
 #executable_layout = #hal.executable.layout<push_constants = 4, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -1146,10 +1146,10 @@ hal.executable private @gemm_unit_N {
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 16 : index,
   target_triple = "x86_64-unknown-unknown-eabi-elf"}>
-#translation = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+#translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @gemm_unit_M_unit_N {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @gemm_unit_M_unit_N ordinal(0) layout(#executable_layout) {translation.info = #translation}
+    hal.executable.entry_point public @gemm_unit_M_unit_N ordinal(0) layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func @gemm_unit_M_unit_N() {
         %c0 = arith.constant 0 : index
@@ -1166,7 +1166,7 @@ hal.executable private @gemm_unit_M_unit_N {
             : !flow.dispatch.tensor<readonly:?x1xf32>{%0} -> tensor<?x1xf32>
         %6 = flow.dispatch.tensor.load %3, offsets = [0, 0], sizes = [1, 1], strides = [1, 1]
             : !flow.dispatch.tensor<readwrite:1x1xf32> -> tensor<1x1xf32>
-        %7 = linalg.matmul {lowering.config = #config}
+        %7 = linalg.matmul {lowering_config = #config}
             ins(%4, %5 : tensor<1x?xf32>, tensor<?x1xf32>) outs(%6 : tensor<1x1xf32>) -> tensor<1x1xf32>
         flow.dispatch.tensor.store %7, %3, offsets = [0, 0], sizes = [1, 1], strides = [1, 1]
             : tensor<1x1xf32> -> !flow.dispatch.tensor<readwrite:1x1xf32>
@@ -1175,10 +1175,10 @@ hal.executable private @gemm_unit_M_unit_N {
     }
   }
 }
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable private @gemm_unit_M_unit_N
 //      CHECK: hal.executable.entry_point public @gemm_unit_M_unit_N
-// CHECK-SAME:  translation.info = #[[TRANSLATION]]
+// CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
@@ -1191,7 +1191,7 @@ hal.executable private @gemm_unit_M_unit_N {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[0, 0, 0, 0, 64, 64, 0, 64], [0, 1, 0, 0, 1, 1, 0, 4], [0, 0, 0, 0, 0, 0, 0, 0]], native_vector_size = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[0, 0, 0, 0, 64, 64, 0, 64], [0, 1, 0, 0, 1, 1, 0, 4], [0, 0, 0, 0, 0, 0, 0, 0]]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -1204,10 +1204,10 @@ hal.executable private @gemm_unit_M_unit_N {
   native_vector_size = 16 : index,
   target_triple = "x86_64-unknown-linux-gnu"}>
 #map = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4, d5, d6, d7)>
-#translation = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+#translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @generic_unit_dims {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @generic_unit_dims layout(#executable_layout) {translation.info = #translation}
+    hal.executable.entry_point public @generic_unit_dims layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func @generic_unit_dims() {
         %0 = hal.interface.constant.load[0] : index
@@ -1223,7 +1223,7 @@ hal.executable private @generic_unit_dims {
         %7 = linalg.init_tensor [1, %0, 1, 1, %1, %2, 1, %3] : tensor<1x?x1x1x?x?x1x?xf32>
         %8 = linalg.generic {
             indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]}
-            ins(%6 : tensor<1x?x1x1x?x?x1x?xf32>) outs(%7 : tensor<1x?x1x1x?x?x1x?xf32>) attrs =  {lowering.config = #config} {
+            ins(%6 : tensor<1x?x1x1x?x?x1x?xf32>) outs(%7 : tensor<1x?x1x1x?x?x1x?xf32>) attrs =  {lowering_config = #config} {
         ^bb0(%arg0: f32, %arg1: f32):
           %9 = arith.addf %arg0, %arg0 : f32
           linalg.yield %9 : f32
@@ -1237,10 +1237,10 @@ hal.executable private @generic_unit_dims {
 }
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 * 64)>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = [64, 64, 64]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert, workload_per_wg = [64, 64, 64]>
 //      CHECK: hal.executable private @generic_unit_dims
 //      CHECK: hal.executable.entry_point public @generic_unit_dims
-// CHECK-SAME:  translation.info = #[[TRANSLATION]]
+// CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
@@ -1257,7 +1257,7 @@ hal.executable private @generic_unit_dims {
 // CHECK-SAME:             offsets = [0, 0, 0, 0, %[[IV0]], %[[IV1]], 0, %[[IV2]]]
 
 // -----
-#config = #iree_codegen.lowering.config<tile_sizes = [[0], [0], [4]], native_vector_size = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[0], [0], [4]]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -1271,10 +1271,10 @@ hal.executable private @generic_unit_dims {
   target_triple = "x86_64-unknown-linux-gnu"}>
 #map0 = affine_map<(d0) -> (d0)>
 #map1 = affine_map<(d0) -> ()>
-#translation = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+#translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @reduce_to_scalar {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @reduce_to_scalar layout(#executable_layout) {translation.info = #translation}
+    hal.executable.entry_point public @reduce_to_scalar layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func @reduce_to_scalar() {
         %0 = hal.interface.constant.load[0] : index
@@ -1288,7 +1288,7 @@ hal.executable private @reduce_to_scalar {
             : !flow.dispatch.tensor<readwrite:f32> -> tensor<f32>
         %5 = linalg.generic {
             indexing_maps = [#map0, #map1], iterator_types = ["reduction"]}
-            ins(%3 : tensor<?xf32>) outs(%4 : tensor<f32>) attrs =  {lowering.config = #config} {
+            ins(%3 : tensor<?xf32>) outs(%4 : tensor<f32>) attrs =  {lowering_config = #config} {
         ^bb0(%arg0: f32, %arg1: f32):
           %6 = arith.addf %arg0, %arg1 : f32
           linalg.yield %6 : f32
@@ -1300,10 +1300,10 @@ hal.executable private @reduce_to_scalar {
     }
   }
 }
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable private @reduce_to_scalar
 //      CHECK: hal.executable.entry_point public @reduce_to_scalar
-// CHECK-SAME:  translation.info = #[[TRANSLATION]]
+// CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
@@ -1325,10 +1325,10 @@ hal.executable private @reduce_to_scalar {
   native_vector_size = 16 : index,
   target_triple = "x86_64-unknown-linux-gnu"}>
 #map = affine_map<() -> ()>
-#translation = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = []>
+#translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @scalar {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @scalar layout(#executable_layout) {translation.info = #translation}
+    hal.executable.entry_point public @scalar layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func @scalar() {
         %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
@@ -1353,10 +1353,10 @@ hal.executable private @scalar {
     }
   }
 }
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = []>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
 //      CHECK: hal.executable private @scalar
 //      CHECK: hal.executable.entry_point public @scalar
-// CHECK-SAME:  translation.info = #[[TRANSLATION]]
+// CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)

--- a/iree/compiler/Codegen/Dialect/LoweringConfig.h
+++ b/iree/compiler/Codegen/Dialect/LoweringConfig.h
@@ -39,13 +39,13 @@ using TileSizesListTypeRef = ArrayRef<SmallVector<int64_t>>;
 namespace mlir {
 namespace iree_compiler {
 //===----------------------------------------------------------------------===//
-// Helpers for getting/setting iree_codegen.translation.info attribute on the
+// Helpers for getting/setting iree_codegen.translation_info attribute on the
 // `hal.executable.entry_point`
 // ===----------------------------------------------------------------------===//
 
 /// Gets the translate executable info attribute value associated with
 /// `entryPointOp`. It expects that the attribute is stored using the identifier
-/// `translation.info`.
+/// `translation_info`.
 IREE::Codegen::TranslationInfoAttr getTranslationInfo(
     IREE::HAL::ExecutableEntryPointOp entryPointOp);
 /// Returns the translation info for the `funcOp` (by looking at the entry
@@ -91,54 +91,47 @@ inline void setTranslationInfo(
 }
 
 //===----------------------------------------------------------------------===//
-// Helpers for getting/setting `iree_codegen.lowering.config` attribute on root
+// Helpers for getting/setting `iree_codegen.lowering_config` attribute on root
 // operations.
 // ===----------------------------------------------------------------------===//
 
 /// Returns the lowering configuration set for an operation. Returns `nullptr`
 /// if no value is set.  It expects that the attribute is stored using the
-/// identifier `lowering.config`.
+/// identifier `lowering_config`.
 IREE::Codegen::LoweringConfigAttr getLoweringConfig(Operation *op);
 
 /// Returns the tile sizes for a particular operation if the
-/// `iree_codegen.lowering.config` attribute is set on it.
+/// `iree_codegen.lowering_config` attribute is set on it.
 SmallVector<int64_t> getTileSizes(Operation *op, unsigned level);
 SmallVector<Value, 4> getTileSizes(OpBuilder &b, Operation *op, unsigned level);
 
 /// Sets the lowering configuration, overwriting existing attribute values.
 void setLoweringConfig(Operation *op, IREE::Codegen::LoweringConfigAttr config);
 
-/// Sets translation for the entry-point function based on op configuration.
-inline LogicalResult setOpConfigAndEntryPointFnTranslation(
-    FuncOp entryPointFn, Operation *op,
-    IREE::Codegen::LoweringConfigAttr config,
-    IREE::Codegen::DispatchLoweringPassPipeline passPipeline,
-    ArrayRef<int64_t> workgroupSize = {}) {
-  auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
-      entryPointFn->getContext(), passPipeline, ArrayRef<int64_t>{});
-  setTranslationInfo(entryPointFn, translationInfo, workgroupSize);
-  return success();
-}
+/// Convenience function that sets the lowering configuration on the operation
+/// and translation info on the entry point op for the common case of specifying
+/// tile sizes to use for the operation, and pass pipeline to use for the
+/// translation.
 inline LogicalResult setOpConfigAndEntryPointFnTranslation(
     FuncOp entryPointFn, Operation *op, TileSizesListTypeRef tileSizes,
-    ArrayRef<int64_t> nativeVectorSize,
     IREE::Codegen::DispatchLoweringPassPipeline passPipeline,
     ArrayRef<int64_t> workgroupSize = {}) {
   MLIRContext *context = entryPointFn.getContext();
-  auto config = IREE::Codegen::LoweringConfigAttr::get(context, tileSizes,
-                                                       nativeVectorSize);
+  auto config = IREE::Codegen::LoweringConfigAttr::get(context, tileSizes);
   setLoweringConfig(op, config);
-  return setOpConfigAndEntryPointFnTranslation(entryPointFn, op, config,
-                                               passPipeline, workgroupSize);
+  auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
+      entryPointFn->getContext(), passPipeline);
+  setTranslationInfo(entryPointFn, translationInfo, workgroupSize);
+  return success();
 }
 
 //===----------------------------------------------------------------------===//
-// Helpers for getting/setting `iree_codegen.compilation.info` attribute on root
+// Helpers for getting/setting `iree_codegen.compilation_info` attribute on root
 // operations to override IREEs default compilation.
 // ===----------------------------------------------------------------------===//
 
-/// Returns the `#iree_codegen.compilation.info` set on the operation. Assumes
-/// that the identifier used is `compilation.info`.
+/// Returns the `#iree_codegen.compilation_info` set on the operation. Assumes
+/// that the identifier used is `compilation_info`.
 IREE::Codegen::CompilationInfoAttr getCompilationInfo(Operation *op);
 
 /// Sets the `config` to use for compiling the operation. If `op` is the root
@@ -147,7 +140,7 @@ IREE::Codegen::CompilationInfoAttr getCompilationInfo(Operation *op);
 void setCompilationInfo(Operation *op,
                         IREE::Codegen::CompilationInfoAttr config);
 
-/// Removes the `#iree_codegen.compilation.info` attribute that is set on the
+/// Removes the `#iree_codegen.compilation_info` attribute that is set on the
 /// operation.
 void eraseCompilationInfo(Operation *op);
 

--- a/iree/compiler/Codegen/Dialect/LoweringConfig.td
+++ b/iree/compiler/Codegen/Dialect/LoweringConfig.td
@@ -8,43 +8,44 @@
 #define IREE_COMPILER_CODEGEN_DIALECT_LOWERINGCONFIG
 
 include "iree/compiler/Codegen/Dialect/IREECodegenDialect.td"
+include "mlir/IR/EnumAttr.td"
 
 // List of pre-existing pipelines for translating executables.
 def CPU_Default
-    : StrEnumAttrCase<"CPUDefault">;
+    : I32EnumAttrCase<"CPUDefault", 0>;
 def CPU_SingleTilingExpert
-    : StrEnumAttrCase<"CPUSingleTilingExpert">;
+    : I32EnumAttrCase<"CPUSingleTilingExpert", 1>;
 def CPU_DoubleTilingExpert
-    : StrEnumAttrCase<"CPUDoubleTilingExpert">;
+    : I32EnumAttrCase<"CPUDoubleTilingExpert", 2>;
 def CPU_ConvTileAndDecomposeExpert
-    : StrEnumAttrCase<"CPUConvTileAndDecomposeExpert">;
+    : I32EnumAttrCase<"CPUConvTileAndDecomposeExpert", 3>;
 def CPU_TileFuseAndVectorize
-    : StrEnumAttrCase<"CPUTileFuseAndVectorize">;
+    : I32EnumAttrCase<"CPUTileFuseAndVectorize", 4>;
 
 def LLVMGPU_SimpleDistribute
-    : StrEnumAttrCase<"LLVMGPUDistribute">;
+    : I32EnumAttrCase<"LLVMGPUDistribute", 5>;
 def LLVMGPU_Vectorize
-    : StrEnumAttrCase<"LLVMGPUVectorize">;
+    : I32EnumAttrCase<"LLVMGPUVectorize", 6>;
 def LLVMGPU_MatmulSimt
-    : StrEnumAttrCase<"LLVMGPUMatmulSimt">;
+    : I32EnumAttrCase<"LLVMGPUMatmulSimt", 7>;
 def LLVMGPU_MatmulTensorCore
-    : StrEnumAttrCase<"LLVMGPUMatmulTensorCore">;
+    : I32EnumAttrCase<"LLVMGPUMatmulTensorCore", 8>;
 
 def SPIRV_Distribute
-    : StrEnumAttrCase<"SPIRVDistribute">;
+    : I32EnumAttrCase<"SPIRVDistribute", 9>;
 def SPIRV_DistributeCopy
-    : StrEnumAttrCase<"SPIRVDistributeCopy">;
+    : I32EnumAttrCase<"SPIRVDistributeCopy", 10>;
 def SPIRV_Vectorize
-    : StrEnumAttrCase<"SPIRVVectorize">;
+    : I32EnumAttrCase<"SPIRVVectorize", 11>;
 def SPIRV_VectorizeToCooperativeOps
-    : StrEnumAttrCase<"SPIRVVectorizeToCooperativeOps">;
+    : I32EnumAttrCase<"SPIRVVectorizeToCooperativeOps", 12>;
 
 def None
-    : StrEnumAttrCase<"None">;
+    : I32EnumAttrCase<"None", 13>;
 
 // EnumAttrCase for all known lowerings for ops within dispatch region
 // to scalar/native-vector code.
-def DispatchLoweringPassPipelineEnum : StrEnumAttr<
+def DispatchLoweringPassPipelineEnum : I32EnumAttr<
     "DispatchLoweringPassPipeline",
     "identifier for pass pipeline use to lower dispatch region",
     [CPU_Default, CPU_SingleTilingExpert, CPU_DoubleTilingExpert,
@@ -54,11 +55,20 @@ def DispatchLoweringPassPipelineEnum : StrEnumAttr<
      SPIRV_Vectorize, SPIRV_VectorizeToCooperativeOps,
      None]> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Codegen";
+  // Don't generate a C++ class! We want to use the AttrDef
+  let genSpecializedAttr = 0;
 }
+
+// Define the AttrDef
+def DispatchLoweringPassPipelineAttr :
+    EnumAttr<IREECodegen_Dialect, DispatchLoweringPassPipelineEnum, ""> {
+  let assemblyFormat = "``$value";
+}
+
 
 def IREECodegen_TranslationInfoAttr :
     AttrDef<IREECodegen_Dialect, "TranslationInfo", []> {
-  let mnemonic = "translation.info";
+  let mnemonic = "translation_info";
   let summary = [{drive dispatch entry point lowering}];
   let description = [{
     Specifies the information that is used to drive the translation of
@@ -67,7 +77,7 @@ def IREECodegen_TranslationInfoAttr :
     `hal.executable.entry_point` operation.
 
     If this operation is already set on the root operation (as part of
-    `iree_codegen.compilation.info`) that drives the compilation of a
+    `iree_codegen.compilation_info`) that drives the compilation of a
     dispatch region (like `linalg.matmul`/`linalg.*conv*`), this
     attribute gets propagated to the entry point function.
 
@@ -81,12 +91,14 @@ def IREECodegen_TranslationInfoAttr :
   }];
 
   let assemblyFormat = [{
-    `<` $passPipeline `,` `workload_per_wg` `=` $workloadPerWorkgroup `>`
+    `<` `` $passPipeline (`,` `workload_per_wg` `=` $workloadPerWorkgroup^)? `>`
   }];
 
   let parameters = (ins
-    AttrParameter<"StringAttr", "">:$passPipeline,
-    AttrParameter<"ArrayAttr", "">:$workloadPerWorkgroup
+    AttrParameter<"IREE::Codegen::DispatchLoweringPassPipelineAttr",
+        "Name of the pipeline to be invoked on the translation unit.">:$passPipeline,
+    DefaultValuedParameter<"ArrayAttr", "ArrayAttr::get($_ctx, {})",
+        "The workload mapped to a single workgroup">:$workloadPerWorkgroup
   );
   let builders = [
     AttrBuilder<(ins "DispatchLoweringPassPipeline":$passPipeline,
@@ -104,7 +116,7 @@ def IREECodegen_TranslationInfoAttr :
 
 def IREECodegen_LoweringConfigAttr :
     AttrDef<IREECodegen_Dialect, "LoweringConfig", []> {
-  let mnemonic = "lowering.config";
+  let mnemonic = "lowering_config";
   let summary = [{drive lowering of an operation within dispatch region}];
   let description = [{
     Specifies the information that is used by backend compiler to
@@ -122,12 +134,14 @@ def IREECodegen_LoweringConfigAttr :
   }];
 
   let assemblyFormat = [{
-    `<` `tile_sizes` `=` $tileSizes `,` `native_vector_size` `=` $nativeVectorSize `>`
+    `<` `tile_sizes` `=` $tileSizes (`,` `native_vector_size` `=` $nativeVectorSize^)? `>`
   }];
 
   let parameters = (ins
-    AttrParameter<"ArrayAttr", "">:$tileSizes,
-    AttrParameter<"ArrayAttr", "">:$nativeVectorSize
+    AttrParameter<"ArrayAttr",
+        "The tile sizes to use for different levels of tiling">:$tileSizes,
+    DefaultValuedParameter<"ArrayAttr", "ArrayAttr::get($_ctx, {})",
+        "The native vector size to use for the given operation">:$nativeVectorSize
   );
   let builders = [
     AttrBuilder<(ins "TileSizesListTypeRef":$tileSizes,
@@ -148,7 +162,7 @@ def IREECodegen_LoweringConfigAttr :
 
 def IREECodegen_CompilationInfoAttr :
     AttrDef<IREECodegen_Dialect, "CompilationInfo", []> {
-  let mnemonic = "compilation.info";
+  let mnemonic = "compilation_info";
   let summary = [{drive lowering of an operation from input dialect}];
   let description = [{
     Specifies the information that allows controlling the compilation
@@ -171,11 +185,13 @@ def IREECodegen_CompilationInfoAttr :
   let parameters = (ins
     AttrParameter<"LoweringConfigAttr", "">:$loweringConfig,
     AttrParameter<"TranslationInfoAttr", "">:$translationInfo,
-    AttrParameter<"ArrayAttr", "">:$workgroupSize
+    DefaultValuedParameter<"ArrayAttr", "ArrayAttr::get($_ctx, {})",
+        "The workgroup size to use during translation.">:$workgroupSize
   );
 
   let assemblyFormat = [{
-    `<` $loweringConfig `,` $translationInfo `,` `workgroup_size` `=` $workgroupSize `>`
+    `<` `lowering_config` `=` $loweringConfig `,` `translation_info` `=` $translationInfo
+    (`,` `workgroup_size` `=` $workgroupSize^)? `>`
   }];
 
   let builders = [

--- a/iree/compiler/Codegen/Dialect/test/lowering_config_attr.mlir
+++ b/iree/compiler/Codegen/Dialect/test/lowering_config_attr.mlir
@@ -1,37 +1,52 @@
 // RUN: iree-opt -split-input-file %s | FileCheck %s
 
-module attributes {
-  translation.info = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = [32, 42]>
-} { }
-// CHECK: #translation = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = [32, 42]>
+module {
+  func @test() attributes { 
+      lowring_config = #iree_codegen.translation_info<CPUDefault, workload_per_wg = [32, 42]>} {
+    return
+  }
+}
+// CHECK: #translation = #iree_codegen.translation_info<CPUDefault, workload_per_wg = [32, 42]>
 
 // -----
 
-module attributes {
-  translation.info = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = []>
-} { }
-// CHECK: #translation = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = []>
+module {
+  builtin.func @test() attributes {
+      translation_info = #iree_codegen.translation_info<CPUDefault>} {
+    return
+  }
+}
+// CHECK: #translation = #iree_codegen.translation_info<CPUDefault>
 
 // -----
 
-module attributes {
-  lowering.config = #iree_codegen.lowering.config<tile_sizes = [], native_vector_size = []>
-} { }
-// CHECK: #config = #iree_codegen.lowering.config<tile_sizes = [], native_vector_size = []>
+module {
+  builtin.func @test() attributes {
+      lowering_config = #iree_codegen.lowering_config<tile_sizes = []>} {
+    return
+  }
+}
+// CHECK: #config = #iree_codegen.lowering_config<tile_sizes = []>
 
 // -----
 
-module attributes {
-  lowering.config = #iree_codegen.lowering.config<tile_sizes = [[], [10]], native_vector_size = [32, 32]>
-} { }
-// CHECK: #config = #iree_codegen.lowering.config<tile_sizes = {{\[}}[], [10]{{\]}}, native_vector_size = [32, 32]>
+module {
+  func @test() attributes {
+      lowering_config = #iree_codegen.lowering_config<tile_sizes = [[], [10]], native_vector_size = [32, 32]>} {
+    return
+  }
+}
+// CHECK: #config = #iree_codegen.lowering_config<tile_sizes = {{\[}}[], [10]{{\]}}, native_vector_size = [32, 32]>
 
 // -----
 
-module attributes {
-  compilation.info = #iree_codegen.compilation.info<
-      #iree_codegen.lowering.config<tile_sizes = [], native_vector_size = []>,
-      #iree_codegen.translation.info<"CPUDefault", workload_per_wg = []>,
-      workgroup_size = []>
-} { }
-// CHECK: #compilation = #iree_codegen.compilation.info<<tile_sizes = [], native_vector_size = []>, <"CPUDefault", workload_per_wg = []>, workgroup_size = []>
+module {
+  func @test() attributes {
+     compilation_info = #iree_codegen.compilation_info<
+         lowering_config = <tile_sizes = []>,
+         translation_info = <CPUDefault>,
+         workgroup_size = []>} {
+    return
+  }
+}
+// CHECK: #compilation = #iree_codegen.compilation_info<lowering_config = <tile_sizes = []>, translation_info = <CPUDefault>>

--- a/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -328,7 +328,6 @@ static LogicalResult setDefaultRootConfig(
   tileSizes.emplace_back(std::move(flowTileSizes));
   return setOpConfigAndEntryPointFnTranslation(
       entryPointFn, partitionableLoopsInterfaceOp, tileSizes,
-      /*nativeVectorSize=*/ArrayRef<int64_t>{},
       DispatchLoweringPassPipeline::CPUDefault);
 }
 
@@ -357,7 +356,7 @@ static LogicalResult setX86SandboxRootConfig(FuncOp entryPointFn,
   tileSizes.push_back(vectorTileSizes);
 
   return setOpConfigAndEntryPointFnTranslation(
-      entryPointFn, op, tileSizes, /*nativeVectorSize=*/ArrayRef<int64_t>{},
+      entryPointFn, op, tileSizes,
       DispatchLoweringPassPipeline::CPUDoubleTilingExpert);
 }
 
@@ -388,7 +387,7 @@ static LogicalResult setX86TileFuseAndVectorizeRootConfig(
   tileSizes.push_back(vectorTileSizes);
 
   return setOpConfigAndEntryPointFnTranslation(
-      entryPointFn, op, tileSizes, vectorTileSizes,
+      entryPointFn, op, tileSizes,
       DispatchLoweringPassPipeline::CPUTileFuseAndVectorize);
 }
 
@@ -421,7 +420,7 @@ static LogicalResult setARMRootConfig(FuncOp entryPointFn,
   tileSizes.push_back(vectorTileSizes);
 
   return setOpConfigAndEntryPointFnTranslation(
-      entryPointFn, op, tileSizes, vectorTileSizes,
+      entryPointFn, op, tileSizes,
       DispatchLoweringPassPipeline::CPUTileFuseAndVectorize);
 }
 
@@ -524,7 +523,7 @@ static LogicalResult setRootConfig(
                                  nativeVectorSize};
 
   return setOpConfigAndEntryPointFnTranslation(
-      entryPointFn, mmt4dOp, tileSizes, nativeVectorSize,
+      entryPointFn, mmt4dOp, tileSizes,
       DispatchLoweringPassPipeline::CPUTileFuseAndVectorize);
 }
 
@@ -558,8 +557,7 @@ static LogicalResult setRootConfig(
   }
   TileSizesListType tileSizes = {workgroupTileSizes};
   return setOpConfigAndEntryPointFnTranslation(
-      entryPointFn, fftOp, tileSizes, /*nativeVectorSize=*/ArrayRef<int64_t>{},
-      DispatchLoweringPassPipeline::CPUDefault);
+      entryPointFn, fftOp, tileSizes, DispatchLoweringPassPipeline::CPUDefault);
 }
 
 /// Sets the lowering configuration for a generic op to use DoubleTilingExpert.
@@ -633,7 +631,6 @@ static LogicalResult setRootConfig(
   tileSizes.push_back(vectorTileSizes);
   return setOpConfigAndEntryPointFnTranslation(
       entryPointFn, genericOp, tileSizes,
-      /*nativeVectorSize=*/ArrayRef<int64_t>{},
       DispatchLoweringPassPipeline::CPUDoubleTilingExpert);
 }
 
@@ -684,7 +681,6 @@ static LogicalResult setRootConfig(
   tileSizes.push_back(vectorTileSizes);
   return setOpConfigAndEntryPointFnTranslation(
       entryPointFn, convOp, tileSizes,
-      /*nativeVectorSize=*/ArrayRef<int64_t>{},
       DispatchLoweringPassPipeline::CPUConvTileAndDecomposeExpert);
 }
 

--- a/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -88,7 +88,7 @@ LogicalResult verifyDoubleTilingExpertPassPipelineConfig(
       IREE::Codegen::DispatchLoweringPassPipeline::CPUDoubleTilingExpert;
   StringRef pipelineName = stringifyEnum(pipeline);
   if (translationInfo.getDispatchLoweringPassPipeline() != pipeline) {
-    return op->emitOpError("expected pipeline in translation.info to be ")
+    return op->emitOpError("expected pipeline in translation_info to be ")
            << pipelineName;
   }
 

--- a/iree/compiler/Codegen/LLVMCPU/test/illegal_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/illegal_configuration.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt -pass-pipeline='hal.executable(hal.executable.variant(iree-llvmcpu-lower-executable-target{test-lowering-configuration=true}))' -verify-diagnostics -split-input-file %s
 
-#config = #iree_codegen.lowering.config<tile_sizes = [], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+#config = #iree_codegen.lowering_config<tile_sizes = []>
+#translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -12,7 +12,7 @@
 hal.executable private @matmul_tensors {
   hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
     hal.executable.entry_point @illegal layout(#executable_layout)  {
-      translation.info = #translation
+      translation_info = #translation
     }
     builtin.module {
       func @illegal() {
@@ -21,7 +21,7 @@ hal.executable private @matmul_tensors {
         %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<8x16xf32>
         %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<4x16xf32>
         // expected-error @+1 {{expected three tiling sizes for CPUDoubleTilingExpert, got 0}}
-        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
+        linalg.matmul {lowering_config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
           outs(%result: memref<4x16xf32>)
         return
       }
@@ -31,8 +31,8 @@ hal.executable private @matmul_tensors {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[4, 8], [8, 8, 0], [0, 0, 8]], native_vector_size = [0, 0, 4]>
-#translation = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[4, 8], [8, 8, 0], [0, 0, 8]], native_vector_size = [0, 0, 4]>
+#translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -43,7 +43,7 @@ hal.executable private @matmul_tensors {
 hal.executable private @matmul_tensors {
   hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
     hal.executable.entry_point @illegal layout(#executable_layout)  {
-      translation.info = #translation
+      translation_info = #translation
     }
     builtin.module {
       func @illegal() {
@@ -52,7 +52,7 @@ hal.executable private @matmul_tensors {
         %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<8x16xf32>
         %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<4x16xf32>
         // expected-error @+1 {{native_vector_size must be same as the last level of tiling}}
-        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
+        linalg.matmul {lowering_config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
           outs(%result: memref<4x16xf32>)
         return
       }
@@ -62,8 +62,8 @@ hal.executable private @matmul_tensors {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[64, 64, 0], [8, 32, 16], [0, 0, 16]], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 0], [8, 32, 16], [0, 0, 16]]>
+#translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -74,7 +74,7 @@ hal.executable private @matmul_tensors {
 hal.executable private @matmul_tensors {
   hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
     hal.executable.entry_point @illegal layout(#executable_layout)  {
-      translation.info = #translation
+      translation_info = #translation
     }
     builtin.module {
       func @illegal() {
@@ -83,7 +83,7 @@ hal.executable private @matmul_tensors {
         %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<8x16xf32>
         %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<4x16xf32>
         // expected-error @+1 {{expected only parallel dims to be set in the second tiling sizes, got 2-th tile size set}}
-        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
+        linalg.matmul {lowering_config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
           outs(%result: memref<4x16xf32>)
         return
       }
@@ -93,8 +93,8 @@ hal.executable private @matmul_tensors {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[64, 64], [8, 0, 0], [0, 16, 16]], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[64, 64], [8, 0, 0], [0, 16, 16]]>
+#translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -105,7 +105,7 @@ hal.executable private @matmul_tensors {
 hal.executable private @matmul_tensors {
   hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
     hal.executable.entry_point @illegal layout(#executable_layout)  {
-      translation.info = #translation
+      translation_info = #translation
     }
     builtin.module {
       func @illegal() {
@@ -114,7 +114,7 @@ hal.executable private @matmul_tensors {
         %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<8x16xf32>
         %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<4x16xf32>
         // expected-error @+1 {{only reduction dims to be set in the third tiling sizes, got 1-th tile size set}}
-        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
+        linalg.matmul {lowering_config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
           outs(%result: memref<4x16xf32>)
         return
       }

--- a/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
@@ -44,12 +44,12 @@ hal.executable private @matmul_tensors  {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[64, 64, 0], [16, 4, 64], [4, 4, 4]{{\]}}, native_vector_size = [4, 4, 4]>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUTileFuseAndVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0], [16, 4, 64], [4, 4, 4]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUTileFuseAndVectorize>
 //      CHECK: hal.executable.entry_point public @matmul_tensors
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.matmul
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -94,12 +94,12 @@ hal.executable private @add {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[64, 64], [1, 4], [0, 0]], native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64], [1, 4], [0, 0]]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable.entry_point public @add
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.generic
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -152,12 +152,12 @@ hal.executable private @add4D  {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[0, 64, 64, 64], [1, 1, 1, 4], [0, 0, 0, 0]], native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 64, 64, 64], [1, 1, 1, 4], [0, 0, 0, 0]]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable.entry_point public @add4D
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.generic
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -203,18 +203,18 @@ hal.executable private @batch_matmul_tensors {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[1, 64, 64, 0], [1, 16, 4, 64], [1, 4, 4, 4]{{\]}}, native_vector_size = [1, 4, 4, 4]>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUTileFuseAndVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 64, 0], [1, 16, 4, 64], [1, 4, 4, 4]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUTileFuseAndVectorize>
 //      CHECK: hal.executable.entry_point public @batch_matmul_tensors
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:  linalg.batch_matmul
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
-#compilation = #iree_codegen.compilation.info<
-    #iree_codegen.lowering.config<tile_sizes = [[64, 64, 0], [32, 32, 0], [0, 0, 32]], native_vector_size = []>,
-    #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>,
+#compilation = #iree_codegen.compilation_info<
+    lowering_config = <tile_sizes = [[64, 64, 0], [32, 32, 0], [0, 0, 32]]>,
+    translation_info  = <CPUDoubleTilingExpert>,
     workgroup_size = []>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
@@ -241,7 +241,7 @@ hal.executable private @preset_config_matmul_tensors  {
             : !flow.dispatch.tensor<readonly:256x512xf32> -> tensor<256x512xf32>
         %init = linalg.init_tensor [128, 512] : tensor<128x512xf32>
         %fill = linalg.fill(%cst, %init) : f32, tensor<128x512xf32> -> tensor<128x512xf32>
-        %gemm = linalg.matmul {compilation.info = #compilation}
+        %gemm = linalg.matmul {compilation_info = #compilation}
             ins(%lhs, %rhs : tensor<128x256xf32>, tensor<256x512xf32>)
             outs(%fill : tensor<128x512xf32>) -> tensor<128x512xf32>
         flow.dispatch.tensor.store %gemm, %result_binding, offsets = [0, 0], sizes = [128, 512], strides = [1, 1]
@@ -252,13 +252,13 @@ hal.executable private @preset_config_matmul_tensors  {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[64, 64, 0], [32, 32, 0], [0, 0, 32]], native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0], [32, 32, 0], [0, 0, 32]]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable.entry_point
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: func @preset_config
 //      CHECK:   linalg.matmul
-// CHECK-SAME:       lowering.config = #[[CONFIG]]
+// CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -296,12 +296,12 @@ hal.executable @tensor_insert {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[64, 64]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
 //      CHECK: hal.executable.entry_point public @tensor_insert_slice
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: tensor.insert_slice
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -339,12 +339,12 @@ hal.executable @extract_slice {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[64, 64]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
 //      CHECK: hal.executable.entry_point public @extract_slice
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: tensor.extract_slice
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 
 // -----
@@ -377,13 +377,13 @@ hal.executable private @static_1d_fft_stage2  {
   }
 }
 
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[64]{{\]}}, native_vector_size = []>
-//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = []>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64]{{\]}}>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
 //       CHECK: hal.executable.entry_point public @static_1d_fft_stage2
-//  CHECK-SAME:     translation.info = #[[TRANSLATION]]
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: func @static_1d_fft_stage2()
 //       CHECK:   iree_linalg_ext.fft
-//  CHECK-SAME:       lowering.config = #[[CONFIG]]
+//  CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -414,13 +414,13 @@ hal.executable private @static_3d_fft_stage3  {
   }
 }
 
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[64, 64, 64]{{\]}}, native_vector_size = []>
-//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = []>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 64]{{\]}}>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
 //       CHECK: hal.executable.entry_point public @static_3d_fft_stage3
-//  CHECK-SAME:     translation.info = #[[TRANSLATION]]
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: func @static_3d_fft_stage3()
 //       CHECK:   iree_linalg_ext.fft
-//  CHECK-SAME:       lowering.config = #[[CONFIG]]
+//  CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -476,15 +476,15 @@ hal.executable private @outs_fusion {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[64, 64, 0], [1, 4, 0], [0, 0, 4]{{\]}}, native_vector_size = []>
-//      CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0], [1, 4, 0], [0, 0, 4]{{\]}}>
+//      CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable.entry_point public @outs_fusion_fn
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 //      CHECK: func @outs_fusion_fn()
 //      CHECK:   linalg.generic
-//  CHECK-NOT:   lowering.config
+//  CHECK-NOT:   lowering_config
 //      CHECK:   linalg.generic
-// CHECK-SAME:       lowering.config = #[[CONFIG]]
+// CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -536,11 +536,12 @@ hal.executable private @conv {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[0, 64, 64, 64, 0, 0, 0], [1, 1, 8, 8, 0, 0, 0], [0, 0, 0, 0, 1, 1, 8]], native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUConvTileAndDecomposeExpert", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 64, 64, 64, 0, 0, 0], [1, 1, 8, 8, 0, 0, 0], [0, 0, 0, 0, 1, 1, 8]]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUConvTileAndDecomposeExpert>
 //      CHECK: hal.executable.entry_point public @conv
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:     linalg.conv_2d_nhwc_hwcf
+//      CHECK:         lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -577,10 +578,10 @@ hal.executable private @conv_static {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[0, 28, 28, 16, 0, 0, 0], [1, 1, 4, 8, 0, 0, 0], [0, 0, 0, 0, 1, 1, 3]], native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUConvTileAndDecomposeExpert", workload_per_wg = []>
-//      CHECK: hal.executable.entry_point public @conv
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 28, 28, 16, 0, 0, 0], [1, 1, 4, 8, 0, 0, 0], [0, 0, 0, 0, 1, 1, 3]]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUConvTileAndDecomposeExpert>
+//      CHECK: hal.executable.entry_point public @conv_static
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:     linalg.conv_2d_nhwc_hwcf
 
 
@@ -624,12 +625,12 @@ hal.executable private @depthwise_conv_static {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[0, 20, 40, 48, 0, 0]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 20, 40, 48, 0, 0]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
 //      CHECK: hal.executable.entry_point public @depthwise_conv_static
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:     linalg.depthwise_conv_2d_nhwc_hwc
-// CHECK-SAME:       lowering.config  = #[[CONFIG]]
+// CHECK-SAME:       lowering_config  = #[[CONFIG]]
 
 // -----
 
@@ -669,12 +670,12 @@ hal.executable private @generic_static {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[16, 32], [16, 16], [0, 0]], native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[16, 32], [16, 16], [0, 0]]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable.entry_point public @generic_static
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
-//      CHECK:       lowering.config = #[[CONFIG]]
+//      CHECK:       lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -717,12 +718,12 @@ hal.executable private @matmul_static {
   }
 }
 
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[28, 8, 0], [4, 4, 60], [4, 4, 4]{{\]}}, native_vector_size = [4, 4, 4]>
-//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUTileFuseAndVectorize", workload_per_wg = []>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[28, 8, 0], [4, 4, 60], [4, 4, 4]{{\]}}>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUTileFuseAndVectorize>
 //       CHECK: hal.executable.entry_point public @matmul_static
-//  CHECK-SAME:     translation.info = #[[TRANSLATION]]
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: linalg.matmul
-//  CHECK-SAME:     lowering.config = #[[CONFIG]]
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -765,12 +766,12 @@ hal.executable private @restrict_num_workgroups {
     }
   }
 }
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[0, 1, 7, 64, 0, 0]{{\]}}, native_vector_size = []>
-//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = []>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 7, 64, 0, 0]{{\]}}>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
 //       CHECK: hal.executable.entry_point public @restrict_num_workgroups
-//  CHECK-SAME:     translation.info = #[[TRANSLATION]]
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: linalg.depthwise_conv_2d_nhwc_hwc
-//  CHECK-SAME:     lowering.config = #[[CONFIG]]
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 
 // -----
@@ -813,12 +814,12 @@ hal.executable private @matmul_x86  {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] =  #iree_codegen.lowering.config<tile_sizes = {{\[}}[64, 64, 0], [8, 32, 0], [0, 0, 16]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] =  #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0], [8, 32, 0], [0, 0, 16]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable.entry_point public @matmul_x86
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.matmul
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -871,12 +872,12 @@ hal.executable private @reduction {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[4, 0, 0], [4, 0, 0], [0, 1, 4]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[4, 0, 0], [4, 0, 0], [0, 1, 4]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable.entry_point public @predict_dispatch_86
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.generic {indexing_maps = [#{{.+}}, #{{.+}}], iterator_types = ["parallel", "reduction", "reduction"]}
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -923,12 +924,12 @@ hal.executable private @matmul_i8_i8_i32  {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[64, 64, 0], [8, 8, 8], [1, 4, 4]{{\]}}, native_vector_size = [1, 4, 4]>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUTileFuseAndVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0], [8, 8, 8], [1, 4, 4]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUTileFuseAndVectorize>
 //      CHECK: hal.executable.entry_point public @matmul_i8_i8_i32
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.matmul
-// CHECK-SAME:       lowering.config = #[[CONFIG]]
+// CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -976,12 +977,12 @@ hal.executable private @gemm_unit_N {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[64, 0, 0], [8, 0, 0], [0, 0, 16]], native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 0, 0], [8, 0, 0], [0, 0, 16]]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable.entry_point public @gemm_unit_N
-// CHECK-SAME:       translation.info = #[[TRANSLATION]]
+// CHECK-SAME:       translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.matmul
-// CHECK-SAME:       lowering.config = #[[CONFIG]]
+// CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -1023,12 +1024,12 @@ hal.executable private @gemm_unit_M_unit_N {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[0, 0, 0], [0, 0, 0], [0, 0, 16]], native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 0], [0, 0, 0], [0, 0, 16]]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable.entry_point public @gemm_unit_M_unit_N
-// CHECK-SAME:       translation.info = #[[TRANSLATION]]
+// CHECK-SAME:       translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.matmul
-// CHECK-SAME:       lowering.config = #[[CONFIG]]
+// CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -1078,12 +1079,12 @@ hal.executable private @generic_unit_dims {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[0, 0, 0, 0, 64, 64, 0, 64], [0, 1, 0, 0, 1, 1, 0, 4], [0, 0, 0, 0, 0, 0, 0, 0]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 0, 0, 64, 64, 0, 64], [0, 1, 0, 0, 1, 1, 0, 4], [0, 0, 0, 0, 0, 0, 0, 0]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable.entry_point public @generic_unit_dim
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.generic
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -1123,12 +1124,12 @@ hal.executable private @reduce_to_scalar {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[0], [0], [4]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0], [0], [4]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable.entry_point public @reduce_to_scalar
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.generic
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -1168,6 +1169,6 @@ hal.executable private @scalar {
     }
   }
 }
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = []>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
 //      CHECK: hal.executable.entry_point public @scalar
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/iree/compiler/Codegen/LLVMCPU/test/test_config_mmt4d.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/test_config_mmt4d.mlir
@@ -22,34 +22,24 @@ hal.executable private @mmt4d_384x384x512_4x1x4_dispatch_0 {
         %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:96x384x4x1xf32>
         %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<readonly:128x384x4x1xf32>
         %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : !flow.dispatch.tensor<readwrite:96x128x4x4xf32>
-        %workgroup_size_x = hal.interface.workgroup.size[0] : index
-        %workgroup_size_y = hal.interface.workgroup.size[1] : index
-        %workgroup_id_x = hal.interface.workgroup.id[0] : index
-        %workgroup_count_x = hal.interface.workgroup.count[0] : index
-        %workgroup_id_y = hal.interface.workgroup.id[1] : index
-        %workgroup_count_y = hal.interface.workgroup.count[1] : index
-        %3 = affine.apply #map0()[%workgroup_id_y, %workgroup_size_y]
-        %4 = affine.apply #map0()[%workgroup_count_y, %workgroup_size_y]
-        scf.for %arg0 = %3 to %c96 step %4 {
-          %5 = affine.apply #map0()[%workgroup_id_x, %workgroup_size_x]
-          %6 = affine.apply #map0()[%workgroup_count_x, %workgroup_size_x]
-          scf.for %arg1 = %5 to %c128 step %6 {
-            %7 = affine.min #map3(%arg0)[%workgroup_size_y]
-            %8 = flow.dispatch.tensor.load %0, offsets = [%arg0, 0, 0, 0], sizes = [%7, 384, 4, 1], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:96x384x4x1xf32> -> tensor<?x384x4x1xf32>
-            %9 = affine.min #map4(%arg1)[%workgroup_size_x]
-            %10 = flow.dispatch.tensor.load %1, offsets = [%arg1, 0, 0, 0], sizes = [%9, 384, 4, 1], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:128x384x4x1xf32> -> tensor<?x384x4x1xf32>
-            %11 = flow.dispatch.tensor.load %2, offsets = [%arg0, %arg1, 0, 0], sizes = [%7, %9, 4, 4], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readwrite:96x128x4x4xf32> -> tensor<?x?x4x4xf32>
-            %12 = linalg.mmt4d {__internal_linalg_transform__ = "workgroup"} ins(%8, %10 : tensor<?x384x4x1xf32>, tensor<?x384x4x1xf32>) outs(%11 : tensor<?x?x4x4xf32>) -> tensor<?x?x4x4xf32>
-            flow.dispatch.tensor.store %12, %2, offsets = [%arg0, %arg1, 0, 0], sizes = [%7, %9, 4, 4], strides = [1, 1, 1, 1] : tensor<?x?x4x4xf32> -> !flow.dispatch.tensor<readwrite:96x128x4x4xf32>
-          }
-        }
+        %8 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [96, 384, 4, 1], strides = [1, 1, 1, 1]
+            : !flow.dispatch.tensor<readonly:96x384x4x1xf32> -> tensor<96x384x4x1xf32>
+        %10 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [128, 384, 4, 1], strides = [1, 1, 1, 1]
+            : !flow.dispatch.tensor<readonly:128x384x4x1xf32> -> tensor<128x384x4x1xf32>
+        %11 = flow.dispatch.tensor.load %2, offsets = [0, 0, 0, 0], sizes = [96, 384, 4, 4], strides = [1, 1, 1, 1]
+            : !flow.dispatch.tensor<readwrite:96x128x4x4xf32> -> tensor<96x128x4x4xf32>
+        %12 = linalg.mmt4d {__internal_linalg_transform__ = "workgroup"}
+            ins(%8, %10 : tensor<96x384x4x1xf32>, tensor<128x384x4x1xf32>) 
+            outs(%11 : tensor<96x128x4x4xf32>) -> tensor<96x128x4x4xf32>
+        flow.dispatch.tensor.store %12, %2, offsets = [0, 0, 0, 0], sizes = [96, 128, 4, 4], strides = [1, 1, 1, 1]
+            : tensor<96x128x4x4xf32> -> !flow.dispatch.tensor<readwrite:96x128x4x4xf32>
         return
       }
     }
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[48, 32], [1, 1, 1, 4, 4, 1], [1, 1, 1, 4, 4, 1]{{\]}}, native_vector_size = [1, 1, 1, 4, 4, 1]
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[48, 32], [1, 1, 1, 4, 4, 1], [1, 1, 1, 4, 4, 1]{{\]}}
 //      CHECK: func @mmt4d_384x384x512_4x1x4_dispatch_0()
 //      CHECK:   linalg.mmt4d
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/iree/compiler/Codegen/LLVMCPU/test/tile_fuse_and_vectorize.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/tile_fuse_and_vectorize.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt %s -iree-llvmcpu-tile-fuse-and-vectorize -cse -canonicalize -split-input-file | FileCheck %s
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[], [16, 16, 32], [16, 16, 16]], native_vector_size = [16, 16, 16]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[], [16, 16, 32], [16, 16, 16]], native_vector_size = [16, 16, 16]>
 #map0 = affine_map<()[s0] -> (s0 * 64)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>
 module  {
@@ -27,7 +27,7 @@ module  {
         %8 = flow.dispatch.tensor.load %0, offsets = [%arg0, 0], sizes = [64, 512], strides = [1, 1] : !flow.dispatch.tensor<readonly:384x512xf32> -> tensor<64x512xf32>
         %9 = flow.dispatch.tensor.load %1, offsets = [0, %arg1], sizes = [512, 64], strides = [1, 1] : !flow.dispatch.tensor<readonly:512x128xf32> -> tensor<512x64xf32>
         %10 = linalg.fill(%cst, %7) : f32, tensor<64x64xf32> -> tensor<64x64xf32>
-        %11 = linalg.matmul {lowering.config = #config} ins(%8, %9 : tensor<64x512xf32>, tensor<512x64xf32>) outs(%10 : tensor<64x64xf32>) -> tensor<64x64xf32>
+        %11 = linalg.matmul {lowering_config = #config} ins(%8, %9 : tensor<64x512xf32>, tensor<512x64xf32>) outs(%10 : tensor<64x64xf32>) -> tensor<64x64xf32>
         %12 = linalg.generic {indexing_maps = [#map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%11 : tensor<64x64xf32>) outs(%7 : tensor<64x64xf32>) {
         ^bb0(%arg2: f32, %arg3: f32):  // no predecessors
           %13 = math.exp %arg2 : f32
@@ -110,7 +110,7 @@ func @matmul_gather() {
       %15 = flow.dispatch.tensor.load %3, offsets = [0, %arg1], sizes = [384, 64], strides = [1, 1] : !flow.dispatch.tensor<readonly:384x512xf32> -> tensor<384x64xf32>
       %16 = linalg.init_tensor [64, 64] : tensor<64x64xf32>
       %17 = linalg.fill(%cst, %16) : f32, tensor<64x64xf32> -> tensor<64x64xf32>
-      %18 = linalg.matmul {lowering.config = #iree_codegen.lowering.config<tile_sizes = [[], [32, 32, 32], [16, 16, 16]], native_vector_size = [16, 16, 16]>} ins(%14, %15 : tensor<64x384xf32>, tensor<384x64xf32>) outs(%17 : tensor<64x64xf32>) -> tensor<64x64xf32>
+      %18 = linalg.matmul {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[], [32, 32, 32], [16, 16, 16]], native_vector_size = [16, 16, 16]>} ins(%14, %15 : tensor<64x384xf32>, tensor<384x64xf32>) outs(%17 : tensor<64x64xf32>) -> tensor<64x64xf32>
       %19 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%18, %11, %12 : tensor<64x64xf32>, tensor<64xi32>, tensor<64x64xf32>) outs(%13 : tensor<64x64xf32>) {
       ^bb0(%arg2: f32, %arg3: i32, %arg4: f32, %arg5: f32):  // no predecessors
         %20 = linalg.index 1 : index
@@ -179,7 +179,7 @@ func @nonvectorizable_matmul_and_vectorizable_generic() {
       %17 = flow.dispatch.tensor.load %5, offsets = [0, %arg1], sizes = [24, 49], strides = [1, 1] : !flow.dispatch.tensor<readonly:24x96xf32> -> tensor<24x49xf32>
       %18 = linalg.init_tensor [16, 49] : tensor<16x49xf32>
       %19 = linalg.fill(%cst, %18) : f32, tensor<16x49xf32> -> tensor<16x49xf32>
-      %20 = linalg.matmul {lowering.config = #iree_codegen.lowering.config<tile_sizes = [[], [16, 16, 32], [16, 16, 16]], native_vector_size = [16, 16, 16]>} ins(%16, %17 : tensor<16x24xf32>, tensor<24x49xf32>) outs(%19 : tensor<16x49xf32>) -> tensor<16x49xf32>
+      %20 = linalg.matmul {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[], [16, 16, 32], [16, 16, 16]], native_vector_size = [16, 16, 16]>} ins(%16, %17 : tensor<16x24xf32>, tensor<24x49xf32>) outs(%19 : tensor<16x49xf32>) -> tensor<16x49xf32>
       %21 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%20, %11, %12, %13, %14 : tensor<16x49xf32>, tensor<49xf32>, tensor<49xf32>, tensor<49xf32>, tensor<49xf32>) outs(%15 : tensor<16x49xf32>) {
       ^bb0(%arg2: f32, %arg3: f32, %arg4: f32, %arg5: f32, %arg6: f32, %arg7: f32):  // no predecessors
         %22 = arith.addf %arg5, %cst_0 : f32

--- a/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -118,9 +118,8 @@ static LogicalResult setContractConfig(FuncOp entryPoint, linalg::LinalgOp op) {
 
         tileSizes.emplace_back(
             std::move(workgroupTileSizes));  // Workgroup level.
-        return setOpConfigAndEntryPointFnTranslation(
-            entryPoint, op, tileSizes,
-            /*nativeVectorSizes=*/ArrayRef<int64_t>{}, pipeline, workgroupSize);
+        return setOpConfigAndEntryPointFnTranslation(entryPoint, op, tileSizes,
+                                                     pipeline, workgroupSize);
       };
   // Infer the MxN size of the matmul based on operands and indexing maps.
   auto lhsShape =
@@ -233,7 +232,7 @@ static LogicalResult setFftConfig(FuncOp entryPoint,
   }
   TileSizesListType tileSizes = {workgroupTileSize};
   return setOpConfigAndEntryPointFnTranslation(
-      entryPoint, op, tileSizes, /*nativeVectorSizes=*/ArrayRef<int64_t>{},
+      entryPoint, op, tileSizes,
       IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUDistribute,
       workgroupSize);
 }
@@ -246,7 +245,7 @@ static LogicalResult setSortConfig(FuncOp entryPoint, Operation *op) {
   if (partitionedLoops.empty()) {
     tileSizes.push_back({});
     return setOpConfigAndEntryPointFnTranslation(
-        entryPoint, op, tileSizes, /*nativeVectorSizes=*/ArrayRef<int64_t>{},
+        entryPoint, op, tileSizes,
         IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUDistribute,
         {1, 1, 1});
   }
@@ -272,7 +271,7 @@ static LogicalResult setSortConfig(FuncOp entryPoint, Operation *op) {
   }
   tileSizes.emplace_back(std::move(workgroupTileSizes));  // Workgroup level
   return setOpConfigAndEntryPointFnTranslation(
-      entryPoint, op, tileSizes, /*nativeVectorSizes=*/ArrayRef<int64_t>{},
+      entryPoint, op, tileSizes,
       IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUDistribute,
       workgroupSize);
 }
@@ -287,9 +286,8 @@ static LogicalResult setRootDefaultConfig(FuncOp entryPoint, Operation *op) {
       interfaceOp.getPartitionableLoops(kNumMaxParallelDims);
   if (partitionedLoops.empty()) {
     tileSizes.push_back({});
-    return setOpConfigAndEntryPointFnTranslation(
-        entryPoint, op, tileSizes, /*nativeVectorSizes=*/ArrayRef<int64_t>{},
-        passPipeline, {1, 1, 1});
+    return setOpConfigAndEntryPointFnTranslation(entryPoint, op, tileSizes,
+                                                 passPipeline, {1, 1, 1});
   }
 
   size_t numLoops = partitionedLoops.back() + 1;
@@ -351,7 +349,7 @@ static LogicalResult setRootDefaultConfig(FuncOp entryPoint, Operation *op) {
   }
   tileSizes.emplace_back(std::move(workgroupTileSizes));  // Workgroup level
   return setOpConfigAndEntryPointFnTranslation(
-      entryPoint, op, tileSizes, /*nativeVectorSizes=*/ArrayRef<int64_t>{},
+      entryPoint, op, tileSizes,
       IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUVectorize,
       workgroupSize);
 }

--- a/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
@@ -31,14 +31,14 @@ hal.executable @add_dispatch_0 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[256]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"LLVMGPUVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[256]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorize>
 //      CHECK: hal.executable.entry_point public @add_dispatch_0
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
 // CHECK-SAME:     workgroup_size = [64 : index, 1 : index, 1 : index]
 //      CHECK: func @add_dispatch_0
 //      CHECK:   linalg.generic
-// CHECK-SAME:       lowering.config = #[[CONFIG]]
+// CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -69,16 +69,16 @@ hal.executable private @dot_dispatch_1  {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[4, 2, 4]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"LLVMGPUMatmulSimt", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[4, 2, 4]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUMatmulSimt>
 //      CHECK: hal.executable.entry_point public @dot_dispatch_1
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
 // CHECK-SAME:     workgroup_size = [2 : index, 4 : index, 1 : index]
 //      CHECK: func @dot_dispatch_1
 //      CHECK:   linalg.fill
-// CHECK-SAME:       lowering.config = #[[CONFIG]]
+// CHECK-SAME:       lowering_config = #[[CONFIG]]
 //      CHECK:   linalg.matmul
-// CHECK-SAME:       lowering.config = #[[CONFIG]]
+// CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -113,14 +113,14 @@ hal.executable @reduction_dispatch {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"LLVMGPUDistribute", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUDistribute>
 //      CHECK: hal.executable.entry_point public @predict_dispatch_153
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.fill
-// CHECK-SAME:   lowering.config = #[[CONFIG]]
+// CHECK-SAME:   lowering_config = #[[CONFIG]]
 //      CHECK: linalg.generic
-// CHECK-SAME:   lowering.config = #[[CONFIG]]
+// CHECK-SAME:   lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -159,12 +159,12 @@ hal.executable @tensor_insert_slice {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[1, 64]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"LLVMGPUVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorize>
 //      CHECK: hal.executable.entry_point public @tensor_insert_slice
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: tensor.insert_slice
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -195,12 +195,12 @@ hal.executable @copy_as_generic {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[1, 64]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"LLVMGPUVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorize>
 //      CHECK: hal.executable.entry_point public @copy_as_generic
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.generic
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -232,12 +232,12 @@ hal.executable private @static_1d_fft_stage2 {
   }
 }
 
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[4]{{\]}}, native_vector_size = []>
-//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"LLVMGPUDistribute", workload_per_wg = []>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[4]{{\]}}>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUDistribute>
 //       CHECK: hal.executable.entry_point public @static_1d_fft_stage2
-//  CHECK-SAME:     translation.info = #[[TRANSLATION]]
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: iree_linalg_ext.fft
-//  CHECK-SAME:     lowering.config = #[[CONFIG]]
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -272,18 +272,18 @@ hal.executable private @static_3d_fft_stage3 {
   }
 }
 
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[1, 1, 8]{{\]}}, native_vector_size = []>
-//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"LLVMGPUDistribute", workload_per_wg = []>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 1, 8]{{\]}}>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUDistribute>
 //       CHECK: hal.executable.entry_point public @static_3d_fft_stage3
-//  CHECK-SAME:     translation.info = #[[TRANSLATION]]
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: iree_linalg_ext.fft
-//  CHECK-SAME:     lowering.config = #[[CONFIG]]
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
-#compilation = #iree_codegen.compilation.info<
-    #iree_codegen.lowering.config<tile_sizes = [[32, 128, 64]], native_vector_size = []>,
-    #iree_codegen.translation.info<"LLVMGPUMatmulSimt", workload_per_wg = [256, 32]>,
+#compilation = #iree_codegen.compilation_info<
+    lowering_config  = <tile_sizes = [[32, 128, 64]]>,
+    translation_info = <LLVMGPUMatmulSimt, workload_per_wg = [256, 32]>,
     workgroup_size = [16, 8, 1]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
@@ -310,7 +310,7 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb">
           : !flow.dispatch.tensor<readonly:256x1024xf32> -> tensor<256x1024xf32>
       %15 = linalg.init_tensor [128, 1024] : tensor<128x1024xf32>
       %16 = linalg.fill(%cst, %15) : f32, tensor<128x1024xf32> -> tensor<128x1024xf32>
-      %17 = linalg.matmul {__internal_linalg_transform__ = "workgroup", compilation.info = #compilation}
+      %17 = linalg.matmul {__internal_linalg_transform__ = "workgroup", compilation_info = #compilation}
           ins(%3, %4 : tensor<128x256xf32>, tensor<256x1024xf32>) outs(%16 : tensor<128x1024xf32>) -> tensor<128x1024xf32>
       flow.dispatch.tensor.store %17, %2, offsets = [0, 0], sizes = [128, 1024], strides = [1, 1] : tensor<128x1024xf32> -> !flow.dispatch.tensor<writeonly:128x1024xf32>
       return
@@ -319,15 +319,15 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb">
 }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[32, 128, 64]{{\]}}
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"LLVMGPUMatmulSimt", workload_per_wg = [256, 32]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 128, 64]{{\]}}
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUMatmulSimt, workload_per_wg = [256, 32]>
 //      CHECK: hal.executable.entry_point public @_lowering_config_test_dispatch_1
-// CHECK-SAME:     translation.info = #[[TRANSLATION]]
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
 // CHECK-SAME:     workgroup_size = [16 : index, 8 : index, 1 : index]
 //      CHECK: linalg.fill
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 //      CHECK: linalg.matmul
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -368,9 +368,9 @@ hal.executable private @sort_op {
   }
 }
 
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[64]{{\]}}, native_vector_size = []>
-//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"LLVMGPUDistribute", workload_per_wg = []>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64]{{\]}}>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUDistribute>
 //       CHECK: hal.executable.entry_point public @sort_op
-//  CHECK-SAME:     translation.info = #[[TRANSLATION]]
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: iree_linalg_ext.sort
-//  CHECK-SAME:     lowering.config = #[[CONFIG]]
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/iree/compiler/Codegen/LLVMGPU/test/illegal_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/illegal_configuration.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt -pass-pipeline='hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target-pass{test-lowering-configuration=true}))' -verify-diagnostics -split-input-file %s
 
-#config = #iree_codegen.lowering.config<tile_sizes = [], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"LLVMGPUMatmulSimt", workload_per_wg = []>
+#config = #iree_codegen.lowering_config<tile_sizes = []>
+#translation = #iree_codegen.translation_info<LLVMGPUMatmulSimt>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -12,7 +12,7 @@
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
     hal.executable.entry_point @illegal layout(#executable_layout) {
-      translation.info = #translation,
+      translation_info = #translation,
       workgroup_size = [32 : index, 8 : index, 8 : index]
     }
     builtin.module {
@@ -22,7 +22,7 @@ hal.executable private @matmul_tensors {
         %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<8x16xf32>
         %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<4x16xf32>
         // expected-error @+1 {{expected workgroup size to be <=1024 for LLVMGPUMatmulSimt, got 2048}}
-        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
+        linalg.matmul {lowering_config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
           outs(%result: memref<4x16xf32>)
         return
       }
@@ -32,8 +32,8 @@ hal.executable private @matmul_tensors {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"LLVMGPUMatmulSimt", workload_per_wg = []>
+#config = #iree_codegen.lowering_config<tile_sizes = []>
+#translation = #iree_codegen.translation_info<LLVMGPUMatmulSimt>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -44,7 +44,7 @@ hal.executable private @matmul_tensors {
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
     hal.executable.entry_point @illegal layout(#executable_layout) {
-      translation.info = #translation,
+      translation_info = #translation,
       workgroup_size = [32 : index, 8 : index, 2 : index]
     }
     builtin.module {
@@ -54,7 +54,7 @@ hal.executable private @matmul_tensors {
         %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<8x16xf32>
         %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<4x16xf32>
         // expected-error @+1 {{expected workgroup z component to be 1 for LLVMGPUMatmulSimt, got 2}}
-        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
+        linalg.matmul {lowering_config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
           outs(%result: memref<4x16xf32>)
         return
       }
@@ -64,8 +64,8 @@ hal.executable private @matmul_tensors {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[32, 32, 16]], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"LLVMGPUMatmulTensorCore", workload_per_wg = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[32, 32, 16]]>
+#translation = #iree_codegen.translation_info<LLVMGPUMatmulTensorCore>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -76,7 +76,7 @@ hal.executable private @matmul_tensors {
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
     hal.executable.entry_point @illegal layout(#executable_layout) {
-      translation.info = #translation,
+      translation_info = #translation,
       workgroup_size = [64 : index, 2 : index, 10 : index]
     }
     builtin.module {
@@ -86,7 +86,7 @@ hal.executable private @matmul_tensors {
         %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<16x32xf32>
         %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<32x32xf32>
         // expected-error @+1 {{expected workgroup size to be <=1024 for LLVMGPUMatmulTensorCore, got 1280}}
-        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<32x16xf32>, memref<16x32xf32>)
+        linalg.matmul {lowering_config = #config} ins(%lhs, %rhs : memref<32x16xf32>, memref<16x32xf32>)
           outs(%result: memref<32x32xf32>)
         return
       }
@@ -96,8 +96,8 @@ hal.executable private @matmul_tensors {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[32, 32, 16]], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"LLVMGPUMatmulTensorCore", workload_per_wg = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[32, 32, 16]]>
+#translation = #iree_codegen.translation_info<LLVMGPUMatmulTensorCore>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -108,7 +108,7 @@ hal.executable private @matmul_tensors {
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
     hal.executable.entry_point @illegal layout(#executable_layout) {
-      translation.info = #translation,
+      translation_info = #translation,
       workgroup_size = [48 : index, 2 : index, 1 : index]
     }
     builtin.module {
@@ -118,7 +118,7 @@ hal.executable private @matmul_tensors {
         %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<16x32xf32>
         %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<32x32xf32>
         // expected-error @+1 {{workgroup size is not 32 aligned for LLVMGPUMatmulTensorCore, got 48}}
-        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<32x16xf32>, memref<16x32xf32>)
+        linalg.matmul {lowering_config = #config} ins(%lhs, %rhs : memref<32x16xf32>, memref<16x32xf32>)
           outs(%result: memref<32x32xf32>)
         return
       }
@@ -128,8 +128,8 @@ hal.executable private @matmul_tensors {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[32, 32, 16]], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"LLVMGPUMatmulTensorCore", workload_per_wg = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[32, 32, 16]]>
+#translation = #iree_codegen.translation_info<LLVMGPUMatmulTensorCore>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -140,7 +140,7 @@ hal.executable private @matmul_tensors {
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
     hal.executable.entry_point @illegal layout(#executable_layout) {
-      translation.info = #translation,
+      translation_info = #translation,
       workgroup_size = [64 : index, 2 : index, 2 : index]
     }
     builtin.module {
@@ -150,7 +150,7 @@ hal.executable private @matmul_tensors {
         %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<16x32xf32>
         %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<32x32xf32>
         // expected-error @+1 {{expected workgroup z component to be 1 for LLVMGPUMatmulTensorCore, got 2}}
-        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<32x16xf32>, memref<16x32xf32>)
+        linalg.matmul {lowering_config = #config} ins(%lhs, %rhs : memref<32x16xf32>, memref<16x32xf32>)
           outs(%result: memref<32x32xf32>)
         return
       }
@@ -160,8 +160,8 @@ hal.executable private @matmul_tensors {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[32, 32, 20]], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"LLVMGPUMatmulTensorCore", workload_per_wg = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[32, 32, 20]]>
+#translation = #iree_codegen.translation_info<LLVMGPUMatmulTensorCore>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -172,7 +172,7 @@ hal.executable private @matmul_tensors {
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
     hal.executable.entry_point @illegal layout(#executable_layout) {
-      translation.info = #translation,
+      translation_info = #translation,
       workgroup_size = [64 : index, 2 : index, 1 : index]
     }
     builtin.module {
@@ -182,7 +182,7 @@ hal.executable private @matmul_tensors {
         %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<16x32xf32>
         %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<32x32xf32>
         // expected-error @+1 {{tensorcore size doesn't factor into second level tile size for LLVMGPUMatmulTensorCore}}
-        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<32x16xf32>, memref<16x32xf32>)
+        linalg.matmul {lowering_config = #config} ins(%lhs, %rhs : memref<32x16xf32>, memref<16x32xf32>)
           outs(%result: memref<32x32xf32>)
         return
       }
@@ -192,8 +192,8 @@ hal.executable private @matmul_tensors {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[32, 32, 16]], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"LLVMGPUMatmulTensorCore", workload_per_wg = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[32, 32, 16]]>
+#translation = #iree_codegen.translation_info<LLVMGPUMatmulTensorCore>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -204,7 +204,7 @@ hal.executable private @matmul_tensors {
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
     hal.executable.entry_point @illegal layout(#executable_layout) {
-      translation.info = #translation,
+      translation_info = #translation,
       workgroup_size = [64 : index, 2 : index, 1 : index]
     }
     builtin.module {
@@ -214,7 +214,7 @@ hal.executable private @matmul_tensors {
         %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<16x32xf32>
         %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<48x32xf32>
         // expected-error @+1 {{lhsShape doesn't factor into first level tile size for LLVMGPUMatmulTensorCore}}
-        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<48x16xf32>, memref<16x32xf32>)
+        linalg.matmul {lowering_config = #config} ins(%lhs, %rhs : memref<48x16xf32>, memref<16x32xf32>)
           outs(%result: memref<48x32xf32>)
         return
       }
@@ -224,8 +224,8 @@ hal.executable private @matmul_tensors {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[32, 32, 16]], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"LLVMGPUMatmulTensorCore", workload_per_wg = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[32, 32, 16]]>
+#translation = #iree_codegen.translation_info<LLVMGPUMatmulTensorCore>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -236,7 +236,7 @@ hal.executable private @matmul_tensors {
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
     hal.executable.entry_point @illegal layout(#executable_layout) {
-      translation.info = #translation,
+      translation_info = #translation,
       workgroup_size = [64 : index, 2 : index, 1 : index]
     }
     builtin.module {
@@ -246,7 +246,7 @@ hal.executable private @matmul_tensors {
         %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<16x48xf32>
         %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<32x48xf32>
         // expected-error @+1 {{rhsShape doesn't factor into first level tile size for LLVMGPUMatmulTensorCore}}
-        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<32x16xf32>, memref<16x48xf32>)
+        linalg.matmul {lowering_config = #config} ins(%lhs, %rhs : memref<32x16xf32>, memref<16x48xf32>)
           outs(%result: memref<32x48xf32>)
         return
       }
@@ -256,8 +256,8 @@ hal.executable private @matmul_tensors {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[2, 32, 32, 16]], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"LLVMGPUMatmulTensorCore", workload_per_wg = [32, 8, 1]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[2, 32, 32, 16]]>
+#translation = #iree_codegen.translation_info<LLVMGPUMatmulTensorCore, workload_per_wg = [32, 8, 1]>
 #executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb">
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
@@ -269,7 +269,7 @@ hal.executable private @matmul_tensors {
 hal.executable private @batch_matmul_func  {
   hal.executable.variant @cuda, target = #executable_target_cuda_nvptx_fb {
     hal.executable.entry_point @illegal layout(#executable_layout) {
-      translation.info = #translation,
+      translation_info = #translation,
       workgroup_size = [64 : index, 2 : index, 1 : index]
     }
 builtin.module {
@@ -301,9 +301,9 @@ builtin.module {
           %7 = memref.subview %0[%arg0, %arg1, 0] [1, 8, 1024] [1, 1, 1] : memref<4x32x1024xf32> to memref<1x8x1024xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 32768 + s0 + d1 * 1024 + d2)>>
           %8 = memref.subview %1[%arg0, 0, %arg2] [1, 1024, 32] [1, 1, 1] : memref<4x1024x64xf32> to memref<1x1024x32xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 65536 + s0 + d1 * 64 + d2)>>
           %9 = memref.subview %2[%arg0, %arg1, %arg2] [1, 8, 32] [1, 1, 1] : memref<4x32x64xf32> to memref<1x8x32xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 2048 + s0 + d1 * 64 + d2)>>
-          linalg.fill(%cst, %9) {lowering.config = #config} : f32, memref<1x8x32xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 2048 + s0 + d1 * 64 + d2)>>
+          linalg.fill(%cst, %9) {lowering_config = #config} : f32, memref<1x8x32xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 2048 + s0 + d1 * 64 + d2)>>
           // expected-error @+1 {{Received first tile dimension of 2 instead of 0 for LLVMGPUMatmulTensorCore}}
-          linalg.batch_matmul {lowering.config = #config} ins(%7, %8 : memref<1x8x1024xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 32768 + s0 + d1 * 1024 + d2)>>, memref<1x1024x32xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 65536 + s0 + d1 * 64 + d2)>>) outs(%9 : memref<1x8x32xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 2048 + s0 + d1 * 64 + d2)>>)
+          linalg.batch_matmul {lowering_config = #config} ins(%7, %8 : memref<1x8x1024xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 32768 + s0 + d1 * 1024 + d2)>>, memref<1x1024x32xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 65536 + s0 + d1 * 64 + d2)>>) outs(%9 : memref<1x8x32xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 2048 + s0 + d1 * 64 + d2)>>)
         }
       }
     }

--- a/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -152,7 +152,7 @@ LogicalResult setConvOpConfig(linalg::LinalgOp linalgOp,
   }
 
   auto funcOp = linalgOp->getParentOfType<FuncOp>();
-  return setOpConfigAndEntryPointFnTranslation(funcOp, linalgOp, tileSizes, {},
+  return setOpConfigAndEntryPointFnTranslation(funcOp, linalgOp, tileSizes,
                                                pipeline, workgroupSize);
 }
 
@@ -261,9 +261,8 @@ LogicalResult setMatmulOpConfig(linalg::LinalgOp op,
   tileSizes.push_back(workgroupTileSizes);
   tileSizes.push_back(invocationTileSizes);
   tileSizes.push_back(reductionTileSizes);
-  return setOpConfigAndEntryPointFnTranslation(op->getParentOfType<FuncOp>(),
-                                               op, tileSizes, {}, pipeline,
-                                               workgroupSize);
+  return setOpConfigAndEntryPointFnTranslation(
+      op->getParentOfType<FuncOp>(), op, tileSizes, pipeline, workgroupSize);
 }
 
 }  // namespace detail
@@ -301,9 +300,8 @@ static LogicalResult setFftOpConfig(spirv::ResourceLimitsAttr limits,
     }
   }
   TileSizesListType tileSizes = {workgroupTileSize};
-  return setOpConfigAndEntryPointFnTranslation(op->getParentOfType<FuncOp>(),
-                                               op, tileSizes, {}, pipeline,
-                                               workgroupSize);
+  return setOpConfigAndEntryPointFnTranslation(
+      op->getParentOfType<FuncOp>(), op, tileSizes, pipeline, workgroupSize);
 }
 
 //===----------------------------------------------------------------------===//
@@ -325,7 +323,7 @@ static LogicalResult setDefaultOpConfig(spirv::ResourceLimitsAttr limits,
     auto pipeline =
         IREE::Codegen::DispatchLoweringPassPipeline::SPIRVDistribute;
     std::array<int64_t, 3> workgroupSize = {1, 1, 1};
-    return setOpConfigAndEntryPointFnTranslation(funcOp, op, {}, {}, pipeline,
+    return setOpConfigAndEntryPointFnTranslation(funcOp, op, {}, pipeline,
                                                  workgroupSize);
   }
 
@@ -363,7 +361,7 @@ static LogicalResult setDefaultOpConfig(spirv::ResourceLimitsAttr limits,
     tileSizes.push_back(workgroupTileSizes);
     tileSizes.push_back(threadTileSizes);
 
-    return setOpConfigAndEntryPointFnTranslation(funcOp, op, tileSizes, {},
+    return setOpConfigAndEntryPointFnTranslation(funcOp, op, tileSizes,
                                                  pipeline, workgroupSize);
   }
 
@@ -490,8 +488,8 @@ static LogicalResult setDefaultOpConfig(spirv::ResourceLimitsAttr limits,
   tileSizes.push_back(workgroupTileSizes);
   tileSizes.push_back(threadTileSizes);
 
-  return setOpConfigAndEntryPointFnTranslation(funcOp, op, tileSizes, {},
-                                               pipeline, workgroupSize);
+  return setOpConfigAndEntryPointFnTranslation(funcOp, op, tileSizes, pipeline,
+                                               workgroupSize);
 }
 
 //===----------------------------------------------------------------------===//
@@ -647,7 +645,7 @@ LogicalResult initSPIRVLaunchConfig(ModuleOp module) {
       rootOperation = computeOp;
     }
 
-    // Propogate the `lowering.config` attribute to the other ops.
+    // Propogate the `lowering_config` attribute to the other ops.
     // TODO(ravishankarm, antiagainst): This is a very specific use (and
     // fragile). In general, this should not be needed. Things are already tiled
     // and distributed. The rest of the compilation must be structured to either

--- a/iree/compiler/Codegen/SPIRV/KernelConfig.h
+++ b/iree/compiler/Codegen/SPIRV/KernelConfig.h
@@ -42,8 +42,8 @@ LogicalResult setMatmulOpConfig(linalg::LinalgOp linalgOp,
 /// Sets CodeGen configuration for GPUs from a specific vendor.
 ///
 /// If the given `rootOp` has known good CodeGen configuration, attaches a
-/// `translation.info` attribute to the entry point containing `rootOp` and a
-/// `lowering.config` attribute to `rootOp`.
+/// `translation_info` attribute to the entry point containing `rootOp` and a
+/// `lowering_config` attribute to `rootOp`.
 ///
 /// Returns success when either no configuration is found or a configuration is
 /// successfullly attached as attribute. Returns failure only when there is an
@@ -58,8 +58,8 @@ LogicalResult setNVIDIACodeGenConfig(const spirv::TargetEnv &targetEnv,
 
 }  // namespace detail
 
-/// Attaches the `translation.info` attribute to entry points in `moduleOp` and
-/// `lowering.config` attributes to all root ops in `moduleOp`'s region.
+/// Attaches the `translation_info` attribute to entry points in `moduleOp` and
+/// `lowering_config` attributes to all root ops in `moduleOp`'s region.
 /// These attributes are used to drive the CodeGen pipeline.
 LogicalResult initSPIRVLaunchConfig(ModuleOp moduleOp);
 

--- a/iree/compiler/Codegen/SPIRV/NVIDIAConfig.cpp
+++ b/iree/compiler/Codegen/SPIRV/NVIDIAConfig.cpp
@@ -104,9 +104,8 @@ static LogicalResult setOpConfig(const spirv::TargetEnv &targetEnv,
   tileSizes.push_back({coopMatSize->m, coopMatSize->n, coopMatSize->k});
   tileSizes.push_back({coopMatSize->m, coopMatSize->n, coopMatSize->k});
 
-  return setOpConfigAndEntryPointFnTranslation(op->getParentOfType<FuncOp>(),
-                                               op, tileSizes, {}, pipeline,
-                                               workgroupSize);
+  return setOpConfigAndEntryPointFnTranslation(
+      op->getParentOfType<FuncOp>(), op, tileSizes, pipeline, workgroupSize);
 }
 
 LogicalResult setNVIDIACodeGenConfig(const spirv::TargetEnv &targetEnv,

--- a/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -210,7 +210,7 @@ void addSPIRVTileAndDistributePassPipeline(OpPassManager &pm) {
 // In the former path for CodeGen, we perform bufferization first, which will
 // turn padding/copy (via flow.dispatch.tensor.load/store pairs) into
 // linalg.generic ops. Then we deduce CodeGen configuration from the linalg.copy
-// op and use a `lowering.config` attribute on it to drive transformations.
+// op and use a `lowering_config` attribute on it to drive transformations.
 //
 // In the latter path for CodeGen, we will see linalg.pad_tensor directly.
 // However, properly tiling and distributing it is an ongoing work. So for now

--- a/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
@@ -51,7 +51,7 @@ static SmallVector<int64_t> getTargetCooperativeOpSize(linalg::LinalgOp op) {
 
 /// Deduces required subgroup counts along all workgroup tiled dimensions.
 ///
-/// `op` should be an operation with a `lowering.config` attribute to specify
+/// `op` should be an operation with a `lowering_config` attribute to specify
 /// tiling sizes for the workgroup and subgroup.
 static SmallVector<int64_t> deduceSubgroupCounts(linalg::LinalgOp op) {
   SmallVector<int64_t> workgroupTileSizes = getTileSizes(op, 0);
@@ -293,7 +293,7 @@ class SPIRVTileAndVectorizeToCooperativeOpsPass final
     if (!rootOp) {
       funcOp.emitError(
           "expected a linalg::ContractionOpInterface op with "
-          "lowering.config attribute");
+          "lowering_config attribute");
       return signalPassFailure();
     }
 

--- a/iree/compiler/Codegen/SPIRV/test/config_adreno_conv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_adreno_conv.mlir
@@ -43,14 +43,14 @@ hal.executable @conv_112x112x512 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[0, 1, 8, 256], [0, 1, 8, 4], [0, 0, 0, 0, 1, 1, 4]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 8, 256], [0, 1, 8, 4], [0, 0, 0, 0, 1, 1, 4]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @conv_112x112x512
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [64 : index, 1 : index, 1 : index]
 //      CHECK: func @conv_112x112x512()
 //      CHECK:   linalg.conv_2d_nhwc_hwcf
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -97,14 +97,14 @@ hal.executable @conv_112x112x32 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[0, 4, 16, 32], [0, 4, 2, 4], [0, 0, 0, 0, 1, 1, 4]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 16, 32], [0, 4, 2, 4], [0, 0, 0, 0, 1, 1, 4]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @conv_112x112x32
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [8 : index, 8 : index, 1 : index]
 //      CHECK: func @conv_112x112x32()
 //      CHECK:   linalg.conv_2d_nhwc_hwcf
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -150,15 +150,15 @@ hal.executable @conv_16x16x16 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[0, 8, 8, 16], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 8, 8, 16], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @conv_16x16x16
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [4 : index, 4 : index, 4 : index]
 
 //      CHECK: func @conv_16x16x16()
 //      CHECK:   linalg.conv_2d_nhwc_hwcf
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -205,14 +205,14 @@ hal.executable @dwconv_28x28x144 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[0, 4, 4, 16], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 16], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @dwconv_28x28x144
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [4 : index, 4 : index, 4 : index]
 //      CHECK: func @dwconv_28x28x144()
 //      CHECK:   linalg.depthwise_conv_2d_nhwc_hwc
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -258,11 +258,11 @@ hal.executable @dwconv_4x4x8 {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[0, 4, 4, 8], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 8], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @dwconv_4x4x8
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [2 : index, 4 : index, 4 : index]
 //      CHECK: func @dwconv_4x4x8()
 //      CHECK:   linalg.depthwise_conv_2d_nhwc_hwc
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/iree/compiler/Codegen/SPIRV/test/config_adreno_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_adreno_matmul.mlir
@@ -43,14 +43,14 @@ hal.executable @matmul_1024x2048x512 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[32, 128], [16, 4], [0, 0, 4]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 128], [16, 4], [0, 0, 4]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @matmul_1024x2048x512
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [32 : index, 2 : index, 1 : index]
 //      CHECK: func @matmul_1024x2048x512()
 //      CHECK:   linalg.matmul
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -97,14 +97,14 @@ hal.executable @matmul_3136x24x96 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[448, 8], [14, 4], [0, 0, 4]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[448, 8], [14, 4], [0, 0, 4]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @matmul_3136x24x96
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [2 : index, 32 : index, 1 : index]
 //      CHECK: func @matmul_3136x24x96()
 //      CHECK:   linalg.matmul
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -151,14 +151,14 @@ hal.executable @matmul_196x64x192 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[28, 64], [7, 4], [0, 0, 8]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[28, 64], [7, 4], [0, 0, 8]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @matmul_196x64x192
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [16 : index, 4 : index, 1 : index]
 //      CHECK: func @matmul_196x64x192()
 //      CHECK:   linalg.matmul
-// CHECK-SAME:      lowering.config = #[[CONFIG]]
+// CHECK-SAME:      lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -197,14 +197,14 @@ hal.executable @matmul_12544x96x16 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[128, 32], [16, 4], [0, 0, 4]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 32], [16, 4], [0, 0, 4]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @matmul_12544x96x16
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [8 : index, 8 : index, 1 : index]
 //      CHECK: func @matmul_12544x96x16()
 //      CHECK:   linalg.matmul
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -249,14 +249,14 @@ hal.executable @matmul_49x160x576 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[7, 32], [7, 4], [0, 0, 8]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[7, 32], [7, 4], [0, 0, 8]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @matmul_49x160x576
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [8 : index, 1 : index, 1 : index]
 //      CHECK: func @matmul_49x160x576()
 //      CHECK:   linalg.matmul
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -303,14 +303,14 @@ hal.executable @batch_matmul_4x384x384 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[1, 32, 128], [1, 16, 4], [0, 0, 0, 4]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 32, 128], [1, 16, 4], [0, 0, 0, 4]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @batch_matmul_4x384x384
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [32 : index, 2 : index, 1 : index]
 //      CHECK: func @batch_matmul_4x384x384()
 //      CHECK:   linalg.batch_matmul
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -357,11 +357,11 @@ hal.executable @batch_matmul_4x8x8 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[1, 8, 8], [1, 1, 4], [0, 0, 0, 16]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 8, 8], [1, 1, 4], [0, 0, 0, 16]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @batch_matmul_4x8x8
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [2 : index, 8 : index, 1 : index]
 //      CHECK: func @batch_matmul_4x8x8()
 //      CHECK:   linalg.batch_matmul
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/iree/compiler/Codegen/SPIRV/test/config_default_conv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_default_conv.mlir
@@ -62,11 +62,11 @@ hal.executable private @conv_pointwise_112x112x32 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[0, 4, 4, 32], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 32], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @conv_pointwise_112x112x32
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [8 : index, 2 : index, 2 : index]
 //      CHECK: func @conv_pointwise_112x112x32()
 //      CHECK:   linalg.conv_2d_nhwc_hwcf
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ext_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ext_ops.mlir
@@ -33,14 +33,14 @@ hal.executable private @static_1d_sort {
 
 // Check that the workgroup count and size are (1, 1, 1) for serializing the computation.
 
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = [], native_vector_size = []>
-//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVDistribute", workload_per_wg = []>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = []>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
 //       CHECK: hal.executable.entry_point public @static_1d_sort
-//  CHECK-SAME:   translation.info = #[[TRANSLATION]]
+//  CHECK-SAME:   translation_info = #[[TRANSLATION]]
 //  CHECK-SAME:   workgroup_size = [1 : index, 1 : index, 1 : index]
 //       CHECK: func @static_1d_sort()
 //       CHECK:   iree_linalg_ext.sort
-//  CHECK-SAME:     lowering.config = #[[CONFIG]]
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -82,14 +82,14 @@ hal.executable private @static_3d_sort {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[1, 0, 16], [1, 0, 1]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVDistribute", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 0, 16], [1, 0, 1]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
 //      CHECK: hal.executable.entry_point public @static_3d_sort
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [16 : index, 1 : index, 1 : index]
 //      CHECK: func @static_3d_sort()
 //      CHECK:   iree_linalg_ext.sort
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -127,14 +127,14 @@ hal.executable private @static_1d_fft_stage2 {
   }
 }
 
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[4]{{\]}}, native_vector_size = []>
-//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVDistribute", workload_per_wg = []>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[4]{{\]}}>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
 //       CHECK: hal.executable.entry_point public @static_1d_fft_stage2
-//  CHECK-SAME:   translation.info = #[[TRANSLATION]]
+//  CHECK-SAME:   translation_info = #[[TRANSLATION]]
 //  CHECK-SAME:   workgroup_size = [16 : index, 1 : index, 1 : index]
 //       CHECK: func @static_1d_fft_stage2()
 //       CHECK:   iree_linalg_ext.fft
-//  CHECK-SAME:     lowering.config = #[[CONFIG]]
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -176,14 +176,14 @@ hal.executable private @static_3d_fft_stage3 {
 }
 
 
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[1, 1, 8]{{\]}}, native_vector_size = []>
-//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVDistribute", workload_per_wg = []>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 1, 8]{{\]}}>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
 //       CHECK: hal.executable.entry_point public @static_3d_fft_stage3
-//  CHECK-SAME:   translation.info = #[[TRANSLATION]]
+//  CHECK-SAME:   translation_info = #[[TRANSLATION]]
 //  CHECK-SAME:   workgroup_size = [16 : index, 1 : index, 1 : index]
 //       CHECK: func @static_3d_fft_stage3()
 //       CHECK:   iree_linalg_ext.fft
-//  CHECK-SAME:     lowering.config = #[[CONFIG]]
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -229,9 +229,9 @@ hal.executable private @tensor_insert {
 }
 // Check that the pipeline is set to `SPIRVDistributeAndCopy`
 
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVDistributeCopy", workload_per_wg = []>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistributeCopy>
 //      CHECK: tensor.insert_slice
-//  CHECK-NOT:     lowering.config
+//  CHECK-NOT:     lowering_config
 
 // -----
 
@@ -273,6 +273,6 @@ hal.executable private @tensor_extract {
     }
   }
 }
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVDistributeCopy", workload_per_wg = []>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistributeCopy>
 //      CHECK: tensor.extract_slice
-//  CHECK-NOT:     lowering.config
+//  CHECK-NOT:     lowering_config

--- a/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ops.mlir
@@ -35,12 +35,12 @@ hal.executable @copy_as_generic {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[1, 16], [1, 1]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVDistribute", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 16], [1, 1]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
 //      CHECK: hal.executable.entry_point public @copy_as_generic
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -79,12 +79,12 @@ hal.executable @tensor_insert {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[0, 2, 32, 1], [0, 1, 1, 1]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVDistribute", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 2, 32, 1], [0, 1, 1, 1]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
 //      CHECK: hal.executable.entry_point public @copy
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -129,12 +129,12 @@ hal.executable @avg_pool {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[0, 2, 2, 8], [0, 1, 1, 1]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVDistribute", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 2, 2, 8], [0, 1, 1, 1]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
 //      CHECK: hal.executable.entry_point public @avg_pool
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.pooling_nhwc_sum
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -180,13 +180,13 @@ hal.executable @max_pool {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[0, 32], [0, 1]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVDistribute", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 32], [0, 1]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
 //      CHECK: hal.executable.entry_point public @max_pool
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [32 : index, 1 : index, 1 : index]
 //      CHECK:   linalg.pooling_nhwc_max
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -237,9 +237,9 @@ hal.executable @elementwise {
   }
 }
 
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVDistribute", workload_per_wg = []>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
 //      CHECK: hal.executable.entry_point public @elementwise
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 
 // -----
 
@@ -297,9 +297,9 @@ hal.executable @dwconv_elementwise {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[0, 4, 2, 0, 4], [0, 1, 1, 0, 1]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVDistribute", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 2, 0, 4], [0, 1, 1, 0, 1]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
 //      CHECK: hal.executable.entry_point public @dwconv_elementwise
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/iree/compiler/Codegen/SPIRV/test/config_default_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_default_matmul.mlir
@@ -44,14 +44,14 @@ hal.executable @batch_matmul_1x3x32 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[0, 1, 32], [0, 1, 1]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVDistribute", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 32], [0, 1, 1]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
 //      CHECK: hal.executable.entry_point public @batch_matmul_1x3x32
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [32 : index, 1 : index, 1 : index]
 //      CHECK: func @batch_matmul_1x3x32()
 //      CHECK:   linalg.batch_matmul
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -98,14 +98,14 @@ hal.executable private @matmul_64x16 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[4, 16], [1, 1]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVDistribute", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[4, 16], [1, 1]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
 //      CHECK: hal.executable.entry_point public @matmul_64x16
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [16 : index, 4 : index, 1 : index]
 //      CHECK: func @matmul_64x16()
 //      CHECK:   linalg.matmul
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -163,14 +163,14 @@ hal.executable @matmul_400x273 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[2, 32], [1, 1]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVDistribute", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[2, 32], [1, 1]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
 //      CHECK: hal.executable.entry_point public @matmul_400x273
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [32 : index, 2 : index, 1 : index]
 //      CHECK: func @matmul_400x273()
 //      CHECK:   linalg.matmul
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -229,14 +229,14 @@ hal.executable @matmul_25x546 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[32, 2], [1, 1]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVDistribute", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 2], [1, 1]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
 //      CHECK: hal.executable.entry_point public @matmul_25x546
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [2 : index, 32 : index, 1 : index]
 //      CHECK: func @matmul_25x546()
 //      CHECK:   linalg.matmul
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -305,11 +305,11 @@ hal.executable private @matmul_pointwise_256x1024 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[16, 256], [8, 8], [0, 0, 4]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[16, 256], [8, 8], [0, 0, 4]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @matmul_pointwise_256x1024
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [32 : index, 2 : index, 1 : index]
 //      CHECK: func @matmul_pointwise_256x1024()
 //      CHECK:   linalg.matmul
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/iree/compiler/Codegen/SPIRV/test/config_mali_conv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_mali_conv.mlir
@@ -44,14 +44,14 @@ hal.executable @conv_112x112x512 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[0, 1, 4, 64], [0, 1, 4, 4], [0, 0, 0, 0, 1, 1, 4]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 4, 64], [0, 1, 4, 4], [0, 0, 0, 0, 1, 1, 4]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @conv_112x112x512
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [16 : index, 1 : index, 1 : index]
 //      CHECK: func @conv_112x112x512()
 //      CHECK:   linalg.conv_2d_nhwc_hwcf
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -98,14 +98,14 @@ hal.executable @conv_112x112x32 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[0, 1, 8, 32], [0, 1, 4, 4], [0, 0, 0, 0, 1, 1, 4]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 8, 32], [0, 1, 4, 4], [0, 0, 0, 0, 1, 1, 4]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @conv_112x112x32
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [8 : index, 2 : index, 1 : index]
 //      CHECK: func @conv_112x112x32()
 //      CHECK:   linalg.conv_2d_nhwc_hwcf
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -151,14 +151,14 @@ hal.executable @conv_16x16x16 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[0, 4, 4, 16], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 16], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @conv_16x16x16
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [4 : index, 2 : index, 2 : index]
 //      CHECK: func @conv_16x16x16()
 //      CHECK:   linalg.conv_2d_nhwc_hwcf
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -205,14 +205,14 @@ hal.executable @dwconv_28x28x144 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[0, 4, 4, 16], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 16], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @dwconv_28x28x144
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [4 : index, 2 : index, 2 : index]
 //      CHECK: func @dwconv_28x28x144()
 //      CHECK:   linalg.depthwise_conv_2d_nhwc_hwc
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -260,11 +260,11 @@ hal.executable @dwconv_1x2x8 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[0, 1, 2, 8], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 2, 8], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @dwconv_1x2x8
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [2 : index, 2 : index, 1 : index]
 //      CHECK: func @dwconv_1x2x8()
 //      CHECK:   linalg.depthwise_conv_2d_nhwc_hwc
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/iree/compiler/Codegen/SPIRV/test/config_mali_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_mali_matmul.mlir
@@ -41,14 +41,14 @@ hal.executable @matmul_1024x2048x512 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[8, 32], [4, 4], [0, 0, 4]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[8, 32], [4, 4], [0, 0, 4]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @matmul_1024x2048x512
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [8 : index, 2 : index, 1 : index]
 //      CHECK: func @matmul_1024x2048x512()
 //      CHECK:   linalg.matmul
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -94,14 +94,14 @@ hal.executable @matmul_3136x24x96 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[32, 8], [4, 4], [0, 0, 4]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 8], [4, 4], [0, 0, 4]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @matmul_3136x24x96
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [2 : index, 8 : index, 1 : index]
 //      CHECK: func @matmul_3136x24x96()
 //      CHECK:   linalg.matmul
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -148,14 +148,14 @@ hal.executable @matmul_196x64x192 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[4, 32], [2, 4], [0, 0, 8]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[4, 32], [2, 4], [0, 0, 8]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @matmul_196x64x192
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [8 : index, 2 : index, 1 : index]
 //      CHECK: func @matmul_196x64x192()
 //      CHECK:   linalg.matmul
-// CHECK-SAME:      lowering.config = #[[CONFIG]]
+// CHECK-SAME:      lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -195,14 +195,14 @@ hal.executable @matmul_12544x96x16 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[8, 32], [4, 4], [0, 0, 4]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[8, 32], [4, 4], [0, 0, 4]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @matmul_12544x96x16
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [8 : index, 2 : index, 1 : index]
 //      CHECK: func @matmul_12544x96x16()
 //      CHECK:   linalg.matmul
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -249,14 +249,14 @@ hal.executable @matmul_49x160x576 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[1, 32], [1, 4], [0, 0, 8]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 32], [1, 4], [0, 0, 8]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @matmul_49x160x576
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [8 : index, 1 : index, 1 : index]
 //      CHECK: func @matmul_49x160x576()
 //      CHECK:   linalg.matmul
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -304,14 +304,14 @@ hal.executable @batch_matmul_4x384x384 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[1, 12, 32], [1, 6, 4], [0, 0, 0, 4]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 12, 32], [1, 6, 4], [0, 0, 0, 4]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @batch_matmul_4x384x384
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [8 : index, 2 : index, 1 : index]
 //      CHECK: func @batch_matmul_4x384x384()
 //      CHECK:   linalg.batch_matmul
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -359,11 +359,11 @@ hal.executable @batch_matmul_4x2x8 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[1, 2, 8], [1, 1, 4], [0, 0, 0, 8]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 2, 8], [1, 1, 4], [0, 0, 0, 8]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.entry_point public @batch_matmul_4x2x8
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [2 : index, 2 : index, 1 : index]
 //      CHECK: func @batch_matmul_4x2x8()
 //      CHECK:   linalg.batch_matmul
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/iree/compiler/Codegen/SPIRV/test/config_nvidia_matmul_cooperative_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_nvidia_matmul_cooperative_ops.mlir
@@ -76,14 +76,14 @@ hal.executable public @matmul_256x1024x128_div_sub {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[16, 16, 16], [16, 16, 16]{{\]}}, native_vector_size = []>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorizeToCooperativeOps", workload_per_wg = []>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[16, 16, 16], [16, 16, 16]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorizeToCooperativeOps>
 //      CHECK: hal.executable.entry_point public @matmul_256x1024x128_div_sub
-// CHECK-SAME:   translation.info = #[[TRANSLATION]]
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [32 : index, 1 : index, 1 : index]
 //      CHECK: func @matmul_256x1024x128_div_sub()
 //      CHECK:   linalg.matmul
-// CHECK-SAME:     lowering.config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -144,6 +144,6 @@ hal.executable public @matmul_256x1024x8 {
   }
 }
 
-//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVVectorize"
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize
 //       CHECK: hal.executable.entry_point public @matmul_256x1024x8
-//  CHECK-SAME:   translation.info = #[[TRANSLATION]]
+//  CHECK-SAME:   translation_info = #[[TRANSLATION]]

--- a/iree/compiler/Codegen/SPIRV/test/promote_workgroup_memory.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/promote_workgroup_memory.mlir
@@ -35,7 +35,7 @@ hal.executable private @matmul_promote_workgroup_memory  {
           %15 = affine.apply affine_map<()[s0] -> (s0 * 16)>()[%3]
           %16 = affine.min affine_map<()[s0] -> (16, s0 * -16 + 75)>()[%3]
           %17 = memref.subview %2[%13, %15] [%14, %16] [1, 1] : memref<25x75xf32> to memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 75 + s0 + d1)>>
-          linalg.matmul {__internal_linalg_transform__ = "workgroup", lowering.config = {tileSizes = [[8, 16, 32], [], [1, 1, 0]]}}
+          linalg.matmul {__internal_linalg_transform__ = "workgroup", lowering_config = {tileSizes = [[8, 16, 32], [], [1, 1, 0]]}}
             ins(%8, %12 : memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 50 + s0 + d1)>>, memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 75 + s0 + d1)>>)
             outs(%17 : memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 75 + s0 + d1)>>)
         }
@@ -103,7 +103,7 @@ hal.executable private @conv_promote_workgroup_memory  {
         %13 = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%3]
         %14 = affine.min affine_map<()[s0] -> (32, s0 * -32 + 11)>()[%3]
         %15 = memref.subview %2[%5, %11, %13, 0] [1, %12, %14, 14] [1, 1, 1, 1] : memref<2x13x11x14xf32> to memref<1x?x?x14xf32, affine_map<(d0, d1, d2, d3)[s0] -> (d0 * 2002 + s0 + d1 * 154 + d2 * 14 + d3)>>
-        linalg.conv_2d_nhwc_hwcf {__internal_linalg_transform__ = "workgroup", lowering.config = {tileSizes = [[0, 1, 4, 32], [], [0, 1, 1, 1]]}, dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>}
+        linalg.conv_2d_nhwc_hwcf {__internal_linalg_transform__ = "workgroup", lowering_config = {tileSizes = [[0, 1, 4, 32], [], [0, 1, 1, 1]]}, dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>}
           ins(%10, %0 : memref<1x?x?x6xf32, affine_map<(d0, d1, d2, d3)[s0] -> (d0 * 1260 + s0 + d1 * 84 + d2 * 6 + d3)>>, memref<3x4x6x14xf32>)
           outs(%15 : memref<1x?x?x14xf32, affine_map<(d0, d1, d2, d3)[s0] -> (d0 * 2002 + s0 + d1 * 154 + d2 * 14 + d3)>>)
         return

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_distribute.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_distribute.mlir
@@ -8,8 +8,8 @@
 #map5 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map6 = affine_map<(d0, d1, d2) -> (d0, d1)>
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[8, 16], [1, 1], [0, 0, 1]], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"SPIRVDistribute", workload_per_wg = [8, 16]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[8, 16], [1, 1], [0, 0, 1]]>
+#translation = #iree_codegen.translation_info<SPIRVDistribute, workload_per_wg = [8, 16]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -21,7 +21,7 @@ hal.executable private @matmul {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
     hal.executable.entry_point @matmul layout(#executable_layout) {
       workgroup_size = [16: index, 8: index, 1: index],
-      translation.info = #translation
+      translation_info = #translation
     }
     builtin.module {
       func @matmul() {
@@ -54,7 +54,7 @@ hal.executable private @matmul {
           %16 = memref.dim %arg2, %c1 : memref<?x?xf32>
           %17 = affine.min #map1()[%1, %16]
           %18 = memref.subview %arg2[%3, %10] [%15, %17] [1, 1]  : memref<?x?xf32> to memref<?x?xf32, #map3>
-          linalg.matmul {lowering.config = #config}
+          linalg.matmul {lowering_config = #config}
             ins(%7, %13 : memref<?x?xf32, #map3>, memref<?x?xf32, #map3>)
             outs(%18 : memref<?x?xf32, #map3>)
         }
@@ -78,8 +78,8 @@ hal.executable private @matmul {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[1, 4, 32], [1, 1, 1]], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"SPIRVDistribute", workload_per_wg = [32, 4, 1]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[1, 4, 32], [1, 1, 1]]>
+#translation = #iree_codegen.translation_info<SPIRVDistribute, workload_per_wg = [32, 4, 1]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -91,7 +91,7 @@ hal.executable private @conv_1d {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
     hal.executable.entry_point @conv_1d layout(#executable_layout) {
       workgroup_size = [32: index, 4: index, 1: index],
-      translation.info = #translation
+      translation_info = #translation
     }
     builtin.module {
       func @conv_1d() {
@@ -115,7 +115,7 @@ hal.executable private @conv_1d {
         %15 = affine.min affine_map<()[s0] -> (32, s0 * -32 + 1)>()[%3]
         %16 = memref.subview %0[%5, %12, %14] [1, %13, %15] [1, 1, 1] : memref<3x6x1xf32> to memref<1x?x?xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 6 + s0 + d1 + d2)>>
         %17 = memref.subview %0[%5, %12, %9] [1, %13, %10] [1, 1, 1] : memref<3x6x1xf32> to memref<1x?x?xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 6 + s0 + d1 + d2)>>
-        linalg.conv_1d_nwc_wcf {lowering.config = #config, dilations = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>}
+        linalg.conv_1d_nwc_wcf {lowering_config = #config, dilations = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>}
           ins(%8, %11 : memref<1x?x1xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 8 + s0 + d1 + d2)>>, memref<3x1x?xf32, affine_map<(d0, d1, d2)[s0] -> (d0 + s0 + d1 + d2)>>)
           outs(%16 : memref<1x?x?xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 6 + s0 + d1 + d2)>>)
         return
@@ -158,8 +158,8 @@ hal.executable private @conv_1d {
 #map6 = affine_map<(d0)[s0] -> (4, -d0 + s0)>
 #map7 = affine_map<(d0)[s0] -> (32, -d0 + s0)>
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[0, 1, 4, 32], [0, 1, 1, 1], [0, 0, 0, 0, 1, 1, 4]], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"SPIRVDistribute", workload_per_wg = [32, 4, 1]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[0, 1, 4, 32], [0, 1, 1, 1], [0, 0, 0, 0, 1, 1, 4]]>
+#translation = #iree_codegen.translation_info<SPIRVDistribute, workload_per_wg = [32, 4, 1]>
 #executable_layout = #hal.executable.layout<push_constants = 9, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -171,7 +171,7 @@ hal.executable private @conv_2d {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
     hal.executable.entry_point @conv_2d layout(#executable_layout) {
       workgroup_size = [32: index, 4: index, 1: index],
-      translation.info = #translation
+      translation_info = #translation
     }
     builtin.module {
       func @conv_2d() {
@@ -225,7 +225,7 @@ hal.executable private @conv_2d {
               %27 = memref.subview %arg2[%arg3, %arg4, %arg5, 0] [%23, %24, %25, %26] [1, 1, 1, 1]
                       : memref<?x?x?x?xf32> to memref<?x?x?x?xf32, #map5>
               linalg.conv_2d_nhwc_hwcf {
-                lowering.config = #config,
+                lowering_config = #config,
                 dilations = dense<1> : tensor<2xi64>,
                 strides = dense<2> : tensor<2xi64>}
                  ins(%21, %arg0 : memref<?x?x?x?xf32, #map5>, memref<?x?x?x?xf32>)
@@ -273,8 +273,8 @@ hal.executable private @conv_2d {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[0, 0, 1, 4, 32], [0, 0, 1, 1, 1]], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"SPIRVDistribute", workload_per_wg = [32, 4, 1]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[0, 0, 1, 4, 32], [0, 0, 1, 1, 1]]>
+#translation = #iree_codegen.translation_info<SPIRVDistribute, workload_per_wg = [32, 4, 1]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -286,7 +286,7 @@ hal.executable private @conv_3d {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
     hal.executable.entry_point @conv_3d layout(#executable_layout) {
       workgroup_size = [32: index, 4: index, 1: index],
-      translation.info = #translation
+      translation_info = #translation
     }
     builtin.module {
       func @conv_3d() {
@@ -309,7 +309,7 @@ hal.executable private @conv_3d {
         %14 = affine.min affine_map<()[s0] -> (32, s0 * -32 + 7)>()[%3]
         %15 = memref.subview %0[%5, %11, %13, 0, 0] [1, %12, %14, 7, 2] [1, 1, 1, 1, 1] : memref<2x7x7x7x2xf32> to memref<1x?x?x7x2xf32, affine_map<(d0, d1, d2, d3, d4)[s0] -> (d0 * 686 + s0 + d1 * 98 + d2 * 14 + d3 * 2 + d4)>>
         %16 = memref.subview %0[%5, %11, %13, 0, 0] [1, %12, %14, 7, 2] [1, 1, 1, 1, 1] : memref<2x7x7x7x2xf32> to memref<1x?x?x7x2xf32, affine_map<(d0, d1, d2, d3, d4)[s0] -> (d0 * 686 + s0 + d1 * 98 + d2 * 14 + d3 * 2 + d4)>>
-        linalg.conv_3d_ndhwc_dhwcf {lowering.config = #config, dilations = dense<1> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>}
+        linalg.conv_3d_ndhwc_dhwcf {lowering_config = #config, dilations = dense<1> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>}
           ins(%10, %2 : memref<1x?x?x8x3xf32, affine_map<(d0, d1, d2, d3, d4)[s0] -> (d0 * 1536 + s0 + d1 * 192 + d2 * 24 + d3 * 3 + d4)>>, memref<2x2x2x3x2xf32>)
           outs(%15 : memref<1x?x?x7x2xf32, affine_map<(d0, d1, d2, d3, d4)[s0] -> (d0 * 686 + s0 + d1 * 98 + d2 * 14 + d3 * 2 + d4)>>)
         return
@@ -343,8 +343,8 @@ hal.executable private @conv_3d {
 #map6 = affine_map<()[s0] -> (32, s0 * -32 + 13)>
 #map7 = affine_map<(d0, d1, d2, d3)[s0] -> (d0 * 1092 + s0 + d1 * 78 + d2 * 6 + d3)>
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[1, 4, 32], [1, 1, 1]], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"SPIRVDistribute", workload_per_wg = [32, 4, 1]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[1, 4, 32], [1, 1, 1]]>
+#translation = #iree_codegen.translation_info<SPIRVDistribute, workload_per_wg = [32, 4, 1]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -357,7 +357,7 @@ module  {
     hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
       hal.executable.entry_point @pooling_nhwc_max layout(#executable_layout) {
         workgroup_size = [32: index, 4: index, 1: index],
-        translation.info = #translation
+        translation_info = #translation
       }
       builtin.module {
         func @pooling_nhwc_max() {
@@ -375,7 +375,7 @@ module  {
           %10 = affine.min #map5()[%4]
           %11 = affine.min #map6()[%3]
           %12 = memref.subview %2[0, %5, %7, 0] [2, %10, %11, 6] [1, 1, 1, 1] : memref<2x14x13x6xf32> to memref<2x?x?x6xf32, #map7>
-          linalg.pooling_nhwc_max {lowering.config = #config, dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>}
+          linalg.pooling_nhwc_max {lowering_config = #config, dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>}
             ins(%9, %1 : memref<2x?x?x6xf32, #map4>, memref<3x4xf32>)
             outs(%12 : memref<2x?x?x6xf32, #map7>)
           return

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt -split-input-file -pass-pipeline='hal.executable(hal.executable.variant(builtin.module(builtin.func(iree-spirv-tile-and-distribute))))' %s | FileCheck %s
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[1, 16], [1, 1]], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"SPIRVDistribute", workload_per_wg = [16, 1]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[1, 16], [1, 1]]>
+#translation = #iree_codegen.translation_info<SPIRVDistribute, workload_per_wg = [16, 1]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -12,7 +12,7 @@
 hal.executable private @static_scatter_update_slice  {
   hal.executable.variant @vulkan_spirv_fb, target = <"vulkan", "vulkan-spirv-fb"> {
     hal.executable.entry_point @static_scatter_update_slice layout(#executable_layout) {
-      translation.info = #translation,
+      translation_info = #translation,
       workgroup_size = [16 : index, 1 : index, 1 : index]
     }
     builtin.module {
@@ -37,7 +37,7 @@ hal.executable private @static_scatter_update_slice  {
             %8 = memref.subview %1[%arg0, 0] [1, 1] [1, 1] : memref<40x1xi32> to memref<1x1xi32, affine_map<(d0, d1)[s0] -> (d0 + s0 + d1)>>
             %9 = memref.cast %8 : memref<1x1xi32, affine_map<(d0, d1)[s0] -> (d0 + s0 + d1)>> to memref<?x1xi32, affine_map<(d0, d1)[s0] -> (d0 + s0 + d1)>>
             %10 = memref.subview %2[0, %arg1] [100, %5] [1, 1] : memref<100x500xi32> to memref<100x?xi32, affine_map<(d0, d1)[s0] -> (d0 * 500 + s0 + d1)>>
-            iree_linalg_ext.scatter {lowering.config = #config} unique_indices(true) ins(%7, %9 : memref<?x?xi32, affine_map<(d0, d1)[s0] -> (d0 * 500 + s0 + d1)>>, memref<?x1xi32, affine_map<(d0, d1)[s0] -> (d0 + s0 + d1)>>) outs(%10 : memref<100x?xi32, affine_map<(d0, d1)[s0] -> (d0 * 500 + s0 + d1)>>)  {
+            iree_linalg_ext.scatter {lowering_config = #config} unique_indices(true) ins(%7, %9 : memref<?x?xi32, affine_map<(d0, d1)[s0] -> (d0 * 500 + s0 + d1)>>, memref<?x1xi32, affine_map<(d0, d1)[s0] -> (d0 + s0 + d1)>>) outs(%10 : memref<100x?xi32, affine_map<(d0, d1)[s0] -> (d0 * 500 + s0 + d1)>>)  {
             ^bb0(%arg2: i32, %arg3: i32):  // no predecessors
               iree_linalg_ext.yield %arg2 : i32
             }

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_sort.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_sort.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt -split-input-file -pass-pipeline='hal.executable(hal.executable.variant(builtin.module(builtin.func(iree-spirv-tile-and-distribute, cse))))' %s | FileCheck %s
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[1, 0, 16], [1, 0, 1]], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"SPIRVDistribute", workload_per_wg = [16, 1]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[1, 0, 16], [1, 0, 1]]>
+#translation = #iree_codegen.translation_info<SPIRVDistribute, workload_per_wg = [16, 1]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -11,7 +11,7 @@
 hal.executable private @static_3d_sort  {
   hal.executable.variant @vulkan_spirv_fb, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
     hal.executable.entry_point @static_3d_sort layout(#executable_layout) {
-      translation.info = #translation,
+      translation_info = #translation,
       workgroup_size = [16 : index, 1 : index, 1 : index]
     }
     builtin.module {
@@ -33,13 +33,13 @@ hal.executable private @static_3d_sort  {
             %5 = memref.cast %4 : memref<1x32x16xi32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 128 + d2)>> to memref<?x?x?xi32>
             %6 = memref.subview %1[%arg0, 0, %arg1] [1, 32, 16] [1, 1, 1] : memref<64x32x128xi32> to memref<1x32x16xi32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 128 + d2)>>
             %7 = memref.cast %6 : memref<1x32x16xi32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 128 + d2)>> to memref<?x32x?xi32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 128 + d2)>>
-            linalg.generic {lowering.config = #config, indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]}
+            linalg.generic {lowering_config = #config, indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]}
               ins(%5 : memref<?x?x?xi32>)
               outs(%6 : memref<1x32x16xi32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 128 + d2)>>) {
               ^bb0(%arg4: i32, %s: i32):  // no predecessors
                 linalg.yield %arg4 : i32
             }
-            iree_linalg_ext.sort {lowering.config = #config} dimension(1) outs(%7 : memref<?x32x?xi32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 128 + d2)>>)  {
+            iree_linalg_ext.sort {lowering_config = #config} dimension(1) outs(%7 : memref<?x32x?xi32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 128 + d2)>>)  {
             ^bb0(%arg2: i32, %arg3: i32):  // no predecessors
               %8 = arith.cmpi slt, %arg2, %arg3 : i32
               iree_linalg_ext.yield %8 : i1

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_batch_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_batch_matmul.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt -split-input-file -pass-pipeline='hal.executable(hal.executable.variant(iree-set-num-workgroups,builtin.module(builtin.func(iree-spirv-tile,iree-spirv-vectorize))))' -cse %s | FileCheck %s
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[1, 8, 64], [1, 8, 4], [0, 0, 0, 4]], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = [64, 8, 1]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[1, 8, 64], [1, 8, 4], [0, 0, 0, 4]]>
+#translation = #iree_codegen.translation_info<SPIRVVectorize, workload_per_wg = [64, 8, 1]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -13,7 +13,7 @@ hal.executable private @fused_fill_batch_matmul {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
     hal.executable.entry_point @fused_fill_batch_matmul layout(#executable_layout) {
       workgroup_size = [16: index, 1: index, 1: index],
-      translation.info = #translation
+      translation_info = #translation
     }
     builtin.module  {
       func @fused_fill_batch_matmul() {
@@ -52,7 +52,7 @@ hal.executable private @fused_fill_batch_matmul {
               %16 = affine.min affine_map<(d0)[s0] -> (-d0 + 1024, s0)>(%arg2)[%workgroup_size_x]
               %17 = linalg.init_tensor [%14, %15, %16] : tensor<?x?x?xf32>
               %18 = linalg.fill(%cst, %17) : f32, tensor<?x?x?xf32> -> tensor<?x?x?xf32>
-              %19 = linalg.batch_matmul {lowering.config = #config} ins(%11, %13 : tensor<?x?x1024xf32>, tensor<?x1024x?xf32>) outs(%18 : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+              %19 = linalg.batch_matmul {lowering_config = #config} ins(%11, %13 : tensor<?x?x1024xf32>, tensor<?x1024x?xf32>) outs(%18 : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
               flow.dispatch.tensor.store %19, %2, offsets = [%arg0, %arg1, %arg2], sizes = [%9, %10, %12], strides = [1, 1, 1] : tensor<?x?x?xf32> -> !flow.dispatch.tensor<writeonly:4x1024x1024xf32>
             }
           }

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt -split-input-file -pass-pipeline='hal.executable(hal.executable.variant(iree-set-num-workgroups,builtin.module(builtin.func(iree-spirv-tile,iree-spirv-vectorize))))' %s | FileCheck %s
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[0, 4, 4, 16], [0, 4, 1, 4], [0, 0, 0, 0, 1, 1, 4]], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = [16, 4, 4]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[0, 4, 4, 16], [0, 4, 1, 4], [0, 0, 0, 0, 1, 1, 4]]>
+#translation = #iree_codegen.translation_info<SPIRVVectorize, workload_per_wg = [16, 4, 4]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -13,7 +13,7 @@ hal.executable private @conv_static_shape_f32 {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
     hal.executable.entry_point @conv_static_shape_f32 layout(#executable_layout) {
       workgroup_size = [4: index, 4: index, 1: index],
-      translation.info = #translation
+      translation_info = #translation
     }
     builtin.module  {
       func @conv_static_shape_f32() {
@@ -56,7 +56,7 @@ hal.executable private @conv_static_shape_f32 {
               %20 = affine.min affine_map<(d0)[s0] -> (-d0 + 16, s0)>(%arg2)[%workgroup_size_x]
               %21 = linalg.init_tensor [1, %18, %19, %20] : tensor<1x?x?x?xf32>
               %22 = linalg.fill(%cst, %21) : f32, tensor<1x?x?x?xf32> -> tensor<1x?x?x?xf32>
-              %23 = linalg.conv_2d_nhwc_hwcf {lowering.config = #config, dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>}
+              %23 = linalg.conv_2d_nhwc_hwcf {lowering_config = #config, dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>}
                 ins(%13, %15 : tensor<1x?x?x8xf32>, tensor<3x3x8x?xf32>)
                 outs(%22 : tensor<1x?x?x?xf32>) -> tensor<1x?x?x?xf32>
               flow.dispatch.tensor.store %23, %2, offsets = [0, %arg0, %arg1, %arg2], sizes = [1, %16, %17, %14], strides = [1, 1, 1, 1] : tensor<1x?x?x?xf32> -> !flow.dispatch.tensor<writeonly:1x112x112x16xf32>
@@ -91,8 +91,8 @@ hal.executable private @conv_static_shape_f32 {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[0, 4, 4, 16], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1]], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = [16, 4, 4]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[0, 4, 4, 16], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1]]>
+#translation = #iree_codegen.translation_info<SPIRVVectorize, workload_per_wg = [16, 4, 4]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -104,7 +104,7 @@ hal.executable private @depthwise_conv_static_shape_f32 {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
     hal.executable.entry_point @depthwise_conv_static_shape_f32 layout(#executable_layout) {
       workgroup_size = [4: index, 4: index, 4: index],
-      translation.info = #translation
+      translation_info = #translation
     }
     builtin.module  {
       func @depthwise_conv_static_shape_f32() {
@@ -147,7 +147,7 @@ hal.executable private @depthwise_conv_static_shape_f32 {
               %20 = affine.min affine_map<(d0)[s0] -> (-d0 + 96, s0)>(%arg2)[%workgroup_size_x]
               %21 = linalg.init_tensor [1, %18, %19, %20] : tensor<1x?x?x?xf32>
               %22 = linalg.fill(%cst, %21) : f32, tensor<1x?x?x?xf32> -> tensor<1x?x?x?xf32>
-              %23 = linalg.depthwise_conv_2d_nhwc_hwc {lowering.config = #config, dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>}
+              %23 = linalg.depthwise_conv_2d_nhwc_hwc {lowering_config = #config, dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>}
                 ins(%14, %15 : tensor<1x?x?x?xf32>, tensor<3x3x?xf32>)
                 outs(%22 : tensor<1x?x?x?xf32>) -> tensor<1x?x?x?xf32>
               flow.dispatch.tensor.store %23, %2, offsets = [0, %arg0, %arg1, %arg2], sizes = [1, %16, %17, %13], strides = [1, 1, 1, 1] : tensor<1x?x?x?xf32> -> !flow.dispatch.tensor<writeonly:1x56x56x96xf32>

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_matmul.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt -split-input-file -pass-pipeline='hal.executable(hal.executable.variant(iree-set-num-workgroups,builtin.module(builtin.func(iree-spirv-tile,iree-spirv-vectorize))))' %s | FileCheck %s
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[8, 64], [8, 4], [0, 0, 4]], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = [64, 8]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[8, 64], [8, 4], [0, 0, 4]]>
+#translation = #iree_codegen.translation_info<SPIRVVectorize, workload_per_wg = [64, 8]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -13,7 +13,7 @@ hal.executable private @matmul_static_shape_f16 {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
     hal.executable.entry_point @matmul_static_shape_f16 layout(#executable_layout) {
       workgroup_size = [16: index, 1: index, 1: index],
-      translation.info = #translation
+      translation_info = #translation
     }
     builtin.module  {
       func @matmul_static_shape_f16() {
@@ -43,7 +43,7 @@ hal.executable private @matmul_static_shape_f16 {
             %12 = affine.min affine_map<(d0)[s0] -> (-d0 + 4096, s0)>(%arg1)[%workgroup_size_x]
             %13 = linalg.init_tensor [%11, %12] : tensor<?x?xf16>
             %14 = linalg.fill(%cst, %13) : f16, tensor<?x?xf16> -> tensor<?x?xf16>
-            %15 = linalg.matmul {lowering.config = #config} ins(%8, %10 : tensor<?x4096xf16>, tensor<4096x?xf16>) outs(%14 : tensor<?x?xf16>) -> tensor<?x?xf16>
+            %15 = linalg.matmul {lowering_config = #config} ins(%8, %10 : tensor<?x4096xf16>, tensor<4096x?xf16>) outs(%14 : tensor<?x?xf16>) -> tensor<?x?xf16>
             flow.dispatch.tensor.store %15, %2, offsets = [%arg0, %arg1], sizes = [%7, %9], strides = [1, 1] : tensor<?x?xf16> -> !flow.dispatch.tensor<writeonly:4096x4096xf16>
           }
         }
@@ -64,8 +64,8 @@ hal.executable private @matmul_static_shape_f16 {
 
 // -----
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[8, 64], [8, 4], [0, 0, 4]], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"SPIRVVectorize", workload_per_wg = [64, 8]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[8, 64], [8, 4], [0, 0, 4]]>
+#translation = #iree_codegen.translation_info<SPIRVVectorize, workload_per_wg = [64, 8]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -77,7 +77,7 @@ hal.executable private @matmul_static_shape_f32 {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
     hal.executable.entry_point @matmul_static_shape_f32 layout(#executable_layout) {
       workgroup_size = [16: index, 1: index, 1: index],
-      translation.info = #translation
+      translation_info = #translation
     }
     builtin.module  {
       func @matmul_static_shape_f32() {
@@ -107,7 +107,7 @@ hal.executable private @matmul_static_shape_f32 {
             %12 = affine.min affine_map<(d0)[s0] -> (-d0 + 4096, s0)>(%arg1)[%workgroup_size_x]
             %13 = linalg.init_tensor [%11, %12] : tensor<?x?xf32>
             %14 = linalg.fill(%cst, %13) : f32, tensor<?x?xf32> -> tensor<?x?xf32>
-            %15 = linalg.matmul {lowering.config = #config} ins(%8, %10 : tensor<?x4096xf32>, tensor<4096x?xf32>) outs(%14 : tensor<?x?xf32>) -> tensor<?x?xf32>
+            %15 = linalg.matmul {lowering_config = #config} ins(%8, %10 : tensor<?x4096xf32>, tensor<4096x?xf32>) outs(%14 : tensor<?x?xf32>) -> tensor<?x?xf32>
             flow.dispatch.tensor.store %15, %2, offsets = [%arg0, %arg1], sizes = [%7, %9], strides = [1, 1] : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:4096x4096xf32>
           }
         }

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_to_cooperative_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_to_cooperative_ops.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt -split-input-file -pass-pipeline='hal.executable(hal.executable.variant(builtin.module(builtin.func(iree-spirv-tile-and-vectorize-to-cooperative-ops))))' %s | FileCheck %s
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[16, 16, 16], [16, 16, 16]], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"SPIRVVectorizeToCooperativeOps", workload_per_wg = [16, 16]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[16, 16, 16], [16, 16, 16]]>
+#translation = #iree_codegen.translation_info<SPIRVVectorizeToCooperativeOps, workload_per_wg = [16, 16]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -31,7 +31,7 @@ hal.executable public @matmul_256x1024x128_div_sub {
            max_compute_workgroup_size = dense<[2147483647, 65535, 65535]> : vector<3xi32>,
            subgroup_size = 32 : i32}>}> {
     hal.executable.entry_point public @matmul_256x1024x128_div_sub layout(#executable_layout) {
-      translation.info = #translation,
+      translation_info = #translation,
       workgroup_size = [32 : index, 1 : index, 1 : index]
     } {
     ^bb0(%arg0: index, %arg1: index, %arg2: index):  // no predecessors
@@ -66,14 +66,14 @@ hal.executable public @matmul_256x1024x128_div_sub {
             %11 = memref.subview %2[%arg0, 0] [16, 128] [1, 1] : memref<256x128xf16> to memref<16x128xf16, affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>>
             %12 = memref.subview %3[0, %arg1] [128, 16] [1, 1] : memref<128x1024xf16> to memref<128x16xf16, affine_map<(d0, d1)[s0] -> (d0 * 1024 + s0 + d1)>>
             %13 = memref.subview %4[%arg0, %arg1] [16, 16] [1, 1] : memref<256x1024xf16> to memref<16x16xf16, affine_map<(d0, d1)[s0] -> (d0 * 1024 + s0 + d1)>>
-            linalg.fill(%cst, %13) {lowering.config = #config} : f16, memref<16x16xf16, affine_map<(d0, d1)[s0] -> (d0 * 1024 + s0 + d1)>>
-            linalg.matmul {lowering.config = #config}
+            linalg.fill(%cst, %13) {lowering_config = #config} : f16, memref<16x16xf16, affine_map<(d0, d1)[s0] -> (d0 * 1024 + s0 + d1)>>
+            linalg.matmul {lowering_config = #config}
               ins(%11, %12 : memref<16x128xf16, affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>>, memref<128x16xf16, affine_map<(d0, d1)[s0] -> (d0 * 1024 + s0 + d1)>>)
               outs(%13 : memref<16x16xf16, affine_map<(d0, d1)[s0] -> (d0 * 1024 + s0 + d1)>>)
             linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]}
               ins(%13, %9, %10 : memref<16x16xf16, affine_map<(d0, d1)[s0] -> (d0 * 1024 + s0 + d1)>>, memref<16x16xf16, affine_map<(d0, d1)[s0] -> (d0 * 1024 + s0 + d1)>>, memref<16x16xf16, affine_map<(d0, d1)[s0] -> (d0 * 1024 + s0 + d1)>>)
               outs(%13 : memref<16x16xf16, affine_map<(d0, d1)[s0] -> (d0 * 1024 + s0 + d1)>>)
-              attrs =  {lowering.config = #config} {
+              attrs =  {lowering_config = #config} {
             ^bb0(%arg2: f16, %arg3: f16, %arg4: f16, %arg5: f16):  // no predecessors
               %14 = arith.divf %arg2, %arg3 : f16
               %15 = arith.subf %14, %arg4 : f16

--- a/iree/compiler/Codegen/SPIRV/test/vectorize_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/vectorize_matmul.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt -split-input-file -iree-spirv-vectorize %s | FileCheck %s
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[2, 128], [1, 4], [0, 0, 4]], native_vector_size = []>
+#config = #iree_codegen.lowering_config<tile_sizes = [[2, 128], [1, 4], [0, 0, 4]]>
 
 func @matmul_2x128x4() {
   %c1 = arith.constant 1 : index
@@ -28,10 +28,10 @@ func @matmul_2x128x4() {
       %10 = scf.for %arg2 = %c0 to %c2 step %c1 iter_args(%arg3 = %9) -> (tensor<2x128xf32>) {
         %11 = scf.for %arg4 = %c0 to %c128 step %c4 iter_args(%arg5 = %arg3) -> (tensor<2x128xf32>) {
           %12 = tensor.extract_slice %arg5[%arg2, %arg4] [1, 4] [1, 1] : tensor<2x128xf32> to tensor<1x4xf32>
-          %13 = linalg.fill(%cst, %12) {lowering.config = #config} : f32, tensor<1x4xf32> -> tensor<1x4xf32>
+          %13 = linalg.fill(%cst, %12) {lowering_config = #config} : f32, tensor<1x4xf32> -> tensor<1x4xf32>
           %14 = tensor.extract_slice %7[%arg2, 0] [1, 4] [1, 1] : tensor<2x4xf32> to tensor<1x4xf32>
           %15 = tensor.extract_slice %8[0, %arg4] [4, 4] [1, 1] : tensor<4x128xf32> to tensor<4x4xf32>
-          %16 = linalg.matmul {lowering.config = #config} ins(%14, %15 : tensor<1x4xf32>, tensor<4x4xf32>) outs(%13 : tensor<1x4xf32>) -> tensor<1x4xf32>
+          %16 = linalg.matmul {lowering_config = #config} ins(%14, %15 : tensor<1x4xf32>, tensor<4x4xf32>) outs(%13 : tensor<1x4xf32>) -> tensor<1x4xf32>
           %17 = tensor.insert_slice %16 into %arg5[%arg2, %arg4] [1, 4] [1, 1] : tensor<1x4xf32> into tensor<2x128xf32>
           scf.yield %17 : tensor<2x128xf32>
         } {iree.spirv.distribute_dim = 0 : index}

--- a/iree/compiler/Codegen/Sandbox/Passes.td
+++ b/iree/compiler/Codegen/Sandbox/Passes.td
@@ -43,7 +43,7 @@ def LinalgFuse : Pass<"linalg-fuse", "FuncOp"> {
 
     // IREE specific options
     Option<"tilingLevel", "tiling-level", "int64_t", /*default=*/"-1",
-      "Use default tiling level used to retrieve the configuration from lowering.config">
+      "Use default tiling level used to retrieve the configuration from lowering_config">
   ];
   let dependentDialects = [
     "::mlir::arith::ArithmeticDialect", "::mlir::AffineDialect",
@@ -109,7 +109,7 @@ def LinalgSingleTilingExpert
 
     // IREE specific options
     Option<"tilingLevel", "tiling-level", "int64_t", /*default=*/"-1",
-      "Use default tiling level used to retrieve the configuration from lowering.config">
+      "Use default tiling level used to retrieve the configuration from lowering_config">
   ];
   let dependentDialects = [
     "::mlir::arith::ArithmeticDialect", "::mlir::AffineDialect",

--- a/iree/compiler/Codegen/Sandbox/test/fusion_expert.mlir
+++ b/iree/compiler/Codegen/Sandbox/test/fusion_expert.mlir
@@ -8,7 +8,7 @@ func @matmul_bias_add(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>, %arg2 : 
   %d1 = tensor.dim %arg1, %c1 : tensor<?x?xf32>
   %init = linalg.init_tensor [%d0, %d1] : tensor<?x?xf32>
   %0 = linalg.fill(%cst, %init) : f32, tensor<?x?xf32> -> tensor<?x?xf32>
-  %1 = linalg.matmul {lowering.config = #iree_codegen.lowering.config<tile_sizes = [[10, 20, 30]], native_vector_size = []>}
+  %1 = linalg.matmul {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[10, 20, 30]]>}
       ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
       outs(%0 : tensor<?x?xf32>) -> tensor<?x?xf32>
   %2 = linalg.generic {
@@ -41,7 +41,7 @@ func @matmul_bias_add_static(%arg0 : tensor<20x60xf32>, %arg1 : tensor<60x120xf3
   %c1 = arith.constant 1 : index
   %init = linalg.init_tensor [20, 120] : tensor<20x120xf32>
   %0 = linalg.fill(%cst, %init) : f32, tensor<20x120xf32> -> tensor<20x120xf32>
-  %1 = linalg.matmul {lowering.config = #iree_codegen.lowering.config<tile_sizes = [[10, 20, 30]], native_vector_size = []>}
+  %1 = linalg.matmul {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[10, 20, 30]]>}
       ins(%arg0, %arg1 : tensor<20x60xf32>, tensor<60x120xf32>)
       outs(%0 : tensor<20x120xf32>) -> tensor<20x120xf32>
   %2 = linalg.generic {

--- a/iree/compiler/Codegen/Sandbox/test/single_tiling_expert.mlir
+++ b/iree/compiler/Codegen/Sandbox/test/single_tiling_expert.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt -pass-pipeline="builtin.func(linalg-single-tiling-expert-driver{tiling-level=0 vectorize})" -split-input-file %s | FileCheck %s
 
 func @matmul(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>, %arg2 : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  %0 = linalg.matmul {lowering.config = #iree_codegen.lowering.config<tile_sizes = [[10, 20, 30]], native_vector_size = []>}
+  %0 = linalg.matmul {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[10, 20, 30]]>}
       ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
       outs(%arg2 : tensor<?x?xf32>) -> tensor<?x?xf32>
   return %0 : tensor<?x?xf32>
@@ -21,7 +21,7 @@ func @matmul(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>, %arg2 : tensor<?x
 // -----
 
  func @matmul_static(%arg0 : tensor<20x60xf32>, %arg1 : tensor<60x80xf32>, %arg2 : tensor<20x80xf32>) -> tensor<20x80xf32> {
-  %0 = linalg.matmul {lowering.config = #iree_codegen.lowering.config<tile_sizes = [[10, 20, 30]], native_vector_size = []>}
+  %0 = linalg.matmul {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[10, 20, 30]]>}
       ins(%arg0, %arg1 : tensor<20x60xf32>, tensor<60x80xf32>)
       outs(%arg2 : tensor<20x80xf32>) -> tensor<20x80xf32>
   return %0 : tensor<20x80xf32>

--- a/iree/compiler/Dialect/HAL/Transforms/test/convert_to_hal.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/convert_to_hal.mlir
@@ -21,7 +21,7 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
   hal.executable private @ex {
     hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
       hal.executable.entry_point public @dispatch ordinal(0) layout(#executable_layout) {
-        translation.info = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = [4]>
+        translation_info = #iree_codegen.translation_info<CPUDefault, workload_per_wg = [4]>
       } {
       ^bb0(%arg0: index, %arg1: index, %arg2: index):  // no predecessors
         %c1 = arith.constant 1 : index

--- a/iree/test/e2e/regression/generate_e2e_matmul_tests.py
+++ b/iree/test/e2e/regression/generate_e2e_matmul_tests.py
@@ -414,11 +414,11 @@ def generate_function(
   compilation_info_attr = ""
   if compilation_info:
     compilation_info_string = (
-        f"#compilation{generate_function.compilation_index} = #iree_codegen.compilation.info<\n"
-        f"  #iree_codegen.lowering.config<tile_sizes = [{compilation_info.tile_sizes}], native_vector_size = {compilation_info.native_vector_size}>,\n"
-        f"  #iree_codegen.translation.info<\"{compilation_info.dispatch_lowering_pass_pipeline}\", workload_per_wg = []>,\n"
+        f"#compilation{generate_function.compilation_index} = #iree_codegen.compilation_info<\n"
+        f"  #iree_codegen.lowering_config<tile_sizes = [{compilation_info.tile_sizes}], native_vector_size = {compilation_info.native_vector_size}>,\n"
+        f"  #iree_codegen.translation_info<\"{compilation_info.dispatch_lowering_pass_pipeline}\", workload_per_wg = []>,\n"
         f"  workgroup_size = {compilation_info.workgroup_size_str()}>\n")
-    compilation_info_attr = f"{{compilation.info = #compilation{generate_function.compilation_index}}} "
+    compilation_info_attr = f"{{compilation_info = #compilation{generate_function.compilation_index}}} "
     func_definition = func_definition + compilation_info_string
     generate_function.compilation_index += 1
 

--- a/iree/test/e2e/regression/lowering_config.mlir
+++ b/iree/test/e2e/regression/lowering_config.mlir
@@ -1,17 +1,17 @@
-#compilation0 = #iree_codegen.compilation.info<
-    #iree_codegen.lowering.config<tile_sizes = [[32, 32], [8, 8, 0], [0, 0, 8]], native_vector_size = []>,
-    #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>,
+#compilation0 = #iree_codegen.compilation_info<
+    lowering_config = <tile_sizes = [[32, 32], [8, 8, 0], [0, 0, 8]]>,
+    translation_info = <CPUDoubleTilingExpert>,
     workgroup_size = []>
-#compilation1 = #iree_codegen.compilation.info<
-    #iree_codegen.lowering.config<tile_sizes = [[64, 64], [4, 4, 0], [0, 0, 4]], native_vector_size = []>,
-    #iree_codegen.translation.info<"CPUDoubleTilingExpert", workload_per_wg = []>,
+#compilation1 = #iree_codegen.compilation_info<
+    lowering_config = <tile_sizes = [[64, 64], [4, 4, 0], [0, 0, 4]]>,
+    translation_info = <CPUDoubleTilingExpert>,
     workgroup_size = []>
 func @lowering_config_test() {
   %a = util.unfoldable_constant dense<1.0> : tensor<128x256xf32>
   %b = util.unfoldable_constant dense<2.0> : tensor<256x512xf32>
   %c = util.unfoldable_constant dense<2.0> : tensor<256x1024xf32>
-  %d = "mhlo.dot"(%a, %b) {compilation.info = #compilation0} : (tensor<128x256xf32>, tensor<256x512xf32>) -> tensor<128x512xf32>
-  %e = "mhlo.dot"(%a, %c) {compilation.info = #compilation1} : (tensor<128x256xf32>, tensor<256x1024xf32>) -> tensor<128x1024xf32>
+  %d = "mhlo.dot"(%a, %b) {compilation_info = #compilation0} : (tensor<128x256xf32>, tensor<256x512xf32>) -> tensor<128x512xf32>
+  %e = "mhlo.dot"(%a, %c) {compilation_info = #compilation1} : (tensor<128x256xf32>, tensor<256x1024xf32>) -> tensor<128x1024xf32>
   check.expect_almost_eq_const(%d, dense<512.0> : tensor<128x512xf32>) : tensor<128x512xf32>
   check.expect_almost_eq_const(%e, dense<512.0> : tensor<128x1024xf32>) : tensor<128x1024xf32>
   return


### PR DESCRIPTION
This path does some cleanups to these attributes.
- Make `native_vector_size` and `workload_per_wg` fields in
  `LoweringConfigAttr` and `TranslationInfoAttr` default valued. More
  fields can now be added in a similar way, and this allows pipelines
  to independently set the values of attributes here without having to
  change the world.
- Drop all uses of `native_vector_size`. They arent needed anymore.
- Move DispatchLoweringPassPipeline to use I32EnumAttr in preparation
  of upcoming changes.
- Make the mnemonics used consistent with upstream usage by dropping
  uses of `.`.
- Fix the assembly format of `CompilationInfoAttr`.