### PR TITLE
Use Moto Edge X30 instead of Pixel 4 for Adreno GPU testing

### DIFF
--- a/build_tools/buildkite/cmake/android/arm64-v8a/pipeline.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/pipeline.yml
@@ -41,7 +41,7 @@ steps:
       - "find build-android/ -name '*.cmake' -exec sed -i \"s!\\$IREE_DOCKER_WORKDIR/!\\$PWD/!g\" {} \\;"
       - "cd build-android/"
       # Pixel 4 ships an old Adreno GPU driver. There are quite a few bugs triggered by our tests.
-      # Disable running Pixel 4 tests entirely on Pixel 4. Moto Edge X30 gets us covered on Adreno GPU.
+      # Disable running tests entirely on Pixel 4. Moto Edge X30 gets us covered on Adreno GPU.
       - "ctest --timeout 900 --output-on-failure --label-exclude \"vulkan\""
     agents:
       - "android-soc=snapdragon-855"

--- a/build_tools/buildkite/cmake/android/arm64-v8a/pipeline.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/pipeline.yml
@@ -33,6 +33,23 @@ steps:
       IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
     timeout_in_minutes: "15"
 
+  - label: "test on Pixel 4 (snapdragon-855, adreno-640)"
+    commands:
+      - "git clean -fdx"
+      - "buildkite-agent artifact download --step build build-artifacts.tgz ./"
+      - "tar xzf build-artifacts.tgz"
+      - "find build-android/ -name '*.cmake' -exec sed -i \"s!\\$IREE_DOCKER_WORKDIR/!\\$PWD/!g\" {} \\;"
+      - "cd build-android/"
+      # Pixel 4 ships an old Adreno GPU driver. There are quite a few bugs triggered by our tests.
+      # Disable running Pixel 4 tests entirely on Pixel 4. Moto Edge X30 gets us covered on Adreno GPU.
+      - "ctest --timeout 900 --output-on-failure --label-exclude \"vulkan\""
+    agents:
+      - "android-soc=snapdragon-855"
+      - "queue=test-android"
+    env:
+      IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
+    timeout_in_minutes: "15"
+
   - label: "test on Moto Edge X30 (snapdragon-8gen1, adreno-730)"
     commands:
       - "git clean -fdx"
@@ -40,9 +57,7 @@ steps:
       - "tar xzf build-artifacts.tgz"
       - "find build-android/ -name '*.cmake' -exec sed -i \"s!\\$IREE_DOCKER_WORKDIR/!\\$PWD/!g\" {} \\;"
       - "cd build-android/"
-      # vulkan tests using khr_shader_float16_int8 are failing on pixel4.
-      # Disabling it until we identify the root cause.
-      - "ctest --timeout 900 --output-on-failure --label-exclude \"^vulkan_uses_vk_khr_shader_float16_int8\\$\""
+      - "ctest --timeout 900 --output-on-failure"
     agents:
       - "android-soc=snapdragon-8gen1"
       - "queue=test-android"

--- a/build_tools/buildkite/cmake/android/arm64-v8a/pipeline.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/pipeline.yml
@@ -33,7 +33,7 @@ steps:
       IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
     timeout_in_minutes: "15"
 
-  - label: "test on Pixel 4 (snapdragon-855, adreno-640)"
+  - label: "test on Moto Edge X30 (snapdragon-8gen1, adreno-730)"
     commands:
       - "git clean -fdx"
       - "buildkite-agent artifact download --step build build-artifacts.tgz ./"
@@ -44,7 +44,7 @@ steps:
       # Disabling it until we identify the root cause.
       - "ctest --timeout 900 --output-on-failure --label-exclude \"^vulkan_uses_vk_khr_shader_float16_int8\\$\""
     agents:
-      - "android-soc=snapdragon-855"
+      - "android-soc=snapdragon-8gen1"
       - "queue=test-android"
     env:
       IREE_DOCKER_WORKDIR: "/usr/src/github/iree"


### PR DESCRIPTION
Pixel 4 has an ancient Adreno GPU driver that carries a few
known bugs triggered by our tests. Use Moto Edge X30,
which as a much recent driver, for Vulkan testing.