### PR TITLE
Update instructions for reproducing TF/TFLite integration tests

### DIFF
--- a/docs/developers/debugging/tf_integrations_test_repro.md
+++ b/docs/developers/debugging/tf_integrations_test_repro.md
@@ -22,10 +22,15 @@ python -m pip install iree-compiler iree-runtime iree-tools-tf iree-tools-tflite
 python -m pip install tf-nightly Pillow
 ```
 
-4. Run the python test command line (this can be obtained from the log of the failing test). For example,
+4. Run the python test command line. The command can be obtained from the run file. For example, if iree_tfl_tests/llvmaot_posenet_i8.run failed,
 
 ```
-cd integrations/tensorflow/test/python
+cd integrations/tensorflow/test/
+cat iree_tfl_tests/llvmaot_posenet_i8.run
+
+# REQUIRES: llvmaot
+# RUN: %PYTHON -m iree_tfl_tests.posenet_i8_test --target_backend=llvmaot -artifacts_dir=%t
+
 python -m iree_tfl_tests.posenet_i8_test -- target_backend=llvmaot -artifacts_dir=/tmp/posenet_i8_failure
 ```
 


### PR DESCRIPTION
The log is messy. It's better to get the python command from run files.

Also, iree_tfl_tests suite and iree_tf_tests suite have different flags. This reduces the confusion about reproducing the issue.

E.g.,

```
❯ cat iree_tfl_tests/llvmaot_posenet_i8.run
# REQUIRES: llvmaot
# RUN: %PYTHON -m iree_tfl_tests.posenet_i8_test --target_backend=llvmaot -artifacts_dir=%t

❯ cat iree_tf_tests/math/llvmaot__abs.run
# REQUIRES: llvmaot
# RUN: %PYTHON -m iree_tf_tests.math.math_test --target_backends=iree_llvmaot --dynamic_dims=false --functions=abs -artifacts_dir=%t
```