### PR TITLE
Remove extra parameter to iree_hal_cuda_buffer_wrap.

### DIFF
--- a/iree/hal/cuda/cuda_allocator.c
+++ b/iree/hal/cuda/cuda_allocator.c
@@ -222,8 +222,8 @@ static iree_status_t iree_hal_cuda_allocator_allocate_buffer(
   iree_hal_buffer_t* buffer = NULL;
   if (iree_status_is_ok(status)) {
     status = iree_hal_cuda_buffer_wrap(
-        allocator->base_device, base_allocator, memory_type, params->access,
-        params->usage, allocation_size,
+        base_allocator, memory_type, params->access, params->usage,
+        allocation_size,
         /*byte_offset=*/0,
         /*byte_length=*/allocation_size, device_ptr, host_ptr, &buffer);
   }


### PR DESCRIPTION
Fixes the compile warning/error reported at https://github.com/google/iree/pull/8556#discussion_r828400899

(tested locally by building and running the CUDA HAL CTS tests, triggered the CUDA CI manually as it is post-submit only by default)