### PR TITLE
[LinalgExt][LinalgTransform] Add support for calling tile_to_in_parallel form IREE.

### DIFF
--- a/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.h"
 #include "iree/compiler/Codegen/Dialect/IREECodegenDialect.h"
 #include "iree/compiler/Codegen/LLVMCPU/KernelDispatch.h"
@@ -40,6 +41,7 @@ class LLVMCPULowerExecutableTargetPass
     // clang-format off
     registry.insert<IREE::Codegen::IREECodegenDialect,
                     IREE::HAL::HALDialect,
+                    IREE::LinalgExt::IREELinalgExtDialect,
                     bufferization::BufferizationDialect,
                     linalg::LinalgDialect,
                     linalg::transform::LinalgTransformDialect,

--- a/iree/compiler/Codegen/LLVMCPU/test/linalg_transform.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/linalg_transform.mlir
@@ -16,13 +16,14 @@ hal.executable private @pad_matmul_static_dispatch_0 {
         %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [250, 500], strides = [1, 1] : !flow.dispatch.tensor<readonly:250x500xf32> -> tensor<250x500xf32>
         %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [500, 1020], strides = [1, 1] : !flow.dispatch.tensor<readonly:500x1020xf32> -> tensor<500x1020xf32>
         %5 = flow.dispatch.tensor.load %2, offsets = [0, 0], sizes = [250, 1020], strides = [1, 1] : !flow.dispatch.tensor<readwrite:250x1020xf32> -> tensor<250x1020xf32>
+
+        //      CHECK: %[[C125:.*]] = arith.constant 125 : index
         //  CHECK-NOT: flow
-        //      CHECK: scf.for
-        // CHECK-NEXT:   subview
-        // CHECK-NEXT:   subview
-        // CHECK-NEXT:   matmul{{.*}}ins{{.*}}outs
-        // CHECK-NEXT: }
-        // CHECK-NEXT: return
+        //      CHECK: iree_linalg_ext.in_parallel %[[C125]] -> () {
+        //      CHECK:   subview
+        //      CHECK:   subview
+        //      CHECK:   matmul{{.*}}ins{{.*}}outs
+        //      CHECK: return
         %6 = linalg.matmul ins(%3, %4 : tensor<250x500xf32>, tensor<500x1020xf32>) outs(%5 : tensor<250x1020xf32>) -> tensor<250x1020xf32>
         flow.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [250, 1020], strides = [1, 1] : tensor<250x1020xf32> -> !flow.dispatch.tensor<readwrite:250x1020xf32>
         return

--- a/iree/compiler/Codegen/LLVMCPU/test/linalg_transform_spec.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/linalg_transform_spec.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt %s 
 
-pdl.pattern @pdl_target : benefit(1) {
+pdl.pattern @pdl_matmul_target : benefit(1) {
   %args = operands
   %results = types
   %0 = operation "linalg.matmul"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
@@ -9,6 +9,12 @@ pdl.pattern @pdl_target : benefit(1) {
 }
 
 iree_linalg_transform.sequence {
-  %0 = match @pdl_target
-  tile %0 {sizes = [2]}
+  %0 = match @pdl_matmul_target
+  // %res contains the tiled op and the linalg_ext.tile op.
+  %tiling_result:2 = tile_to_iree_linalg_ext_tile_op %0 {sizes = [2]}
+  %2 = rewrite_iree_linalg_ext_tile_to_in_parallel %tiling_result#1
+  // Bufferize happens at the IREE level on HAL operations, we cannot just 
+  // call the linalg_transform.bufferize operation here.
+  // Instead it happens automatically at the end of the linalg-transform-interp
+  // pass.
 }

--- a/iree/tools/BUILD
+++ b/iree/tools/BUILD
@@ -120,6 +120,8 @@ cc_library(
         "//llvm-external-projects/iree-dialects:IREEInputDialect",
         "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
         "//llvm-external-projects/iree-dialects:IREELinalgExtPasses",
+        "//llvm-external-projects/iree-dialects:IREELinalgTransformDialect",
+        "//llvm-external-projects/iree-dialects:IREELinalgTransformDialectTransforms",
         "//llvm-external-projects/iree-dialects:IREEPyDMDialect",
         "@llvm-project//mlir:IR",
     ],

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -225,6 +225,11 @@ if(${IREE_BUILD_COMPILER})
       "init_iree_passes.h"
     DEPS
       IREEInputDialect
+      IREELinalgExtDialect
+      IREELinalgExtTransforms
+      IREELinalgExtOpInterfaceImpl
+      IREELinalgTransformDialect
+      IREELinalgTransformDialectTransforms
       IREEPyDMDialect
       MLIRIR
       iree::compiler::Bindings::Native::Transforms

--- a/iree/tools/init_iree_dialects.h
+++ b/iree/tools/init_iree_dialects.h
@@ -15,7 +15,10 @@
 #include "iree-dialects/Dialect/Input/InputDialect.h"
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree-dialects/Dialect/LinalgExt/IR/TiledOpInterface.h"
+#include "iree-dialects/Dialect/LinalgExt/LinalgExtBufferization.h"
+#include "iree-dialects/Dialect/LinalgExt/Passes/Passes.h"
 #include "iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.h"
+#include "iree-dialects/Dialect/LinalgTransform/Passes.h"
 #include "iree-dialects/Dialect/PyDM/IR/PyDMDialect.h"
 #include "iree/compiler/Codegen/Dialect/IREECodegenDialect.h"
 #include "iree/compiler/Codegen/Interfaces/Interfaces.h"
@@ -48,8 +51,11 @@ inline void registerIreeDialects(DialectRegistry &registry) {
                   IREE::PYDM::IREEPyDMDialect>();
   // clang-format on
 
+  // External models.
   IREE::Flow::registerPartitionableLoopsInterfaceModels(registry);
+  IREE::LinalgExt::registerBufferizableOpInterfaceExternalModels(registry);
   IREE::LinalgExt::registerTiledOpInterfaceExternalModels(registry);
+  IREE::LinalgExt::registerTilingInterfaceExternalModels(registry);
   IREE::Util::registerUtilExternalModels(registry);
   registerCodegenInterfaces(registry);
 }

--- a/llvm-external-projects/iree-dialects/BUILD
+++ b/llvm-external-projects/iree-dialects/BUILD
@@ -679,6 +679,7 @@ cc_library(
     ],
     deps = [
         ":IREEDialectsTransforms",
+        ":IREELinalgExtDialect",
         ":IREELinalgTransformDialect",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Affine",

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h
@@ -19,13 +19,18 @@ namespace iree_compiler {
 namespace IREE {
 namespace LinalgExt {
 
+struct TilingResult {
+  TileOp tileOp;
+  Operation *tiledOp;
+};
+
 /// Pattern to tile a TilingInterface op using a TileOp.
 struct LinalgExtTilingPattern
     : public OpInterfaceRewritePattern<TilingInterface> {
   LinalgExtTilingPattern(MLIRContext *context, linalg::LinalgTilingOptions opt)
       : OpInterfaceRewritePattern<TilingInterface>(context), options(opt) {}
 
-  FailureOr<Operation *>
+  FailureOr<TilingResult>
   returningMatchAndRewrite(TilingInterface op, PatternRewriter &rewriter) const;
 
   LogicalResult matchAndRewrite(TilingInterface op,

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.td
@@ -257,7 +257,9 @@ def LowerToLLVMOp : Transform_Op<"lower_to_llvm"> {
 }
 
 def GetParentLoopOp : Linalg_Transform_Operation<"get_parent_loop", [
-    TransformOpInterface, TargetableSingleOperandTransformOpTrait]> {
+    TransformOpInterface, 
+    TargetableSingleOperandTransformOpTrait
+  ]> {
   let description = [{Obtains a handle to a parent loop of the given
   operation.}];
 
@@ -274,7 +276,9 @@ def GetParentLoopOp : Linalg_Transform_Operation<"get_parent_loop", [
 }
 
 def UnrollLoopOp : Linalg_Transform_Operation<"unroll_loop", [
-    TransformOpInterface, TargetableSingleOperandTransformOpTrait]> {
+    TransformOpInterface, 
+    TargetableSingleOperandTransformOpTrait
+  ]> {
   let description = [{Unrolls the given loop with the given unroll factor.}];
 
   let arguments = (ins PDL_Operation:$target,
@@ -301,7 +305,9 @@ def PeelLoopOp : Linalg_Transform_Operation<"peel_loop", [
 
 
 def PipelineLoopOp : Linalg_Transform_Operation<"pipeline_loop", [
-    TransformOpInterface, TargetableSingleOperandTransformOpTrait]> {
+    TransformOpInterface,
+    TargetableSingleOperandTransformOpTrait
+  ]> {
   let arguments = (ins PDL_Operation:$target,
                    DefaultValuedAttr<I64Attr, "1">:$iteration_interval,
                    DefaultValuedAttr<I64Attr, "10">:$read_latency);
@@ -315,30 +321,32 @@ def PipelineLoopOp : Linalg_Transform_Operation<"pipeline_loop", [
 }
 
 def OutlineLoopOp : Linalg_Transform_Operation<"outline_loop", [
-    DeclareOpInterfaceMethods<TransformOpInterface, ["apply"]>]> {
+    DeclareOpInterfaceMethods<TransformOpInterface, ["apply"]>
+  ]> {
   let arguments = (ins PDL_Operation:$target,
                    StrAttr:$func_name);
   let results = (outs PDL_Operation:$transformed);
 
   let assemblyFormat = "$target attr-dict";
-
-  let extraClassDeclaration = [{
-    ::mlir::FailureOr<::mlir::FuncOp> applyToOne(::mlir::scf::ForOp loop);
-  }];
 }
 
-def PrintOp : Transform_Op<"print"> {
-  let arguments = (ins StrAttr:$name);
+def PrintOp : Transform_Op<"print", [ 
+    DeclareOpInterfaceMethods<TransformOpInterface, ["apply"]>
+  ]> {
+  let arguments = (ins Optional<PDL_Operation>:$target,
+                       StrAttr:$name);
   let description = [{Prints the module.}];
-  let assemblyFormat = "attr-dict";
+  let assemblyFormat = "($target^)? attr-dict";
 }
 
 //===----------------------------------------------------------------------===//
 // LinalgExt specific transforms
 //===----------------------------------------------------------------------===//
 
-def TileToLinalgExtTileOp : Linalg_Transform_Operation<"tile_to_iree_linalg_ext_tile_op",
-    [TransformOpInterface, TargetableSingleOperandTransformOpTrait]> {
+def TileToLinalgExtTileOp : 
+    Linalg_Transform_Operation<"tile_to_iree_linalg_ext_tile_op", [
+      DeclareOpInterfaceMethods<TransformOpInterface, ["apply"]>
+    ]> {
   let description = [{Tile a linalg op with linalg_ext.tile op along a single
   dimension.}];
 
@@ -351,14 +359,10 @@ def TileToLinalgExtTileOp : Linalg_Transform_Operation<"tile_to_iree_linalg_ext_
 
   let arguments = (ins PDL_Operation:$target,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$sizes);
-  let results = (outs PDL_Operation:$transformed);
+  let results = (outs PDL_Operation:$tiled_op,
+                      PDL_Operation:$tile_op);
 
   let assemblyFormat = "$target attr-dict";
-
-  let extraClassDeclaration = [{
-    ::mlir::FailureOr<Operation *> applyToOne(
-        ::mlir::Operation *target);
-  }];
 }
 
 def RewriteLinalgExtTileToScfForOp :

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/Functional.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/Functional.h
@@ -62,10 +62,24 @@ public:
 /// the given arguments.
 template <typename OpT, typename PatternT, typename... Args,
           bool = PatternConcept<PatternT>::verify()>
-auto applyAt(OpT op, PatternT &&pattern, Args &&... args) {
+auto applyAt(OpT op, PatternT &&pattern, Args &&...args) {
   detail::SimpleRewriter rewriter(op->getContext());
   rewriter.setInsertionPoint(op);
   return pattern(op, rewriter, std::forward<Args>(args)...);
+}
+
+template <typename OpT, typename PatternT>
+auto applyReturningPatternAt(PatternT &&pattern, OpT op) {
+  detail::SimpleRewriter rewriter(op.getContext());
+  rewriter.setInsertionPoint(op);
+  return pattern.returningMatchAndRewrite(op, rewriter);
+}
+
+template <typename PatternT>
+auto applyReturningPatternAt(PatternT &&pattern, Operation *op) {
+  detail::SimpleRewriter rewriter(op->getContext());
+  rewriter.setInsertionPoint(op);
+  return pattern.returningMatchAndRewrite(op, rewriter);
 }
 
 /// Given a scope, apply a pattern with the given arguments until the first
@@ -73,7 +87,7 @@ auto applyAt(OpT op, PatternT &&pattern, Args &&... args) {
 /// pattern rewriter.
 template <typename PatternT, typename... Args,
           bool = PatternConcept<PatternT>::verify()>
-auto applyOnceIn(Operation *scope, PatternT &&pattern, Args &&... args) {
+auto applyOnceIn(Operation *scope, PatternT &&pattern, Args &&...args) {
   assert(scope->hasTrait<OpTrait::IsIsolatedFromAbove>() &&
          "scope is not isolated from above");
   using Traits = llvm::function_traits<std::decay_t<PatternT>>;
@@ -114,7 +128,7 @@ struct UnpackFailureOr<FailureOr<NestedType>> {
 /// match at all.
 template <typename PatternT, typename... Args,
           bool = PatternConcept<PatternT>::verify()>
-auto applyForEachIn(Operation *scope, PatternT &&pattern, Args &&... args) {
+auto applyForEachIn(Operation *scope, PatternT &&pattern, Args &&...args) {
   using Traits = llvm::function_traits<std::decay_t<PatternT>>;
   using Unpack = detail::UnpackFailureOr<typename Traits::result_t>;
 
@@ -138,7 +152,7 @@ auto applyForEachIn(Operation *scope, PatternT &&pattern, Args &&... args) {
 /// Apply a pattern directly on an operation, for each operation in a list.
 template <typename ListT, typename PatternT, typename... Args,
           bool = PatternConcept<PatternT>::verify()>
-auto applyForEach(ListT &&list, PatternT &&pattern, Args &&... args) {
+auto applyForEach(ListT &&list, PatternT &&pattern, Args &&...args) {
   using Traits = llvm::function_traits<std::decay_t<PatternT>>;
   using Unpack = detail::UnpackFailureOr<typename Traits::result_t>;
 
@@ -278,8 +292,9 @@ struct GenericSequence : public std::tuple<UniqueFunctionTs...> {
 
       // The previous pattern succeeded. Unpack the results into a tuple to pass
       // as arguments to the next pattern.
-      auto args = UnpackIntoTuple<std::remove_reference_t<decltype(
-          *prevResult)>>::apply(std::move(*prevResult));
+      auto args =
+          UnpackIntoTuple<std::remove_reference_t<decltype(*prevResult)>>::
+              apply(std::move(*prevResult));
       // Grab the first result value as the operation.
       Operation *nextOp = std::get<0>(args);
       if (!detail::IsaOr<OpT>::apply(nextOp))
@@ -314,7 +329,7 @@ struct SequenceBuilder {
   /// caller and does not recurse.
   template <typename PatternT, typename... Args,
             bool = PatternConcept<PatternT>::verify()>
-  auto begin(PatternT &&pattern, Args &&... args) {
+  auto begin(PatternT &&pattern, Args &&...args) {
     using Traits = llvm::function_traits<std::decay_t<PatternT>>;
     using OpT = typename Traits::template arg_t<0>;
     using ResultT = typename Traits::result_t;

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/TilingToTileOp.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/TilingToTileOp.cpp
@@ -19,11 +19,6 @@
 using namespace mlir;
 using namespace mlir::iree_compiler::IREE::LinalgExt;
 
-struct TilingResult {
-  TileOp tileOp;
-  Operation *tiledOp;
-};
-
 static TilingResult tileToTileOp(PatternRewriter &rewriter, TilingInterface op,
                                  int64_t tiledDim, Value tileSize) {
   Location loc = op->getLoc();
@@ -61,7 +56,7 @@ static TilingResult tileToTileOp(PatternRewriter &rewriter, TilingInterface op,
   return TilingResult{tileOp, tiledOp};
 }
 
-FailureOr<Operation *>
+FailureOr<TilingResult>
 mlir::iree_compiler::IREE::LinalgExt::LinalgExtTilingPattern::
     returningMatchAndRewrite(TilingInterface op,
                              PatternRewriter &rewriter) const {
@@ -102,5 +97,5 @@ mlir::iree_compiler::IREE::LinalgExt::LinalgExtTilingPattern::
   TilingResult tilingResult = tileToTileOp(rewriter, op, dim, tileSizes[dim]);
   rewriter.replaceOp(op, tilingResult.tileOp->getResults());
 
-  return tilingResult.tiledOp;
+  return tilingResult;
 }

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/Transforms/TransformInterpreter.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/Transforms/TransformInterpreter.cpp
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.h"
 #include "iree-dialects/Dialect/LinalgTransform/Passes.h"
 #include "iree-dialects/Dialect/LinalgTransform/TrackingCSE.h"
@@ -237,7 +238,8 @@ struct InterpreterPass : public PassWrapper<InterpreterPass, Pass> {
 
   void getDependentDialects(DialectRegistry &registry) const override {
     // clang-format off
-    registry.insert<arith::ArithmeticDialect,
+    registry.insert<mlir::iree_compiler::IREE::LinalgExt::IREELinalgExtDialect,
+                    arith::ArithmeticDialect,
                     AffineDialect,
                     bufferization::BufferizationDialect,
                     func::FuncDialect,

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tiling-to-tile-op.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tiling-to-tile-op.mlir
@@ -28,7 +28,7 @@ module {
   }
   iree_linalg_transform.sequence {
     %0 = match @match_linalg_matmul
-    %1 = tile_to_iree_linalg_ext_tile_op %0 {sizes = [10]}
+    %1:2 = tile_to_iree_linalg_ext_tile_op %0 {sizes = [10]}
   }
 }
 
@@ -63,6 +63,6 @@ module {
   }
   iree_linalg_transform.sequence {
     %0 = match @match_linalg_matmul
-    %1 = tile_to_iree_linalg_ext_tile_op %0 {sizes = [10]}
+    %1:2 = tile_to_iree_linalg_ext_tile_op %0 {sizes = [10]}
   }
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/tile.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/tile.mlir
@@ -40,5 +40,6 @@ pdl.pattern @pdl_target : benefit(1) {
 
 iree_linalg_transform.sequence {
   %0 = match @pdl_target
-  tile %0 {sizes = [4, 4, 4]}
+  %1 = tile %0 {sizes = [4, 4, 4]}
+  print %1 {name = "Tiled"} 
 }


### PR DESCRIPTION
This revision updates the linalg_transform test to use tiling to the LinalgExt parallel abstractions.
These abstractions will be later connected to the proper workgroup concepts.
    
In the process, the PrintOp gains an optional argument to more easily print the handles resulting from
transformations.
    
`tile_to_iree_linalg_ext_tile_op` is extended to return 2 values: the tiled operation and the linalg_ext.tile_op.