### PR TITLE
[CUDA] Add pattern to collapse vector.transfer_read to 2D when possible

### DIFF
--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
@@ -92,20 +92,143 @@ static void createAsyncGroups(FuncOp funcOp) {
 }
 
 namespace {
+/// Apply tranformation to drop unit dims in destination of vector.transfer_read
+/// Ops such that the resulting vector is 2D
+/// Example:
+/// ```
+/// %cst = arith.constant 0.000000e+00 : f32
+/// %c2 = arith.constant 2 : index
+/// %c3 = arith.constant 3 : index
+/// %c4 = arith.constant 4 : index
+/// %0 = vector.transfer_read %a[%c2, %c3, %c4], %cst {in_bounds = [true, true,
+/// true]} : memref<128x16x256xf32>, vector<16x1x8xf32>
+/// To:
+/// ```
+/// #map = affine_map<(d0, d1) -> (d0 * 4096 + d1 + 8964)>
+/// %c0 = arith.constant 0 : index
+/// %cst = arith.constant 0.000000e+00 : f32
+/// %0 = memref.subview %arg0[2, 3, 4] [16, 1, 8] [1, 1, 1] :
+/// memref<128x16x256xf32> to memref<16x8xf32, #map> %1 = vector.transfer_read
+/// %0[%c0, %c0], %cst {in_bounds = [true, true]} : memref<16x8xf32, #map>,
+/// vector<16x8xf32> %2 = vector.broadcast %1 : vector<16x8xf32> to
+/// vector<1x16x8xf32> %3 = vector.transpose %2, [1, 0, 2] : vector<1x16x8xf32>
+/// to vector<16x1x8xf32>
+/// ```
+struct FlattenTransferReadOp : public OpRewritePattern<vector::TransferReadOp> {
+  using OpRewritePattern<vector::TransferReadOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::TransferReadOp transferReadOp,
+                                PatternRewriter& rewriter) const override {
+    auto loc = transferReadOp.getLoc();
+    Value vector = transferReadOp.vector();
+    VectorType vectorType = vector.getType().cast<VectorType>();
+    Value source = transferReadOp.source();
+    MemRefType sourceType = source.getType().dyn_cast<MemRefType>();
+    // Contiguity check is valid on tensors only.
+    if (!sourceType) return failure();
+    // Already 2D or lower nothing to do.
+    if (vectorType.getRank() < 3) return failure();
+    // The innermost dim is always considered non-unit as it wont be dropped
+    // Therefore, we initialize `numberOfNonUnitDims` to 1 and not 0
+    int numberOfNonUnitDims = 1;
+    // Track of the location of the outer non-unit dim in the source
+    // vector e.g if vector<1x16x1x32> -> vector<16x32> here the outer non-unit
+    // dim is the one with size 16 at index 1 in the source vector. We
+    // initialize as: `indexOfOuterNonUnitDim` = vectorType.getRank() - 2 = 2,
+    // which is the highest index it can have for any 4D shape, we then traverse
+    // the source vector shape to update this value to `indexOfOuterNonUnitDim`
+    // = 1. This works out nicely for a case like vector<1x1x1x32> ->
+    // vector<1x32> where `numberOfNonUnitDims` is desired to be 2, as the unit
+    // dim adjacent to the innermost dim is considered the outermost non-unit
+    // dim for the rest of the pattern if an actual outer non-unit dim does not
+    // exist
+    int indexOfOuterNonUnitDim = vectorType.getRank() - 2;
+    for (int i = 0; i < vectorType.getRank() - 1; i++) {
+      if (vectorType.getShape()[i] != 1) {
+        numberOfNonUnitDims++;
+        indexOfOuterNonUnitDim = i;
+      }
+    }
+    // Bail out if 2D vector cannot be formed
+    if (numberOfNonUnitDims > 2) {
+      return failure();
+    }
+    int rankOfCollapsedVector = 2;
+    // TODO: generalize this pattern, relax the requirements here.
+    if (transferReadOp.hasOutOfBoundsDim()) return failure();
+    if (!transferReadOp.permutation_map().isMinorIdentity()) return failure();
+    if (transferReadOp.mask()) return failure();
+    ArrayAttr newInBoundsAttr = rewriter.getBoolArrayAttr(
+        SmallVector<bool>(rankOfCollapsedVector, true));
+    auto newidentityMap =
+        rewriter.getMultiDimIdentityMap(rankOfCollapsedVector);
+
+    SmallVector<int64_t> vectorShapeCollapse = {
+        vectorType.getShape()[indexOfOuterNonUnitDim],
+        vectorType.getShape()[vectorType.getRank() - 1]};
+    SmallVector<int64_t> vectorShapeBroadcast = vectorShapeCollapse;
+    for (int i = 0; i < vectorType.getRank() - rankOfCollapsedVector; i++) {
+      vectorShapeBroadcast.insert(vectorShapeBroadcast.begin(), 1);
+    }
+
+    VectorType vectorTypeCollapse =
+        VectorType::get(vectorShapeCollapse, vectorType.getElementType());
+    VectorType vectorTypeBroadcast =
+        VectorType::get(vectorShapeBroadcast, vectorType.getElementType());
+
+    SmallVector<OpFoldResult> subViewOffsets, subViewSizes, subViewStrides;
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    for (int i = 0; i < vectorType.getRank(); i++) {
+      subViewOffsets.push_back(transferReadOp.indices()[i]);
+      subViewSizes.push_back(rewriter.getIndexAttr(vectorType.getShape()[i]));
+      subViewStrides.push_back(rewriter.getIndexAttr(1));
+    }
+    MemRefType resultType = memref::SubViewOp::inferRankReducedResultType(
+                                rankOfCollapsedVector, sourceType,
+                                subViewOffsets, subViewSizes, subViewStrides)
+                                .cast<MemRefType>();
+    Value subView = rewriter.create<memref::SubViewOp>(
+        loc, resultType, source, subViewOffsets, subViewSizes, subViewStrides);
+    Value readCollapse = rewriter.create<vector::TransferReadOp>(
+        loc, vectorTypeCollapse, subView, ValueRange{c0, c0}, newidentityMap,
+        transferReadOp.padding(), transferReadOp.mask(), newInBoundsAttr);
+
+    Value readBroadcast = rewriter.create<vector::BroadcastOp>(
+        loc, vectorTypeBroadcast, readCollapse);
+    SmallVector<int64_t> tranposePermutation;
+    for (int i = 0; i < vectorType.getRank(); i++) {
+      if (i == vectorType.getRank() - 2) continue;
+      tranposePermutation.push_back(i);
+    }
+    tranposePermutation.insert(
+        tranposePermutation.begin() + indexOfOuterNonUnitDim,
+        vectorType.getRank() - 2);
+    rewriter.replaceOpWithNewOp<vector::TransposeOp>(
+        transferReadOp, readBroadcast, tranposePermutation);
+    return success();
+  }
+};
 
 struct LLVMGPUVectorToGPUPass
     : public LLVMGPUVectorToGPUBase<LLVMGPUVectorToGPUPass> {
   void getDependentDialects(DialectRegistry& registry) const override {
-    registry.insert<gpu::GPUDialect>();
+    registry.insert<gpu::GPUDialect, AffineDialect, memref::MemRefDialect>();
   }
 
   void runOnOperation() override {
-    RewritePatternSet patterns(getOperation().getContext());
+    auto funcOp = getOperation();
+    RewritePatternSet flatternpatterns(funcOp.getContext());
+    flatternpatterns.insert<FlattenTransferReadOp>(funcOp.getContext());
+    if (failed(applyPatternsAndFoldGreedily(funcOp,
+                                            std::move(flatternpatterns)))) {
+      return signalPassFailure();
+    }
+    RewritePatternSet patterns(funcOp.getContext());
     populatePrepareVectorToMMAPatterns(patterns);
     (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
 
-    convertVectorToMMAOps(getOperation());
-    createAsyncGroups(getOperation());
+    convertVectorToMMAOps(funcOp);
+    createAsyncGroups(funcOp);
   }
 };
 }  // namespace

