### PR TITLE
Allow tracy to find symbols and debug info in dynamic-library modules in Android benchmarks

### DIFF
--- a/build_tools/benchmarks/run_benchmarks_on_android.py
+++ b/build_tools/benchmarks/run_benchmarks_on_android.py
@@ -372,10 +372,11 @@ def run_benchmarks_for_category(
       capture_filename = None
       if do_capture and benchmark_key not in skip_captures:
         run_cmd = [
-            "TRACY_NO_EXIT=1", "taskset",
+            "TRACY_NO_EXIT=1",
+            f"IREE_PRESERVE_DYLIB_TEMP_FILES={ANDROID_TMP_DIR}", "taskset",
             benchmark_info.deduce_taskset(),
-            os.path.join(ANDROID_TMP_DIR, TRACED_TOOL_REL_DIR, tool),
-            f"--flagfile={MODEL_FLAGFILE_NAME}"
+            os.path.join(ANDROID_TMP_DIR, TRACED_TOOL_REL_DIR,
+                         tool), f"--flagfile={MODEL_FLAGFILE_NAME}"
         ]
 
         # Just launch the traced benchmark tool with TRACY_NO_EXIT=1 without


### PR DESCRIPTION
(Part 1/7 of tracy fixes, PR #8655)

Passing IREE_PRESERVE_DYLIB_TEMP_FILES allows tracy capture to read the dynamic library mappings -- otherwise, by the time tracy capture reads them, the temp file backing the mapping is gone, making it impossible to read the mapping.

It is important however to preserve the android benchmarks' ability to clean up all temporary files, otherwise the benchmarking devices get cluttered and can run out of disk space over time. This is particularly a concern with CI devices (this benchmarking script is what is used in CI).

Since the script is already deleting the entire ANDROID_TMP_DIR, the simplest was to move the dylib temp files there. That is done by extending the semantics of IREE_PRESERVE_DYLIB_TEMP_FILES so that when it's set to any other string than "1", it becomes the explicitly specified temp dir.

The C code was already honoring the semi-standard env var TMPDIR so we could almost just use that (in addition to continuine to pass IREE_PRESERVE_DYLIB_TEMP_FILES=1). The problem is that since TMPDIR is semi-standard, we can't know how many other places will also have their behavior changed by setting it (and it's open-ended beyond just IREE code, e.g. debuggers and other tools that we might use). And as the script is literally doing a `rm -rf` on that... we may want to continue to know exactly what we are storing there. So it's useful to have a dedicated env var to set specifically the path for dylib temp files.
