### PR TITLE
Align HAL heap buffers to a configuration-defined minimum alignment.

### DIFF
--- a/iree/base/alignment.h
+++ b/iree/base/alignment.h
@@ -10,6 +10,7 @@
 #ifndef IREE_BASE_ALIGNMENT_H_
 #define IREE_BASE_ALIGNMENT_H_
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
@@ -50,11 +51,23 @@ static inline iree_host_size_t iree_host_align(iree_host_size_t value,
   return (value + (alignment - 1)) & ~(alignment - 1);
 }
 
+// Returns true if |value| matches the given minimum |alignment|.
+static inline bool iree_host_size_has_alignment(iree_host_size_t value,
+                                                iree_host_size_t alignment) {
+  return iree_host_align(value, alignment) == value;
+}
+
 // Aligns |value| up to the given power-of-two |alignment| if required.
 // https://en.wikipedia.org/wiki/Data_structure_alignment#Computing_padding
 static inline iree_device_size_t iree_device_align(
     iree_device_size_t value, iree_device_size_t alignment) {
   return (value + (alignment - 1)) & ~(alignment - 1);
+}
+
+// Returns true if |value| matches the given minimum |alignment|.
+static inline bool iree_device_size_has_alignment(
+    iree_device_size_t value, iree_device_size_t alignment) {
+  return iree_device_align(value, alignment) == value;
 }
 
 // Returns the size of a struct padded out to iree_max_align_t.

