### PR TITLE
Fix CUDA options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ cmake_dependent_option(IREE_ENABLE_EMITC "Enables MLIR EmitC dependencies." ON $
 
 option(IREE_HAL_DRIVER_DEFAULTS "Sets the default value for all runtime HAL drivers" ON)
 # CUDA support must be explicitly enabled.
-set(IREE_HAL_DRIVER_CUDA_DEFAULT OFF)
+option(IREE_HAL_DRIVER_CUDA_DEFAULT OFF)
 
 # Vulkan is not natively supported on Apple platforms.
 # Metal should generally be used instead, though MoltenVK may also work.


### PR DESCRIPTION
Use option instead of set. set prevents turning it on reliably

TEST: Verify cuda backend is built when IREE_HAL_DRIVER_CUDA_DEFAULT=ON