--- a/iree/compiler/Codegen/LLVMGPU/test/vector_to_gpu.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/vector_to_gpu.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt %s -allow-unregistered-dialect -iree-llvmgpu-vector-to-gpu -canonicalize | FileCheck %s
+// RUN: iree-opt %s -allow-unregistered-dialect -iree-llvmgpu-vector-to-gpu -canonicalize -split-input-file | FileCheck %s
 
 // CHECK-LABEL: func @copies_to_asyncs
 func @copies_to_asyncs(%a: memref<1024x1024xf32>) {
@@ -18,3 +18,116 @@ func @copies_to_asyncs(%a: memref<1024x1024xf32>) {
   // CHECK: gpu.device_async_wait %[[G]]
   return
 }
+
+// -----
+
+func @ksplitmatmul_basic(%a: memref<128x16x256xf32>) -> vector<16x1x8xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %0 = vector.transfer_read %a[%c2, %c3, %c4], %cst {in_bounds = [true, true, true]} : memref<128x16x256xf32>, vector<16x1x8xf32>
+  return %0 : vector<16x1x8xf32>
+}
+//   CHECK-DAG:#[[$MAP:.*]] = affine_map<(d0, d1) -> (d0 * 4096 + d1 + 8964)>
+// CHECK-LABEL: func @ksplitmatmul_basic
+//   CHECK-DAG: %[[ID:.*]] = arith.constant 0 : index  
+//   CHECK-DAG: %[[CST:.*]] = arith.constant 0.000000e+00 : f32
+//       CHECK: %[[M:.*]] = memref.subview
+//  CHECK-SAME:[2, 3, 4] [16, 1, 8] [1, 1, 1] 
+//  CHECK-SAME:memref<128x16x256xf32> to memref<16x8xf32, #[[$MAP]]>
+//       CHECK: vector.transfer_read %[[M]][%[[ID]], %[[ID]]]
+//  CHECK-SAME: {in_bounds = [true, true]} : memref<16x8xf32, #[[$MAP]]>, vector<16x8xf32>
+//       CHECK: vector.broadcast %{{.*}} : vector<16x8xf32> to vector<1x16x8xf32>
+//       CHECK: vector.transpose %{{.*}} [1, 0, 2] : vector<1x16x8xf32> to vector<16x1x8xf32>
+//       CHECK: return %{{.*}} : vector<16x1x8xf32>
+
+// -----
+
+func @ksplitmatmul_nounitdim(%a: memref<128x16x256xf32>) -> vector<16x2x8xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %0 = vector.transfer_read %a[%c2, %c3, %c4], %cst {in_bounds = [true, true, true]} : memref<128x16x256xf32>, vector<16x2x8xf32>
+  return %0 : vector<16x2x8xf32>
+}
+// CHECK-LABEL: func @ksplitmatmul_nounitdim
+//   CHECK-DAG: %[[ID:.*]] = arith.constant 2 : index
+//   CHECK-DAG: %[[ID2:.*]] = arith.constant 3 : index
+//   CHECK-DAG: %[[ID3:.*]] = arith.constant 4 : index    
+//   CHECK-DAG: %[[CST:.*]] = arith.constant 0.000000e+00 : f32
+//       CHECK: vector.transfer_read %{{.*}}[%[[ID]], %[[ID2]], %[[ID3]]]
+//  CHECK-SAME: {in_bounds = [true, true, true]} : memref<128x16x256xf32>, vector<16x2x8xf32>
+//       CHECK: return %{{.*}} : vector<16x2x8xf32>
+
+// -----
+
+func @ksplitmatmul_4D(%a: memref<128x16x32x256xf32>) -> vector<16x1x1x8xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %c5 = arith.constant 5 : index
+  %0 = vector.transfer_read %a[%c2, %c3, %c4, %c5], %cst {in_bounds = [true, true, true, true]} : memref<128x16x32x256xf32>, vector<16x1x1x8xf32>
+  return %0 : vector<16x1x1x8xf32>
+}
+//   CHECK-DAG:#[[$MAP:.*]] = affine_map<(d0, d1) -> (d0 * 131072 + d1 + 287749)>
+// CHECK-LABEL: func @ksplitmatmul_4D
+//   CHECK-DAG: %[[ID:.*]] = arith.constant 0 : index 
+//   CHECK-DAG: %[[CST:.*]] = arith.constant 0.000000e+00 : f32
+//       CHECK: %[[M:.*]] = memref.subview
+//  CHECK-SAME:[2, 3, 4, 5] [16, 1, 1, 8] [1, 1, 1, 1]
+//  CHECK-SAME: memref<128x16x32x256xf32> to memref<16x8xf32, #[[$MAP]]>
+//       CHECK: vector.transfer_read %[[M]][%[[ID]], %[[ID]]]
+//  CHECK-SAME: {in_bounds = [true, true]} :  memref<16x8xf32, #[[$MAP]]>, vector<16x8xf32>
+//       CHECK: vector.broadcast %{{.*}} : vector<16x8xf32> to vector<1x1x16x8xf32>
+//       CHECK: vector.transpose %{{.*}} [2, 0, 1, 3] : vector<1x1x16x8xf32> to vector<16x1x1x8xf32>
+//       CHECK: return %{{.*}} : vector<16x1x1x8xf32>
+
+// -----
+
+func @ksplitmatmul_4D_negative(%a: memref<128x16x32x256xf32>) -> vector<16x1x8x1xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %c5 = arith.constant 5 : index
+  %0 = vector.transfer_read %a[%c2, %c3, %c4, %c5], %cst {in_bounds = [true, true, true, true]} : memref<128x16x32x256xf32>, vector<16x1x8x1xf32>
+  return %0 : vector<16x1x8x1xf32>
+}
+
+// CHECK-LABEL: func @ksplitmatmul_4D_negative
+//   CHECK-DAG: %[[ID:.*]] = arith.constant 2 : index
+//   CHECK-DAG: %[[ID2:.*]] = arith.constant 3 : index
+//   CHECK-DAG: %[[ID3:.*]] = arith.constant 4 : index
+//   CHECK-DAG: %[[ID4:.*]] = arith.constant 5 : index     
+//   CHECK-DAG: %[[CST:.*]] = arith.constant 0.000000e+00 : f32
+//       CHECK: vector.transfer_read %{{.*}}[%[[ID]], %[[ID2]], %[[ID3]], %[[ID4]]]
+//  CHECK-SAME: {in_bounds = [true, true, true, true]} : memref<128x16x32x256xf32>, vector<16x1x8x1xf32>
+//       CHECK: return %{{.*}} : vector<16x1x8x1xf32>
+
+// -----
+
+func @ksplitmatmul_4D_allone(%a: memref<128x16x32x256xf32>) -> vector<1x1x1x1xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %c5 = arith.constant 5 : index
+  %0 = vector.transfer_read %a[%c2, %c3, %c4, %c5], %cst {in_bounds = [true, true, true, true]} : memref<128x16x32x256xf32>, vector<1x1x1x1xf32>
+  return %0 : vector<1x1x1x1xf32>
+}
+
+//   CHECK-DAG:#[[$MAP:.*]] = affine_map<(d0, d1) -> (d0 * 256 + d1 + 287749)>
+// CHECK-LABEL: func @ksplitmatmul_4D_allone
+//   CHECK-DAG: %[[ID:.*]] = arith.constant 0 : index 
+//   CHECK-DAG: %[[CST:.*]] = arith.constant 0.000000e+00 : f32
+//       CHECK: %[[M:.*]] = memref.subview
+//  CHECK-SAME:[2, 3, 4, 5] [1, 1, 1, 1] [1, 1, 1, 1]
+//  CHECK-SAME: memref<128x16x32x256xf32> to memref<1x1xf32, #[[$MAP]]>
+//       CHECK: vector.transfer_read %[[M]][%[[ID]], %[[ID]]]
+//  CHECK-SAME: {in_bounds = [true, true]} :  memref<1x1xf32, #[[$MAP]]>, vector<1x1xf32>
+//       CHECK: vector.broadcast %{{.*}} : vector<1x1xf32> to vector<1x1x1x1xf32>
+//   CHECK-NOT: vector.transpose
+//       CHECK: return %{{.*}} : vector<1x1x1x1xf32>


### PR DESCRIPTION
This is needed to lower these ops in the tensorcore pipeline