### PR TITLE
Switch presubmit scripts to use main branch

### DIFF
--- a/build_tools/buildkite/presubmit.yml
+++ b/build_tools/buildkite/presubmit.yml
@@ -21,12 +21,11 @@ steps:
       - thedyrt/skip-checkout#0870506e0b5d4becc164c6e64dbc331938f0bdcf:
           cd: /tmp/
     commands: |
-      # TODO: Switch to main branch
       curl \
-        https://raw.githubusercontent.com/GMNGeoffrey/iree/whole-new-world/build_tools/buildkite/check_cla.py \
+        https://raw.githubusercontent.com/google/iree/main/build_tools/buildkite/check_cla.py \
         | python3 - ${BUILDKITE_COMMIT} \
       || curl \
-        https://raw.githubusercontent.com/GMNGeoffrey/iree/whole-new-world/build_tools/buildkite/cla_failure.yml \
+        https://raw.githubusercontent.com/google/iree/main/build_tools/buildkite/cla_failure.yml \
         | buildkite-agent pipeline upload
 
   - wait
@@ -40,7 +39,6 @@ steps:
           cd: /tmp/
     commands: |
       export BUILDKITE_ACCESS_TOKEN="$(gcloud secrets versions access latest --secret=iree-buildkite-presubmit-pipelines)"
-      # TODO: Switch to main branch
       curl \
-        https://raw.githubusercontent.com/GMNGeoffrey/iree/whole-new-world/build_tools/buildkite/wait_for_pipeline_success.py \
+        https://raw.githubusercontent.com/google/iree/main/build_tools/buildkite/wait_for_pipeline_success.py \
         | python3 - gcmn-test-pipeline

--- a/build_tools/buildkite/presubmit_bootstrap.yml
+++ b/build_tools/buildkite/presubmit_bootstrap.yml
@@ -21,9 +21,8 @@ steps:
       - thedyrt/skip-checkout#0870506e0b5d4becc164c6e64dbc331938f0bdcf:
           cd: /tmp/
     commands: |
-      # TODO: Switch to main branch.
       # Piped rather than wget to avoid unnecessary intermediate files (that can
       # cause confusion if not handled properly)
       curl \
-        https://raw.githubusercontent.com/GMNGeoffrey/iree/whole-new-world/build_tools/buildkite/presubmit.yml \
+        https://raw.githubusercontent.com/google/iree/main/build_tools/buildkite/presubmit.yml \
         | buildkite-agent pipeline upload


### PR DESCRIPTION
Now that this is checked in to the main branch we don't have
bootstrapping problems by pointing at it.