### PR TITLE
Illustrate gcc-11.2.0 build error

### DIFF
--- a/iree/base/status.c
+++ b/iree/base/status.c
@@ -628,7 +628,7 @@ iree_status_annotate(iree_status_t base_status, iree_string_view_t message) {
                                     (iree_status_payload_t*)payload);
 }
 
-static IREE_MUST_USE_RESULT iree_status_t
+static /*IREE_MUST_USE_RESULT*/ iree_status_t
 iree_status_annotate_vf(iree_status_t base_status, const char* format,
                         va_list varargs_0, va_list varargs_1) {
   if (iree_status_is_ok(base_status)) return base_status;


### PR DESCRIPTION
I experience a build error with gcc-11.2.0 which goes away by commenting out 1 instance of the `IREE_MUST_USE_RESULT` macro.

Has someone experienced something similar?

> /bin/cc --version

cc (Debian 11.2.0-16) 11.2.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.