### PR TITLE
Revert enabling Vulkan ASan tests, with cleanup.

### DIFF
--- a/build_tools/bazel/build_core.sh
+++ b/build_tools/bazel/build_core.sh
@@ -13,7 +13,7 @@
 # Looks at environment variables and uses CI-friendly defaults if they are not
 # set.
 # IREE_LLVMAOT_DISABLE: Do not run tests that require LLVM-AOT. Default: 0
-# IREE_VULKAN_DISABLE: Do not run tests that require Vulkan. Default: 1
+# IREE_VULKAN_DISABLE: Do not run tests that require Vulkan. Default: 0
 # BUILD_TAG_FILTERS: Passed to bazel to filter targets to build.
 #   See https://docs.bazel.build/versions/master/command-line-reference.html#flag--build_tag_filters)
 #   Default: "-nokokoro"

--- a/build_tools/cmake/test.sh
+++ b/build_tools/cmake/test.sh
@@ -18,7 +18,8 @@ fi
 # Respect the user setting, but default to as many jobs as we have cores.
 export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-$(nproc)}
 
-# Respect the user setting, but default to turning on vulkan and llvmaot.
+# Respect the user setting, but default to turning off the vulkan tests
+# and turning on the llvmaot ones.
 export IREE_VULKAN_DISABLE=${IREE_VULKAN_DISABLE:-0}
 export IREE_LLVMAOT_DISABLE=${IREE_LLVMAOT_DISABLE:-0}
 # CUDA is off by default.

--- a/build_tools/cmake/test.sh
+++ b/build_tools/cmake/test.sh
@@ -18,8 +18,7 @@ fi
 # Respect the user setting, but default to as many jobs as we have cores.
 export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-$(nproc)}
 
-# Respect the user setting, but default to turning off the vulkan tests
-# and turning on the llvmaot ones.
+# Respect the user setting, but default to turning on vulkan and llvmaot.
 export IREE_VULKAN_DISABLE=${IREE_VULKAN_DISABLE:-0}
 export IREE_LLVMAOT_DISABLE=${IREE_LLVMAOT_DISABLE:-0}
 # CUDA is off by default.

--- a/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader-asan/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader-asan/build.sh
@@ -52,8 +52,10 @@ echo "------------------"
 # Respect the user setting, but default to as many jobs as we have cores.
 export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-$(nproc)}
 
-# Respect the user setting, but default to turning on vulkan and llvmaot.
-export IREE_VULKAN_DISABLE=${IREE_VULKAN_DISABLE:-0}
+# Respect the user setting, but default to turning off the vulkan tests
+# and turning on the llvmaot ones.
+# TODO(#5716): Fix and enable Vulkan tests.
+export IREE_VULKAN_DISABLE=${IREE_VULKAN_DISABLE:-1}
 export IREE_LLVMAOT_DISABLE=${IREE_LLVMAOT_DISABLE:-0}
 # CUDA is off by default.
 export IREE_CUDA_DISABLE=${IREE_CUDA_DISABLE:-1}
@@ -103,11 +105,7 @@ label_exclude_regex="($(IFS="|" ; echo "${label_exclude_args[*]?}"))"
 # These tests currently have asan failures
 # TODO(#5715): Fix these
 declare -a excluded_tests=(
-  # Mysterious "LeakSanitizer has encountered a fatal error." crashes
   "iree/samples/simple_embedding/simple_embedding_vulkan_test"
-  "iree/tools/test/iree-benchmark-module.mlir.test"
-  "iree/tools/test/iree-run-module.mlir.test"
-  "iree/tools/test/multiple_exported_functions.mlir.test"
 )
 
 # Prefix with `^` anchor
@@ -122,5 +120,5 @@ cd ${CMAKE_BUILD_DIR?}
 
 echo "Testing with ctest"
 ctest --timeout 900 --output-on-failure \
-  --label-exclude "${label_exclude_regex}" \
+  --label-exclude "^driver=cuda$|^driver=vulkan$" \
   --exclude-regex "${excluded_tests_regex?}"

--- a/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader-asan/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader-asan/build.sh
@@ -120,5 +120,5 @@ cd ${CMAKE_BUILD_DIR?}
 
 echo "Testing with ctest"
 ctest --timeout 900 --output-on-failure \
-  --label-exclude "^driver=cuda$|^driver=vulkan$" \
+  --label-exclude "${label_exclude_regex}" \
   --exclude-regex "${excluded_tests_regex?}"


### PR DESCRIPTION
Attempt #2 at https://github.com/google/iree/pull/8545, with less forward-looking changes :/