### PR TITLE
Advance upstream forks every hour

### DIFF
--- a/.github/workflows/advance_upstream_forks.yml
+++ b/.github/workflows/advance_upstream_forks.yml
@@ -7,9 +7,9 @@
 name: Advance Upstream Forks
 
 on:
-  # TODO(gcmn): Enable cron once this is stable
-  # schedule:
-  #   - cron: '0 10 * * *'
+  schedule:
+    # Every hour
+    - cron: '0 * * * *'
 
   workflow_dispatch:
 


### PR DESCRIPTION
This is stable. Doing this every hour seems reasonable, since it's not
too expensive and it means that whoever's integrating will likely have
a recent baseline to work with.