### PR TITLE
Add wasm-linker-path options and leave system linker path unset.

### DIFF
--- a/build_tools/bazel/iree_bytecode_module.bzl
+++ b/build_tools/bazel/iree_bytecode_module.bzl
@@ -76,7 +76,8 @@ def iree_bytecode_module(
                 "$(location %s)" % (translate_tool),
                 " ".join(flags),
                 "-iree-llvm-embedded-linker-path=$(location %s)" % (linker_tool),
-                "-iree-llvm-system-linker-path=$(location %s)" % (linker_tool),
+                "-iree-llvm-wasm-linker-path=$(location %s)" % (linker_tool),
+                # Note: -iree-llvm-system-linker-path is left unspecified.
                 "-o $(location %s)" % (module),
                 "$(location %s)" % (translate_src),
             ]),

--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -111,8 +111,9 @@ function(iree_bytecode_module)
   # If an LLVM CPU backend is enabled, supply the linker tool.
   if(IREE_LLD_TARGET)
     iree_get_executable_path(_LINKER_TOOL_EXECUTABLE "lld")
-    list(APPEND _ARGS "-iree-llvm-system-linker-path=\"${_LINKER_TOOL_EXECUTABLE}\"")
     list(APPEND _ARGS "-iree-llvm-embedded-linker-path=\"${_LINKER_TOOL_EXECUTABLE}\"")
+    list(APPEND _ARGS "-iree-llvm-wasm-linker-path=\"${_LINKER_TOOL_EXECUTABLE}\"")
+    # Note: -iree-llvm-system-linker-path is left unspecified.
   endif()
 
   # Depending on the binary instead of the target here given we might not have

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp
@@ -137,12 +137,12 @@ LLVMTargetOptions getLLVMTargetOptionsFromFlags() {
       llvm::cl::init(targetOptions.debugSymbols));
   targetOptions.debugSymbols = clDebugSymbols;
 
-  static llvm::cl::opt<std::string> clLinkerPath(
+  static llvm::cl::opt<std::string> clSystemLinkerPath(
       "iree-llvm-system-linker-path",
       llvm::cl::desc("Tool used to link system shared libraries produced by "
                      "IREE (for -iree-llvm-link-embedded=false)."),
       llvm::cl::init(""));
-  targetOptions.linkerPath = clLinkerPath;
+  targetOptions.systemLinkerPath = clSystemLinkerPath;
 
   static llvm::cl::opt<std::string> clEmbeddedLinkerPath(
       "iree-llvm-embedded-linker-path",
@@ -150,6 +150,13 @@ LLVMTargetOptions getLLVMTargetOptionsFromFlags() {
                      "-iree-llvm-link-embedded=true)."),
       llvm::cl::init(""));
   targetOptions.embeddedLinkerPath = clEmbeddedLinkerPath;
+
+  static llvm::cl::opt<std::string> clWasmLinkerPath(
+      "iree-llvm-wasm-linker-path",
+      llvm::cl::desc("Tool used to link WebAssembly modules produced by "
+                     "IREE (for -iree-llvm-target-triple=wasm32-*)."),
+      llvm::cl::init(""));
+  targetOptions.wasmLinkerPath = clWasmLinkerPath;
 
   static llvm::cl::opt<bool> clLinkEmbedded(
       "iree-llvm-link-embedded",

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.h
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.h
@@ -41,12 +41,16 @@ struct LLVMTargetOptions {
   // Sanitizer Kind for CPU Kernels
   SanitizerKind sanitizerKind = SanitizerKind::kNone;
 
-  // Tool to use for linking (like lld). Acts as a prefix to the command line
-  // and can contain additional arguments.
-  std::string linkerPath;
+  // Tool to use for native platform linking (like ld on Unix or link.exe on
+  // Windows). Acts as a prefix to the command line and can contain additional
+  // arguments.
+  std::string systemLinkerPath;
 
-  // Tool to use for linking embedded ELFs specifically. Must be lld.
+  // Tool to use for linking embedded ELFs. Must be lld.
   std::string embeddedLinkerPath;
+
+  // Tool to use for linking WebAssembly modules. Must be wasm-ld or lld.
+  std::string wasmLinkerPath;
 
   // Build for the IREE embedded platform-agnostic ELF loader.
   // Note: this is ignored for target machines that do not support the ELF

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LinkerTool.cpp
@@ -110,8 +110,8 @@ void Artifacts::keepAllFiles() {
 std::string LinkerTool::getSystemToolPath() const {
   // Always use the -iree-llvm-system-linker-path flag when specified as it's
   // explicitly telling us what to use.
-  if (!targetOptions.linkerPath.empty()) {
-    return targetOptions.linkerPath;
+  if (!targetOptions.systemLinkerPath.empty()) {
+    return targetOptions.systemLinkerPath;
   }
 
   // Allow users to override the automatic search with an environment variable.


### PR DESCRIPTION
Based on discussion at https://github.com/google/iree/pull/8584 and [on Discord](https://discord.com/channels/689900678990135345/689900680009482386/954411704765276180).

This leaves `iree-llvm-system-linker-path` unset in the build system so it always uses the search code in UnixLinkerTool or WindowsLinkerTool, rather than use the generic lld driver.

When used from an install, users can still choose to either trust the automatic discovery or explicitly specify individual linker tools. Now they can also set a different tool for WebAssembly linking.