--- a/iree/base/allocator.h
+++ b/iree/base/allocator.h
@@ -117,46 +117,6 @@ static bool iree_const_byte_span_is_empty(iree_const_byte_span_t span) {
 #endif  // IREE_COMPILER_MSVC
 
 //===----------------------------------------------------------------------===//
-// C11 aligned_alloc compatibility shim
-//===----------------------------------------------------------------------===//
-
-#if defined(IREE_PLATFORM_WINDOWS)
-// https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/aligned-malloc
-#define iree_aligned_alloc(alignment, size) _aligned_malloc(size, alignment)
-#define iree_aligned_free(p) _aligned_free(p)
-#elif defined(_ISOC11_SOURCE)
-// https://en.cppreference.com/w/c/memory/aligned_alloc
-#define iree_aligned_alloc(alignment, size) aligned_alloc(alignment, size)
-#define iree_aligned_free(p) free(p)
-#elif _POSIX_C_SOURCE >= 200112L
-// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_memalign.html
-static inline void* iree_aligned_alloc(size_t alignment, size_t size) {
-  void* ptr = NULL;
-  return posix_memalign(&ptr, alignment, size) == 0 ? ptr : NULL;
-}
-#define iree_aligned_free(p) free(p)
-#else
-// Emulates alignment with normal malloc. We overallocate by at least the
-// alignment + the size of a pointer, store the base pointer at p[-1], and
-// return the aligned pointer. This lets us easily get the base pointer in free
-// to pass back to the system.
-static inline void* iree_aligned_alloc(size_t alignment, size_t size) {
-  void* base_ptr = malloc(size + alignment + sizeof(uintptr_t));
-  if (!base_ptr) return NULL;
-  uintptr_t* aligned_ptr = (uintptr_t*)iree_host_align(
-      (uintptr_t)base_ptr + sizeof(uintptr_t), alignment);
-  aligned_ptr[-1] = (uintptr_t)base_ptr;
-  return aligned_ptr;
-}
-static inline void iree_aligned_free(void* p) {
-  if (IREE_UNLIKELY(!p)) return;
-  uintptr_t* aligned_ptr = (uintptr_t*)p;
-  void* base_ptr = (void*)aligned_ptr[-1];
-  free(base_ptr);
-}
-#endif  // IREE_PLATFORM_WINDOWS
-
-//===----------------------------------------------------------------------===//
 // iree_allocator_t (std::allocator-like interface)
 //===----------------------------------------------------------------------===//
 
@@ -246,6 +206,7 @@ IREE_API_EXPORT iree_status_t iree_allocator_malloc_uninitialized(
 // If the reallocation fails then the original |inout_ptr| is unmodified.
 //
 // WARNING: when extending the newly allocated bytes are undefined.
+// TODO(benvanik): make them zeros; we should have an _uninitialized if needed.
 IREE_API_EXPORT iree_status_t iree_allocator_realloc(
     iree_allocator_t allocator, iree_host_size_t byte_length, void** inout_ptr);
 

--- a/iree/base/config.h
+++ b/iree/base/config.h
@@ -155,6 +155,14 @@ typedef IREE_DEVICE_SIZE_T iree_device_size_t;
 // Enables optional HAL features. Each of these may add several KB to the final
 // binary when linked dynamically.
 
+#if !defined(IREE_HAL_HEAP_BUFFER_ALIGNMENT)
+// Power of two byte alignment required on all host heap buffers.
+// Executables are compiled with alignment expectations and the runtime
+// alignment must be greater than or equal to the alignment set in the compiler.
+// External buffers wrapped by HAL buffers must meet this alignment requirement.
+#define IREE_HAL_HEAP_BUFFER_ALIGNMENT 64
+#endif  // IREE_HAL_HEAP_BUFFER_ALIGNMENT
+
 #if !defined(IREE_HAL_COMMAND_BUFFER_VALIDATION_ENABLE)
 // Enables additional validation of commands issued against command buffers.
 // This adds small amounts of per-command overhead but in all but the most

--- a/iree/hal/buffer.h
+++ b/iree/hal/buffer.h
@@ -517,22 +517,6 @@ IREE_API_EXPORT iree_status_t iree_hal_subspan_buffer_create(
     iree_allocator_t host_allocator, iree_hal_buffer_t** out_buffer);
 
 //===----------------------------------------------------------------------===//
-// iree_hal_heap_buffer_t
-//===----------------------------------------------------------------------===//
-
-// Wraps an existing host allocation in a buffer.
-// When the buffer is destroyed the provided |data_allocator| will be used to
-// free |data|. Pass iree_allocator_null() to wrap without ownership semantics.
-//
-// |out_buffer| must be released by the caller.
-IREE_API_EXPORT iree_status_t iree_hal_heap_buffer_wrap(
-    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
-    iree_hal_memory_access_t allowed_access,
-    iree_hal_buffer_usage_t allowed_usage, iree_device_size_t allocation_size,
-    iree_byte_span_t data, iree_allocator_t data_allocator,
-    iree_hal_buffer_t** out_buffer);
-
-//===----------------------------------------------------------------------===//
 // iree_hal_buffer_t implementation details
 //===----------------------------------------------------------------------===//
 

--- a/iree/hal/buffer_heap_impl.h
+++ b/iree/hal/buffer_heap_impl.h
@@ -38,6 +38,26 @@ iree_status_t iree_hal_heap_buffer_create(
     iree_allocator_t data_allocator, iree_allocator_t host_allocator,
     iree_hal_buffer_t** out_buffer);
 
+// Wraps an existing host allocation in a buffer.
+// When the buffer is destroyed the provided |data_allocator| will be used to
+// free |data| using iree_allocator_free. Pass iree_allocator_null() to wrap
+// without ownership semantics.
+//
+// The buffer must be aligned to at least IREE_HAL_HEAP_BUFFER_ALIGNMENT.
+// Note that it will be freed as a normal unaligned allocation. If we find
+// ourselves wanting to wrap aligned allocations requiring
+// iree_allocator_free_aligned then we'll need a flag to indicate that.
+//
+// |out_buffer| must be released by the caller.
+iree_status_t iree_hal_heap_buffer_wrap(iree_hal_allocator_t* allocator,
+                                        iree_hal_memory_type_t memory_type,
+                                        iree_hal_memory_access_t allowed_access,
+                                        iree_hal_buffer_usage_t allowed_usage,
+                                        iree_device_size_t allocation_size,
+                                        iree_byte_span_t data,
+                                        iree_allocator_t data_allocator,
+                                        iree_hal_buffer_t** out_buffer);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/iree/hal/cts/buffer_mapping_test.h
+++ b/iree/hal/cts/buffer_mapping_test.h
@@ -541,7 +541,6 @@ TEST_P(buffer_mapping_test, MapRangeWrite) {
 }
 
 // TODO(scotttodd): iree_hal_allocator_wrap_buffer
-// TODO(scotttodd): iree_hal_heap_buffer_wrap
 
 }  // namespace cts
 }  // namespace hal

