### PR TITLE
Disable Vulkan lit tests under ASan due to flaky crashes.

### DIFF
--- a/build_tools/bazel/build_core.sh
+++ b/build_tools/bazel/build_core.sh
@@ -13,7 +13,9 @@
 # Looks at environment variables and uses CI-friendly defaults if they are not
 # set.
 # IREE_LLVMAOT_DISABLE: Do not run tests that require LLVM-AOT. Default: 0
-# IREE_VULKAN_DISABLE: Do not run tests that require Vulkan. Default: 1
+# IREE_VULKAN_DISABLE: Do not run lit tests that require Vulkan. Default: 0
+# IREE_VULKAN_DISABLE_RUNTIME: Do not run runtime tests that require Vulkan.
+#   Default: 0
 # BUILD_TAG_FILTERS: Passed to bazel to filter targets to build.
 #   See https://docs.bazel.build/versions/master/command-line-reference.html#flag--build_tag_filters)
 #   Default: "-nokokoro"
@@ -30,6 +32,9 @@ if ! [[ -v IREE_LLVMAOT_DISABLE ]]; then
 fi
 if ! [[ -v IREE_VULKAN_DISABLE ]]; then
   IREE_VULKAN_DISABLE=0
+fi
+if ! [[ -v IREE_VULKAN_DISABLE_RUNTIME ]]; then
+  IREE_VULKAN_DISABLE_RUNTIME=0
 fi
 
 declare -a test_env_args=(
@@ -56,7 +61,7 @@ default_test_tag_filters+=("-vulkan_uses_vk_khr_shader_float16_int8")
 # CUDA CI testing disabled until we setup a target for it.
 default_test_tag_filters+=("-driver=cuda")
 
-if [[ "${IREE_VULKAN_DISABLE?}" == 1 ]]; then
+if [[ "${IREE_VULKAN_DISABLE_RUNTIME?}" == 1 ]]; then
   default_test_tag_filters+=("-driver=vulkan")
 fi
 if [[ "${IREE_LLVMAOT_DISABLE?}" == 1 ]]; then

--- a/build_tools/cmake/test.sh
+++ b/build_tools/cmake/test.sh
@@ -20,6 +20,7 @@ export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-$(nproc)}
 
 # Respect the user setting, but default to turning on vulkan and llvmaot.
 export IREE_VULKAN_DISABLE=${IREE_VULKAN_DISABLE:-0}
+export IREE_VULKAN_DISABLE_RUNTIME=${IREE_VULKAN_DISABLE_RUNTIME:-0}
 export IREE_LLVMAOT_DISABLE=${IREE_LLVMAOT_DISABLE:-0}
 # CUDA is off by default.
 export IREE_CUDA_DISABLE=${IREE_CUDA_DISABLE:-1}
@@ -49,7 +50,7 @@ declare -a label_exclude_args=(
   #   ^bindings/
 )
 
-if [[ "${IREE_VULKAN_DISABLE?}" == 1 ]]; then
+if [[ "${IREE_VULKAN_DISABLE_RUNTIME?}" == 1 ]]; then
   label_exclude_args+=("^driver=vulkan$")
 fi
 if [[ "${IREE_LLVMAOT_DISABLE?}" == 1 ]]; then

--- a/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader-asan/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader-asan/build.sh
@@ -52,10 +52,11 @@ echo "------------------"
 # Respect the user setting, but default to as many jobs as we have cores.
 export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-$(nproc)}
 
-# Respect the user setting, but default to turning off the vulkan tests
+# Respect the user setting, but default to turning off the vulkan lit tests
 # and turning on the llvmaot ones.
 # TODO(#5716): Fix and enable Vulkan lit tests.
 export IREE_VULKAN_DISABLE=${IREE_VULKAN_DISABLE:-1}
+export IREE_VULKAN_DISABLE_RUNTIME=${IREE_VULKAN_DISABLE_RUNTIME:-0}
 export IREE_LLVMAOT_DISABLE=${IREE_LLVMAOT_DISABLE:-0}
 # CUDA is off by default.
 export IREE_CUDA_DISABLE=${IREE_CUDA_DISABLE:-1}
@@ -85,7 +86,7 @@ declare -a label_exclude_args=(
   #   ^bindings/
 )
 
-if [[ "${IREE_VULKAN_DISABLE?}" == 1 ]]; then
+if [[ "${IREE_VULKAN_DISABLE_RUNTIME?}" == 1 ]]; then
   label_exclude_args+=("^driver=vulkan$")
 fi
 if [[ "${IREE_LLVMAOT_DISABLE?}" == 1 ]]; then

--- a/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader-asan/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader-asan/build.sh
@@ -52,8 +52,10 @@ echo "------------------"
 # Respect the user setting, but default to as many jobs as we have cores.
 export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-$(nproc)}
 
-# Respect the user setting, but default to turning on vulkan and llvmaot.
-export IREE_VULKAN_DISABLE=${IREE_VULKAN_DISABLE:-0}
+# Respect the user setting, but default to turning off the vulkan tests
+# and turning on the llvmaot ones.
+# TODO(#5716): Fix and enable Vulkan lit tests.
+export IREE_VULKAN_DISABLE=${IREE_VULKAN_DISABLE:-1}
 export IREE_LLVMAOT_DISABLE=${IREE_LLVMAOT_DISABLE:-0}
 # CUDA is off by default.
 export IREE_CUDA_DISABLE=${IREE_CUDA_DISABLE:-1}
@@ -105,9 +107,6 @@ label_exclude_regex="($(IFS="|" ; echo "${label_exclude_args[*]?}"))"
 declare -a excluded_tests=(
   # Mysterious "LeakSanitizer has encountered a fatal error." crashes
   "iree/samples/simple_embedding/simple_embedding_vulkan_test"
-  "iree/tools/test/iree-benchmark-module.mlir.test"
-  "iree/tools/test/iree-run-module.mlir.test"
-  "iree/tools/test/multiple_exported_functions.mlir.test"
 )
 
 # Prefix with `^` anchor


### PR DESCRIPTION
After https://github.com/google/iree/pull/8489 there are some other crashes ([logs here](https://source.cloud.google.com/results/invocations/0e50997d-c8b7-46d9-aca9-665fee3309f9/targets/iree%2Fgcp_ubuntu%2Fcmake%2Flinux%2Fx86-swiftshader-asan%2Fmain/log)). This should disable lit tests that use Vulkan while still running the tests under `iree/hal/vulkan/`.

See https://github.com/google/iree/issues/5716