### PR TITLE
Expose missing register functions in compiler CAPI

### DIFF
--- a/llvm-external-projects/iree-compiler-api/BUILD.bazel
+++ b/llvm-external-projects/iree-compiler-api/BUILD.bazel
@@ -71,6 +71,7 @@ cc_library(
         "//iree/compiler/InputConversion/TOSA",
         "//iree/compiler/Pipelines",
         "//iree/compiler/Utils",
+        "//iree/tools:init_passes_and_dialects",
         "//iree/tools:init_targets",
         "//iree/tools:iree_translate_lib",
         "@llvm-project//lld:COFF",

--- a/llvm-external-projects/iree-compiler-api/include/iree-compiler-c/Compiler.h
+++ b/llvm-external-projects/iree-compiler-api/include/iree-compiler-c/Compiler.h
@@ -29,8 +29,6 @@ DEFINE_C_API_STRUCT(IreeCompilerOptions, void);
 
 MLIR_CAPI_EXPORTED void ireeCompilerRegisterAllDialects(MlirContext context);
 MLIR_CAPI_EXPORTED void ireeCompilerRegisterAllPasses();
-MLIR_CAPI_EXPORTED void ireeCompilerRegisterAllIREETranslations();
-MLIR_CAPI_EXPORTED void ireeCompilerRegisterVMTargets();
 MLIR_CAPI_EXPORTED void ireeCompilerRegisterTargetBackends();
 
 //===----------------------------------------------------------------------===//

--- a/llvm-external-projects/iree-compiler-api/include/iree-compiler-c/Compiler.h
+++ b/llvm-external-projects/iree-compiler-api/include/iree-compiler-c/Compiler.h
@@ -27,6 +27,10 @@ DEFINE_C_API_STRUCT(IreeCompilerOptions, void);
 // Registration.
 //===----------------------------------------------------------------------===//
 
+MLIR_CAPI_EXPORTED void ireeCompilerRegisterAllDialects(MlirContext context);
+MLIR_CAPI_EXPORTED void ireeCompilerRegisterAllPasses();
+MLIR_CAPI_EXPORTED void ireeCompilerRegisterAllIREETranslations();
+MLIR_CAPI_EXPORTED void ireeCompilerRegisterVMTargets();
 MLIR_CAPI_EXPORTED void ireeCompilerRegisterTargetBackends();
 
 //===----------------------------------------------------------------------===//

--- a/llvm-external-projects/iree-compiler-api/lib/CAPI/CMakeLists.txt
+++ b/llvm-external-projects/iree-compiler-api/lib/CAPI/CMakeLists.txt
@@ -32,6 +32,9 @@ add_mlir_public_c_api_library(IREECompilerAPICompilerCAPI
     iree::compiler::Dialect::VM::Target::Bytecode::Bytecode
     iree::compiler::Pipelines
 
+    # Passes and dialects.
+    iree::tools::init_passes_and_dialects
+
     # All HAL Targets.
     iree::tools::init_targets
 

--- a/llvm-external-projects/iree-compiler-api/lib/CAPI/Compiler.cpp
+++ b/llvm-external-projects/iree-compiler-api/lib/CAPI/Compiler.cpp
@@ -9,7 +9,6 @@
 #include "iree/compiler/ConstEval/Passes.h"
 #include "iree/compiler/Dialect/VM/IR/VMOps.h"
 #include "iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.h"
-#include "iree/compiler/Dialect/VM/Target/init_targets.h"
 #include "iree/compiler/InputConversion/MHLO/Passes.h"
 #include "iree/compiler/InputConversion/TOSA/Passes.h"
 #include "iree/compiler/Pipelines/Pipelines.h"
@@ -18,7 +17,6 @@
 #include "iree/tools/init_dialects.h"
 #include "iree/tools/init_passes.h"
 #include "iree/tools/init_targets.h"
-#include "iree/tools/init_translations.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Pass.h"
 #include "mlir/CAPI/Support.h"
@@ -72,15 +70,6 @@ void ireeCompilerRegisterAllDialects(MlirContext context) {
 
 void ireeCompilerRegisterAllPasses() {
   registerAllPasses();
-}
-
-void ireeCompilerRegisterAllIREETranslations() {
-  registerMlirTranslations();
-  registerIreeTranslations();
-}
-
-void ireeCompilerRegisterVMTargets() {
-  registerVMTargets();
 }
 
 void ireeCompilerRegisterTargetBackends() {

--- a/llvm-external-projects/iree-compiler-api/lib/CAPI/Compiler.cpp
+++ b/llvm-external-projects/iree-compiler-api/lib/CAPI/Compiler.cpp
@@ -13,7 +13,6 @@
 #include "iree/compiler/InputConversion/TOSA/Passes.h"
 #include "iree/compiler/Pipelines/Pipelines.h"
 #include "iree/compiler/Utils/OptionUtils.h"
-#include "iree/tools/init_targets.h"
 #include "iree/tools/init_dialects.h"
 #include "iree/tools/init_passes.h"
 #include "iree/tools/init_targets.h"
@@ -68,13 +67,9 @@ void ireeCompilerRegisterAllDialects(MlirContext context) {
   unwrap(context)->appendDialectRegistry(registry);
 }
 
-void ireeCompilerRegisterAllPasses() {
-  registerAllPasses();
-}
+void ireeCompilerRegisterAllPasses() { registerAllPasses(); }
 
-void ireeCompilerRegisterTargetBackends() {
-  registerHALTargetBackends();
-}
+void ireeCompilerRegisterTargetBackends() { registerHALTargetBackends(); }
 
 IreeCompilerOptions ireeCompilerOptionsCreate() {
   auto options = new CompilerOptions;

--- a/llvm-external-projects/iree-compiler-api/lib/CAPI/Compiler.cpp
+++ b/llvm-external-projects/iree-compiler-api/lib/CAPI/Compiler.cpp
@@ -9,11 +9,16 @@
 #include "iree/compiler/ConstEval/Passes.h"
 #include "iree/compiler/Dialect/VM/IR/VMOps.h"
 #include "iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.h"
+#include "iree/compiler/Dialect/VM/Target/init_targets.h"
 #include "iree/compiler/InputConversion/MHLO/Passes.h"
 #include "iree/compiler/InputConversion/TOSA/Passes.h"
 #include "iree/compiler/Pipelines/Pipelines.h"
 #include "iree/compiler/Utils/OptionUtils.h"
 #include "iree/tools/init_targets.h"
+#include "iree/tools/init_dialects.h"
+#include "iree/tools/init_passes.h"
+#include "iree/tools/init_targets.h"
+#include "iree/tools/init_translations.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Pass.h"
 #include "mlir/CAPI/Support.h"
@@ -59,7 +64,28 @@ struct CompilerOptions {
 
 DEFINE_C_API_PTR_METHODS(IreeCompilerOptions, CompilerOptions)
 
-void ireeCompilerRegisterTargetBackends() { registerHALTargetBackends(); }
+void ireeCompilerRegisterAllDialects(MlirContext context) {
+  DialectRegistry registry;
+  registerAllDialects(registry);
+  unwrap(context)->appendDialectRegistry(registry);
+}
+
+void ireeCompilerRegisterAllPasses() {
+  registerAllPasses();
+}
+
+void ireeCompilerRegisterAllIREETranslations() {
+  registerMlirTranslations();
+  registerIreeTranslations();
+}
+
+void ireeCompilerRegisterVMTargets() {
+  registerVMTargets();
+}
+
+void ireeCompilerRegisterTargetBackends() {
+  registerHALTargetBackends();
+}
 
 IreeCompilerOptions ireeCompilerOptionsCreate() {
   auto options = new CompilerOptions;


### PR DESCRIPTION
I was trying to use just the C to create a MLIR module with the MLIR API, compile with the IREE compiler API, and then run with IREE runtime API. In the process I've noticed that the registry functions contained in this PR were missing. With these functions added to the C API I was able to successfully generate a MLIR module and run it in pure C.