--- a/iree/runtime/demo/hello_world_explained.c
+++ b/iree/runtime/demo/hello_world_explained.c
@@ -191,7 +191,8 @@ static iree_status_t iree_runtime_demo_perform_mul(
     iree_hal_buffer_view_t* arg0 = NULL;
     if (iree_status_is_ok(status)) {
       static const iree_hal_dim_t arg0_shape[1] = {4};
-      static const float arg0_data[4] = {1.0f, 1.1f, 1.2f, 1.3f};
+      static const float iree_alignas(64)
+          arg0_data[4] = {1.0f, 1.1f, 1.2f, 1.3f};
       status = iree_hal_buffer_view_wrap_or_clone_heap_buffer(
           device_allocator,
           // Shape dimensions and rank:
@@ -230,7 +231,8 @@ static iree_status_t iree_runtime_demo_perform_mul(
     iree_hal_buffer_view_t* arg1 = NULL;
     if (iree_status_is_ok(status)) {
       static const iree_hal_dim_t arg1_shape[1] = {4};
-      static const float arg1_data[4] = {10.0f, 100.0f, 1000.0f, 10000.0f};
+      static const float iree_alignas(64)
+          arg1_data[4] = {10.0f, 100.0f, 1000.0f, 10000.0f};
       status = iree_hal_buffer_view_wrap_or_clone_heap_buffer(
           device_allocator, arg1_shape, IREE_ARRAYSIZE(arg1_shape),
           IREE_HAL_ELEMENT_TYPE_FLOAT_32,

--- a/iree/runtime/demo/hello_world_terse.c
+++ b/iree/runtime/demo/hello_world_terse.c
@@ -78,7 +78,8 @@ static void iree_runtime_demo_perform_mul(iree_runtime_session_t* session) {
   // %arg0: tensor<4xf32>
   iree_hal_buffer_view_t* arg0 = NULL;
   static const iree_hal_dim_t arg0_shape[1] = {4};
-  static const float arg0_data[4] = {1.0f, 1.1f, 1.2f, 1.3f};
+  static const float iree_alignas(IREE_HAL_HEAP_BUFFER_ALIGNMENT)
+      arg0_data[4] = {1.0f, 1.1f, 1.2f, 1.3f};
   IREE_CHECK_OK(iree_hal_buffer_view_wrap_or_clone_heap_buffer(
       iree_runtime_session_device_allocator(session), arg0_shape,
       IREE_ARRAYSIZE(arg0_shape), IREE_HAL_ELEMENT_TYPE_FLOAT_32,
@@ -102,7 +103,8 @@ static void iree_runtime_demo_perform_mul(iree_runtime_session_t* session) {
   // %arg1: tensor<4xf32>
   iree_hal_buffer_view_t* arg1 = NULL;
   static const iree_hal_dim_t arg1_shape[1] = {4};
-  static const float arg1_data[4] = {10.0f, 100.0f, 1000.0f, 10000.0f};
+  static const float iree_alignas(IREE_HAL_HEAP_BUFFER_ALIGNMENT)
+      arg1_data[4] = {10.0f, 100.0f, 1000.0f, 10000.0f};
   IREE_CHECK_OK(iree_hal_buffer_view_wrap_or_clone_heap_buffer(
       iree_runtime_session_device_allocator(session), arg1_shape,
       IREE_ARRAYSIZE(arg1_shape), IREE_HAL_ELEMENT_TYPE_FLOAT_32,

--- a/iree/samples/custom_modules/custom_modules_test.cc
+++ b/iree/samples/custom_modules/custom_modules_test.cc
@@ -131,8 +131,8 @@ TEST_F(CustomModulesTest, ReverseAndPrint) {
 TEST_F(CustomModulesTest, PrintTensor) {
   // Allocate the buffer we'll be printing.
   static iree_hal_dim_t kShape[] = {2, 4};
-  static float kBufferContents[2 * 4] = {0.0f, 1.0f, 2.0f, 3.0f,
-                                         4.0f, 5.0f, 6.0f, 7.0f};
+  static float iree_alignas(IREE_HAL_HEAP_BUFFER_ALIGNMENT)
+      kBufferContents[2 * 4] = {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f};
   iree_hal_buffer_params_t params = {0};
   params.type =
       IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
@@ -179,8 +179,8 @@ TEST_F(CustomModulesTest, PrintTensor) {
 TEST_F(CustomModulesTest, RoundTripTensor) {
   // Allocate the buffer we'll be printing/parsing.
   static iree_hal_dim_t kShape[] = {2, 4};
-  static float kBufferContents[2 * 4] = {0.0f, 1.0f, 2.0f, 3.0f,
-                                         4.0f, 5.0f, 6.0f, 7.0f};
+  static float iree_alignas(IREE_HAL_HEAP_BUFFER_ALIGNMENT)
+      kBufferContents[2 * 4] = {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f};
   iree_hal_buffer_params_t params = {0};
   params.type =
       IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;


### PR DESCRIPTION
This is required to make some of the SIMD code we emit happy. Given that 95% of our buffers are suballocated in the compiler the larger-than-max_align-alignment isn't a large cost relative to the simplicity and potential perf benefits it has.

This does now require all imported buffers match the alignment. There's no way to query this today from allocators beyond using the config.h value but that's fine for now as we are only ever wrapping buffers in files that should already be aligned.

Fixes #8506.