### PR TITLE
Enable selecting which drivers to build in Bazel

### DIFF
--- a/build_tools/bazel/iree.bazelrc
+++ b/build_tools/bazel/iree.bazelrc
@@ -28,11 +28,15 @@ test --test_output=errors
 startup --windows_enable_symlinks
 build --enable_runfiles
 
-
 # TODO: Transition to the explicit init_py mechanism. See #2405
 # This is commented out while considering transition path but left as a
 # breadcrumb.
 # build --incompatible_default_to_explicit_init_py
+
+###############################################################################
+# Build settings flag aliases. See https://bazel.build/rules/config
+###############################################################################
+build --flag_alias=iree_drivers=//iree/hal/drivers:enabled_drivers
 
 ###############################################################################
 # Options for "generic_gcc" builds

--- a/iree/build_defs.oss.bzl
+++ b/iree/build_defs.oss.bzl
@@ -6,14 +6,6 @@
 
 """Common Bazel definitions for IREE."""
 
-# Target to the FileCheck binary.
-INTREE_FILECHECK_TARGET = "@llvm-project//llvm:FileCheck"
-
-# Temporarily disabled pending build system changes.
-IREE_CUDA_DEPS = [
-    # "//iree/hal/cuda/registration"
-]
-
 def platform_trampoline_deps(basename, path = "base"):
     """Produce a list of deps for the given `basename` platform target.
 

--- a/iree/hal/drivers/BUILD
+++ b/iree/hal/drivers/BUILD
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("//iree:build_defs.oss.bzl", "IREE_CUDA_DEPS")
+load("@bazel_skylib//rules:common_settings.bzl", "string_list_flag")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -12,19 +12,65 @@ package(
     licenses = ["notice"],  # Apache 2.0
 )
 
+ALL_DRIVERS = [
+    "dylib",
+    "dylib-sync",
+    "vmvx",
+    "vmvx-sync",
+    "vulkan",
+    "cuda",
+]
+
+string_list_flag(
+    name = "enabled_drivers",
+    build_setting_default = [
+        "dylib",
+        "dylib-sync",
+        "vmvx",
+        "vmvx-sync",
+        "vulkan",
+    ],
+)
+
+[
+    config_setting(
+        name = "{}_enabled".format(driver),
+        flag_values = {
+            ":enabled_drivers": driver,
+        },
+    )
+    for driver in ALL_DRIVERS
+]
+
 cc_library(
     name = "drivers",
     srcs = ["init.c"],
     hdrs = ["init.h"],
     deps = [
-        "//iree/base",
-        "//iree/base:tracing",
-    ] + [
-        # TODO(*): select() and only pull in based on build configuration.
-        "//iree/hal/dylib/registration",
-        "//iree/hal/dylib/registration:sync",
-        "//iree/hal/vmvx/registration",
-        "//iree/hal/vmvx/registration:sync",
-        "//iree/hal/vulkan/registration",
-    ] + IREE_CUDA_DEPS,
+               "//iree/base",
+               "//iree/base:tracing",
+           ] + select({
+               ":dylib_enabled": ["//iree/hal/dylib/registration"],
+               "//conditions:default": [],
+           }) +
+           select({
+               ":dylib-sync_enabled": ["//iree/hal/dylib/registration:sync"],
+               "//conditions:default": [],
+           }) +
+           select({
+               ":vmvx_enabled": ["//iree/hal/vmvx/registration"],
+               "//conditions:default": [],
+           }) +
+           select({
+               ":vmvx-sync_enabled": ["//iree/hal/vmvx/registration:sync"],
+               "//conditions:default": [],
+           }) +
+           select({
+               ":vulkan_enabled": ["//iree/hal/vulkan/registration"],
+               "//conditions:default": [],
+           }) +
+           select({
+               ":cuda_enabled": ["//iree/hal/cuda/registration"],
+               "//conditions:default": [],
+           }),
 )


### PR DESCRIPTION
This is using the new-ish build settings configuration. With this, you
can do something like
`bazel build --iree_drivers=dylib //iree/tools:iree-run-module` to only
build with the dylib driver.