### PR TITLE
 Update presubmit pipeline for fixes when fetching existing branch

### DIFF
--- a/build_tools/buildkite/pipelines/presubmit.yml
+++ b/build_tools/buildkite/pipelines/presubmit.yml
@@ -28,7 +28,7 @@ steps:
   # Buildkite)?
   - label: ":face_with_monocle: :admission_tickets: :raised_hand: Checking CLA"
     plugins:
-      - https://github.com/GMNGeoffrey/smooth-checkout-buildkite-plugin#4e353abe72:
+      - https://github.com/GMNGeoffrey/smooth-checkout-buildkite-plugin#24e54e7729:
           repos:
             - config:
                 - url: ${BUILDKITE_REPO}
@@ -42,7 +42,7 @@ steps:
 
   - label: "Executing gcmn-test-pipeline"
     plugins:
-      - https://github.com/GMNGeoffrey/smooth-checkout-buildkite-plugin#4e353abe72:
+      - https://github.com/GMNGeoffrey/smooth-checkout-buildkite-plugin#24e54e7729:
           repos:
             - config:
                 - url: ${BUILDKITE_REPO}


### PR DESCRIPTION
Pulls in
[hasura/smooth-checkout-buildkite-plugin@24e54e7729 (#25)](https://github.com/hasura/smooth-checkout-buildkite-plugin/pull/25/commits/24e54e7729).
Previously, the fetch would pull in the remote branch but not update
the local branch and then when running checkout, because the local
branch already existed, it would check out that instead of creating a
new local branch from the remote branch.