### PR TITLE
Aligning read file contents in tools.

### DIFF
--- a/iree/base/internal/file_io.h
+++ b/iree/base/internal/file_io.h
@@ -20,14 +20,30 @@ extern "C" {
 // Returns IREE_STATUS_NOT_FOUND if the file does not exist.
 iree_status_t iree_file_exists(const char* path);
 
+// Loaded file contents.
+typedef struct iree_file_contents_t {
+  iree_allocator_t allocator;
+  union {
+    iree_byte_span_t buffer;
+    iree_const_byte_span_t const_buffer;
+  };
+} iree_file_contents_t;
+
+// Returns an allocator that deallocates the |contents|.
+// This can be passed to functions that require a deallocation mechanism.
+iree_allocator_t iree_file_contents_deallocator(iree_file_contents_t* contents);
+
+// Frees memory associated with |contents|.
+void iree_file_contents_free(iree_file_contents_t* contents);
+
 // Synchronously reads a file's contents into memory.
 //
 // Returns the contents of the file in |out_contents|.
-// |allocator| is used to allocate the memory and the caller must use the same
-// allocator when freeing it.
+// |allocator| is used to allocate the memory and the caller must use
+// iree_file_contents_free to release the memory.
 iree_status_t iree_file_read_contents(const char* path,
                                       iree_allocator_t allocator,
-                                      iree_byte_span_t* out_contents);
+                                      iree_file_contents_t** out_contents);
 
 // Synchronously writes a byte buffer into a file.
 // Existing contents are overwritten.
@@ -40,10 +56,10 @@ iree_status_t iree_file_write_contents(const char* path,
 // don't contain NUL).
 //
 // Returns the contents of the file in |out_contents|.
-// |allocator| is used to allocate the memory and the caller must use the same
-// allocator when freeing it.
+// |allocator| is used to allocate the memory and the caller must use
+// iree_file_contents_free to release the memory.
 iree_status_t iree_stdin_read_contents(iree_allocator_t allocator,
-                                       iree_byte_span_t* out_contents);
+                                       iree_file_contents_t** out_contents);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/iree/base/internal/file_io_test.cc
+++ b/iree/base/internal/file_io_test.cc
@@ -62,17 +62,17 @@ TEST(FileIO, ReadWriteContents) {
       iree_make_const_byte_span(write_contents.data(), write_contents.size())));
 
   // Read the contents from disk.
-  iree_byte_span_t read_contents;
+  iree_file_contents_t* read_contents = NULL;
   IREE_ASSERT_OK(iree_file_read_contents(path.c_str(), iree_allocator_system(),
                                          &read_contents));
 
   // Expect the contents are equal.
-  EXPECT_EQ(write_contents.size(), read_contents.data_length);
-  EXPECT_EQ(memcmp(write_contents.data(), read_contents.data,
-                   read_contents.data_length),
+  EXPECT_EQ(write_contents.size(), read_contents->const_buffer.data_length);
+  EXPECT_EQ(memcmp(write_contents.data(), read_contents->const_buffer.data,
+                   read_contents->const_buffer.data_length),
             0);
 
-  iree_allocator_free(iree_allocator_system(), read_contents.data);
+  iree_file_contents_free(read_contents);
 }
 
 }  // namespace

