### PR TITLE
Bumping HAL buffer alignment 64->128.

### DIFF
--- a/iree/base/config.h
+++ b/iree/base/config.h
@@ -160,7 +160,7 @@ typedef IREE_DEVICE_SIZE_T iree_device_size_t;
 // Executables are compiled with alignment expectations and the runtime
 // alignment must be greater than or equal to the alignment set in the compiler.
 // External buffers wrapped by HAL buffers must meet this alignment requirement.
-#define IREE_HAL_HEAP_BUFFER_ALIGNMENT 64
+#define IREE_HAL_HEAP_BUFFER_ALIGNMENT 128
 #endif  // IREE_HAL_HEAP_BUFFER_ALIGNMENT
 
 #if !defined(IREE_HAL_COMMAND_BUFFER_VALIDATION_ENABLE)

--- a/iree/compiler/Dialect/Stream/IR/StreamTypes.cpp
+++ b/iree/compiler/Dialect/Stream/IR/StreamTypes.cpp
@@ -42,8 +42,8 @@ static llvm::cl::opt<Favor> partitioningFavor(
 // TODO(#8506): remove the flag once the bug is fixed.
 static llvm::cl::opt<uint64_t> streamDefaultBufferAlignment(
     "iree-stream-default-buffer-alignment",
-    llvm::cl::desc("the default value of stream alignment"),
-    llvm::cl::init(64ull));
+    llvm::cl::desc("Default buffer alignment for stream buffer resources."),
+    llvm::cl::init(128ull));
 
 //===----------------------------------------------------------------------===//
 // #stream.resource_config<...>


### PR DESCRIPTION
Trying to see if this helps any benchmarks but we aren't tracking any of the devices that would be most sensitive to it (x64 with AVX & co) so I doubt we'll see anything.