### PR TITLE
Bump timeout limit to 30min for tests on moto phones

### DIFF
--- a/build_tools/buildkite/cmake/android/arm64-v8a/pipeline.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/pipeline.yml
@@ -63,7 +63,7 @@ steps:
       - "queue=test-android"
     env:
       IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
-    timeout_in_minutes: "15"
+    timeout_in_minutes: "30"
 
 notify:
   - email: "bdi-build-cop+buildkite@grotations.appspotmail.com"


### PR DESCRIPTION
There is a strange issue happening there, causing a ~10min gap
after downloading and before testing starts. Before the issue
is fixed, increase the timeout to avoid putting commits into a
test failure mode.