### PR TITLE
Rewrite InParallel to HAL

### DIFF
--- a/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -408,9 +408,6 @@ void addCPUDefaultPassPipeline(OpPassManager &passManager) {
 }
 
 void addLinalgTransformInterpPasses(OpPassManager &passManager) {
-  // Sets the number of workgroups to be {1, 1, 1} for now.
-  passManager.addPass(createSetNumWorkgroupsPass());
-
   // Give control to the linalg_transform dialect.
   passManager.addPass(createLinalgTransformInterpreterPass());
   // Dropping the schedule is only needed if we want to embed the transform in

--- a/iree/compiler/Codegen/LLVMCPU/test/linalg_transform.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/linalg_transform.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt %s  -pass-pipeline='hal.executable(hal.executable.variant(iree-llvmcpu-lower-executable-target))' --iree-codegen-use-linalg-transform-interp --linalg-transform-file-name=%p/linalg_transform_spec.mlir | FileCheck %s
+// RUN: iree-opt %s  -pass-pipeline='hal.executable(hal.executable.variant(iree-llvmcpu-lower-executable-target))' --iree-codegen-use-linalg-transform-interp --linalg-transform-file-name=%p/linalg_transform_spec.mlir -allow-unregistered-dialect | FileCheck %s
 
 #device_target_cpu = #hal.device.target<"cpu", {executable_targets = [#hal.executable.target<"llvm", "embedded-elf-x86_64", {cpu_features = "", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "x86_64-unknown-unknown-eabi-elf"}>]}>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [#hal.descriptor_set.layout<0, bindings = [#hal.descriptor_set.binding<0, storage_buffer>, #hal.descriptor_set.binding<1, storage_buffer>, #hal.descriptor_set.binding<2, storage_buffer>]>]>
@@ -16,13 +16,16 @@ hal.executable private @pad_matmul_static_dispatch_0 {
         %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [250, 500], strides = [1, 1] : !flow.dispatch.tensor<readonly:250x500xf32> -> tensor<250x500xf32>
         %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [500, 1020], strides = [1, 1] : !flow.dispatch.tensor<readonly:500x1020xf32> -> tensor<500x1020xf32>
         %5 = flow.dispatch.tensor.load %2, offsets = [0, 0], sizes = [250, 1020], strides = [1, 1] : !flow.dispatch.tensor<readwrite:250x1020xf32> -> tensor<250x1020xf32>
-
-        //      CHECK: %[[C125:.*]] = arith.constant 125 : index
-        //  CHECK-NOT: flow
-        //      CHECK: iree_linalg_ext.in_parallel %[[C125]] -> () {
-        //      CHECK:   subview
-        //      CHECK:   subview
-        //      CHECK:   matmul{{.*}}ins{{.*}}outs
+        
+        //      CHECK: "iree_linalg_ext.hal.executable.entry_point"()
+        //  CHECK-DAG:   %[[C1:.*]] = arith.constant 1 : index
+        //  CHECK-DAG:   %[[C125:.*]] = arith.constant 125 : index
+        //      CHECK:   iree_linalg_ext.hal.return %[[C125]], %[[C1]], %[[C1]] : index, index, index
+        //      CHECK: iree_linalg_ext.hal.interface.workgroup.id[0] : index
+        //      CHECK: iree_linalg_ext.hal.interface.workgroup.count[0] : index
+        //      CHECK: subview
+        //      CHECK: subview
+        //      CHECK: matmul{{.*}}ins{{.*}}outs
         //      CHECK: return
         %6 = linalg.matmul ins(%3, %4 : tensor<250x500xf32>, tensor<500x1020xf32>) outs(%5 : tensor<250x1020xf32>) -> tensor<250x1020xf32>
         flow.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [250, 1020], strides = [1, 1] : tensor<250x1020xf32> -> !flow.dispatch.tensor<readwrite:250x1020xf32>

--- a/iree/compiler/Codegen/LLVMCPU/test/linalg_transform_spec.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/linalg_transform_spec.mlir
@@ -13,6 +13,8 @@ iree_linalg_transform.sequence {
   // %res contains the tiled op and the linalg_ext.tile op.
   %tiling_result:2 = tile_to_iree_linalg_ext_tile_op %0 {sizes = [2]}
   %2 = rewrite_iree_linalg_ext_tile_to_in_parallel %tiling_result#1
+  // TODO: Ideally we would bufferize here but we can't atm.
+  rewrite_iree_linalg_ext_in_parallel_to_hal %2
   // Bufferize happens at the IREE level on HAL operations, we cannot just 
   // call the linalg_transform.bufferize operation here.
   // Instead it happens automatically at the end of the linalg-transform-interp

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -50,6 +50,118 @@ class IREELinalgExt_Op<string mnemonic, list<Trait> traits = []> :
 }
 
 //===----------------------------------------------------------------------===//
+// Temporary stripped-down copies of IREE HAL ops needed for composition.
+// These can be removed once dialects can register transformations with the 
+// transform dialect.
+//===----------------------------------------------------------------------===//
+def IREELinalgExt_Dim : TypeAlias<Index>;
+
+def IREELinalgExt_HALInterfaceWorkgroupIDOp : Op<IREELinalgExt_Dialect, "hal.interface.workgroup.id"> {
+  let summary = [{returns the index of the current workgroup in the grid}];
+  let description = [{
+    The global workgroup ID in the range of
+      `[0, iree_linalg_ext.hal.interface.workgroup.count)` along each XYZ dimension.
+
+    Corresponds to the `WorkgroupId` SPIR-V built-in and the `blockIdx` CUDA
+    built-in variable.
+
+    ```mlir
+    %x = iree_linalg_ext.hal.interface.workgroup.id[0] : index
+    %y = iree_linalg_ext.hal.interface.workgroup.id[1] : index
+    %z = iree_linalg_ext.hal.interface.workgroup.id[2] : index
+    ```
+  }];
+
+  let arguments = (ins IndexAttr:$dimension);
+  let results = (outs IREELinalgExt_Dim:$result);
+
+  let builders = [
+    OpBuilder<(ins "unsigned":$dim),
+    [{
+      build($_builder, $_state, $_builder.getIndexType(), $_builder.getIndexAttr(dim));
+    }]>,
+  ];
+
+  let assemblyFormat = [{
+    `[` $dimension `]` attr-dict `:` type($result)
+  }];
+}
+
+def IREELinalgExt_HALInterfaceWorkgroupCountOp : Op<IREELinalgExt_Dialect, "hal.interface.workgroup.count"> {
+  let summary = [{returns the total workgroup count of the grid}];
+  let description = [{
+    The total number of workgroups along each dimension in the dispatch grid.
+
+    Corresponds to the `NumWorkgroups` SPIR-V built-in and the `gridDim` CUDA
+    built-in variable.
+
+    ```mlir
+    %x = hal.interface.workgroup.count[0] : index
+    %y = hal.interface.workgroup.count[1] : index
+    %z = hal.interface.workgroup.count[2] : index
+    ```
+  }];
+
+  let arguments = (ins IndexAttr:$dimension);
+  let results = (outs IREELinalgExt_Dim:$result);
+
+  let builders = [
+    OpBuilder<(ins "unsigned":$dim),
+    [{
+      build($_builder, $_state, $_builder.getIndexType(), $_builder.getIndexAttr(dim));
+    }]>,
+  ];
+
+  let assemblyFormat = [{
+    `[` $dimension `]` attr-dict `:` type($result)
+  }];
+}
+
+// Stripped-down version of the HAL::ExecutableEntryPoint op. 
+// Using a custom op in generic form is not deemed acceptable but we should not 
+// either blindly take the complexity.
+def IREELinalgExt_HALExecutableEntryPointOp : Op<IREELinalgExt_Dialect, "hal.executable.entry_point", [
+    IsolatedFromAbove,
+  ]> {
+  let summary = [{executable entry point declaration}];
+  let description = [{
+    An entry point exported by the executable with statically-available
+    information describing the IO interface it uses and other dispatch metadata.
+
+    The `workgroup_count_region` region represents the
+    computation that returns the number of workgroups to use. 
+    It returns the number of workgroups along x, y, and z.
+
+    Note: this is a stripped-down of the HAL::ExecutableEntryPoint to only keep
+    the essential information needed to perform the transformation.
+    This is only used within the parent func of an IREELinalgExt_InParallelOp 
+    that is in the process of translating to the HAL abstraction.
+    This goes away once transform dialect ops can be registered from different
+    dialects. 
+  }];
+
+  // This op only propagates information to HAL, it inherits none of the design.
+  let arguments = (ins);
+  let regions = (region SizedRegion<1>:$workgroup_count_region);
+}
+
+
+def IREELinalgExt_HALReturnOp : Op<IREELinalgExt_Dialect, "hal.return", [Terminator]> {
+  let summary = [{return from a hal.executable.entry_point region}];
+  let description = [{
+    Returns the given values from the region and back to the host code.
+  }];
+
+  let arguments = (ins
+    Variadic<AnyType>:$operands
+  );
+
+  let assemblyFormat = [{
+    ($operands^ `:` type($operands))? attr-dict
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // Non-structured ops
 //===----------------------------------------------------------------------===//
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h
@@ -83,6 +83,20 @@ struct InParallelOpToAsyncRewriter : public OpRewritePattern<InParallelOp> {
   }
 };
 
+/// Pattern to rewrite a InParallelOp to the HAL dialect.
+struct InParallelOpToHALRewriter : public OpRewritePattern<InParallelOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  FailureOr<SmallVector<Operation *>>
+  returningMatchAndRewrite(InParallelOp inParallelOp,
+                           PatternRewriter &rewriter) const;
+
+  LogicalResult matchAndRewrite(InParallelOp inParallelOp,
+                                PatternRewriter &rewriter) const override {
+    return returningMatchAndRewrite(inParallelOp, rewriter);
+  }
+};
+
 /// Pattern to rewrite a InParallelOp to an scf::ForOp.
 struct InParallelOpToScfForRewriter : public OpRewritePattern<InParallelOp> {
   using OpRewritePattern::OpRewritePattern;

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.td
@@ -413,6 +413,20 @@ def RewriteLinalgExtInParallelToAsyncOp :
   }];
 }
 
+def RewriteLinalgExtInParallelToHALOp :
+  Linalg_Transform_Operation<"rewrite_iree_linalg_ext_in_parallel_to_hal", [
+    DeclareOpInterfaceMethods<TransformOpInterface, ["apply"]>
+  ]> {
+
+  let description = [{Rewrite linalg_ext.in_parallel op to use HAL ops.}];
+  let arguments = (ins PDL_Operation:$target);
+  // TODO: Determine whether we want to return something here, the only natural
+  // results would be the resulting insertTensorOps.
+  // let results = (outs PDL_Operation:$transformed);
+
+  let assemblyFormat = "$target attr-dict";
+}
+
 def RewriteLinalgExtInParallelToScfForOp :
   Linalg_Transform_Operation<"rewrite_iree_linalg_ext_in_parallel_to_scf_for",
     [TransformOpInterface, TargetableSingleOperandTransformOpTrait]> {

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_library(IREELinalgExtTransforms
   InParallelToAsync.cpp
+  InParallelToHAL.cpp
   InParallelToSequentialFor.cpp
   TilingExternalModels.cpp
   TileToSequentialFor.cpp

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/InParallelToHAL.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/InParallelToHAL.cpp
@@ -1,0 +1,116 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cstdlib>
+
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h"
+#include "iree-dialects/Dialect/LinalgExt/Transforms/Utils.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/SCF/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/AffineExpr.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/STLExtras.h"
+
+using namespace mlir;
+using namespace mlir::iree_compiler::IREE::LinalgExt;
+
+// TODO: This also needs to do the work of `SetNumWorkgroups` but we can't
+// depend on HAL atm.
+FailureOr<SmallVector<Operation *>> mlir::iree_compiler::IREE::LinalgExt::
+    InParallelOpToHALRewriter::returningMatchAndRewrite(
+        iree_compiler::IREE::LinalgExt::InParallelOp inParallelOp,
+        PatternRewriter &rewriter) const {
+  // TODO: InParallelOp must be nested under a hal variant.
+  // We can enable this once we have a proper interface and we split the impl.
+  // iree-dialects cannot depend on HAL atm.
+  // if (!inParallelOp->getParentOfType<HAL::VariantOp>())
+  //   return inParallelOp->emitError("No enclosing HAL::VariantOp");
+
+  // TODO: Ideally only do this on buffers but we can't atm.
+  // Bufferize happens at the IREE level on HAL operations, we cannot just
+  // call the linalg_transform.bufferize operation here.
+  // Instead it happens automatically at the end of the linalg-transform-interp
+  // pass.
+
+  // TODO: #of enclosing InParallelOp determine the #idx in:
+  //   hal.interface.workgroup.id[#idx] : index
+  //   hal.interface.workgroup.count[#idx] : index
+  unsigned numEnclosingInParallelOps = 0;
+
+  // If inParallelOp.num_threads() is already a HAL op, stop applying.
+  Operation *numThreadOp = inParallelOp.num_threads().getDefiningOp();
+  if (numThreadOp && isa<HALInterfaceWorkgroupIDOp>(numThreadOp))
+    return failure();
+
+  // Rewriter-based RAUW operates on Operation* atm, bail if we can't get it.
+  Operation *numThreadDefiningOp = inParallelOp.num_threads().getDefiningOp();
+  if (!numThreadDefiningOp)
+    return failure();
+
+  Location loc = inParallelOp.getLoc();
+
+  // Custom hal.executable.entry_point.
+  // TODO: getOrCreate at top-level when multiple InParallelOp are used and
+  // replace the corresponding return.
+  // TODO: pull in the proper dims as the bbArgs for dynamic sizes.
+  auto region = std::make_unique<Region>();
+  auto entryPointOp = rewriter.create<HALExecutableEntryPointOp>(loc);
+  Block &block = entryPointOp.workgroup_count_region().emplaceBlock();
+  {
+    OpBuilder::InsertionGuard g(rewriter);
+    rewriter.setInsertionPointToStart(&block);
+    Value one = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Operation *op = rewriter.clone(*numThreadOp);
+    rewriter.create<HALReturnOp>(loc, TypeRange{},
+                                 ValueRange{op->getResult(0), one, one});
+  }
+  auto idOp = rewriter.create<HALInterfaceWorkgroupIDOp>(
+      loc, numEnclosingInParallelOps);
+  auto countOp = rewriter.create<HALInterfaceWorkgroupCountOp>(
+      loc, numEnclosingInParallelOps);
+
+  // Get a reference to the terminator that will subsequently be moved.
+  PerformConcurrentlyOp performConcurrentlyOp = inParallelOp.getTerminator();
+
+  // First, update the uses of num_threads() within the inParallelOp block.
+  rewriter.replaceOpWithinBlock(numThreadDefiningOp, countOp.result(),
+                                &inParallelOp.region().front());
+
+  // Steal the iree_compiler::IREE::LinalgExt::InParallel ops, right before the
+  // inParallelOp. Replace the bbArg by the HAL id.
+  SmallVector<Value> bbArgsTranslated{idOp.result()};
+  rewriter.mergeBlockBefore(&inParallelOp.region().front(), inParallelOp,
+                            bbArgsTranslated);
+
+  // If we were on buffers, we would be done here.
+  if (inParallelOp->getNumResults() == 0) {
+    rewriter.eraseOp(inParallelOp);
+    return {};
+  }
+
+  // On tensors, we need to create sequential insertSlice ops.
+  rewriter.setInsertionPoint(inParallelOp);
+  SmallVector<Value> results;
+  SmallVector<Operation *> resultingOps;
+  for (ParallelInsertSliceOp op : performConcurrentlyOp.yieldingOps()) {
+    resultingOps.push_back(rewriter.create<tensor::InsertSliceOp>(
+        loc, op.source(), op.dest(), op.getMixedOffsets(), op.getMixedSizes(),
+        op.getMixedStrides()));
+    results.push_back(resultingOps.back()->getResult(0));
+  }
+  rewriter.replaceOp(inParallelOp, results);
+  rewriter.eraseOp(performConcurrentlyOp);
+
+  return resultingOps;
+}

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/LinalgTransformOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/LinalgTransformOps.cpp
@@ -844,6 +844,7 @@ transform::TileToLinalgExtTileOp::apply(transform::TransformResults &results,
     targets.front()->emitError("Cannot tile op: Not a TilingInterface");
     return failure();
   }
+
   FailureOr<iree_compiler::IREE::LinalgExt::TilingResult> result =
       functional::applyReturningPatternAt(pattern, tilingInterfaceOp);
   if (failed(result))
@@ -895,6 +896,14 @@ transform::RewriteLinalgExtInParallelToAsyncOp::applyToOne(
     return result;
   };
   return functional::applyAt(target, functionalRewrite);
+}
+
+LogicalResult transform::RewriteLinalgExtInParallelToHALOp::apply(
+    transform::TransformResults &results, transform::TransformState &state) {
+  LinalgExt::InParallelOpToHALRewriter pattern(this->getContext());
+  ArrayRef<Operation *> targets = state.getPayloadOps(target());
+  return functional::applyReturningPatternAt(
+      pattern, cast<LinalgExt::InParallelOp>(targets.front()));
 }
 
 FailureOr<scf::ForOp>


### PR DESCRIPTION
This revision adds a rewrite of InParallel to HAL and makes it available in the transform dialect.
The PR also adds a copy of the necessary HAL ops to LinalgExt to avoid using fake generic ops to transport the IR until it can be lowered to HAL.
These can be removed once the transform dialect allows external registration of ops.

The revision also disables the sequential `createSetNumWorkgroupsPass` so that the body of the real `hal.executable.entry_point` remains empty for now.
The information relevant in the body will be propagated back in a subsequent commit.

Produced IR currently resembles the following:

```
module {
  hal.executable private @pad_matmul_static_dispatch_0 {
    hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
      hal.executable.entry_point public @pad_matmul_static_dispatch_0 ordinal(0) layout(#executable_layout) {translation_info = #translation}
      builtin.module {
        func @pad_matmul_static_dispatch_0() {
          %c0 = arith.constant 0 : index
          %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : memref<250x500xf32>
          memref.assume_alignment %0, 64 : memref<250x500xf32>
          %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : memref<500x1020xf32>
          memref.assume_alignment %1, 64 : memref<500x1020xf32>
          %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(64) : memref<250x1020xf32>
          memref.assume_alignment %2, 64 : memref<250x1020xf32>
          "iree_linalg_ext.hal.executable.entry_point"() ({
            %c125 = arith.constant 125 : index
            %c1 = arith.constant 1 : index
            iree_linalg_ext.hal.return %c125, %c1, %c1 : index, index, index
          }) : () -> ()
          %3 = iree_linalg_ext.hal.interface.workgroup.id[0] : index
          %4 = iree_linalg_ext.hal.interface.workgroup.count[0] : index
          %5 = affine.apply #map0()[%3]
          %6 = affine.min #map1()[%3]
          %7 = memref.subview %2[%5, 0] [%6, 1020] [1, 1] : memref<250x1020xf32> to memref<?x1020xf32, #map2>
          %8 = memref.subview %0[%5, 0] [%6, 500] [1, 1] : memref<250x500xf32> to memref<?x500xf32, #map3>
          linalg.matmul {iree_linalg_transform.matched} ins(%8, %1 : memref<?x500xf32, #map3>, memref<500x1020xf32>) outs(%7 : memref<?x1020xf32, #map2>)
          return
        }
      }
    }
  }
}
```