### PR TITLE
Return error instead of asserting in bufferization copy callback.

### DIFF
--- a/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -126,8 +126,8 @@ static LogicalResult defaultDeallocationFn(OpBuilder &builder, Location loc,
 }
 static LogicalResult defaultMemCpyFn(OpBuilder &builder, Location loc,
                                      Value from, Value to) {
-  createLinalgCopyOp(builder, loc, from, to);
-  return success();
+  Operation *copyOp = createLinalgCopyOp(builder, loc, from, to);
+  return success(static_cast<bool>(copyOp));
 }
 
 std::unique_ptr<OperationPass<ModuleOp>> createIREEComprehensiveBufferizePass(

--- a/iree/compiler/Codegen/Common/MemrefCopyToLinalg.cpp
+++ b/iree/compiler/Codegen/Common/MemrefCopyToLinalg.cpp
@@ -24,6 +24,7 @@ struct MemrefCopyOpToLinalg : public OpRewritePattern<memref::CopyOp> {
     Operation *linalgCopy =
         createLinalgCopyOp(rewriter, copyOp.getLoc(), copyOp.source(),
                            copyOp.target(), copyOp->getAttrs());
+    if (!linalgCopy) return failure();
     rewriter.replaceOp(copyOp, linalgCopy->getResults());
     return success();
   }

--- a/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/iree/compiler/Codegen/Utils/Utils.cpp
@@ -487,11 +487,15 @@ SmallVector<LoopTilingAndDistributionInfo> getTiledAndDistributedLoopInfo(
 /// memref::CopyOp.
 Operation *createLinalgCopyOp(OpBuilder &b, Location loc, Value from, Value to,
                               ArrayRef<NamedAttribute> attributes) {
-  auto memrefTypeFrom = from.getType().cast<MemRefType>();
-  auto memrefTypeTo = to.getType().cast<MemRefType>();
-  (void)memrefTypeFrom;
-  assert(memrefTypeFrom && memrefTypeTo &&
-         memrefTypeFrom.getRank() == memrefTypeTo.getRank());
+  auto memrefTypeFrom = from.getType().dyn_cast<MemRefType>();
+  auto memrefTypeTo = to.getType().dyn_cast<MemRefType>();
+  if (!memrefTypeFrom || !memrefTypeTo ||
+      memrefTypeFrom.getRank() != memrefTypeTo.getRank()) {
+    mlir::emitError(
+        loc, "unable to generate copy op within bufferization from type ")
+        << memrefTypeFrom << " to " << memrefTypeTo;
+    return nullptr;
+  }
   AffineMap id =
       AffineMap::getMultiDimIdentityMap(memrefTypeTo.getRank(), b.getContext());
   SmallVector<StringRef> iteratorTypes(memrefTypeTo.getRank(),


### PR DESCRIPTION
Current callback just asserts that the copy callback can insert a
valid copy. Return a nullptr, and throw an error when copy cannot be
generated. Also update all call sites to handle the error.