### PR TITLE
Add a pass to bufferize early copy only dispatches.

### DIFF
--- a/iree/compiler/Codegen/Common/BUILD
+++ b/iree/compiler/Codegen/Common/BUILD
@@ -105,5 +105,6 @@ cc_library(
         "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:VectorOps",
         "@llvm-project//mlir:VectorTransforms",
+        "@llvm-project//mlir:ViewLikeInterface",
     ],
 )

--- a/iree/compiler/Codegen/Common/BUILD
+++ b/iree/compiler/Codegen/Common/BUILD
@@ -35,6 +35,7 @@ cc_library(
     name = "Common",
     srcs = [
         "BufferizationAnalysis.cpp",
+        "BufferizeCopyOnlyDispatchesPass.cpp",
         "CleanupBufferAllocViewPass.cpp",
         "ConvertToDestinationPassingStylePass.cpp",
         "DemoteF32ToF16.cpp",

--- a/iree/compiler/Codegen/Common/BufferizationAnalysis.cpp
+++ b/iree/compiler/Codegen/Common/BufferizationAnalysis.cpp
@@ -561,7 +561,7 @@ LogicalResult createTensorEquivalenceClasses(func::FuncOp funcOp,
             })
         .Case<vector::TransferWriteOp>(
             [&](vector::TransferWriteOp transferWriteOp) {
-              if (!transferWriteOp.result().getType().isa<RankedTensorType>()) {
+              if (!transferWriteOp.source().getType().isa<RankedTensorType>()) {
                 return success();
               }
               return analyseDestructiveUpdateOp(transferWriteOp, nullptr,

--- a/iree/compiler/Codegen/Common/BufferizationAnalysis.cpp
+++ b/iree/compiler/Codegen/Common/BufferizationAnalysis.cpp
@@ -14,11 +14,13 @@
 #include "iree/compiler/Codegen/Common/BufferizationAnalysis.h"
 
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowTypes.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
@@ -66,7 +68,7 @@ static bool canUsersHandleSubviews(Operation *op) {
 
 /// Walks the use-def chain and see if this value comes from a read-only tensor.
 static bool isFromReadOnlyTensor(Value v, const BufferizationPlan &plan) {
-  auto definingOp = v.getDefiningOp();
+  Operation *definingOp = v.getDefiningOp();
   if (!definingOp) {
     auto arg = v.cast<BlockArgument>();
     return TypeSwitch<Operation *, bool>(arg.getOwner()->getParentOp())
@@ -79,22 +81,7 @@ static bool isFromReadOnlyTensor(Value v, const BufferizationPlan &plan) {
         })
         .Default([&](Operation *op) { return false; });
   }
-  return TypeSwitch<Operation *, bool>(definingOp)
-      .Case<arith::ConstantOp>(
-          [&](arith::ConstantOp constantOp) { return true; })
-      .Case<tensor::CollapseShapeOp, tensor::ExpandShapeOp>(
-          [&](auto op) { return isFromReadOnlyTensor(op.src(), plan); })
-      .Case<tensor::ExtractSliceOp>([&](tensor::ExtractSliceOp sliceOp) {
-        return isFromReadOnlyTensor(sliceOp.source(), plan);
-      })
-      .Case<IREE::Flow::DispatchTensorLoadOp>(
-          [&](IREE::Flow::DispatchTensorLoadOp loadOp) {
-            return loadOp.source()
-                       .getType()
-                       .cast<IREE::Flow::DispatchTensorType>()
-                       .getAccess() == IREE::Flow::TensorAccess::ReadOnly;
-          })
-      .Default([&](Operation *op) { return false; });
+  return isReadOnly(v);
 }
 
 /// Adds the result of `std.constant` to its set (there is nothing to tie to
@@ -586,7 +573,7 @@ LogicalResult createTensorEquivalenceClasses(func::FuncOp funcOp,
         .Case<scf::ForOp>(
             [&](scf::ForOp forOp) { return analyseScfForOp(forOp, plan); })
         .Case<scf::YieldOp, linalg::InitTensorOp, tensor::DimOp,
-              tensor::ExtractOp, tensor::PadOp>(
+              tensor::ExtractOp, tensor::PadOp, bufferization::ToMemrefOp>(
             [&](Operation *op) { return success(); })
         .Default([&](Operation *op) -> LogicalResult {
           if (llvm::any_of(op->getOperands(),

--- a/iree/compiler/Codegen/Common/BufferizeCopyOnlyDispatchesPass.cpp
+++ b/iree/compiler/Codegen/Common/BufferizeCopyOnlyDispatchesPass.cpp
@@ -47,7 +47,7 @@ static OpFoldResult getOpFoldResult(OpBuilder &builder, Location loc,
                                     AffineExpr expr,
                                     SmallVector<Value> &symbols) {
   AffineMap m = AffineMap::get(0, symbols.size(), expr);
-  return builder.create<AffineApplyOp>(loc, m, symbols).getResult();
+  return applyMapToValues(builder, loc, m, symbols)[0];
 }
 
 /// Methods to build the Affine Expr for arithmetic operations.

--- a/iree/compiler/Codegen/Common/BufferizeCopyOnlyDispatchesPass.cpp
+++ b/iree/compiler/Codegen/Common/BufferizeCopyOnlyDispatchesPass.cpp
@@ -1,0 +1,243 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===- BufferizeCopyOnlyDispatchesPassPass.cpp ----------------------------===//
+//
+// This pass converts dispatches that are copy only into a form where backends
+// can tile and distribute them appropriately.
+//
+//===----------------------------------------------------------------------===//
+
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Passes.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+static OpFoldResult add(OpBuilder &builder, Location loc, OpFoldResult lhs,
+                        OpFoldResult rhs) {
+  auto lhsAttr = lhs.dyn_cast<Attribute>();
+  auto rhsAttr = rhs.dyn_cast<Attribute>();
+  if (lhsAttr && rhsAttr) {
+    int64_t result = lhsAttr.cast<IntegerAttr>().getInt() +
+                     rhsAttr.cast<IntegerAttr>().getInt();
+    return builder.getIndexAttr(result);
+  }
+  // Generate the affine.apply that computes the result
+  SmallVector<Value> operands;
+  AffineExpr resultExpr = nullptr;
+  auto addToResult = [&](OpFoldResult ofr) {
+    AffineExpr e;
+    if (auto attr = ofr.dyn_cast<Attribute>()) {
+      e = getAffineConstantExpr(attr.cast<IntegerAttr>().getInt(),
+                                builder.getContext());
+    } else {
+      e = getAffineSymbolExpr(operands.size(), builder.getContext());
+      operands.push_back(ofr.get<Value>());
+    }
+    resultExpr = resultExpr ? resultExpr + e : e;
+  };
+  addToResult(lhs);
+  addToResult(rhs);
+  AffineMap map = AffineMap::get(0, operands.size(), resultExpr);
+  return builder.create<AffineApplyOp>(loc, map, operands).getResult();
+}
+
+/// Pattern to fold `tensor.extract_slice` into `flow.dispatch.tensor.load`
+/// operation.
+static FailureOr<SmallVector<OpFoldResult>> foldOffsetsSizesAndStrides(
+    OpBuilder &builder, Location loc, OffsetSizeAndStrideOpInterface producer,
+    OffsetSizeAndStrideOpInterface consumer) {
+  auto checkOne = [](OpFoldResult ofr) -> bool {
+    auto attr = ofr.dyn_cast<Attribute>();
+    return attr && attr.cast<IntegerAttr>().getInt() == 1;
+  };
+  auto producerStrides = producer.getMixedStrides();
+  auto consumerStrides = consumer.getMixedStrides();
+  if (producerStrides.size() != consumerStrides.size()) {
+    return static_cast<LogicalResult>(producer->emitOpError(
+        "expected same number of offsets/sizes/strides for producer and "
+        "consumer"));
+  }
+
+  if (!llvm::all_of(producer.getMixedStrides(), checkOne)) {
+    return static_cast<LogicalResult>(
+        producer->emitOpError("expected all strides to be 1"));
+  }
+  if (!llvm::all_of(consumer.getMixedStrides(), checkOne)) {
+    return static_cast<LogicalResult>(
+        consumer->emitOpError("expected all strides to be 1"));
+  }
+
+  // Combined offsets is the addition of the two offsets.
+  return llvm::to_vector(llvm::map_range(
+      llvm::zip(producer.getMixedOffsets(), consumer.getMixedOffsets()),
+      [&](std::tuple<OpFoldResult, OpFoldResult> t) {
+        return add(builder, loc, std::get<0>(t), std::get<1>(t));
+      }));
+}
+
+static bool isDirectlyFromDispatchTensorLoad(Value v) {
+  // Might eventually need to walk the use-def chain a bit, but for now,
+  // just check for the value defined by a flow.dispatch.tensor.load.
+  return v.getDefiningOp<IREE::Flow::DispatchTensorLoadOp>() != nullptr;
+}
+
+namespace {
+
+/// Pattern to fold `flow.dispatch.tensor.load` -> `tensor.extract_slice`.
+// TODO(ravishankarm): Eventually this should go in as a canonicalization at the
+// Flow level.
+struct FoldTensorLoadWithExtractSlice
+    : OpRewritePattern<tensor::ExtractSliceOp> {
+  using OpRewritePattern<tensor::ExtractSliceOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::ExtractSliceOp extractSliceOp,
+                                PatternRewriter &rewriter) const override {
+    auto dispatchTensorLoadOp =
+        extractSliceOp.source()
+            .getDefiningOp<IREE::Flow::DispatchTensorLoadOp>();
+    if (!dispatchTensorLoadOp) return failure();
+
+    FailureOr<SmallVector<OpFoldResult>> offsets =
+        foldOffsetsSizesAndStrides(rewriter, dispatchTensorLoadOp->getLoc(),
+                                   dispatchTensorLoadOp, extractSliceOp);
+    if (failed(offsets)) {
+      return failure();
+    }
+
+    SmallVector<OpFoldResult> strides(offsets->size(),
+                                      rewriter.getIndexAttr(1));
+    rewriter.replaceOpWithNewOp<IREE::Flow::DispatchTensorLoadOp>(
+        extractSliceOp, extractSliceOp.getType(), dispatchTensorLoadOp.source(),
+        dispatchTensorLoadOp.source_dims(), offsets.getValue(),
+        extractSliceOp.getMixedSizes(), strides);
+    return success();
+  }
+};
+
+/// Pattern to fold `tensor.insert_slice` with `flow.dispatch.tensor.store`
+/// oeprations.
+// TODO(ravishankarm): Eventually this should go in as a canonicalization at the
+// Flow level.
+struct FoldInsertSliceWithTensorStoreOp
+    : OpRewritePattern<IREE::Flow::DispatchTensorStoreOp> {
+  using OpRewritePattern<IREE::Flow::DispatchTensorStoreOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      IREE::Flow::DispatchTensorStoreOp dispatchTensorStoreOp,
+      PatternRewriter &rewriter) const override {
+    auto insertSliceOp =
+        dispatchTensorStoreOp.value().getDefiningOp<tensor::InsertSliceOp>();
+    if (!insertSliceOp) return failure();
+
+    FailureOr<SmallVector<OpFoldResult>> offsets =
+        foldOffsetsSizesAndStrides(rewriter, dispatchTensorStoreOp->getLoc(),
+                                   insertSliceOp, dispatchTensorStoreOp);
+    if (failed(offsets)) {
+      return failure();
+    }
+
+    SmallVector<OpFoldResult> strides(offsets->size(),
+                                      rewriter.getIndexAttr(1));
+    rewriter.replaceOpWithNewOp<IREE::Flow::DispatchTensorStoreOp>(
+        dispatchTensorStoreOp, insertSliceOp.source(),
+        dispatchTensorStoreOp.target(), dispatchTensorStoreOp.target_dims(),
+        offsets.getValue(), insertSliceOp.getMixedSizes(), strides);
+    return success();
+  }
+};
+
+struct BufferizeCopyOnlyDispatchesPass
+    : public BufferizeCopyOnlyDispatchesBase<BufferizeCopyOnlyDispatchesPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry
+        .insert<AffineDialect, IREE::Flow::FlowDialect, linalg::LinalgDialect,
+                memref::MemRefDialect, tensor::TensorDialect>();
+  }
+
+  void runOnOperation() override;
+};
+}  // namespace
+
+void BufferizeCopyOnlyDispatchesPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  ModuleOp module = getOperation();
+
+  /// First apply the `flow.dispatch.tensor.load` -> `tensor.extract_slice` and
+  /// `tensor.insert_slice` -> `flow.dispatch.tensor.store` operation.
+  RewritePatternSet patterns(context);
+  patterns
+      .insert<FoldInsertSliceWithTensorStoreOp, FoldTensorLoadWithExtractSlice>(
+          context);
+  if (failed(applyPatternsAndFoldGreedily(module, std::move(patterns)))) {
+    return signalPassFailure();
+  }
+
+  SmallVector<Operation *> copyOnlyFunctions;
+  auto funcOps = module.getOps<FuncOp>();
+  for (auto funcOp : funcOps) {
+    /// Check if the dispatch has all flow.dispatch.tensor.store operations
+    /// coming from flow.dispatch.tensor.load operations. If so, this dispatch
+    /// is just a copy dispatch.
+    auto walkResult = funcOp.walk(
+        [&](IREE::Flow::DispatchTensorStoreOp storeOp) -> WalkResult {
+          return success(isDirectlyFromDispatchTensorLoad(storeOp.value()));
+        });
+    if (walkResult.wasInterrupted()) continue;
+    // The function is just a copy.
+    copyOnlyFunctions.push_back(funcOp);
+  }
+
+  // There are no copy-only functions. So nothing to do.
+  if (copyOnlyFunctions.empty()) return;
+
+  // Bufferize the dispatch to create a `linalg.generic` as a copy operation.
+  // This can then be used by the backends to tile and distribute.
+  // Currently bufferization does not handle single function bufferization. So
+  // check that all functions are copy only and can be bufferized.
+  if (copyOnlyFunctions.size() !=
+      std::distance(funcOps.begin(), funcOps.end())) {
+    module.emitOpError(
+        "module contains functions that are both copy only and not copy only. "
+        "This is currently unhandled.");
+    return signalPassFailure();
+  }
+
+  // Create an apply the bufferization passes.
+  OpPassManager bufferizationPipeline(module.getOperationName());
+  addLinalgBufferizePasses(bufferizationPipeline);
+  if (failed(runPipeline(bufferizationPipeline, module))) {
+    return signalPassFailure();
+  }
+
+  // Check that there are no allocs created.
+  auto hasAlloc = module.walk(
+      [&](memref::AllocOp /*op*/) -> WalkResult { return failure(); });
+  if (hasAlloc.wasInterrupted()) {
+    module.emitOpError(
+        "unexpected allocations while bufferizing copy dispatch");
+    return signalPassFailure();
+  }
+}
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createBufferizeCopyOnlyDispatchesPass() {
+  return std::make_unique<BufferizeCopyOnlyDispatchesPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_cc_library(
     "DestructiveUpdateUtils.h"
   SRCS
     "BufferizationAnalysis.cpp"
+    "BufferizeCopyOnlyDispatchesPass.cpp"
     "CleanupBufferAllocViewPass.cpp"
     "ConvertToDestinationPassingStylePass.cpp"
     "DemoteF32ToF16.cpp"

--- a/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -80,6 +80,7 @@ iree_cc_library(
     MLIRTransforms
     MLIRVector
     MLIRVectorTransforms
+    MLIRViewLikeInterface
     iree::compiler::Codegen::Common::FoldTensorExtractOpIncGen
     iree::compiler::Codegen::Dialect::IREECodegenDialect
     iree::compiler::Codegen::Interfaces::BufferizationInterfaces

--- a/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
+++ b/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
@@ -323,24 +323,6 @@ static SmallVector<NamedAttribute> PruneAttributeList(linalg::GenericOp op) {
   return preservedAttrs;
 }
 
-static bool isFromReadOnlyTensor(Value v) {
-  return TypeSwitch<Operation *, bool>(v.getDefiningOp())
-      .Case<arith::ConstantOp>(
-          [&](arith::ConstantOp constantOp) { return true; })
-      .Case<tensor::CollapseShapeOp, tensor::ExpandShapeOp>(
-          [&](auto op) { return isFromReadOnlyTensor(op.src()); })
-      .Case<tensor::CastOp, tensor::ExtractSliceOp>(
-          [&](auto op) { return isFromReadOnlyTensor(op.source()); })
-      .Case<IREE::Flow::DispatchTensorLoadOp>(
-          [&](IREE::Flow::DispatchTensorLoadOp loadOp) {
-            return loadOp.source()
-                       .getType()
-                       .cast<IREE::Flow::DispatchTensorType>()
-                       .getAccess() == IREE::Flow::TensorAccess::ReadOnly;
-          })
-      .Default([&](Operation *op) { return false; });
-}
-
 namespace {
 /// Adapts Linalg ops input operand to output operand. This is required for not
 /// creating extra alloca ops. For more details, see
@@ -366,7 +348,7 @@ struct AdaptLinalgInputOperandToOutputOperand
     SmallVector<Value> newOperands;
     SmallVector<AffineMap> maps;
     for (auto in : op.getInputOperands()) {
-      if (!operand && !isFromReadOnlyTensor(in->get()) &&
+      if (!operand && !isReadOnly(in->get()) &&
           op.getTiedIndexingMap(in) == op.getTiedIndexingMap(outputOperand) &&
           in->get().getType() == outputOperand->get().getType()) {
         operand = in;

--- a/iree/compiler/Codegen/Common/LinalgBufferizePass.cpp
+++ b/iree/compiler/Codegen/Common/LinalgBufferizePass.cpp
@@ -1109,6 +1109,10 @@ void LinalgBufferizePass::runOnOperation() {
         })
         .Case<vector::TransferWriteOp>(
             [&](vector::TransferWriteOp transferWriteOp) {
+              if (!transferWriteOp.source().getType().isa<RankedTensorType>()) {
+                // Nothing to do when source is not a tensor.
+                return success();
+              }
               if (failed(getOrAllocateResultBuffers(b, transferWriteOp, bvm,
                                                     plan, allocationFn))) {
                 return failure();

--- a/iree/compiler/Codegen/Common/test/BUILD
+++ b/iree/compiler/Codegen/Common/test/BUILD
@@ -20,6 +20,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         [
             "affinemin_canonicalization.mlir",
+            "bufferize_copy_only_dispatches.mlir",
             "canonicalize_interface_load_store.mlir",
             "convert_to_destination_passing_style.mlir",
             "dead_alloc.mlir",

--- a/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "affinemin_canonicalization.mlir"
+    "bufferize_copy_only_dispatches.mlir"
     "canonicalize_interface_load_store.mlir"
     "convert_to_destination_passing_style.mlir"
     "dead_alloc.mlir"

--- a/iree/compiler/Codegen/Common/test/bufferize_copy_only_dispatches.mlir
+++ b/iree/compiler/Codegen/Common/test/bufferize_copy_only_dispatches.mlir
@@ -8,33 +8,53 @@ builtin.module {
     %dest_size_x = hal.interface.constant.load[3] : index
     %dest_offset_y = hal.interface.constant.load[4] : index
     %dest_offset_x = hal.interface.constant.load[5] : index
-    %insert_offset_y = hal.interface.constant.load[6] : index
-    %insert_offset_x = hal.interface.constant.load[7] : index
+    %dest_stride_y = hal.interface.constant.load[6] : index
+    %dest_stride_x = hal.interface.constant.load[7] : index
+    %insert_offset_y = hal.interface.constant.load[8] : index
+    %insert_offset_x = hal.interface.constant.load[9] : index
+    %insert_stride_y = hal.interface.constant.load[10] : index
+    %insert_stride_x = hal.interface.constant.load[11] : index
+    %dest_binding_size_y = hal.interface.constant.load[12] : index
+    %dest_binding_size_x = hal.interface.constant.load[13] : index
     %source = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
         : !flow.dispatch.tensor<readonly:?x?xi32>{%source_size_y, %source_size_x}
     %dest = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
-        : !flow.dispatch.tensor<readwrite:?x?xi32>{%dest_size_y, %dest_size_x}
-    %source_load = flow.dispatch.tensor.load %source, offsets = [0, 0], sizes = [%source_size_y, %source_size_x], strides = [1, 1]
+        : !flow.dispatch.tensor<readwrite:?x?xi32>{%dest_binding_size_y, %dest_binding_size_x}
+    %source_load = flow.dispatch.tensor.load %source, offsets = [0, 0],sizes = [%source_size_y, %source_size_x], strides = [1, 1]
         : !flow.dispatch.tensor<readonly:?x?xi32>{%source_size_y, %source_size_x} -> tensor<?x?xi32>
-    %dest_load = flow.dispatch.tensor.load %dest, offsets = [0, 0], sizes = [%dest_size_y, %dest_size_x], strides = [1, 1]
-        : !flow.dispatch.tensor<readwrite:?x?xi32>{%dest_size_y, %dest_size_x} -> tensor<?x?xi32>
-    %insert = tensor.insert_slice %source_load into %dest_load[%insert_offset_y, %insert_offset_x] [%source_size_y, %source_size_x] [1, 1] : tensor<?x?xi32> into tensor<?x?xi32>
-    flow.dispatch.tensor.store %insert, %dest, offsets = [%dest_offset_y, %dest_offset_x], sizes = [%source_size_y, %source_size_x], strides = [1, 1]
-        : tensor<?x?xi32> -> !flow.dispatch.tensor<readwrite:?x?xi32>{%dest_size_y, %dest_size_x}
+    %dest_load = flow.dispatch.tensor.load %dest, offsets = [%dest_offset_y, %dest_offset_x], sizes = [%dest_size_y, %dest_size_x],
+        strides = [%dest_stride_y, %dest_stride_x]
+        : !flow.dispatch.tensor<readwrite:?x?xi32>{%dest_binding_size_y, %dest_binding_size_x} -> tensor<?x?xi32>
+    %insert = tensor.insert_slice %source_load into
+        %dest_load[%insert_offset_y, %insert_offset_x] [%source_size_y, %source_size_x] [%insert_stride_y, %insert_stride_x]
+        : tensor<?x?xi32> into tensor<?x?xi32>
+    flow.dispatch.tensor.store %insert, %dest, offsets = [%dest_offset_y, %dest_offset_x], sizes = [%dest_size_y, %dest_size_x],
+        strides = [%dest_stride_y, %dest_stride_x]
+        : tensor<?x?xi32> -> !flow.dispatch.tensor<readwrite:?x?xi32>{%dest_binding_size_y, %dest_binding_size_x}
     return
   }
 }
-//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1] -> (s0 + s1)>
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0, s1] -> (s0 * s1)>
 //      CHECK: func @tensor_insert_slice()
+//  CHECK-DAG:   %[[SOURCE_SIZE_Y:.+]] = hal.interface.constant.load[0]
+//  CHECK-DAG:   %[[SOURCE_SIZE_X:.+]] = hal.interface.constant.load[1]
 //  CHECK-DAG:   %[[DEST_OFFSET_Y:.+]] = hal.interface.constant.load[4]
 //  CHECK-DAG:   %[[DEST_OFFSET_X:.+]] = hal.interface.constant.load[5]
-//  CHECK-DAG:   %[[INSERT_OFFSET_Y:.+]] = hal.interface.constant.load[6]
-//  CHECK-DAG:   %[[INSERT_OFFSET_X:.+]] = hal.interface.constant.load[7]
+//  CHECK-DAG:   %[[DEST_STRIDE_Y:.+]] = hal.interface.constant.load[6]
+//  CHECK-DAG:   %[[DEST_STRIDE_X:.+]] = hal.interface.constant.load[7]
+//  CHECK-DAG:   %[[INSERT_OFFSET_Y:.+]] = hal.interface.constant.load[8]
+//  CHECK-DAG:   %[[INSERT_OFFSET_X:.+]] = hal.interface.constant.load[9]
+//  CHECK-DAG:   %[[INSERT_STRIDE_Y:.+]] = hal.interface.constant.load[10]
+//  CHECK-DAG:   %[[INSERT_STRIDE_X:.+]] = hal.interface.constant.load[11]
 //  CHECK-DAG:   %[[SOURCE:.+]] = hal.interface.binding.subspan set(0) binding(0)
 //  CHECK-DAG:   %[[DEST:.+]] = hal.interface.binding.subspan set(0) binding(1)
-//  CHECK-DAG:   %[[OFFSET_Y:.+]] = affine.apply #[[MAP0]]()[%[[INSERT_OFFSET_Y]], %[[DEST_OFFSET_Y]]]
-//  CHECK-DAG:   %[[OFFSET_X:.+]] = affine.apply #[[MAP0]]()[%[[INSERT_OFFSET_X]], %[[DEST_OFFSET_X]]]
-//  CHECK-DAG:   %[[SUBVIEW:.+]] = memref.subview %[[DEST]][%[[OFFSET_Y]], %[[OFFSET_X]]]
+//  CHECK-DAG:   %[[OFFSET_Y:.+]] = affine.apply #[[MAP0]]()[%[[INSERT_OFFSET_Y]], %[[DEST_STRIDE_Y]], %[[DEST_OFFSET_Y]]]
+//  CHECK-DAG:   %[[OFFSET_X:.+]] = affine.apply #[[MAP0]]()[%[[INSERT_OFFSET_X]], %[[DEST_STRIDE_X]], %[[DEST_OFFSET_X]]]
+//  CHECK-DAG:   %[[STRIDE_Y:.+]] = affine.apply #[[MAP1]]()[%[[DEST_STRIDE_Y]], %[[INSERT_STRIDE_Y]]]
+//  CHECK-DAG:   %[[STRIDE_X:.+]] = affine.apply #[[MAP1]]()[%[[DEST_STRIDE_X]], %[[INSERT_STRIDE_X]]]
+//  CHECK-DAG:   %[[SUBVIEW:.+]] = memref.subview %[[DEST]][%[[OFFSET_Y]], %[[OFFSET_X]]] [%[[SOURCE_SIZE_Y]], %[[SOURCE_SIZE_X]]]
+// CHECK-SAME:       [%[[STRIDE_Y]], %[[STRIDE_X]]]
 //      CHECK:   linalg.generic
 // CHECK-SAME:       ins(%[[SOURCE]] :
 // CHECK-SAME:       outs(%[[SUBVIEW]] :
@@ -47,38 +67,52 @@ builtin.module {
     %source_size_x = hal.interface.constant.load[1] : index
     %dest_size_y = hal.interface.constant.load[2] : index
     %dest_size_x = hal.interface.constant.load[3] : index
-    %dest_offset_y = hal.interface.constant.load[4] : index
-    %dest_offset_x = hal.interface.constant.load[5] : index
+    %source_offset_y = hal.interface.constant.load[4] : index
+    %source_offset_x = hal.interface.constant.load[5] : index
     %extract_offset_y = hal.interface.constant.load[6] : index
     %extract_offset_x = hal.interface.constant.load[7] : index
-    %slice_size_y = hal.interface.constant.load[8] : index
-    %slice_size_x = hal.interface.constant.load[9] : index
+    %extract_stride_y = hal.interface.constant.load[8] : index
+    %extract_stride_x = hal.interface.constant.load[9] : index
+    %source_stride_y = hal.interface.constant.load[10] : index
+    %source_stride_x = hal.interface.constant.load[11] : index
     %source = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
         : !flow.dispatch.tensor<readonly:?x?xi32>{%source_size_y, %source_size_x}
     %dest = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
         : !flow.dispatch.tensor<readwrite:?x?xi32>{%dest_size_y, %dest_size_x}
-    %source_load = flow.dispatch.tensor.load %source, offsets = [0, 0], sizes = [%source_size_y, %source_size_x], strides = [1, 1]
+    %source_load = flow.dispatch.tensor.load %source, offsets = [%source_offset_y, %source_offset_x], sizes = [%source_size_y, %source_size_x],
+        strides = [%source_stride_y, %source_stride_x]
         : !flow.dispatch.tensor<readonly:?x?xi32>{%source_size_y, %source_size_x} -> tensor<?x?xi32>
-    %extract = tensor.extract_slice %source_load[%extract_offset_y, %extract_offset_x] [%slice_size_y, %slice_size_x] [1, 1] : tensor<?x?xi32> to tensor<?x?xi32>
-    flow.dispatch.tensor.store %extract, %dest, offsets = [%dest_offset_y, %dest_offset_x], sizes = [%slice_size_y, %slice_size_x], strides = [1, 1]
+    %extract = tensor.extract_slice %source_load[%extract_offset_y, %extract_offset_x] [%dest_size_y, %dest_size_x]
+        [%extract_stride_y, %extract_stride_x] : tensor<?x?xi32> to tensor<?x?xi32>
+    flow.dispatch.tensor.store %extract, %dest, offsets = [0, 0], sizes = [%dest_size_y, %dest_size_x], strides = [1, 1]
         : tensor<?x?xi32> -> !flow.dispatch.tensor<readwrite:?x?xi32>{%dest_size_y, %dest_size_x}
     return
   }
 }
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0, s1] -> (s0 * s1)>
 //      CHECK: func @tensor_extract_slice()
-//  CHECK-DAG:   %[[DEST_OFFSET_Y:.+]] = hal.interface.constant.load[4]
-//  CHECK-DAG:   %[[DEST_OFFSET_X:.+]] = hal.interface.constant.load[5]
+//  CHECK-DAG:   %[[DEST_SIZE_Y:.+]] = hal.interface.constant.load[2]
+//  CHECK-DAG:   %[[DEST_SIZE_X:.+]] = hal.interface.constant.load[3]
+//  CHECK-DAG:   %[[SOURCE_OFFSET_Y:.+]] = hal.interface.constant.load[4]
+//  CHECK-DAG:   %[[SOURCE_OFFSET_X:.+]] = hal.interface.constant.load[5]
 //  CHECK-DAG:   %[[EXTRACT_OFFSET_Y:.+]] = hal.interface.constant.load[6]
 //  CHECK-DAG:   %[[EXTRACT_OFFSET_X:.+]] = hal.interface.constant.load[7]
-//  CHECK-DAG:   %[[SLICE_SIZE_Y:.+]] = hal.interface.constant.load[8]
-//  CHECK-DAG:   %[[SLICE_SIZE_X:.+]] = hal.interface.constant.load[9]
+//  CHECK-DAG:   %[[EXTRACT_STRIDE_Y:.+]] = hal.interface.constant.load[8]
+//  CHECK-DAG:   %[[EXTRACT_STRIDE_X:.+]] = hal.interface.constant.load[9]
+//  CHECK-DAG:   %[[SOURCE_STRIDE_Y:.+]] = hal.interface.constant.load[10]
+//  CHECK-DAG:   %[[SOURCE_STRIDE_X:.+]] = hal.interface.constant.load[11]
 //  CHECK-DAG:   %[[SOURCE:.+]] = hal.interface.binding.subspan set(0) binding(0)
 //  CHECK-DAG:   %[[DEST:.+]] = hal.interface.binding.subspan set(0) binding(1)
-//  CHECK-DAG:   %[[SOURCE_SUBVIEW:.+]] = memref.subview %[[SOURCE]][%[[EXTRACT_OFFSET_Y]], %[[EXTRACT_OFFSET_X]]] [%[[SLICE_SIZE_Y:.+]], %[[SLICE_SIZE_X]]]
-//  CHECK-DAG:   %[[DEST_SUBVIEW:.+]] = memref.subview %[[DEST]][%[[DEST_OFFSET_Y]], %[[DEST_OFFSET_X]]] [%[[SLICE_SIZE_Y]], %[[SLICE_SIZE_X]]]
+//  CHECK-DAG:   %[[OFFSET_Y:.+]] = affine.apply #[[MAP0]]()[%[[EXTRACT_OFFSET_Y]], %[[SOURCE_STRIDE_Y]], %[[SOURCE_OFFSET_Y]]]
+//  CHECK-DAG:   %[[STRIDE_Y:.+]] = affine.apply #[[MAP1]]()[%[[SOURCE_STRIDE_Y]], %[[EXTRACT_STRIDE_Y]]]
+//  CHECK-DAG:   %[[OFFSET_X:.+]] = affine.apply #[[MAP0]]()[%[[EXTRACT_OFFSET_X]], %[[SOURCE_STRIDE_X]], %[[SOURCE_OFFSET_X]]]
+//  CHECK-DAG:   %[[STRIDE_X:.+]] = affine.apply #[[MAP1]]()[%[[SOURCE_STRIDE_X]], %[[EXTRACT_STRIDE_X]]]
+//  CHECK-DAG:   %[[SOURCE_SUBVIEW:.+]] = memref.subview %[[SOURCE]][%[[OFFSET_Y]], %[[OFFSET_X]]] [%[[DEST_SIZE_Y]], %[[DEST_SIZE_X]]]
+// CHECK-SAME:       [%[[STRIDE_Y]], %[[STRIDE_X]]]
 //      CHECK:   linalg.generic
 // CHECK-SAME:       ins(%[[SOURCE_SUBVIEW]] :
-// CHECK-SAME:       outs(%[[DEST_SUBVIEW]] :
+// CHECK-SAME:       outs(%[[DEST]] :
 
 // -----
 
@@ -103,3 +137,23 @@ builtin.module {
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       ins(%[[SOURCE_SUBVIEW]] : memref<2x3xf32, #{{[a-zA-Z0-9]+}}>)
 //  CHECK-SAME:       outs(%[[DEST_SUBVIEW]] : memref<2x3xf32, #{{[a-zA-Z0-9]+}}>)
+
+// -----
+
+builtin.module {
+  func @concatenate_cst() {
+    %cst = arith.constant dense<0> : tensor<2x3xi32>
+    %c0 = arith.constant 0 : index
+    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readwrite:2x5xi32>
+    flow.dispatch.tensor.store %cst, %0, offsets = [0, 2], sizes = [2, 3], strides = [1, 1] : tensor<2x3xi32> -> !flow.dispatch.tensor<readwrite:2x5xi32>
+    return
+  }
+}
+// CHECK-LABEL: func @concatenate_cst()
+//   CHECK-DAG:   %[[CST:.+]] = arith.constant dense<0> : tensor<2x3xi32>
+//   CHECK-DAG:   %[[ZERO:.+]] = bufferization.to_memref %[[CST]] : memref<2x3xi32>
+//   CHECK-DAG:   %[[DEST_BINDING:.+]] = hal.interface.binding.subspan
+//   CHECK-DAG:   %[[SUBVIEW:.+]] = memref.subview %[[DEST_BINDING]][0, 2] [2, 3]
+//       CHECK:   linalg.generic
+//  CHECK-SAME:       ins(%[[ZERO]] :
+//  CHECK-SAME:       outs(%[[SUBVIEW]] :

--- a/iree/compiler/Codegen/Common/test/bufferize_copy_only_dispatches.mlir
+++ b/iree/compiler/Codegen/Common/test/bufferize_copy_only_dispatches.mlir
@@ -1,0 +1,105 @@
+// RUN: iree-opt -iree-codegen-bufferize-copy-only-dispatches -split-input-file %s | FileCheck %s
+
+builtin.module {
+  func @tensor_insert_slice() {
+    %source_size_y = hal.interface.constant.load[0] : index
+    %source_size_x = hal.interface.constant.load[1] : index
+    %dest_size_y = hal.interface.constant.load[2] : index
+    %dest_size_x = hal.interface.constant.load[3] : index
+    %dest_offset_y = hal.interface.constant.load[4] : index
+    %dest_offset_x = hal.interface.constant.load[5] : index
+    %insert_offset_y = hal.interface.constant.load[6] : index
+    %insert_offset_x = hal.interface.constant.load[7] : index
+    %source = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
+        : !flow.dispatch.tensor<readonly:?x?xi32>{%source_size_y, %source_size_x}
+    %dest = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
+        : !flow.dispatch.tensor<readwrite:?x?xi32>{%dest_size_y, %dest_size_x}
+    %source_load = flow.dispatch.tensor.load %source, offsets = [0, 0], sizes = [%source_size_y, %source_size_x], strides = [1, 1]
+        : !flow.dispatch.tensor<readonly:?x?xi32>{%source_size_y, %source_size_x} -> tensor<?x?xi32>
+    %dest_load = flow.dispatch.tensor.load %dest, offsets = [0, 0], sizes = [%dest_size_y, %dest_size_x], strides = [1, 1]
+        : !flow.dispatch.tensor<readwrite:?x?xi32>{%dest_size_y, %dest_size_x} -> tensor<?x?xi32>
+    %insert = tensor.insert_slice %source_load into %dest_load[%insert_offset_y, %insert_offset_x] [%source_size_y, %source_size_x] [1, 1] : tensor<?x?xi32> into tensor<?x?xi32>
+    flow.dispatch.tensor.store %insert, %dest, offsets = [%dest_offset_y, %dest_offset_x], sizes = [%source_size_y, %source_size_x], strides = [1, 1]
+        : tensor<?x?xi32> -> !flow.dispatch.tensor<readwrite:?x?xi32>{%dest_size_y, %dest_size_x}
+    return
+  }
+}
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1] -> (s0 + s1)>
+//      CHECK: func @tensor_insert_slice()
+//  CHECK-DAG:   %[[DEST_OFFSET_Y:.+]] = hal.interface.constant.load[4]
+//  CHECK-DAG:   %[[DEST_OFFSET_X:.+]] = hal.interface.constant.load[5]
+//  CHECK-DAG:   %[[INSERT_OFFSET_Y:.+]] = hal.interface.constant.load[6]
+//  CHECK-DAG:   %[[INSERT_OFFSET_X:.+]] = hal.interface.constant.load[7]
+//  CHECK-DAG:   %[[SOURCE:.+]] = hal.interface.binding.subspan set(0) binding(0)
+//  CHECK-DAG:   %[[DEST:.+]] = hal.interface.binding.subspan set(0) binding(1)
+//  CHECK-DAG:   %[[OFFSET_Y:.+]] = affine.apply #[[MAP0]]()[%[[INSERT_OFFSET_Y]], %[[DEST_OFFSET_Y]]]
+//  CHECK-DAG:   %[[OFFSET_X:.+]] = affine.apply #[[MAP0]]()[%[[INSERT_OFFSET_X]], %[[DEST_OFFSET_X]]]
+//  CHECK-DAG:   %[[SUBVIEW:.+]] = memref.subview %[[DEST]][%[[OFFSET_Y]], %[[OFFSET_X]]]
+//      CHECK:   linalg.generic
+// CHECK-SAME:       ins(%[[SOURCE]] :
+// CHECK-SAME:       outs(%[[SUBVIEW]] :
+
+// -----
+
+builtin.module {
+  func @tensor_extract_slice() {
+    %source_size_y = hal.interface.constant.load[0] : index
+    %source_size_x = hal.interface.constant.load[1] : index
+    %dest_size_y = hal.interface.constant.load[2] : index
+    %dest_size_x = hal.interface.constant.load[3] : index
+    %dest_offset_y = hal.interface.constant.load[4] : index
+    %dest_offset_x = hal.interface.constant.load[5] : index
+    %extract_offset_y = hal.interface.constant.load[6] : index
+    %extract_offset_x = hal.interface.constant.load[7] : index
+    %slice_size_y = hal.interface.constant.load[8] : index
+    %slice_size_x = hal.interface.constant.load[9] : index
+    %source = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
+        : !flow.dispatch.tensor<readonly:?x?xi32>{%source_size_y, %source_size_x}
+    %dest = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
+        : !flow.dispatch.tensor<readwrite:?x?xi32>{%dest_size_y, %dest_size_x}
+    %source_load = flow.dispatch.tensor.load %source, offsets = [0, 0], sizes = [%source_size_y, %source_size_x], strides = [1, 1]
+        : !flow.dispatch.tensor<readonly:?x?xi32>{%source_size_y, %source_size_x} -> tensor<?x?xi32>
+    %extract = tensor.extract_slice %source_load[%extract_offset_y, %extract_offset_x] [%slice_size_y, %slice_size_x] [1, 1] : tensor<?x?xi32> to tensor<?x?xi32>
+    flow.dispatch.tensor.store %extract, %dest, offsets = [%dest_offset_y, %dest_offset_x], sizes = [%slice_size_y, %slice_size_x], strides = [1, 1]
+        : tensor<?x?xi32> -> !flow.dispatch.tensor<readwrite:?x?xi32>{%dest_size_y, %dest_size_x}
+    return
+  }
+}
+//      CHECK: func @tensor_extract_slice()
+//  CHECK-DAG:   %[[DEST_OFFSET_Y:.+]] = hal.interface.constant.load[4]
+//  CHECK-DAG:   %[[DEST_OFFSET_X:.+]] = hal.interface.constant.load[5]
+//  CHECK-DAG:   %[[EXTRACT_OFFSET_Y:.+]] = hal.interface.constant.load[6]
+//  CHECK-DAG:   %[[EXTRACT_OFFSET_X:.+]] = hal.interface.constant.load[7]
+//  CHECK-DAG:   %[[SLICE_SIZE_Y:.+]] = hal.interface.constant.load[8]
+//  CHECK-DAG:   %[[SLICE_SIZE_X:.+]] = hal.interface.constant.load[9]
+//  CHECK-DAG:   %[[SOURCE:.+]] = hal.interface.binding.subspan set(0) binding(0)
+//  CHECK-DAG:   %[[DEST:.+]] = hal.interface.binding.subspan set(0) binding(1)
+//  CHECK-DAG:   %[[SOURCE_SUBVIEW:.+]] = memref.subview %[[SOURCE]][%[[EXTRACT_OFFSET_Y]], %[[EXTRACT_OFFSET_X]]] [%[[SLICE_SIZE_Y:.+]], %[[SLICE_SIZE_X]]]
+//  CHECK-DAG:   %[[DEST_SUBVIEW:.+]] = memref.subview %[[DEST]][%[[DEST_OFFSET_Y]], %[[DEST_OFFSET_X]]] [%[[SLICE_SIZE_Y]], %[[SLICE_SIZE_X]]]
+//      CHECK:   linalg.generic
+// CHECK-SAME:       ins(%[[SOURCE_SUBVIEW]] :
+// CHECK-SAME:       outs(%[[DEST_SUBVIEW]] :
+
+// -----
+
+builtin.module {
+  func @UpSampling1D() {
+    %c0 = arith.constant 0 : index
+    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readwrite:2x16x3xf32>
+    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:2x8x3xf32>
+    %2 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [2, 8, 3], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:2x8x3xf32> -> tensor<2x8x3xf32>
+    %3 = tensor.extract_slice %2[0, 0, 0] [2, 1, 3] [1, 1, 1] : tensor<2x8x3xf32> to tensor<2x3xf32>
+    %4 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [2, 16, 3], strides = [1, 1, 1] : !flow.dispatch.tensor<readwrite:2x16x3xf32> -> tensor<2x16x3xf32>
+    %5 = tensor.insert_slice %3 into %4[0, 0, 0] [2, 1, 3] [1, 1, 1] : tensor<2x3xf32> into tensor<2x16x3xf32>
+    flow.dispatch.tensor.store %5, %0, offsets = [0, 0, 0], sizes = [2, 16, 3], strides = [1, 1, 1] : tensor<2x16x3xf32> -> !flow.dispatch.tensor<readwrite:2x16x3xf32>
+    return
+  }
+}
+// CHECK-LABEL: func @UpSampling1D()
+//   CHECK-DAG:   %[[DEST:.+]] = hal.interface.binding.subspan set(0) binding(0)
+//   CHECK-DAG:   %[[SOURCE:.+]] = hal.interface.binding.subspan set(0) binding(1)
+//   CHECK-DAG:   %[[SOURCE_SUBVIEW:.+]] = memref.subview %[[SOURCE]][0, 0, 0] [2, 1, 3]
+//   CHECK-DAG:   %[[DEST_SUBVIEW:.+]] = memref.subview %[[DEST]][0, 0, 0] [2, 1, 3]
+//       CHECK:   linalg.generic
+//  CHECK-SAME:       ins(%[[SOURCE_SUBVIEW]] : memref<2x3xf32, #{{[a-zA-Z0-9]+}}>)
+//  CHECK-SAME:       outs(%[[DEST_SUBVIEW]] : memref<2x3xf32, #{{[a-zA-Z0-9]+}}>)

--- a/iree/compiler/Codegen/Common/test/insert_distribution_info.mlir
+++ b/iree/compiler/Codegen/Common/test/insert_distribution_info.mlir
@@ -307,37 +307,43 @@ hal.executable private @preset_config_matmul_tensors {
   ]>
 ]>
 #executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm", "system-elf-x86_64">
-#translation = #iree_codegen.translation_info<CPUDefault>
-hal.executable public @tensor_insert {
+#translation = #iree_codegen.translation_info<CPUBufferOpsTileAndVectorize>
+hal.executable public @copy_op {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @tensor_insert_slice layout(#executable_layout) {translation_info = #translation}
+    hal.executable.entry_point public @copy_op layout(#executable_layout) {translation_info = #translation}
     builtin.module {
-      func @tensor_insert_slice() {
-        %0 = hal.interface.constant.load[0] : index
-        %1 = hal.interface.constant.load[1] : index
-        %2 = hal.interface.constant.load[2] : index
-        %3 = hal.interface.constant.load[3] : index
-        %4 = hal.interface.constant.load[4] : index
-        %5 = hal.interface.constant.load[5] : index
-        %6 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
-            : !flow.dispatch.tensor<readonly:?x?xi32>{%0, %1}
-        %7 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
-            : !flow.dispatch.tensor<readwrite:?x?xi32>{%2, %3}
-        %8 = flow.dispatch.tensor.load %6, offsets = [0, 0], sizes = [%0, %1], strides = [1, 1]
-            : !flow.dispatch.tensor<readonly:?x?xi32>{%0, %1} -> tensor<?x?xi32>
-        %9 = flow.dispatch.tensor.load %7, offsets = [0, 0], sizes = [%0, %1], strides = [1, 1]
-            : !flow.dispatch.tensor<readwrite:?x?xi32>{%2, %3} -> tensor<?x?xi32>
-        %10 = tensor.insert_slice %8 into %9[%4, %5] [%0, %1] [1, 1] {lowering_config = #config} : tensor<?x?xi32> into tensor<?x?xi32>
-        flow.dispatch.tensor.store %10, %7, offsets = [0, 0], sizes = [%2, %3], strides = [1, 1]
-            : tensor<?x?xi32> -> !flow.dispatch.tensor<readwrite:?x?xi32>{%2, %3}
+      func @copy_op() {
+        %source_size_y = hal.interface.constant.load[0] : index
+        %source_size_x = hal.interface.constant.load[1] : index
+        %dest_size_y = hal.interface.constant.load[2] : index
+        %dest_size_x = hal.interface.constant.load[3] : index
+        %source_offset_y = hal.interface.constant.load[4] : index
+        %source_offset_x = hal.interface.constant.load[5] : index
+        %dest_offset_y = hal.interface.constant.load[6] : index
+        %dest_offset_x = hal.interface.constant.load[7] : index
+        %slice_size_y = hal.interface.constant.load[8] : index
+        %slice_size_x = hal.interface.constant.load[9] : index
+        %source = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<?x?xi32>{%source_size_y, %source_size_x}
+        %dest = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<?x?xi32>{%dest_size_y, %dest_size_x}
+        %source_subview = memref.subview %source[%source_offset_y, %source_offset_x] [%slice_size_y, %slice_size_x] [1, 1] : memref<?x?xi32> to memref<?x?xi32, offset : ?, strides : [?, ?]>
+        %dest_subview = memref.subview %dest[%dest_offset_y, %dest_offset_x] [%slice_size_y, %slice_size_x] [1, 1] : memref<?x?xi32> to memref<?x?xi32, offset : ?, strides : [?, ?]>
+        linalg.generic {
+            indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+            iterator_types = ["parallel", "parallel"]}
+            ins(%source_subview : memref<?x?xi32, offset : ?, strides : [?, ?]>)
+            outs(%dest_subview : memref<?x?xi32, offset : ?, strides : [?, ?]>)
+            attrs = {lowering_config = #config} {
+          ^bb0(%arg0: i32, %arg1: i32):
+            linalg.yield %arg0 : i32
+          }
         return
       }
     }
   }
 }
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault, workload_per_wg = [64, 64]>
-//      CHECK: hal.executable.entry_point public @tensor_insert
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUBufferOpsTileAndVectorize, workload_per_wg = [64, 64]>
+//      CHECK: hal.executable.entry_point public @copy_op
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:   (%[[ARG0:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: index
@@ -346,56 +352,6 @@ hal.executable public @tensor_insert {
 //  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
 //  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]]]
 //      CHECK:   hal.return %[[D0]], %[[D1]], %[[C1]]
-//      CHECK: func @tensor_insert_slice()
-
-// -----
-
-#config = #iree_codegen.lowering_config<tile_sizes = [[64, 64]]>
-#executable_layout = #hal.executable.layout<push_constants = 0, sets = [
-  #hal.descriptor_set.layout<0, bindings = [
-    #hal.descriptor_set.binding<0, storage_buffer>,
-    #hal.descriptor_set.binding<1, storage_buffer>
-  ]>
-]>
-#executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm", "system-elf-x86_64">
-#translation = #iree_codegen.translation_info<CPUDefault>
-hal.executable public @extract_slice {
-  hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @extract_slice layout(#executable_layout) {translation_info = #translation}
-    builtin.module {
-      func @extract_slice() {
-        %0 = hal.interface.constant.load[0] : index
-        %1 = hal.interface.constant.load[1] : index
-        %2 = hal.interface.constant.load[2] : index
-        %3 = hal.interface.constant.load[3] : index
-        %4 = hal.interface.constant.load[4] : index
-        %5 = hal.interface.constant.load[5] : index
-        %6 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
-            : !flow.dispatch.tensor<readonly:?x?xi32>{%0, %1}
-        %7 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
-            : !flow.dispatch.tensor<writeonly:?x?xi32>{%2, %3}
-        %8 = flow.dispatch.tensor.load %6, offsets = [0, 0], sizes = [%0, %1], strides = [1, 1]
-            : !flow.dispatch.tensor<readonly:?x?xi32>{%0, %1} -> tensor<?x?xi32>
-        %9 = tensor.extract_slice %8[%4, %5] [%2, %3] [1, 1] {lowering_config = #config} : tensor<?x?xi32> to tensor<?x?xi32>
-        flow.dispatch.tensor.store %9, %7, offsets = [0, 0], sizes = [%2, %3], strides = [1, 1]
-            : tensor<?x?xi32> -> !flow.dispatch.tensor<writeonly:?x?xi32>{%2, %3}
-        return
-      }
-    }
-  }
-}
-//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault, workload_per_wg = [64, 64]>
-//      CHECK: hal.executable.entry_point public @extract_slice
-// CHECK-SAME:     translation_info = #[[TRANSLATION]]
-// CHECK-NEXT:   (%[[ARG0:[a-zA-Z0-9]+]]: index
-// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: index
-// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]: index)
-//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
-//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]]]
-//      CHECK:   hal.return %[[D0]], %[[D1]], %[[C1]]
-//      CHECK: func @extract_slice()
 
 // -----
 

--- a/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
+++ b/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
@@ -388,8 +388,8 @@ hal.executable public @copy_op {
 //  CHECK-DAG:     %[[LB_X:.+]] = affine.apply #[[MAP1]]()[%[[WG_ID_X]]]
 //  CHECK-DAG:     %[[STEP_X:.+]] = affine.apply #[[MAP1]]()[%[[WG_COUNT_X]]]
 //      CHECK:     scf.for %[[IV1:.+]] = %[[LB_X]] to %[[SLICE_SIZE_X]] step %[[STEP_X]]
-//  CHECK-DAG:       %[[TILESIZE_Y:.+]] = affine.min #[[MAP2]](%[[ARG0]])[%[[SLICE_SIZE_Y]]]
-//  CHECK-DAG:       %[[TILESIZE_X:.+]] = affine.min #[[MAP2]](%[[ARG1]])[%[[SLICE_SIZE_X]]]
+//  CHECK-DAG:       %[[TILESIZE_Y:.+]] = affine.min #[[MAP2]](%[[IV0]])[%[[SLICE_SIZE_Y]]]
+//  CHECK-DAG:       %[[TILESIZE_X:.+]] = affine.min #[[MAP2]](%[[IV1]])[%[[SLICE_SIZE_X]]]
 //  CHECK-DAG:       %[[SOURCE_SUBVIEW:.+]] = memref.subview %[[SOURCE]][%[[IV0]], %[[IV1]]]
 //  CHECK-DAG:       %[[DEST_SUBVIEW:.+]] = memref.subview %[[DEST]][%[[IV0]], %[[IV1]]]
 //      CHECK:       linalg.generic

--- a/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
+++ b/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
@@ -327,29 +327,35 @@ hal.executable private @preset_config_matmul_tensors {
   ]>
 ]>
 #executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm", "system-elf-x86_64">
-#translation = #iree_codegen.translation_info<CPUDefault>
-hal.executable public @tensor_insert {
+#translation = #iree_codegen.translation_info<CPUBufferOpsTileAndVectorize, workload_per_wg = [64, 64]>
+hal.executable public @copy_op {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @tensor_insert_slice layout(#executable_layout) {translation_info = #translation}
+    hal.executable.entry_point public @copy_op layout(#executable_layout) {translation_info = #translation}
     builtin.module {
-      func @tensor_insert_slice() {
-        %0 = hal.interface.constant.load[0] : index
-        %1 = hal.interface.constant.load[1] : index
-        %2 = hal.interface.constant.load[2] : index
-        %3 = hal.interface.constant.load[3] : index
-        %4 = hal.interface.constant.load[4] : index
-        %5 = hal.interface.constant.load[5] : index
-        %6 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
-            : !flow.dispatch.tensor<readonly:?x?xi32>{%0, %1}
-        %7 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
-            : !flow.dispatch.tensor<readwrite:?x?xi32>{%2, %3}
-        %8 = flow.dispatch.tensor.load %6, offsets = [0, 0], sizes = [%0, %1], strides = [1, 1]
-            : !flow.dispatch.tensor<readonly:?x?xi32>{%0, %1} -> tensor<?x?xi32>
-        %9 = flow.dispatch.tensor.load %7, offsets = [0, 0], sizes = [%0, %1], strides = [1, 1]
-            : !flow.dispatch.tensor<readwrite:?x?xi32>{%2, %3} -> tensor<?x?xi32>
-        %10 = tensor.insert_slice %8 into %9[%4, %5] [%0, %1] [1, 1] {lowering_config = #config} : tensor<?x?xi32> into tensor<?x?xi32>
-        flow.dispatch.tensor.store %10, %7, offsets = [0, 0], sizes = [%2, %3], strides = [1, 1]
-            : tensor<?x?xi32> -> !flow.dispatch.tensor<readwrite:?x?xi32>{%2, %3}
+      func @copy_op() {
+        %source_size_y = hal.interface.constant.load[0] : index
+        %source_size_x = hal.interface.constant.load[1] : index
+        %dest_size_y = hal.interface.constant.load[2] : index
+        %dest_size_x = hal.interface.constant.load[3] : index
+        %source_offset_y = hal.interface.constant.load[4] : index
+        %source_offset_x = hal.interface.constant.load[5] : index
+        %dest_offset_y = hal.interface.constant.load[6] : index
+        %dest_offset_x = hal.interface.constant.load[7] : index
+        %slice_size_y = hal.interface.constant.load[8] : index
+        %slice_size_x = hal.interface.constant.load[9] : index
+        %source = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<?x?xi32>{%source_size_y, %source_size_x}
+        %dest = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<?x?xi32>{%dest_size_y, %dest_size_x}
+        %source_subview = memref.subview %source[%source_offset_y, %source_offset_x] [%slice_size_y, %slice_size_x] [1, 1] : memref<?x?xi32> to memref<?x?xi32, offset : ?, strides : [?, ?]>
+        %dest_subview = memref.subview %dest[%dest_offset_y, %dest_offset_x] [%slice_size_y, %slice_size_x] [1, 1] : memref<?x?xi32> to memref<?x?xi32, offset : ?, strides : [?, ?]>
+        linalg.generic {
+            indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+            iterator_types = ["parallel", "parallel"]}
+            ins(%source_subview : memref<?x?xi32, offset : ?, strides : [?, ?]>)
+            outs(%dest_subview : memref<?x?xi32, offset : ?, strides : [?, ?]>)
+            attrs = {lowering_config = #config} {
+          ^bb0(%arg0: i32, %arg1: i32):
+            linalg.yield %arg0 : i32
+          }
         return
       }
     }
@@ -357,103 +363,38 @@ hal.executable public @tensor_insert {
 }
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 * 64)>
 //  CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0)[s0] -> (64, -d0 + s0)>
-//  CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0)[s0] -> (d0 + s0)>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
-//      CHECK: hal.executable.entry_point public @tensor_insert
-// CHECK-SAME:     translation_info = #[[TRANSLATION]]
-//      CHECK: func @tensor_insert_slice()
-//  CHECK-DAG:   %[[SIZE_Y:.+]] = hal.interface.constant.load[0] : index
-//  CHECK-DAG:   %[[SIZE_X:.+]] = hal.interface.constant.load[1] : index
-//  CHECK-DAG:   %[[DEST_SIZE_Y:.+]] = hal.interface.constant.load[2] : index
-//  CHECK-DAG:   %[[DEST_SIZE_X:.+]] = hal.interface.constant.load[3] : index
-//  CHECK-DAG:   %[[OFFSET_Y:.+]] = hal.interface.constant.load[4] : index
-//  CHECK-DAG:   %[[OFFSET_X:.+]] = hal.interface.constant.load[5] : index
-//  CHECK-DAG:   %[[WG_ID_X:.+]] = hal.interface.workgroup.id[0]
-//  CHECK-DAG:   %[[WG_COUNT_X:.+]] = hal.interface.workgroup.count[0]
-//  CHECK-DAG:   %[[WG_ID_Y:.+]] = hal.interface.workgroup.id[1]
-//  CHECK-DAG:   %[[WG_COUNT_Y:.+]] = hal.interface.workgroup.count[1]
-//  CHECK-DAG:   %[[LB_Y:.+]] = affine.apply #[[MAP1]]()[%[[WG_ID_Y]]]
-//  CHECK-DAG:   %[[STEP_Y:.+]] = affine.apply #[[MAP1]]()[%[[WG_COUNT_Y]]]
-//      CHECK:   scf.for %[[IV0:.+]] = %[[LB_Y]] to %[[SIZE_Y]] step %[[STEP_Y]]
-//  CHECK-DAG:     %[[TILESIZE_Y:.+]] = affine.min #[[MAP2]](%[[IV0]])[%[[SIZE_Y]]]
-//  CHECK-DAG:     %[[LB_X:.+]] = affine.apply #[[MAP1]]()[%[[WG_ID_X]]]
-//  CHECK-DAG:     %[[STEP_X:.+]] = affine.apply #[[MAP1]]()[%[[WG_COUNT_X]]]
-//      CHECK:     scf.for %[[IV1:.+]] = %[[LB_X]] to %[[SIZE_X]] step %[[STEP_X]]
-//  CHECK-DAG:       %[[TILESIZE_X:.+]] = affine.min #[[MAP2]](%[[IV1]])[%[[SIZE_X]]]
-//  CHECK-DAG:       %[[SOURCE:.+]] = flow.dispatch.tensor.load
-// CHECK-SAME:           offsets = [%[[IV0]], %[[IV1]]], sizes = [%[[TILESIZE_Y]], %[[TILESIZE_X]]]
-//  CHECK-DAG:       %[[STORE_OFFSET_Y:.+]] = affine.apply #[[MAP3]](%[[IV0]])[%[[OFFSET_Y]]]
-//  CHECK-DAG:       %[[STORE_OFFSET_X:.+]] = affine.apply #[[MAP3]](%[[IV1]])[%[[OFFSET_X]]]
-//      CHECK:       flow.dispatch.tensor.store %[[SOURCE]]
-// CHECK-SAME:           offsets = [%[[STORE_OFFSET_Y]], %[[STORE_OFFSET_X]]], sizes = [%[[TILESIZE_Y]], %[[TILESIZE_X]]]
-
-// -----
-
-#config = #iree_codegen.lowering_config<tile_sizes = [[64, 64]]>
-#executable_layout = #hal.executable.layout<push_constants = 0, sets = [
-  #hal.descriptor_set.layout<0, bindings = [
-    #hal.descriptor_set.binding<0, storage_buffer>,
-    #hal.descriptor_set.binding<1, storage_buffer>
-  ]>
-]>
-#executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm", "system-elf-x86_64">
-#translation = #iree_codegen.translation_info<CPUDefault>
-hal.executable public @extract_slice {
-  hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @extract_slice layout(#executable_layout) {translation_info = #translation}
-    builtin.module {
-      func @extract_slice() {
-        %0 = hal.interface.constant.load[0] : index
-        %1 = hal.interface.constant.load[1] : index
-        %2 = hal.interface.constant.load[2] : index
-        %3 = hal.interface.constant.load[3] : index
-        %4 = hal.interface.constant.load[4] : index
-        %5 = hal.interface.constant.load[5] : index
-        %6 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
-            : !flow.dispatch.tensor<readonly:?x?xi32>{%0, %1}
-        %7 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
-            : !flow.dispatch.tensor<writeonly:?x?xi32>{%2, %3}
-        %8 = flow.dispatch.tensor.load %6, offsets = [0, 0], sizes = [%0, %1], strides = [1, 1]
-            : !flow.dispatch.tensor<readonly:?x?xi32>{%0, %1} -> tensor<?x?xi32>
-        %9 = tensor.extract_slice %8[%4, %5] [%2, %3] [1, 1] {lowering_config = #config} : tensor<?x?xi32> to tensor<?x?xi32>
-        flow.dispatch.tensor.store %9, %7, offsets = [0, 0], sizes = [%2, %3], strides = [1, 1]
-            : tensor<?x?xi32> -> !flow.dispatch.tensor<writeonly:?x?xi32>{%2, %3}
-        return
-      }
-    }
-  }
-}
-//  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 * 64)>
-//  CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0)[s0] -> (64, -d0 + s0)>
-//  CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0)[s0] -> (d0 + s0)>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
-//      CHECK: hal.executable.entry_point public @extract_slice
-// CHECK-SAME:     translation_info = #[[TRANSLATION]]
-//      CHECK: func @extract_slice()
+//      CHECK: func @copy_op()
 //  CHECK-DAG:   %[[SOURCE_SIZE_Y:.+]] = hal.interface.constant.load[0] : index
 //  CHECK-DAG:   %[[SOURCE_SIZE_X:.+]] = hal.interface.constant.load[1] : index
-//  CHECK-DAG:   %[[SIZE_Y:.+]] = hal.interface.constant.load[2] : index
-//  CHECK-DAG:   %[[SIZE_X:.+]] = hal.interface.constant.load[3] : index
-//  CHECK-DAG:   %[[OFFSET_Y:.+]] = hal.interface.constant.load[4] : index
-//  CHECK-DAG:   %[[OFFSET_X:.+]] = hal.interface.constant.load[5] : index
+//  CHECK-DAG:   %[[DEST_SIZE_Y:.+]] = hal.interface.constant.load[2] : index
+//  CHECK-DAG:   %[[DEST_SIZE_X:.+]] = hal.interface.constant.load[3] : index
+//  CHECK-DAG:   %[[SOURCE_OFFSET_Y:.+]] = hal.interface.constant.load[4] : index
+//  CHECK-DAG:   %[[SOURCE_OFFSET_X:.+]] = hal.interface.constant.load[5] : index
+//  CHECK-DAG:   %[[DEST_OFFSET_Y:.+]] = hal.interface.constant.load[6] : index
+//  CHECK-DAG:   %[[DEST_OFFSET_X:.+]] = hal.interface.constant.load[7] : index
+//  CHECK-DAG:   %[[SLICE_SIZE_Y:.+]] = hal.interface.constant.load[8] : index
+//  CHECK-DAG:   %[[SLICE_SIZE_X:.+]] = hal.interface.constant.load[9] : index
+//  CHECK-DAG:   %[[SOURCE_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(0)
+//  CHECK-DAG:   %[[DEST_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(1)
+//  CHECK-DAG:   %[[SOURCE:.+]] = memref.subview %[[SOURCE_BINDING]][%[[SOURCE_OFFSET_Y]], %[[SOURCE_OFFSET_X]]]
+//  CHECK-DAG:   %[[DEST:.+]] = memref.subview %[[DEST_BINDING]][%[[DEST_OFFSET_Y]], %[[DEST_OFFSET_X]]]
 //  CHECK-DAG:   %[[WG_ID_X:.+]] = hal.interface.workgroup.id[0]
 //  CHECK-DAG:   %[[WG_COUNT_X:.+]] = hal.interface.workgroup.count[0]
 //  CHECK-DAG:   %[[WG_ID_Y:.+]] = hal.interface.workgroup.id[1]
 //  CHECK-DAG:   %[[WG_COUNT_Y:.+]] = hal.interface.workgroup.count[1]
 //  CHECK-DAG:   %[[LB_Y:.+]] = affine.apply #[[MAP1]]()[%[[WG_ID_Y]]]
 //  CHECK-DAG:   %[[STEP_Y:.+]] = affine.apply #[[MAP1]]()[%[[WG_COUNT_Y]]]
-//      CHECK:   scf.for %[[IV0:.+]] = %[[LB_Y]] to %[[SIZE_Y]] step %[[STEP_Y]]
-//  CHECK-DAG:     %[[TILESIZE_Y:.+]] = affine.min #[[MAP2]](%[[IV0]])[%[[SIZE_Y]]]
+//      CHECK:   scf.for %[[IV0:.+]] = %[[LB_Y]] to %[[SLICE_SIZE_Y]] step %[[STEP_Y]]
 //  CHECK-DAG:     %[[LB_X:.+]] = affine.apply #[[MAP1]]()[%[[WG_ID_X]]]
 //  CHECK-DAG:     %[[STEP_X:.+]] = affine.apply #[[MAP1]]()[%[[WG_COUNT_X]]]
-//      CHECK:     scf.for %[[IV1:.+]] = %[[LB_X]] to %[[SIZE_X]] step %[[STEP_X]]
-//  CHECK-DAG:       %[[TILESIZE_X:.+]] = affine.min #[[MAP2]](%[[IV1]])[%[[SIZE_X]]]
-//  CHECK-DAG:       %[[LOAD_OFFSET_Y:.+]] = affine.apply #[[MAP3]](%[[IV0]])[%[[OFFSET_Y]]]
-//  CHECK-DAG:       %[[LOAD_OFFSET_X:.+]] = affine.apply #[[MAP3]](%[[IV1]])[%[[OFFSET_X]]]
-//  CHECK-DAG:       %[[SOURCE:.+]] = flow.dispatch.tensor.load
-// CHECK-SAME:           offsets = [%[[LOAD_OFFSET_Y]], %[[LOAD_OFFSET_X]]], sizes = [%[[TILESIZE_Y]], %[[TILESIZE_X]]]
-//      CHECK:       flow.dispatch.tensor.store %[[SOURCE]]
-// CHECK-SAME:           offsets = [%[[IV0]], %[[IV1]]], sizes = [%[[TILESIZE_Y]], %[[TILESIZE_X]]]
+//      CHECK:     scf.for %[[IV1:.+]] = %[[LB_X]] to %[[SLICE_SIZE_X]] step %[[STEP_X]]
+//  CHECK-DAG:       %[[TILESIZE_Y:.+]] = affine.min #[[MAP2]](%[[ARG0]])[%[[SLICE_SIZE_Y]]]
+//  CHECK-DAG:       %[[TILESIZE_X:.+]] = affine.min #[[MAP2]](%[[ARG1]])[%[[SLICE_SIZE_X]]]
+//  CHECK-DAG:       %[[SOURCE_SUBVIEW:.+]] = memref.subview %[[SOURCE]][%[[IV0]], %[[IV1]]]
+//  CHECK-DAG:       %[[DEST_SUBVIEW:.+]] = memref.subview %[[DEST]][%[[IV0]], %[[IV1]]]
+//      CHECK:       linalg.generic
+// CHECK-SAME:           ins(%[[SOURCE_SUBVIEW]] :
+// CHECK-SAME:           outs(%[[DEST_SUBVIEW]] :
 
 // -----
 

--- a/iree/compiler/Codegen/Dialect/LoweringConfig.td
+++ b/iree/compiler/Codegen/Dialect/LoweringConfig.td
@@ -23,8 +23,9 @@ def CPU_TileFuseAndVectorize
     : I32EnumAttrCase<"CPUTileFuseAndVectorize", 4>;
 def CPU_BufferOpsTileAndVectorize
     : I32EnumAttrCase<"CPUBufferOpsTileAndVectorize", 5>;
-def CPU_SandboxCodegen
-    : I32EnumAttrCase<"CPUSandboxCodegen", 6>;
+
+def Linalg_TransformInterpCodegen
+    : I32EnumAttrCase<"LinalgTransformInterpCodegen", 6>;
 
 def LLVMGPU_SimpleDistribute
     : I32EnumAttrCase<"LLVMGPUDistribute", 7>;
@@ -54,7 +55,7 @@ def DispatchLoweringPassPipelineEnum : I32EnumAttr<
     "identifier for pass pipeline use to lower dispatch region",
     [CPU_Default, CPU_SingleTilingExpert, CPU_DoubleTilingExpert,
      CPU_ConvTileAndDecomposeExpert, CPU_TileFuseAndVectorize,
-     CPU_BufferOpsTileAndVectorize, CPU_SandboxCodegen,
+     CPU_BufferOpsTileAndVectorize, Linalg_TransformInterpCodegen,
      LLVMGPU_SimpleDistribute, LLVMGPU_Vectorize, LLVMGPU_MatmulSimt,
      LLVMGPU_MatmulTensorCore, SPIRV_Distribute, SPIRV_DistributeCopy, SPIRV_Vectorize,
      SPIRV_VectorizeToCooperativeOps, None]> {

--- a/iree/compiler/Codegen/Dialect/LoweringConfig.td
+++ b/iree/compiler/Codegen/Dialect/LoweringConfig.td
@@ -21,29 +21,31 @@ def CPU_ConvTileAndDecomposeExpert
     : I32EnumAttrCase<"CPUConvTileAndDecomposeExpert", 3>;
 def CPU_TileFuseAndVectorize
     : I32EnumAttrCase<"CPUTileFuseAndVectorize", 4>;
+def CPU_BufferOpsTileAndVectorize
+    : I32EnumAttrCase<"CPUBufferOpsTileAndVectorize", 5>;
 def CPU_SandboxCodegen
-    : I32EnumAttrCase<"LinalgTransformInterpCodegen", 5>;
+    : I32EnumAttrCase<"CPUSandboxCodegen", 6>;
 
 def LLVMGPU_SimpleDistribute
-    : I32EnumAttrCase<"LLVMGPUDistribute",6>;
+    : I32EnumAttrCase<"LLVMGPUDistribute", 7>;
 def LLVMGPU_Vectorize
-    : I32EnumAttrCase<"LLVMGPUVectorize", 7>;
+    : I32EnumAttrCase<"LLVMGPUVectorize", 8>;
 def LLVMGPU_MatmulSimt
-    : I32EnumAttrCase<"LLVMGPUMatmulSimt", 8>;
+    : I32EnumAttrCase<"LLVMGPUMatmulSimt", 9>;
 def LLVMGPU_MatmulTensorCore
-    : I32EnumAttrCase<"LLVMGPUMatmulTensorCore", 9>;
+    : I32EnumAttrCase<"LLVMGPUMatmulTensorCore", 10>;
 
 def SPIRV_Distribute
-    : I32EnumAttrCase<"SPIRVDistribute", 10>;
+    : I32EnumAttrCase<"SPIRVDistribute", 11>;
 def SPIRV_DistributeCopy
-    : I32EnumAttrCase<"SPIRVDistributeCopy", 11>;
+    : I32EnumAttrCase<"SPIRVDistributeCopy", 12>;
 def SPIRV_Vectorize
-    : I32EnumAttrCase<"SPIRVVectorize", 12>;
+    : I32EnumAttrCase<"SPIRVVectorize", 13>;
 def SPIRV_VectorizeToCooperativeOps
-    : I32EnumAttrCase<"SPIRVVectorizeToCooperativeOps", 13>;
+    : I32EnumAttrCase<"SPIRVVectorizeToCooperativeOps", 14>;
 
 def None
-    : I32EnumAttrCase<"None", 14>;
+    : I32EnumAttrCase<"None", 15>;
 
 // EnumAttrCase for all known lowerings for ops within dispatch region
 // to scalar/native-vector code.
@@ -52,10 +54,10 @@ def DispatchLoweringPassPipelineEnum : I32EnumAttr<
     "identifier for pass pipeline use to lower dispatch region",
     [CPU_Default, CPU_SingleTilingExpert, CPU_DoubleTilingExpert,
      CPU_ConvTileAndDecomposeExpert, CPU_TileFuseAndVectorize,
-     CPU_SandboxCodegen, LLVMGPU_SimpleDistribute, LLVMGPU_Vectorize,
-     LLVMGPU_MatmulSimt, LLVMGPU_MatmulTensorCore, SPIRV_Distribute,
-     SPIRV_DistributeCopy, SPIRV_Vectorize, SPIRV_VectorizeToCooperativeOps,
-     None]> {
+     CPU_BufferOpsTileAndVectorize, CPU_SandboxCodegen,
+     LLVMGPU_SimpleDistribute, LLVMGPU_Vectorize, LLVMGPU_MatmulSimt,
+     LLVMGPU_MatmulTensorCore, SPIRV_Distribute, SPIRV_DistributeCopy, SPIRV_Vectorize,
+     SPIRV_VectorizeToCooperativeOps, None]> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Codegen";
   // Don't generate a C++ class! We want to use the AttrDef
   let genSpecializedAttr = 0;

--- a/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -626,9 +626,14 @@ static LogicalResult setRootConfig(
   tileSizes.push_back(flowTileSizes);
   tileSizes.push_back(l1TileSizes);
   tileSizes.push_back(vectorTileSizes);
-  return setOpConfigAndEntryPointFnTranslation(
-      entryPointFn, genericOp, tileSizes,
-      DispatchLoweringPassPipeline::CPUDoubleTilingExpert);
+
+  // For non-tensor based ops use the Buffer ops pipeline.
+  auto passPipeline =
+      genericOp.hasTensorSemantics()
+          ? DispatchLoweringPassPipeline::CPUDoubleTilingExpert
+          : DispatchLoweringPassPipeline::CPUBufferOpsTileAndVectorize;
+  return setOpConfigAndEntryPointFnTranslation(entryPointFn, genericOp,
+                                               tileSizes, passPipeline);
 }
 
 /// Sets the lowering configuration for linalg.conv_2d_nhwc_hwcf and

--- a/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -828,24 +828,10 @@ static FailureOr<Operation *> getRootOperation(
   if (rootOperation) return rootOperation;
 
   // If no root operation is found yet. Look for linalg generic ops.
-  for (auto op : computeOps) {
-    if (isa<linalg::GenericOp>(op)) {
+  for (auto op : llvm::reverse(computeOps)) {
+    if (isa<linalg::LinalgOp>(op)) {
       if (failed(updateRootOperation(op))) return failure();
     }
-  }
-  if (rootOperation) return rootOperation;
-
-  // TODO(ravishankarm): Currently there is a corner case of a dispatch region
-  // with just a `tensor.extract_slice`/`tensor.insert_slice`. Those need to be
-  // folded with `flow.dispatch.tensor.load`/`flow.dispatch.tensor.store` ops
-  // respectively. This should go hand-in-hand with dropping the external model
-  // implementation of the `TiledOpInterface` for these ops. Till we cross that
-  // bridge, handle that case.
-  // Throw in linalg.fill here as well, though that should never happen either.
-  if (computeOps.size() == 1 &&
-      isa<linalg::FillOp, tensor::ExtractSliceOp, tensor::InsertSliceOp>(
-          computeOps[0])) {
-    rootOperation = computeOps[0];
   }
   return rootOperation;
 }

--- a/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -193,6 +193,10 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
             addCPUDefaultPassPipeline(nestedModulePM);
             break;
           case IREE::Codegen::DispatchLoweringPassPipeline::
+              CPUBufferOpsTileAndVectorize:
+            addCPUBufferOpsTileAndVectorizePipeline(nestedModulePM);
+            break;
+          case IREE::Codegen::DispatchLoweringPassPipeline::
               CPUSingleTilingExpert:
             addSingleTilingExpertPassPipeline(nestedModulePM);
             break;

--- a/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -429,6 +429,7 @@ static void addLowerToLLVMPasses(OpPassManager &passManager) {
 void buildLLVMCPUCodegenPassPipeline(OpPassManager &passManager) {
   passManager.nest<ModuleOp>().nest<FuncOp>().addPass(
       createTypePropagationPass());
+  passManager.nest<ModuleOp>().addPass(createBufferizeCopyOnlyDispatchesPass());
   passManager.addPass(createLLVMCPULowerExecutableTargetPass());
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
   addLowerToLLVMPasses(nestedModulePM);

--- a/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -204,28 +204,11 @@ void addCPUBufferOpsTileAndVectorizePipeline(OpPassManager &passManager) {
   passManager.addPass(createCanonicalizerPass());
   passManager.addPass(createCSEPass());
 
-  // Add the sandbox single tiling expert to tile and vectorize.
-  {
-    LinalgSingleTilingExpertPassOptions options;
-    options.vectorize = true;
-    options.vectorizePadding = true;
-    options.tilingLevel = static_cast<int64_t>(TilingLevel::L1Tiles);
-    passManager.addNestedPass<FuncOp>(
-        createLinalgSingleTilingExpertPass(options));
-    passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
-    passManager.addNestedPass<FuncOp>(createCSEPass());
-  }
+  // This pipeline should also vectorize these ops, but they arent today because
+  // of a correctness issue. See Issue #8579.
 
   // Run IREE specific passes before vector lowering expert.
   passManager.addNestedPass<FuncOp>(createRemoveSingleIterationLoopPass());
-
-  // Add the vector lowering expert.
-  {
-    OpPassManager &nestedFuncPassManager = passManager.nest<FuncOp>();
-    LinalgVectorLoweringPassOptions options;
-    options.splitVectorTransfersTo = "linalg-copy";
-    addLowerToVectorTransforms(nestedFuncPassManager, options);
-  }
 }
 
 void addDoubleTilingExpertPassPipeline(OpPassManager &passManager) {

--- a/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
@@ -272,7 +272,7 @@ hal.executable @copy_op {
   hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
     hal.executable.entry_point @copy_op layout(#executable_layout)
     builtin.module {
-      func.func @tensor_insert_slice() {
+      func.func @copy_op() {
         %d0 = hal.interface.constant.load[0] : index
         %d1 = hal.interface.constant.load[1] : index
         %d2 = hal.interface.constant.load[2] : index

--- a/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
@@ -268,9 +268,9 @@ hal.executable private @preset_config_matmul_tensors  {
     #hal.descriptor_set.binding<1, storage_buffer>
   ]>
 ]>
-hal.executable @tensor_insert {
+hal.executable @copy_op {
   hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
-    hal.executable.entry_point @tensor_insert_slice layout(#executable_layout)
+    hal.executable.entry_point @copy_op layout(#executable_layout)
     builtin.module {
       func.func @tensor_insert_slice() {
         %d0 = hal.interface.constant.load[0] : index
@@ -279,73 +279,28 @@ hal.executable @tensor_insert {
         %d3 = hal.interface.constant.load[3] : index
         %o0 = hal.interface.constant.load[4] : index
         %o1 = hal.interface.constant.load[5] : index
-        %source_binding = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
-            : !flow.dispatch.tensor<readonly:?x?xi32>{%d0, %d1}
-        %dest_binding = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
-            : !flow.dispatch.tensor<readwrite:?x?xi32>{%d2, %d3}
-        %source = flow.dispatch.tensor.load %source_binding, offsets = [0, 0], sizes = [%d0, %d1], strides = [1, 1]
-            : !flow.dispatch.tensor<readonly:?x?xi32>{%d0, %d1} -> tensor<?x?xi32>
-        %dest = flow.dispatch.tensor.load %dest_binding, offsets = [0, 0], sizes = [%d0, %d1], strides = [1, 1]
-            : !flow.dispatch.tensor<readwrite:?x?xi32>{%d2, %d3} -> tensor<?x?xi32>
-        %result = tensor.insert_slice %source into %dest[%o0, %o1] [%d0, %d1] [1, 1] : tensor<?x?xi32> into tensor<?x?xi32>
-        flow.dispatch.tensor.store %result, %dest_binding, offsets = [0, 0], sizes = [%d2, %d3], strides = [1, 1]
-            : tensor<?x?xi32> -> !flow.dispatch.tensor<readwrite:?x?xi32>{%d2, %d3}
+        %source = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<?x?xi32>{%d0, %d1}
+        %dest = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<?x?xi32>{%d2, %d3}
+        %dest_view = memref.subview %dest[%o0, %o1] [%d0, %d1] [1, 1] : memref<?x?xi32> to memref<?x?xi32, offset : ?, strides : [?, ?]>
+              linalg.generic {
+                  indexing_maps = [affine_map<(d0, d1) -> (d0, d1)> , affine_map<(d0, d1) -> (d0, d1)>],
+                  iterator_types = ["parallel", "parallel"]}
+                  ins(%source : memref<?x?xi32>) outs(%dest_view : memref<?x?xi32, offset : ?, strides : [?, ?]>) {
+                ^bb0(%arg0 : i32, %arg1 : i32):
+                  linalg.yield %arg0 : i32
+                }
         return
       }
     }
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64]{{\]}}>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
-//      CHECK: hal.executable.entry_point public @tensor_insert_slice
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64], [1, 4], [0, 0]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
+//      CHECK: hal.executable.entry_point public @copy_op
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
-//      CHECK: tensor.insert_slice
-// CHECK-SAME:     lowering_config = #[[CONFIG]]
-
-// -----
-
-#executable_layout = #hal.executable.layout<push_constants = 0, sets = [
-  #hal.descriptor_set.layout<0, bindings = [
-    #hal.descriptor_set.binding<0, storage_buffer>,
-    #hal.descriptor_set.binding<1, storage_buffer>
-  ]>
-]>
-hal.executable @extract_slice {
-  hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
-    hal.executable.entry_point @extract_slice layout(#executable_layout)
-    builtin.module {
-      func.func @extract_slice() {
-        %d0 = hal.interface.constant.load[0] : index
-        %d1 = hal.interface.constant.load[1] : index
-        %d2 = hal.interface.constant.load[2] : index
-        %d3 = hal.interface.constant.load[3] : index
-        %o0 = hal.interface.constant.load[4] : index
-        %o1 = hal.interface.constant.load[5] : index
-        %source_binding = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
-            : !flow.dispatch.tensor<readonly:?x?xi32>{%d0, %d1}
-        %dest_binding = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
-            : !flow.dispatch.tensor<writeonly:?x?xi32>{%d2, %d3}
-        %source = flow.dispatch.tensor.load %source_binding, offsets = [0, 0], sizes = [%d0, %d1], strides = [1, 1]
-            : !flow.dispatch.tensor<readonly:?x?xi32>{%d0, %d1} -> tensor<?x?xi32>
-        %dest = flow.dispatch.tensor.load %dest_binding, offsets = [0, 0], sizes = [%d0, %d1], strides = [1, 1]
-            : !flow.dispatch.tensor<writeonly:?x?xi32>{%d2, %d3} -> tensor<?x?xi32>
-        %result = tensor.extract_slice %source[%o0, %o1] [%d0, %d1] [1, 1] : tensor<?x?xi32> to tensor<?x?xi32>
-        flow.dispatch.tensor.store %result, %dest_binding, offsets = [0, 0], sizes = [%d2, %d3], strides = [1, 1]
-            : tensor<?x?xi32> -> !flow.dispatch.tensor<writeonly:?x?xi32>{%d2, %d3}
-        return
-      }
-    }
-  }
-}
-
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64]{{\]}}>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
-//      CHECK: hal.executable.entry_point public @extract_slice
-// CHECK-SAME:     translation_info = #[[TRANSLATION]]
-//      CHECK: tensor.extract_slice
-// CHECK-SAME:     lowering_config = #[[CONFIG]]
-
+//      CHECK:   linalg.generic
+// CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
 

--- a/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
@@ -282,13 +282,13 @@ hal.executable @copy_op {
         %source = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<?x?xi32>{%d0, %d1}
         %dest = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<?x?xi32>{%d2, %d3}
         %dest_view = memref.subview %dest[%o0, %o1] [%d0, %d1] [1, 1] : memref<?x?xi32> to memref<?x?xi32, offset : ?, strides : [?, ?]>
-              linalg.generic {
-                  indexing_maps = [affine_map<(d0, d1) -> (d0, d1)> , affine_map<(d0, d1) -> (d0, d1)>],
-                  iterator_types = ["parallel", "parallel"]}
-                  ins(%source : memref<?x?xi32>) outs(%dest_view : memref<?x?xi32, offset : ?, strides : [?, ?]>) {
-                ^bb0(%arg0 : i32, %arg1 : i32):
-                  linalg.yield %arg0 : i32
-                }
+        linalg.generic {
+            indexing_maps = [affine_map<(d0, d1) -> (d0, d1)> , affine_map<(d0, d1) -> (d0, d1)>],
+            iterator_types = ["parallel", "parallel"]}
+            ins(%source : memref<?x?xi32>) outs(%dest_view : memref<?x?xi32, offset : ?, strides : [?, ?]>) {
+          ^bb0(%arg0 : i32, %arg1 : i32):
+            linalg.yield %arg0 : i32
+          }
         return
       }
     }
@@ -296,7 +296,7 @@ hal.executable @copy_op {
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64], [1, 4], [0, 0]{{\]}}>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUBufferOpsTileAndVectorize>
 //      CHECK: hal.executable.entry_point public @copy_op
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic

--- a/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -438,20 +438,6 @@ LogicalResult initGPULaunchConfig(ModuleOp moduleOp) {
     }
 
     if (!rootOperation) {
-      // TODO(ravishankarm): Currently you could have dispatches with a single
-      // tensor.insert_slice or a tensor.extract_slice. Those are handled by
-      // tile + distribute as well since these ops have an external model
-      // implementing the `TiledOpInterface`. This is legacy. These ops shouldnt
-      // implement this interface, and backends must be able to handle a
-      // dispatch with flow.dispatch.tensor.load -> flow.dispatch.tensor.store.
-      // Till this is cleaned up, set a configuration for this.
-      if (computeOps.size() == 1 &&
-          isa<tensor::ExtractSliceOp, tensor::InsertSliceOp>(computeOps[0])) {
-        rootOperation = computeOps[0];
-      }
-    }
-
-    if (!rootOperation) {
       // setTranslationInfo(
       //    funcOp,
       //    IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUDistribute,

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -13,6 +13,7 @@
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "mlir/Dialect/GPU/GPUDialect.h"
+#include "mlir/Dialect/SCF/SCF.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Pass/PassRegistry.h"
@@ -36,7 +37,7 @@ class LLVMGPULowerExecutableTargetPass
     registry
         .insert<IREE::Codegen::IREECodegenDialect, IREE::HAL::HALDialect,
                 linalg::LinalgDialect, IREE::LinalgExt::IREELinalgExtDialect,
-                vector::VectorDialect, gpu::GPUDialect>();
+                vector::VectorDialect, gpu::GPUDialect, scf::SCFDialect>();
   }
 
   LLVMGPULowerExecutableTargetPass() = default;

--- a/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -188,6 +188,7 @@ static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
 
 void buildLLVMGPUTransformPassPipeline(OpPassManager &pm, bool useROCM) {
   pm.nest<ModuleOp>().nest<FuncOp>().addPass(createTypePropagationPass());
+  pm.nest<ModuleOp>().addPass(createBufferizeCopyOnlyDispatchesPass());
   pm.addPass(createLLVMGPULowerExecutableTargetPass());
   OpPassManager &nestedModulePM = pm.nest<ModuleOp>();
   //===--------------------------------------------------------------------===//

--- a/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
@@ -130,50 +130,6 @@ hal.executable @reduction_dispatch {
     #hal.descriptor_set.binding<1, storage_buffer>
   ]>
 ]>
-hal.executable @tensor_insert_slice {
-  hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @tensor_insert_slice layout(#executable_layout)
-    builtin.module {
-      func.func @tensor_insert_slice() {
-        %c0 = arith.constant 0 : index
-        %size_y = hal.interface.constant.load[0] : index
-        %size_x = hal.interface.constant.load[1] : index
-        %dest_size_y = hal.interface.constant.load[2] : index
-        %dest_size_x = hal.interface.constant.load[3] : index
-        %offset_y = hal.interface.constant.load[4] : index
-        %offset_x = hal.interface.constant.load[5] : index
-        %source_binding = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
-            : !flow.dispatch.tensor<readonly:?x?xi32>{%size_y, %size_x}
-        %dest_binding = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
-            : !flow.dispatch.tensor<readwrite:?x?xi32>{%dest_size_y, %dest_size_x}
-        %source = flow.dispatch.tensor.load %source_binding, offsets = [0, 0], sizes = [%size_y, %size_x], strides = [1, 1]
-            : !flow.dispatch.tensor<readonly:?x?xi32>{%size_y, %size_x} -> tensor<?x?xi32>
-        %dest = flow.dispatch.tensor.load %dest_binding, offsets = [0, 0], sizes = [%dest_size_y, %dest_size_x], strides = [1, 1]
-            : !flow.dispatch.tensor<readwrite:?x?xi32>{%dest_size_y, %dest_size_x} -> tensor<?x?xi32>
-        %result = tensor.insert_slice %source into %dest[%offset_y, %offset_x] [%size_y, %size_x] [1, 1]
-            : tensor<?x?xi32> into tensor<?x?xi32>
-        flow.dispatch.tensor.store %result, %dest_binding, offsets = [0, 0], sizes = [%dest_size_y, %dest_size_x], strides = [1, 1]
-            : tensor<?x?xi32> -> !flow.dispatch.tensor<readwrite:?x?xi32>{%dest_size_y, %dest_size_x}
-        return
-      }
-    }
-  }
-}
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64]{{\]}}>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorize>
-//      CHECK: hal.executable.entry_point public @tensor_insert_slice
-// CHECK-SAME:     translation_info = #[[TRANSLATION]]
-//      CHECK: tensor.insert_slice
-// CHECK-SAME:     lowering_config = #[[CONFIG]]
-
-// -----
-
-#executable_layout = #hal.executable.layout<push_constants = 0, sets = [
-  #hal.descriptor_set.layout<0, bindings = [
-    #hal.descriptor_set.binding<0, storage_buffer>,
-    #hal.descriptor_set.binding<1, storage_buffer>
-  ]>
-]>
 hal.executable @copy_as_generic {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
     hal.executable.entry_point @copy_as_generic layout(#executable_layout)

--- a/iree/compiler/Codegen/Passes.h
+++ b/iree/compiler/Codegen/Passes.h
@@ -232,6 +232,11 @@ void populateUnfusedFMAOpsPassPatterns(MLIRContext *context,
 /// to memrefs
 void addCPUDefaultPassPipeline(OpPassManager &passManager);
 
+/// Populates the passes to lower linalg ops on buffers. Currenly this pipeline
+/// is only used for dispatches that just copy data from input interfaces to
+/// output interface.
+void addCPUBufferOpsTileAndVectorizePipeline(OpPassManager &passManager);
+
 /// Populates the passes needed to multi level tile and lowering of linalg ops
 /// on tensors to vectors operations.
 LogicalResult verifyTensorToVectorsPassPipelineConfig(

--- a/iree/compiler/Codegen/Passes.h
+++ b/iree/compiler/Codegen/Passes.h
@@ -60,6 +60,12 @@ void addIREEComprehensiveBufferizePasses(
 /// allocations and view operations.
 std::unique_ptr<OperationPass<FuncOp>> createCleanupBufferAllocViewPass();
 
+/// Pass to bufferize dispatches that are copying from one interface to another.
+/// This will create a `linalg.generic` op which is a copy that can then be
+/// used by backends to handle appropriately.
+std::unique_ptr<OperationPass<ModuleOp>>
+createBufferizeCopyOnlyDispatchesPass();
+
 /// Create a pass to convert a model using f32 type to the equivalent one
 /// using f16.
 std::unique_ptr<OperationPass<ModuleOp>> createDemoteF32ToF16Pass();

--- a/iree/compiler/Codegen/Passes.td
+++ b/iree/compiler/Codegen/Passes.td
@@ -59,6 +59,13 @@ def ForOpCanonicalization :
   let constructor = "mlir::iree_compiler::createForOpCanonicalizationPass()";
 }
 
+def BufferizeCopyOnlyDispatches :
+  Pass<"iree-codegen-bufferize-copy-only-dispatches", "ModuleOp"> {
+  let summary =
+      "Bufferize dispatches that copy to/from interfaces to convert to a linalg.copy op";
+  let constructor = "mlir::iree_compiler::createBufferizeCopyOnlyDispatchesPass()";
+}
+
 def LinalgBufferize :
     Pass<"iree-codegen-linalg-bufferize", "func::FuncOp"> {
   let summary = "Convert from to Linalg ops on tensors to buffers";

--- a/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -357,7 +357,11 @@ static LogicalResult setDefaultOpConfig(spirv::ResourceLimitsAttr limits,
 
   // Special case for non-linalg ops.
   auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
-  if (!linalgOp || linalgOp.getNumOutputs() != 1) {
+  // TODO(#8580): Ops with buffer semantics, like those created by copy-only
+  // dispatches can be vectorized too, but that code fails compilation. So
+  // disabling that for now.
+  if (!linalgOp || linalgOp.getNumOutputs() != 1 ||
+      linalgOp.hasBufferSemantics()) {
     auto pipeline =
         IREE::Codegen::DispatchLoweringPassPipeline::SPIRVDistribute;
 

--- a/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -615,17 +615,19 @@ LogicalResult initSPIRVLaunchConfig(ModuleOp module) {
       rootOperation = computeOp;
     }
 
-    // If there are still no root op, check for any linalg.generic op.
-    Operation *computeOp = computeOps.back();
-    if (failed(setDefaultOpConfig(limits, computeOp))) return failure();
+    if (!rootOperation) {
+      // If there are still no root op, check for any linalg.generic op.
+      Operation *computeOp = computeOps.back();
+      if (failed(setDefaultOpConfig(limits, computeOp))) return failure();
 
-    // Check if the op configuration was set.
-    if (!getLoweringConfig(computeOp)) {
-      return computeOp->emitOpError(
-          "without known roots, the last compute operation in the tiled "
-          "loop body is expected to be set as root");
+      // Check if the op configuration was set.
+      if (!getLoweringConfig(computeOp)) {
+        return computeOp->emitOpError(
+            "without known roots, the last compute operation in the tiled "
+            "loop body is expected to be set as root");
+      }
+      rootOperation = computeOp;
     }
-    rootOperation = computeOp;
 
     // Propogate the `lowering_config` attribute to the other ops.
     // TODO(ravishankarm, antiagainst): This is a very specific use (and

--- a/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -251,7 +251,7 @@ void addSPIRVTileAndDistributeCopyPassPipeline(OpPassManager &pm) {
 
 void buildSPIRVCodegenPassPipeline(OpPassManager &pm) {
   pm.nest<ModuleOp>().nest<FuncOp>().addPass(createTypePropagationPass());
-
+  pm.nest<ModuleOp>().addPass(createBufferizeCopyOnlyDispatchesPass());
   pm.addPass(createSPIRVLowerExecutableTargetPass());
 
   addMemRefLoweringPasses(pm.nest<ModuleOp>());

--- a/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ext_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ext_ops.mlir
@@ -193,7 +193,7 @@ hal.executable private @static_3d_fft_stage3 {
     #hal.descriptor_set.binding<1, storage_buffer>
   ]>
 ]>
-hal.executable private @tensor_insert {
+hal.executable private @copy_op {
   hal.executable.variant @vulkan_spirv_fb, target = <"vulkan", "vulkan-spirvfb", {
       spv.target_env = #spv.target_env<#spv.vce<v1.4, [Shader], []>, Unknown:IntegratedGPU, {
         max_compute_shared_memory_size = 32768 : i32,
@@ -201,78 +201,30 @@ hal.executable private @tensor_insert {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @tensor_insert layout(#executable_layout)
+    hal.executable.entry_point @copy_op layout(#executable_layout)
     builtin.module {
-      func.func @tensor_insert() {
+      func.func @copy_op() {
         %offset_y = hal.interface.constant.load[0] : index
         %offset_x = hal.interface.constant.load[1] : index
         %source_size_y = hal.interface.constant.load[2] : index
         %source_size_x = hal.interface.constant.load[3] : index
         %dest_size_y = hal.interface.constant.load[4] : index
         %dest_size_x = hal.interface.constant.load[5] : index
-        %source_binding = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
-            : !flow.dispatch.tensor<readonly:?x?xf32>{%source_size_y, %source_size_x}
-        %dest_binding = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
-            : !flow.dispatch.tensor<readwrite:?x?xf32>{%dest_size_y, %dest_size_x}
-        %source = flow.dispatch.tensor.load %source_binding, offsets = [0, 0], sizes = [%source_size_y, %source_size_y], strides = [1, 1]
-            : !flow.dispatch.tensor<readonly:?x?xf32>{%source_size_y, %source_size_x} -> tensor<?x?xf32>
-        %dest = flow.dispatch.tensor.load %dest_binding, offsets = [0, 0], sizes = [%dest_size_y, %dest_size_x], strides = [1, 1]
-            : !flow.dispatch.tensor<readwrite:?x?xf32>{%dest_size_y, %dest_size_x} -> tensor<?x?xf32>
-        %insert = tensor.insert_slice %source into %dest[%offset_y, %offset_x] [%source_size_y, %source_size_x] [1, 1]
-            : tensor<?x?xf32> into tensor<?x?xf32>
-        flow.dispatch.tensor.store %insert, %dest_binding, offsets = [0, 0], sizes = [%dest_size_y, %dest_size_x], strides = [1, 1]
-            : tensor<?x?xf32> -> !flow.dispatch.tensor<readwrite:?x?xf32>{%dest_size_y, %dest_size_x}
+        %source = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<?x?xf32>{%source_size_y, %source_size_x}
+        %dest = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<?x?xf32>{%dest_size_y, %dest_size_x}
+        linalg.generic {
+            indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+            iterator_types = ["parallel", "parallel"]}
+            ins(%source : memref<?x?xf32>) outs(%dest : memref<?x?xf32>) {
+          ^bb0(%b0 : f32, %b1 : f32):
+            linalg.yield %b0 : f32
+          }
         return
       }
     }
   }
 }
-// Check that the pipeline is set to `SPIRVDistributeAndCopy`
-
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistributeCopy>
-//      CHECK: tensor.insert_slice
-//  CHECK-NOT:     lowering_config
-
-// -----
-
-#executable_layout = #hal.executable.layout<push_constants = 0, sets = [
-  #hal.descriptor_set.layout<0, bindings = [
-    #hal.descriptor_set.binding<0, storage_buffer>,
-    #hal.descriptor_set.binding<1, storage_buffer>
-  ]>
-]>
-hal.executable private @tensor_extract {
-  hal.executable.variant @vulkan_spirv_fb, target = <"vulkan", "vulkan-spirvfb", {
-      spv.target_env = #spv.target_env<#spv.vce<v1.4, [Shader], []>, Unknown:IntegratedGPU, {
-        max_compute_shared_memory_size = 32768 : i32,
-        max_compute_workgroup_invocations = 512 : i32,
-        max_compute_workgroup_size = dense<512> : vector<3xi32>,
-        subgroup_size = 16 : i32}>
-    }> {
-    hal.executable.entry_point @tensor_extract layout(#executable_layout)
-    builtin.module {
-      func.func @tensor_extract() {
-        %offset_y = hal.interface.constant.load[0] : index
-        %offset_x = hal.interface.constant.load[1] : index
-        %source_size_y = hal.interface.constant.load[2] : index
-        %source_size_x = hal.interface.constant.load[3] : index
-        %result_size_y = hal.interface.constant.load[4] : index
-        %result_size_x = hal.interface.constant.load[5] : index
-        %source_binding = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
-            : !flow.dispatch.tensor<readonly:?x?xf32>{%source_size_y, %source_size_x}
-        %result_binding = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
-            : !flow.dispatch.tensor<writeonly:?x?xf32>{%result_size_y, %result_size_x}
-        %source = flow.dispatch.tensor.load %source_binding, offsets = [0, 0], sizes = [%source_size_y, %source_size_y], strides = [1, 1]
-            : !flow.dispatch.tensor<readonly:?x?xf32>{%source_size_y, %source_size_x} -> tensor<?x?xf32>
-        %extract = tensor.extract_slice %source[%offset_y, %offset_x] [%result_size_y, %result_size_x] [1, 1]
-            : tensor<?x?xf32> to tensor<?x?xf32>
-        flow.dispatch.tensor.store %extract, %result_binding, offsets = [0, 0], sizes = [%result_size_y, %result_size_x], strides = [1, 1]
-            : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:?x?xf32>{%result_size_y, %result_size_x}
-        return
-      }
-    }
-  }
-}
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistributeCopy>
-//      CHECK: tensor.extract_slice
-//  CHECK-NOT:     lowering_config
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 16], [1, 1]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
+//      CHECK: linalg.generic
+// CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ops.mlir
@@ -79,7 +79,7 @@ hal.executable @tensor_insert {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 2, 32, 1], [0, 1, 1, 1]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 1, 64], [0, 1, 1, 1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
 //      CHECK: hal.executable.entry_point public @copy
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]

--- a/iree/compiler/Codegen/Utils/Utils.h
+++ b/iree/compiler/Codegen/Utils/Utils.h
@@ -58,7 +58,7 @@ inline bool isVMVXBackend(func::FuncOp entryPointFn) {
 }
 
 /// Checks if a tensor value is generated from a read-only object, like
-/// and itnerface binding with read-only attribute or from an `arith.constant`
+/// and interface binding with read-only attribute or from an `arith.constant`
 /// operation.
 bool isReadOnly(Value v);
 

--- a/iree/compiler/Codegen/Utils/Utils.h
+++ b/iree/compiler/Codegen/Utils/Utils.h
@@ -57,6 +57,11 @@ inline bool isVMVXBackend(func::FuncOp entryPointFn) {
   return isVMVXBackend(variantOp);
 }
 
+/// Checks if a tensor value is generated from a read-only object, like
+/// and itnerface binding with read-only attribute or from an `arith.constant`
+/// operation.
+bool isReadOnly(Value v);
+
 //===----------------------------------------------------------------------===//
 // Utility functions to set configurations
 //===----------------------------------------------------------------------===//

--- a/third_party/llvm-project.branch-pin
+++ b/third_party/llvm-project.branch-pin
@@ -1,1 +1,0 @@
-patched-llvm-project-20220324

--- a/third_party/llvm-project.branch-pin
+++ b/third_party/llvm-project.branch-pin
@@ -1,0 +1,1 @@
+patched-llvm-project-20220324


### PR DESCRIPTION
For cases where the dispatches are copy only , i.e. data is transfered
from one interface binding to another, bufferizing early results in a
`linalg.generic` (i.e. a copy) operation in the dispatch. The backends
can use this to generate code.  This is the first step in dropping
`TiledOpInterface` for `tensor.insert_slice` and
`tensor.extract_slice` operations.  This commit also adds patterns to
fold these operations with the `flow.dispatch.tensor.load` and
`flow.dispatch.tensor.store` operations. Eventually these patterns
will be moved to canonicalizations when the `TiledOpInterface`
implementation for `tensor.insert_slice` and `tensor.extract_slice`
are dropped.

Fixes #8509