### PR TITLE
Replacing iree_hal_allocator_wrap_buffer with _import_buffer.

### DIFF
--- a/bindings/python/iree/runtime/hal.cc
+++ b/bindings/python/iree/runtime/hal.cc
@@ -442,7 +442,7 @@ void SetupHalBindings(pybind11::module m) {
       .def(
           "allocate_buffer",
           [](HalAllocator& self, int memory_type, int allowed_usage,
-             iree_host_size_t allocation_size) {
+             iree_device_size_t allocation_size) {
             iree_hal_buffer_params_t params = {0};
             params.type = memory_type;
             params.usage = allowed_usage;

--- a/experimental/rocm/rocm_allocator.c
+++ b/experimental/rocm/rocm_allocator.c
@@ -123,7 +123,7 @@ static void iree_hal_rocm_buffer_free(iree_hal_rocm_context_wrapper_t* context,
 static iree_status_t iree_hal_rocm_allocator_allocate_buffer(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     const iree_hal_buffer_params_t* IREE_RESTRICT params,
-    iree_host_size_t allocation_size, iree_const_byte_span_t initial_data,
+    iree_device_size_t allocation_size, iree_const_byte_span_t initial_data,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   iree_hal_rocm_allocator_t* allocator =
       iree_hal_rocm_allocator_cast(base_allocator);
@@ -216,19 +216,11 @@ static void iree_hal_rocm_allocator_deallocate_buffer(
   iree_hal_buffer_destroy(base_buffer);
 }
 
-static iree_status_t iree_hal_rocm_allocator_wrap_buffer(
-    iree_hal_allocator_t* IREE_RESTRICT base_allocator,
-    const iree_hal_buffer_params_t* IREE_RESTRICT params, iree_byte_span_t data,
-    iree_allocator_t data_allocator,
-    iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
-  return iree_make_status(IREE_STATUS_UNAVAILABLE,
-                          "wrapping of external buffers not supported");
-}
-
 static iree_status_t iree_hal_rocm_allocator_import_buffer(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     const iree_hal_buffer_params_t* IREE_RESTRICT params,
     iree_hal_external_buffer_t* IREE_RESTRICT external_buffer,
+    iree_hal_buffer_release_callback_t release_callback,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   return iree_make_status(IREE_STATUS_UNAVAILABLE,
                           "importing from external buffers not supported");
@@ -252,7 +244,6 @@ static const iree_hal_allocator_vtable_t iree_hal_rocm_allocator_vtable = {
     .query_compatibility = iree_hal_rocm_allocator_query_compatibility,
     .allocate_buffer = iree_hal_rocm_allocator_allocate_buffer,
     .deallocate_buffer = iree_hal_rocm_allocator_deallocate_buffer,
-    .wrap_buffer = iree_hal_rocm_allocator_wrap_buffer,
     .import_buffer = iree_hal_rocm_allocator_import_buffer,
     .export_buffer = iree_hal_rocm_allocator_export_buffer,
 };

--- a/iree/hal/allocator.c
+++ b/iree/hal/allocator.c
@@ -117,7 +117,7 @@ iree_hal_allocator_query_compatibility(
 
 IREE_API_EXPORT iree_status_t iree_hal_allocator_allocate_buffer(
     iree_hal_allocator_t* IREE_RESTRICT allocator,
-    iree_hal_buffer_params_t params, iree_host_size_t allocation_size,
+    iree_hal_buffer_params_t params, iree_device_size_t allocation_size,
     iree_const_byte_span_t initial_data,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   IREE_ASSERT_ARGUMENT(allocator);
@@ -140,25 +140,11 @@ IREE_API_EXPORT void iree_hal_allocator_deallocate_buffer(
   IREE_TRACE_ZONE_END(z0);
 }
 
-IREE_API_EXPORT iree_status_t iree_hal_allocator_wrap_buffer(
-    iree_hal_allocator_t* IREE_RESTRICT allocator,
-    iree_hal_buffer_params_t params, iree_byte_span_t data,
-    iree_allocator_t data_allocator, iree_hal_buffer_t** out_buffer) {
-  IREE_ASSERT_ARGUMENT(allocator);
-  IREE_ASSERT_ARGUMENT(out_buffer);
-  *out_buffer = NULL;
-  IREE_TRACE_ZONE_BEGIN(z0);
-  iree_hal_buffer_params_canonicalize(&params);
-  iree_status_t status = _VTABLE_DISPATCH(allocator, wrap_buffer)(
-      allocator, &params, data, data_allocator, out_buffer);
-  IREE_TRACE_ZONE_END(z0);
-  return status;
-}
-
 IREE_API_EXPORT iree_status_t iree_hal_allocator_import_buffer(
     iree_hal_allocator_t* IREE_RESTRICT allocator,
     iree_hal_buffer_params_t params,
     iree_hal_external_buffer_t* IREE_RESTRICT external_buffer,
+    iree_hal_buffer_release_callback_t release_callback,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   IREE_ASSERT_ARGUMENT(allocator);
   IREE_ASSERT_ARGUMENT(external_buffer);
@@ -167,7 +153,7 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_import_buffer(
   IREE_TRACE_ZONE_BEGIN(z0);
   iree_hal_buffer_params_canonicalize(&params);
   iree_status_t status = _VTABLE_DISPATCH(allocator, import_buffer)(
-      allocator, &params, external_buffer, out_buffer);
+      allocator, &params, external_buffer, release_callback, out_buffer);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/iree/hal/buffer.h
+++ b/iree/hal/buffer.h
@@ -117,7 +117,7 @@ enum iree_hal_memory_access_bits_t {
                                IREE_HAL_MEMORY_ACCESS_WRITE |
                                IREE_HAL_MEMORY_ACCESS_DISCARD,
 };
-typedef uint32_t iree_hal_memory_access_t;
+typedef uint16_t iree_hal_memory_access_t;
 
 // Bitfield that defines how a buffer is intended to be used.
 // Usage allows the driver to appropriately place the buffer for more
@@ -562,8 +562,11 @@ struct iree_hal_buffer_t {
   iree_hal_allocator_t* device_allocator;
   // TODO(benvanik): bit pack these; could be ~4 bytes vs 12.
   iree_hal_memory_type_t memory_type;
-  iree_hal_memory_access_t allowed_access;
   iree_hal_buffer_usage_t allowed_usage;
+  iree_hal_memory_access_t allowed_access;
+
+  // Implementation-defined flags.
+  uint16_t flags;
 };
 
 IREE_API_EXPORT void iree_hal_buffer_initialize(

--- a/iree/hal/buffer_heap_impl.h
+++ b/iree/hal/buffer_heap_impl.h
@@ -33,30 +33,24 @@ typedef struct iree_hal_heap_allocator_statistics_t {
 iree_status_t iree_hal_heap_buffer_create(
     iree_hal_allocator_t* allocator,
     iree_hal_heap_allocator_statistics_t* statistics,
-    iree_hal_memory_type_t memory_type, iree_hal_memory_access_t allowed_access,
-    iree_hal_buffer_usage_t allowed_usage, iree_device_size_t allocation_size,
-    iree_allocator_t data_allocator, iree_allocator_t host_allocator,
-    iree_hal_buffer_t** out_buffer);
+    const iree_hal_buffer_params_t* params, iree_device_size_t allocation_size,
+    iree_const_byte_span_t initial_data, iree_allocator_t data_allocator,
+    iree_allocator_t host_allocator, iree_hal_buffer_t** out_buffer);
 
 // Wraps an existing host allocation in a buffer.
-// When the buffer is destroyed the provided |data_allocator| will be used to
-// free |data| using iree_allocator_free. Pass iree_allocator_null() to wrap
-// without ownership semantics.
+// When the buffer is destroyed the provided |release_callback| will be called.
 //
-// The buffer must be aligned to at least IREE_HAL_HEAP_BUFFER_ALIGNMENT.
-// Note that it will be freed as a normal unaligned allocation. If we find
-// ourselves wanting to wrap aligned allocations requiring
-// iree_allocator_free_aligned then we'll need a flag to indicate that.
+// The buffer must be aligned to at least IREE_HAL_HEAP_BUFFER_ALIGNMENT and if
+// it is not the call will fail with IREE_STATUS_OUT_OF_RANGE.
 //
-// |out_buffer| must be released by the caller.
-iree_status_t iree_hal_heap_buffer_wrap(iree_hal_allocator_t* allocator,
-                                        iree_hal_memory_type_t memory_type,
-                                        iree_hal_memory_access_t allowed_access,
-                                        iree_hal_buffer_usage_t allowed_usage,
-                                        iree_device_size_t allocation_size,
-                                        iree_byte_span_t data,
-                                        iree_allocator_t data_allocator,
-                                        iree_hal_buffer_t** out_buffer);
+// |out_buffer| must be released by the caller. |data| must be kept live for the
+// lifetime of the wrapping buffer.
+iree_status_t iree_hal_heap_buffer_wrap(
+    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
+    iree_hal_memory_access_t allowed_access,
+    iree_hal_buffer_usage_t allowed_usage, iree_device_size_t allocation_size,
+    iree_byte_span_t data, iree_hal_buffer_release_callback_t release_callback,
+    iree_hal_buffer_t** out_buffer);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/iree/hal/buffer_view_util.c
+++ b/iree/hal/buffer_view_util.c
@@ -199,67 +199,6 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_view_allocate_buffer(
   return status;
 }
 
-IREE_API_EXPORT iree_status_t iree_hal_buffer_view_wrap_heap_buffer(
-    iree_hal_allocator_t* allocator, const iree_hal_dim_t* shape,
-    iree_host_size_t shape_rank, iree_hal_element_type_t element_type,
-    iree_hal_encoding_type_t encoding_type,
-    iree_hal_buffer_params_t buffer_params, iree_byte_span_t data,
-    iree_allocator_t data_allocator, iree_hal_buffer_view_t** out_buffer_view) {
-  IREE_ASSERT_ARGUMENT(allocator);
-  IREE_ASSERT_ARGUMENT(out_buffer_view);
-  IREE_TRACE_ZONE_BEGIN(z0);
-  iree_hal_buffer_params_canonicalize(&buffer_params);
-
-  // NOTE: this will fail if the data cannot be imported into the allocator.
-  iree_hal_buffer_t* buffer = NULL;
-  iree_status_t status = iree_hal_allocator_wrap_buffer(
-      allocator, buffer_params, data, data_allocator, &buffer);
-
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_buffer_view_create(
-        buffer, shape, shape_rank, element_type, encoding_type,
-        iree_hal_allocator_host_allocator(allocator), out_buffer_view);
-  }
-
-  iree_hal_buffer_release(buffer);
-  IREE_TRACE_ZONE_END(z0);
-  return status;
-}
-
-IREE_API_EXPORT iree_status_t iree_hal_buffer_view_wrap_or_clone_heap_buffer(
-    iree_hal_allocator_t* allocator, const iree_hal_dim_t* shape,
-    iree_host_size_t shape_rank, iree_hal_element_type_t element_type,
-    iree_hal_encoding_type_t encoding_type,
-    iree_hal_buffer_params_t buffer_params, iree_byte_span_t data,
-    iree_allocator_t data_allocator, iree_hal_buffer_view_t** out_buffer_view) {
-  IREE_ASSERT_ARGUMENT(allocator);
-  iree_hal_buffer_params_canonicalize(&buffer_params);
-
-  // Not all HAL implementations support wrapping buffers, and of those that do
-  // some may only support it in special situations such as when the buffer is
-  // not DEVICE_VISIBLE. The user application can query whether the wrapping is
-  // possible and decide to use alternative means of upload if it is not; we
-  // make no policy (other than validity) over what's best here.
-  iree_hal_buffer_compatibility_t compatibility =
-      iree_hal_allocator_query_compatibility(
-          allocator,
-          iree_hal_buffer_params_with_usage(buffer_params,
-                                            IREE_HAL_BUFFER_USAGE_MAPPING),
-          (iree_device_size_t)data.data_length);
-  bool wrap_allowed = iree_all_bits_set(
-      compatibility, IREE_HAL_BUFFER_COMPATIBILITY_IMPORTABLE);
-  if (wrap_allowed) {
-    return iree_hal_buffer_view_wrap_heap_buffer(
-        allocator, shape, shape_rank, element_type, encoding_type,
-        buffer_params, data, data_allocator, out_buffer_view);
-  } else {
-    return iree_hal_buffer_view_allocate_buffer(
-        allocator, shape, shape_rank, element_type, encoding_type,
-        buffer_params, iree_make_const_byte_span(data.data, data.data_length),
-        out_buffer_view);
-  }
-}
-
 static iree_status_t iree_hal_buffer_view_generate_buffer_in_situ(
     iree_hal_allocator_t* allocator, const iree_hal_dim_t* shape,
     iree_host_size_t shape_rank, iree_hal_element_type_t element_type,
@@ -320,13 +259,15 @@ static iree_status_t iree_hal_buffer_view_generate_buffer_on_host(
     return status;
   }
 
-  // Try to wrap the host allocation to avoid the extra allocation and copy -
-  // this call will either hang on to the memory or do the copy and immediately
-  // free it.
-  return iree_hal_buffer_view_wrap_or_clone_heap_buffer(
+  // Allocate the buffer with the data we just generated.
+  // We could try importing but that may create buffers that are slower to
+  // access and we want users to opt in to that instead.
+  status = iree_hal_buffer_view_allocate_buffer(
       allocator, shape, shape_rank, element_type, encoding_type, buffer_params,
-      iree_make_byte_span(host_ptr, allocation_size), host_allocator,
-      out_buffer_view);
+      iree_make_const_byte_span(host_ptr, allocation_size), out_buffer_view);
+
+  iree_allocator_free(host_allocator, host_ptr);
+  return status;
 }
 
 IREE_API_EXPORT iree_status_t iree_hal_buffer_view_generate_buffer(

--- a/iree/hal/buffer_view_util.h
+++ b/iree/hal/buffer_view_util.h
@@ -65,41 +65,6 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_view_allocate_buffer(
     iree_hal_buffer_params_t buffer_params, iree_const_byte_span_t initial_data,
     iree_hal_buffer_view_t** out_buffer_view);
 
-// Imports a host buffer using |allocator| and wraps it in a buffer view.
-//
-// This is equivalent to:
-//   1. iree_hal_allocator_wrap_buffer
-//   2. iree_hal_buffer_view_create
-//
-// NOTE: not all buffers can be imported and not all allocators support
-// importing. See iree_hal_allocator_wrap_buffer for more information.
-// Fails if the buffer cannot be imported.
-IREE_API_EXPORT iree_status_t iree_hal_buffer_view_wrap_heap_buffer(
-    iree_hal_allocator_t* allocator, const iree_hal_dim_t* shape,
-    iree_host_size_t shape_rank, iree_hal_element_type_t element_type,
-    iree_hal_encoding_type_t encoding_type,
-    iree_hal_buffer_params_t buffer_params, iree_byte_span_t data,
-    iree_allocator_t data_allocator, iree_hal_buffer_view_t** out_buffer_view);
-
-// Tries to import a host buffer using |allocator| and wrap it in a buffer view.
-// If the buffer cannot be imported then a new buffer will be allocated and the
-// source data will be copied into it.
-//
-// This is equivalent to:
-//   if iree_hal_allocator_query_compatibility ok:
-//     1. iree_hal_allocator_wrap_buffer
-//     2. iree_hal_buffer_view_create
-//   else:
-//     1. iree_hal_allocator_allocate_buffer
-//     2. iree_hal_buffer_write_data
-//     3. iree_hal_buffer_view_create
-IREE_API_EXPORT iree_status_t iree_hal_buffer_view_wrap_or_clone_heap_buffer(
-    iree_hal_allocator_t* allocator, const iree_hal_dim_t* shape,
-    iree_host_size_t shape_rank, iree_hal_element_type_t element_type,
-    iree_hal_encoding_type_t encoding_type,
-    iree_hal_buffer_params_t buffer_params, iree_byte_span_t data,
-    iree_allocator_t data_allocator, iree_hal_buffer_view_t** out_buffer_view);
-
 typedef iree_status_t(IREE_API_PTR* iree_hal_buffer_view_generator_callback_t)(
     iree_hal_buffer_mapping_t* mapping, void* user_data);
 

--- a/iree/hal/cts/buffer_mapping_test.h
+++ b/iree/hal/cts/buffer_mapping_test.h
@@ -540,8 +540,6 @@ TEST_P(buffer_mapping_test, MapRangeWrite) {
   iree_hal_buffer_release(buffer);
 }
 
-// TODO(scotttodd): iree_hal_allocator_wrap_buffer
-
 }  // namespace cts
 }  // namespace hal
 }  // namespace iree

--- a/iree/hal/cuda/cuda_allocator.c
+++ b/iree/hal/cuda/cuda_allocator.c
@@ -153,7 +153,7 @@ static void iree_hal_cuda_buffer_free(iree_hal_cuda_context_wrapper_t* context,
 static iree_status_t iree_hal_cuda_allocator_allocate_buffer(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     const iree_hal_buffer_params_t* IREE_RESTRICT params,
-    iree_host_size_t allocation_size, iree_const_byte_span_t initial_data,
+    iree_device_size_t allocation_size, iree_const_byte_span_t initial_data,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   iree_hal_cuda_allocator_t* allocator =
       iree_hal_cuda_allocator_cast(base_allocator);
@@ -270,19 +270,11 @@ static void iree_hal_cuda_allocator_deallocate_buffer(
   iree_hal_buffer_destroy(base_buffer);
 }
 
-static iree_status_t iree_hal_cuda_allocator_wrap_buffer(
-    iree_hal_allocator_t* IREE_RESTRICT base_allocator,
-    const iree_hal_buffer_params_t* IREE_RESTRICT params, iree_byte_span_t data,
-    iree_allocator_t data_allocator,
-    iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
-  return iree_make_status(IREE_STATUS_UNAVAILABLE,
-                          "wrapping of external buffers not supported");
-}
-
 static iree_status_t iree_hal_cuda_allocator_import_buffer(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     const iree_hal_buffer_params_t* IREE_RESTRICT params,
     iree_hal_external_buffer_t* IREE_RESTRICT external_buffer,
+    iree_hal_buffer_release_callback_t release_callback,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   return iree_make_status(IREE_STATUS_UNAVAILABLE,
                           "importing from external buffers not supported");
@@ -306,7 +298,6 @@ static const iree_hal_allocator_vtable_t iree_hal_cuda_allocator_vtable = {
     .query_compatibility = iree_hal_cuda_allocator_query_compatibility,
     .allocate_buffer = iree_hal_cuda_allocator_allocate_buffer,
     .deallocate_buffer = iree_hal_cuda_allocator_deallocate_buffer,
-    .wrap_buffer = iree_hal_cuda_allocator_wrap_buffer,
     .import_buffer = iree_hal_cuda_allocator_import_buffer,
     .export_buffer = iree_hal_cuda_allocator_export_buffer,
 };

--- a/iree/hal/utils/buffer_transfer.c
+++ b/iree/hal/utils/buffer_transfer.c
@@ -70,8 +70,7 @@ IREE_API_EXPORT iree_status_t iree_hal_device_submit_transfer_range_and_wait(
   if (!source_buffer) {
     // Allocate staging memory with a copy of the host data. We only initialize
     // the portion being transferred.
-    // TODO(benvanik): use wrap_buffer if supported to avoid the
-    // allocation/copy.
+    // TODO(benvanik): use import if supported to avoid the allocation/copy.
     // TODO(benvanik): make this device-local + host-visible? can be better for
     // uploads as we know we are never going to read it back.
     const iree_hal_buffer_params_t source_params = {
@@ -92,8 +91,7 @@ IREE_API_EXPORT iree_status_t iree_hal_device_submit_transfer_range_and_wait(
   if (!target_buffer) {
     // Allocate uninitialized staging memory for the transfer target.
     // We only allocate enough for the portion we are transfering.
-    // TODO(benvanik): use wrap_buffer if supported to avoid the
-    // allocation/copy.
+    // TODO(benvanik): use import if supported to avoid the allocation/copy.
     const iree_hal_buffer_params_t target_params = {
         .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
                 IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,

--- a/iree/hal/vulkan/vma_allocator.cc
+++ b/iree/hal/vulkan/vma_allocator.cc
@@ -233,7 +233,7 @@ iree_hal_vulkan_vma_allocator_query_compatibility(
 static iree_status_t iree_hal_vulkan_vma_allocator_allocate_internal(
     iree_hal_vulkan_vma_allocator_t* IREE_RESTRICT allocator,
     const iree_hal_buffer_params_t* IREE_RESTRICT params,
-    iree_host_size_t allocation_size, iree_const_byte_span_t initial_data,
+    iree_device_size_t allocation_size, iree_const_byte_span_t initial_data,
     VmaAllocationCreateFlags flags,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   // Guard against the corner case where the requested buffer size is 0. The
@@ -353,7 +353,7 @@ static iree_status_t iree_hal_vulkan_vma_allocator_allocate_internal(
 static iree_status_t iree_hal_vulkan_vma_allocator_allocate_buffer(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     const iree_hal_buffer_params_t* IREE_RESTRICT params,
-    iree_host_size_t allocation_size, iree_const_byte_span_t initial_data,
+    iree_device_size_t allocation_size, iree_const_byte_span_t initial_data,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   iree_hal_vulkan_vma_allocator_t* allocator =
       iree_hal_vulkan_vma_allocator_cast(base_allocator);
@@ -369,21 +369,13 @@ static void iree_hal_vulkan_vma_allocator_deallocate_buffer(
   iree_hal_buffer_destroy(base_buffer);
 }
 
-static iree_status_t iree_hal_vulkan_vma_allocator_wrap_buffer(
-    iree_hal_allocator_t* IREE_RESTRICT base_allocator,
-    const iree_hal_buffer_params_t* IREE_RESTRICT params, iree_byte_span_t data,
-    iree_allocator_t data_allocator,
-    iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
-  // TODO(#7242): use VK_EXT_external_memory_host to import memory.
-  return iree_make_status(IREE_STATUS_UNAVAILABLE,
-                          "wrapping of external buffers not supported");
-}
-
 static iree_status_t iree_hal_vulkan_vma_allocator_import_buffer(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     const iree_hal_buffer_params_t* IREE_RESTRICT params,
     iree_hal_external_buffer_t* IREE_RESTRICT external_buffer,
+    iree_hal_buffer_release_callback_t release_callback,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
+  // TODO(#7242): use VK_EXT_external_memory_host to import memory.
   return iree_make_status(IREE_STATUS_UNAVAILABLE,
                           "importing from external buffers not supported");
 }
@@ -408,7 +400,6 @@ const iree_hal_allocator_vtable_t iree_hal_vulkan_vma_allocator_vtable = {
     iree_hal_vulkan_vma_allocator_query_compatibility,
     /*.allocate_buffer=*/iree_hal_vulkan_vma_allocator_allocate_buffer,
     /*.deallocate_buffer=*/iree_hal_vulkan_vma_allocator_deallocate_buffer,
-    /*.wrap_buffer=*/iree_hal_vulkan_vma_allocator_wrap_buffer,
     /*.import_buffer=*/iree_hal_vulkan_vma_allocator_import_buffer,
     /*.export_buffer=*/iree_hal_vulkan_vma_allocator_export_buffer,
 };

--- a/iree/runtime/demo/hello_world_explained.c
+++ b/iree/runtime/demo/hello_world_explained.c
@@ -191,9 +191,8 @@ static iree_status_t iree_runtime_demo_perform_mul(
     iree_hal_buffer_view_t* arg0 = NULL;
     if (iree_status_is_ok(status)) {
       static const iree_hal_dim_t arg0_shape[1] = {4};
-      static const float iree_alignas(64)
-          arg0_data[4] = {1.0f, 1.1f, 1.2f, 1.3f};
-      status = iree_hal_buffer_view_wrap_or_clone_heap_buffer(
+      static const float arg0_data[4] = {1.0f, 1.1f, 1.2f, 1.3f};
+      status = iree_hal_buffer_view_allocate_buffer(
           device_allocator,
           // Shape dimensions and rank:
           arg0_shape, IREE_ARRAYSIZE(arg0_shape),
@@ -211,8 +210,7 @@ static iree_status_t iree_runtime_demo_perform_mul(
               .usage = IREE_HAL_BUFFER_USAGE_ALL,
           },
           // The actual heap buffer to wrap or clone and its allocator:
-          iree_make_byte_span((void*)arg0_data, sizeof(arg0_data)),
-          iree_allocator_null(),
+          iree_make_const_byte_span(arg0_data, sizeof(arg0_data)),
           // Buffer view + storage are returned and owned by the caller:
           &arg0);
     }
@@ -231,9 +229,8 @@ static iree_status_t iree_runtime_demo_perform_mul(
     iree_hal_buffer_view_t* arg1 = NULL;
     if (iree_status_is_ok(status)) {
       static const iree_hal_dim_t arg1_shape[1] = {4};
-      static const float iree_alignas(64)
-          arg1_data[4] = {10.0f, 100.0f, 1000.0f, 10000.0f};
-      status = iree_hal_buffer_view_wrap_or_clone_heap_buffer(
+      static const float arg1_data[4] = {10.0f, 100.0f, 1000.0f, 10000.0f};
+      status = iree_hal_buffer_view_allocate_buffer(
           device_allocator, arg1_shape, IREE_ARRAYSIZE(arg1_shape),
           IREE_HAL_ELEMENT_TYPE_FLOAT_32,
           IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
@@ -243,8 +240,7 @@ static iree_status_t iree_runtime_demo_perform_mul(
               .access = IREE_HAL_MEMORY_ACCESS_READ,
               .usage = IREE_HAL_BUFFER_USAGE_ALL,
           },
-          iree_make_byte_span((void*)arg1_data, sizeof(arg1_data)),
-          iree_allocator_null(), &arg1);
+          iree_make_const_byte_span(arg1_data, sizeof(arg1_data)), &arg1);
     }
     if (iree_status_is_ok(status)) {
       IREE_IGNORE_ERROR(iree_hal_buffer_view_fprint(

--- a/iree/runtime/demo/hello_world_terse.c
+++ b/iree/runtime/demo/hello_world_terse.c
@@ -78,9 +78,8 @@ static void iree_runtime_demo_perform_mul(iree_runtime_session_t* session) {
   // %arg0: tensor<4xf32>
   iree_hal_buffer_view_t* arg0 = NULL;
   static const iree_hal_dim_t arg0_shape[1] = {4};
-  static const float iree_alignas(IREE_HAL_HEAP_BUFFER_ALIGNMENT)
-      arg0_data[4] = {1.0f, 1.1f, 1.2f, 1.3f};
-  IREE_CHECK_OK(iree_hal_buffer_view_wrap_or_clone_heap_buffer(
+  static const float arg0_data[4] = {1.0f, 1.1f, 1.2f, 1.3f};
+  IREE_CHECK_OK(iree_hal_buffer_view_allocate_buffer(
       iree_runtime_session_device_allocator(session), arg0_shape,
       IREE_ARRAYSIZE(arg0_shape), IREE_HAL_ELEMENT_TYPE_FLOAT_32,
       IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
@@ -90,8 +89,7 @@ static void iree_runtime_demo_perform_mul(iree_runtime_session_t* session) {
           .access = IREE_HAL_MEMORY_ACCESS_READ,
           .usage = IREE_HAL_BUFFER_USAGE_ALL,
       },
-      iree_make_byte_span((void*)arg0_data, sizeof(arg0_data)),
-      iree_allocator_null(), &arg0));
+      iree_make_const_byte_span(arg0_data, sizeof(arg0_data)), &arg0));
   IREE_CHECK_OK(iree_hal_buffer_view_fprint(
       stdout, arg0, /*max_element_count=*/4096,
       iree_runtime_session_host_allocator(session)));
@@ -103,9 +101,8 @@ static void iree_runtime_demo_perform_mul(iree_runtime_session_t* session) {
   // %arg1: tensor<4xf32>
   iree_hal_buffer_view_t* arg1 = NULL;
   static const iree_hal_dim_t arg1_shape[1] = {4};
-  static const float iree_alignas(IREE_HAL_HEAP_BUFFER_ALIGNMENT)
-      arg1_data[4] = {10.0f, 100.0f, 1000.0f, 10000.0f};
-  IREE_CHECK_OK(iree_hal_buffer_view_wrap_or_clone_heap_buffer(
+  static const float arg1_data[4] = {10.0f, 100.0f, 1000.0f, 10000.0f};
+  IREE_CHECK_OK(iree_hal_buffer_view_allocate_buffer(
       iree_runtime_session_device_allocator(session), arg1_shape,
       IREE_ARRAYSIZE(arg1_shape), IREE_HAL_ELEMENT_TYPE_FLOAT_32,
       IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
@@ -115,8 +112,7 @@ static void iree_runtime_demo_perform_mul(iree_runtime_session_t* session) {
           .access = IREE_HAL_MEMORY_ACCESS_READ,
           .usage = IREE_HAL_BUFFER_USAGE_ALL,
       },
-      iree_make_byte_span((void*)arg1_data, sizeof(arg1_data)),
-      iree_allocator_null(), &arg1));
+      iree_make_const_byte_span(arg1_data, sizeof(arg1_data)), &arg1));
   IREE_CHECK_OK(iree_hal_buffer_view_fprint(
       stdout, arg1, /*max_element_count=*/4096,
       iree_runtime_session_host_allocator(session)));

--- a/iree/samples/custom_modules/custom_modules_test.cc
+++ b/iree/samples/custom_modules/custom_modules_test.cc
@@ -131,19 +131,19 @@ TEST_F(CustomModulesTest, ReverseAndPrint) {
 TEST_F(CustomModulesTest, PrintTensor) {
   // Allocate the buffer we'll be printing.
   static iree_hal_dim_t kShape[] = {2, 4};
-  static float iree_alignas(IREE_HAL_HEAP_BUFFER_ALIGNMENT)
-      kBufferContents[2 * 4] = {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f};
+  static const float kBufferContents[2 * 4] = {0.0f, 1.0f, 2.0f, 3.0f,
+                                               4.0f, 5.0f, 6.0f, 7.0f};
   iree_hal_buffer_params_t params = {0};
   params.type =
       IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
   params.usage = IREE_HAL_BUFFER_USAGE_ALL;
   iree_hal_buffer_view_t* buffer_view = nullptr;
-  IREE_ASSERT_OK(iree_hal_buffer_view_wrap_or_clone_heap_buffer(
+  IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer(
       hal_allocator_, kShape, IREE_ARRAYSIZE(kShape),
       IREE_HAL_ELEMENT_TYPE_FLOAT_32, IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
       params,
-      iree_make_byte_span((void*)kBufferContents, sizeof(kBufferContents)),
-      iree_allocator_null(), &buffer_view));
+      iree_make_const_byte_span(kBufferContents, sizeof(kBufferContents)),
+      &buffer_view));
 
   // Pass in the tensor as an expanded HAL buffer.
   iree::vm::ref<iree_vm_list_t> inputs;
@@ -179,19 +179,19 @@ TEST_F(CustomModulesTest, PrintTensor) {
 TEST_F(CustomModulesTest, RoundTripTensor) {
   // Allocate the buffer we'll be printing/parsing.
   static iree_hal_dim_t kShape[] = {2, 4};
-  static float iree_alignas(IREE_HAL_HEAP_BUFFER_ALIGNMENT)
-      kBufferContents[2 * 4] = {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f};
+  static const float kBufferContents[2 * 4] = {0.0f, 1.0f, 2.0f, 3.0f,
+                                               4.0f, 5.0f, 6.0f, 7.0f};
   iree_hal_buffer_params_t params = {0};
   params.type =
       IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
   params.usage = IREE_HAL_BUFFER_USAGE_ALL;
   iree_hal_buffer_view_t* buffer_view = nullptr;
-  IREE_ASSERT_OK(iree_hal_buffer_view_wrap_or_clone_heap_buffer(
+  IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer(
       hal_allocator_, kShape, IREE_ARRAYSIZE(kShape),
       IREE_HAL_ELEMENT_TYPE_FLOAT_32, IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
       params,
-      iree_make_byte_span((void*)kBufferContents, sizeof(kBufferContents)),
-      iree_allocator_null(), &buffer_view));
+      iree_make_const_byte_span(kBufferContents, sizeof(kBufferContents)),
+      &buffer_view));
 
   // Pass in the tensor as an expanded HAL buffer.
   iree::vm::ref<iree_vm_list_t> inputs;

--- a/iree/samples/dynamic_shapes/main.c
+++ b/iree/samples/dynamic_shapes/main.c
@@ -17,8 +17,6 @@ iree_status_t reduce_sum_1d(iree_runtime_session_t* session, const int* values,
   iree_hal_buffer_view_t* arg0 = NULL;
   const iree_hal_dim_t arg0_shape[1] = {values_length};
 
-  // TODO(scotttodd): use iree_hal_buffer_view_wrap_or_clone_heap_buffer
-  //   * debugging some apparent memory corruption with the stack-local value
   iree_status_t status = iree_ok_status();
   if (iree_status_is_ok(status)) {
     status = iree_hal_buffer_view_allocate_buffer(
@@ -66,8 +64,6 @@ iree_status_t reduce_sum_2d(iree_runtime_session_t* session, const int* values,
   iree_hal_buffer_view_t* arg0 = NULL;
   const iree_hal_dim_t arg0_shape[2] = {values_length / 3, 3};
 
-  // TODO(scotttodd): use iree_hal_buffer_view_wrap_or_clone_heap_buffer
-  //   * debugging some apparent memory corruption with the stack-local value
   iree_status_t status = iree_ok_status();
   if (iree_status_is_ok(status)) {
     status = iree_hal_buffer_view_allocate_buffer(
@@ -109,8 +105,6 @@ iree_status_t add_one(iree_runtime_session_t* session, const int* values,
   iree_hal_buffer_view_t* arg0 = NULL;
   const iree_hal_dim_t arg0_shape[1] = {values_length};
 
-  // TODO(scotttodd): use iree_hal_buffer_view_wrap_or_clone_heap_buffer
-  //   * debugging some apparent memory corruption with the stack-local value
   iree_status_t status = iree_ok_status();
   if (iree_status_is_ok(status)) {
     status = iree_hal_buffer_view_allocate_buffer(

--- a/iree/samples/variables_and_state/main.c
+++ b/iree/samples/variables_and_state/main.c
@@ -42,8 +42,6 @@ iree_status_t counter_set_value(iree_runtime_session_t* session,
   iree_hal_buffer_view_t* arg0 = NULL;
   int arg0_data[1] = {new_value};
 
-  // TODO(scotttodd): use iree_hal_buffer_view_wrap_or_clone_heap_buffer
-  //   * debugging some apparent memory corruption with the stack-local value
   iree_status_t status = iree_ok_status();
   if (iree_status_is_ok(status)) {
     status = iree_hal_buffer_view_allocate_buffer(
@@ -77,8 +75,6 @@ iree_status_t counter_add_to_value(iree_runtime_session_t* session, int x) {
   iree_hal_buffer_view_t* arg0 = NULL;
   int arg0_data[1] = {x};
 
-  // TODO(scotttodd): use iree_hal_buffer_view_wrap_or_clone_heap_buffer
-  //   * debugging some apparent memory corruption with the stack-local value
   iree_status_t status = iree_ok_status();
   if (iree_status_is_ok(status)) {
     status = iree_hal_buffer_view_allocate_buffer(

--- a/iree/tools/utils/image_util.c
+++ b/iree/tools/utils/image_util.c
@@ -135,7 +135,7 @@ iree_status_t iree_tools_utils_buffer_view_from_image(
     iree_host_size_t element_byte =
         iree_hal_element_dense_byte_count(element_type);
     // SINT_8 and UINT_8 perform direct buffer wrap.
-    result = iree_hal_buffer_view_wrap_or_clone_heap_buffer(
+    result = iree_hal_buffer_view_allocate_buffer(
         allocator, shape, shape_rank, element_type,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
@@ -144,8 +144,8 @@ iree_status_t iree_tools_utils_buffer_view_from_image(
             .access = IREE_HAL_MEMORY_ACCESS_READ,
             .usage = IREE_HAL_BUFFER_USAGE_ALL,
         },
-        iree_make_byte_span((void*)pixel_data, element_byte * buffer_length),
-        iree_allocator_null(), out_buffer_view);
+        iree_make_const_byte_span(pixel_data, element_byte * buffer_length),
+        out_buffer_view);
   }
   stbi_image_free(pixel_data);
   IREE_TRACE_ZONE_END(z0);


### PR DESCRIPTION
This removes the special case wrapping path that only made sense for local host devices.

Fixes #8535.