### PR TITLE
Fix exit codes in web sample scripts and whitespace in input.

### DIFF
--- a/build_tools/cmake/build_runtime_emscripten.sh
+++ b/build_tools/cmake/build_runtime_emscripten.sh
@@ -19,7 +19,7 @@ set -e
 if ! command -v emcmake &> /dev/null
 then
     echo "'emcmake' not found, setup environment according to https://emscripten.org/docs/getting_started/downloads.html"
-    exit
+    exit 1
 fi
 
 CMAKE_BIN=${CMAKE_BIN:-$(which cmake)}

--- a/experimental/web/sample_dynamic/build_sample.sh
+++ b/experimental/web/sample_dynamic/build_sample.sh
@@ -24,7 +24,7 @@ set -e
 if ! command -v emcmake &> /dev/null
 then
   echo "'emcmake' not found, setup environment according to https://emscripten.org/docs/getting_started/downloads.html"
-  exit
+  exit 1
 fi
 
 CMAKE_BIN=${CMAKE_BIN:-$(which cmake)}

--- a/experimental/web/sample_dynamic/index.html
+++ b/experimental/web/sample_dynamic/index.html
@@ -80,8 +80,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <label for="function-arguments-input" class="form-label">Function arguments:</label>
         <br><span class="form-text">In the form <code>dim1xdim2xtype=val1,val2,...</code>, one per line</span>
         <textarea type="text" id="function-arguments-input" spellcheck="false" class="form-control"
-                  style="min-width:400px; width:initial; min-height:100px; resize:both; font-family: monospace;">
-        </textarea>
+                  style="min-width:400px; width:initial; min-height:100px; resize:both; font-family: monospace;"></textarea>
       </p>
 
       <button id="call-function" class="btn btn-primary" type="button"
@@ -95,8 +94,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <p>
       <h4><label for="function-outputs" class="form-label">Function outputs:</label></h4>
       <textarea type="text" id="function-outputs" readonly spellcheck="false" class="form-control"
-                style="min-width:400px; width:initial; height:100px; resize:both; font-family: monospace;">
-      </textarea>
+                style="min-width:400px; width:initial; height:100px; resize:both; font-family: monospace;"></textarea>
     </p>
 
     <hr>

--- a/experimental/web/sample_static/build_sample.sh
+++ b/experimental/web/sample_static/build_sample.sh
@@ -24,7 +24,7 @@ set -e
 if ! command -v emcmake &> /dev/null
 then
   echo "'emcmake' not found, setup environment according to https://emscripten.org/docs/getting_started/downloads.html"
-  exit
+  exit 1
 fi
 
 CMAKE_BIN=${CMAKE_BIN:-$(which cmake)}


### PR DESCRIPTION
I've been running these with `bash .\experimental\web\sample_dynamic\build_sample.sh %CD%/../iree-build/install && bash .\experimental\web\sample_dynamic\serve_sample.sh` now, and the lack of a failure exit code was continuing past the short-circuiting `&&`.