--- a/iree/base/internal/flags.c
+++ b/iree/base/internal/flags.c
@@ -449,15 +449,16 @@ static iree_status_t iree_flags_parse_file(iree_string_view_t file_path) {
   // NOTE: safe to use file_path.data here as it will always have a NUL
   // terminator.
   iree_allocator_t allocator = iree_flags_leaky_allocator();
-  iree_byte_span_t file_contents;
+  iree_file_contents_t* file_contents = NULL;
   IREE_RETURN_IF_ERROR(
       iree_file_read_contents(file_path.data, allocator, &file_contents),
       "while trying to parse flagfile");
 
   // Run through the file line-by-line.
   int line_number = 0;
-  iree_string_view_t contents = iree_make_string_view(
-      (const char*)file_contents.data, file_contents.data_length);
+  iree_string_view_t contents =
+      iree_make_string_view((const char*)file_contents->buffer.data,
+                            file_contents->buffer.data_length);
   while (!iree_string_view_is_empty(contents)) {
     // Split into a single line and the entire rest of the file contents.
     iree_string_view_t line;

--- a/iree/hal/local/BUILD
+++ b/iree/hal/local/BUILD
@@ -43,6 +43,7 @@ cc_binary_benchmark(
         ":local",
         "//iree/base",
         "//iree/base:tracing",
+        "//iree/base/internal:file_io",
         "//iree/base/internal:flags",
         "//iree/hal",
         "//iree/hal/local/loaders:embedded_library_loader",

--- a/iree/hal/local/CMakeLists.txt
+++ b/iree/hal/local/CMakeLists.txt
@@ -44,6 +44,7 @@ iree_cc_binary_benchmark(
     ::executable_library
     ::local
     iree::base
+    iree::base::internal::file_io
     iree::base::internal::flags
     iree::base::tracing
     iree::hal

--- a/iree/runtime/session.c
+++ b/iree/runtime/session.c
@@ -225,21 +225,18 @@ iree_runtime_session_append_bytecode_module_from_file(
 
   // TODO(#3909): actually map the memory here. For now we just load the
   // contents.
-  iree_allocator_t flatbuffer_allocator =
-      iree_runtime_session_host_allocator(session);
-  iree_byte_span_t flatbuffer_data;
+  iree_file_contents_t* flatbuffer_contents = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_file_read_contents(file_path, flatbuffer_allocator,
-                                  &flatbuffer_data));
+      z0, iree_file_read_contents(file_path,
+                                  iree_runtime_session_host_allocator(session),
+                                  &flatbuffer_contents));
 
   iree_status_t status =
       iree_runtime_session_append_bytecode_module_from_memory(
-          session,
-          iree_make_const_byte_span(flatbuffer_data.data,
-                                    flatbuffer_data.data_length),
-          flatbuffer_allocator);
+          session, flatbuffer_contents->const_buffer,
+          iree_file_contents_deallocator(flatbuffer_contents));
   if (!iree_status_is_ok(status)) {
-    iree_allocator_free(flatbuffer_allocator, flatbuffer_data.data);
+    iree_file_contents_free(flatbuffer_contents);
   }
 
   IREE_TRACE_ZONE_END(z0);

--- a/iree/tools/BUILD
+++ b/iree/tools/BUILD
@@ -77,13 +77,12 @@ cc_binary(
 
 cc_binary(
     name = "iree-dump-module",
-    srcs = ["iree-dump-module-main.cc"],
+    srcs = ["iree-dump-module-main.c"],
     deps = [
         "//iree/base",
         "//iree/base/internal:file_io",
         "//iree/base/internal/flatcc:debugging",
         "//iree/schemas:bytecode_module_def_c_fbs",
-        "//iree/tools/utils:vm_util",
     ],
 )
 

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -135,14 +135,13 @@ iree_cc_binary(
   NAME
     iree-dump-module
   SRCS
-    "iree-dump-module-main.cc"
+    "iree-dump-module-main.c"
   DEPS
     flatcc::runtime
     iree::base
     iree::base::internal::file_io
     iree::base::internal::flatcc::debugging
     iree::schemas::bytecode_module_def_c_fbs
-    iree::tools::utils::vm_util
 )
 
 iree_cc_binary(

--- a/iree/tools/iree-dump-module-main.c
+++ b/iree/tools/iree-dump-module-main.c
@@ -4,14 +4,11 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <iostream>
-#include <string>
-#include <utility>
+#include <stdio.h>
 
 #include "iree/base/api.h"
 #include "iree/base/internal/file_io.h"
 #include "iree/schemas/bytecode_module_def_json_printer.h"
-#include "iree/tools/utils/vm_util.h"
 
 // Today we just print to JSON. We could do something more useful (size
 // analysis, etc), but JSON should be enough.
@@ -19,22 +16,26 @@
 // We could also move all of this into iree-translate (mlir -> vmfb -> json),
 // though having a tiny little tool not reliant on LLVM is nice (can run this
 // on a device).
-extern "C" int main(int argc, char** argv) {
+int main(int argc, char** argv) {
   if (argc < 2) {
-    std::cerr << "Syntax: iree-dump-module module.vmfb > module.json\n";
+    fprintf(stderr, "Syntax: iree-dump-module module.vmfb > module.json\n");
     return 1;
   }
-  std::string module_contents;
-  IREE_CHECK_OK(iree::GetFileContents(argv[1], &module_contents));
+
+  iree_file_contents_t* flatbuffer_contents = NULL;
+  IREE_CHECK_OK(iree_file_read_contents(argv[1], iree_allocator_system(),
+                                        &flatbuffer_contents));
 
   // Print direct to stdout.
   flatcc_json_printer_t printer;
-  flatcc_json_printer_init(&printer, /*fp=*/nullptr);
+  flatcc_json_printer_init(&printer, /*fp=*/NULL);
   flatcc_json_printer_set_skip_default(&printer, true);
   bytecode_module_def_print_json(
-      &printer, reinterpret_cast<const char*>(module_contents.data()),
-      module_contents.size());
+      &printer, (const char*)flatbuffer_contents->const_buffer.data,
+      flatbuffer_contents->const_buffer.data_length);
   flatcc_json_printer_clear(&printer);
+
+  iree_file_contents_free(flatbuffer_contents);
 
   return 0;
 }

--- a/iree/tools/utils/BUILD
+++ b/iree/tools/utils/BUILD
@@ -40,7 +40,6 @@ cc_library(
         "//iree/base:cc",
         "//iree/base:logging",
         "//iree/base:tracing",
-        "//iree/base/internal:file_io",
         "//iree/base/internal:span",
         "//iree/hal",
         "//iree/modules/hal",

--- a/iree/tools/utils/CMakeLists.txt
+++ b/iree/tools/utils/CMakeLists.txt
@@ -41,7 +41,6 @@ iree_cc_library(
   DEPS
     iree::base
     iree::base::cc
-    iree::base::internal::file_io
     iree::base::internal::span
     iree::base::logging
     iree::base::tracing

--- a/iree/tools/utils/vm_util.h
+++ b/iree/tools/utils/vm_util.h
@@ -20,10 +20,8 @@
 
 namespace iree {
 
-// TODO(benvanik) Update these when we can use RAII with the C API.
-
-// Synchronously reads a file's contents into a string.
-Status GetFileContents(const char* path, std::string* out_contents);
+// NOTE: this file is not best-practice and needs to be rewritten; consider this
+// appropriate only for test code.
 
 // Parses |input_strings| into a variant list of VM scalars and buffers.
 // Scalars should be in the format:


### PR DESCRIPTION
All file buffers in memory will be aligned to 4096B at the cost of 4096 + 64B.
4096 is higher than any alignment the compiler would produce and will ensure any alignment requirements the compiler has can be satisfied.

This also replaces the uses of the old C++ helper with the C API. This isn't the best API but should get us by for longer - I still have some cross-platform memory mapping code stashed that will eventually replace this.