### PR TITLE
Tracy fixes (OVERVIEW - sending out individual PRs for review)

### DIFF
--- a/build_tools/cmake/build_android_benchmark.sh
+++ b/build_tools/cmake/build_android_benchmark.sh
@@ -64,7 +64,8 @@ cd build-host
   -DIREE_BUILD_COMPILER=ON \
   -DIREE_BUILD_TESTS=OFF \
   -DIREE_BUILD_BENCHMARKS=ON \
-  -DIREE_BUILD_SAMPLES=OFF
+  -DIREE_BUILD_SAMPLES=OFF \
+  -DIREE_USE_SYSTEM_LINKER_FOR_MODULES_IN_TESTS_AND_BENCHMARKS=ON
 
 "${CMAKE_BIN}" --build . --target install -- -k 0
 # Also generate artifacts for benchmarking on Android.

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/UnixLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/UnixLinkerTool.cpp
@@ -28,10 +28,34 @@ class UnixLinkerTool : public LinkerTool {
     if (!toolPath.empty()) return toolPath;
 
     // No explicit linker specified, search the environment for common tools.
-    toolPath = findToolInEnvironment({"ld", "ld.gold", "ld.lld"});
+    // We want LLD:
+    // * On Apple, we want the system linker, which is named `ld`
+    if (targetIsApple()) {
+      // On macOS, the standard system linker is `ld`, and it's
+      // unconditionally what we want to use.
+      toolPath = findToolInEnvironment({"ld"});
+    } else {
+      // On Linux, the only linker basename that's standard is `ld` but it could
+      // be any of ld.bfd, ld.gold, ld.lld, which are inequivalent in the way
+      // explained in the comment below on the -shared flag. We specifically
+      // want ld.lld here, however we still search for `ld` as a fallback name,
+      // in case the linker would be ld.lld but would be installed only under
+      // the name `ld`.
+      //
+      // Having `ld` as a fallback name also makes sense (at least
+      // theoretically) on "generic Unix": `ld` is the standard name of the
+      // system linker, and `-static -shared` should in theory be supported by
+      // the system linker (as suggested by both the FreeBSD and GNU man pages
+      // for ld).
+      //
+      // On the other hand, on Linux where the possible fallbacks are ld.bfd or
+      // ld.gold, we are specifically not interested in falling back on any
+      // of these, at least given current behavior.
+      toolPath = findToolInEnvironment({"ld.lld", "ld"});
+    }
     if (!toolPath.empty()) return toolPath;
 
-    llvm::errs() << "No Unix linker tool specified or discovered\n";
+    llvm::errs() << "No Unix linker tool found in environment.\n";
     return "";
   }
 
@@ -54,7 +78,7 @@ class UnixLinkerTool : public LinkerTool {
         "-o " + artifacts.libraryFile.path,
     };
 
-    if (targetTriple.isOSDarwin() || targetTriple.isiOS()) {
+    if (targetIsApple()) {
       // Statically link all dependencies so we don't have any runtime deps.
       // We cannot have any imports in the module we produce.
       flags.push_back("-static");
@@ -73,6 +97,27 @@ class UnixLinkerTool : public LinkerTool {
       // Statically link all dependencies so we don't have any runtime deps.
       // We cannot have any imports in the module we produce.
       flags.push_back("-static");
+
+      // Generate a dynamic library (ELF type: ET_DYN), otherwise dlopen()
+      // won't succeed on it. This is not incompatible with -static. The GNU
+      // man page for ld, `man ld`, says the following:
+      //
+      //   -static
+      //       Do not link against shared libraries. [...] This option can be
+      //       used with -shared. Doing so means that a shared library is
+      //       being created but that all of the library's external references
+      //       must be resolved by pulling in entries from static libraries.
+      //
+      // While that much is said in the GNU ld man page, the reality is that
+      // out of ld.bfd, ld.gold and ld.lld, only ld.lld actually implements
+      // that. Meanwhile, ld.bfd interprets -static -shared as just -static,
+      // and ld.gold rejects -static -shared outright as "incompatible".
+      //
+      // So here we are effectively relying on the linker being ld.lld, which
+      // is the case because we are using Android NDK clang, which execs
+      // Android NDK ld, which is ld.lld, see strace results mentioned in
+      // AndroidLinkerTool class comment.
+      flags.push_back("-shared");
     }
 
     // Strip debug information (only, no relocations) when not requested.
@@ -89,6 +134,11 @@ class UnixLinkerTool : public LinkerTool {
     auto commandLine = llvm::join(flags, " ");
     if (failed(runLinkCommand(commandLine))) return llvm::None;
     return artifacts;
+  }
+
+ private:
+  bool targetIsApple() const {
+    return targetTriple.isOSDarwin() || targetTriple.isiOS();
   }
 };
 

--- a/iree/hal/dylib/registration/BUILD
+++ b/iree/hal/dylib/registration/BUILD
@@ -60,6 +60,7 @@ cc_library(
         "//iree/hal/local",
         "//iree/hal/local:sync_driver",
         "//iree/hal/local/loaders:embedded_library_loader",
+        "//iree/hal/local/loaders:system_library_loader",
     ],
 )
 

--- a/iree/hal/dylib/registration/CMakeLists.txt
+++ b/iree/hal/dylib/registration/CMakeLists.txt
@@ -49,6 +49,7 @@ iree_cc_library(
     iree::hal
     iree::hal::local
     iree::hal::local::loaders::embedded_library_loader
+    iree::hal::local::loaders::system_library_loader
     iree::hal::local::sync_driver
   DEFINES
     "IREE_HAL_HAVE_DYLIB_SYNC_DRIVER_MODULE=1"


### PR DESCRIPTION
This tracks my remaining changes to make Tracy fully work for IREE on Android and desktop Linux.

Not sending this PR for review -- sending out each commit as a separate PR for review, as soon as the previous one is merged. Feel free to start looking at the diffs here, but the suggestion is to focus on one commit at a time here, or to use this PR as providing context regarding the overall changes.

Invidual commits:

1. **Merged as #8659.** This adds a CMake option to build benchmark modules with the system linker, not the embedded linker. Despite fairly serious attempts (details available on request) I wasn't able to get Tracy to work with embedded modules, so this seems necessary at the moment.
2. **Merged as #8645.** We need to set the env var to preserve dylib temp files, otherwise by the time tracy capture tries to read the mappings, the file backing the mapping is gone and the mapping isn't actually readable anymore (and mprotect can't recover that anymore). However, we also need to ensure that our android CI benchmark scripts don't pollute device with leftover files otherwise devices fill up quickly. So this adds the necessary control to ensure all that.
3. **Merged as #8665.** This fixes AndroidLinkerTool to make it generate a shared object (i.e. have ELF type ET_DYN) as required for dlopen() to work on it.
4. **Merged as #8670.** While working on the next commit in this series, on UnixLinkerTool which handles both Apple and general-Unix cases, I realized that we had a bit too much magic nestled in `findToolInEnvironment`: having it search both our own executable dir and the environment made for confusing call sites where it wasn't clear when we're interested in one or the other. This would be useful if we actually needed to search both, but in practice, it seems that each call site knows which or the two cases it falls in (own executable dir or environment) so this makes code more explicit in this respect and allows the following commit to be less error-prone.
5. **Merged as #8673.** [UnixLinker: trim toolnames (Apple) and generate shared lib (non-Apple)](https://github.com/google/iree/pull/8655/commits/8ee94f8957dd32813504acf6d49736d7cfc9a218) So on Apple, now that it's clear that we're only searching the environment for a system linker, it's also clear that we only need to search for `ld`. And on non-Apple, similarly to the Android situation above, we weren't so far generating a shared object. Doing so makes us explicitly require LLD so we trim the toolnames list accordingly.

There used to be two additional commits in this queue but they have been dropped following [this Discord conversation](https://discord.com/channels/689900678990135345/689906000043573354/958463311479996446). Dropping 6. means that **The `dylib-sync` driver remains incompatible with system-linked modules**, which implies that for full Tracy support one should run the `dylib` driver (or any other driver supporting system-linked modules), not `dylib-sync`. Dropping 7. means that the traces recorded in CI benchmarks remain without information about module code (so for good traces with `dylib` one shoud build benchmarks locally with the `IREE_BYTECODE_MODULE_FORCE_SYSTEM_DYLIB_LINKER` option).

6. [dylib-sync: try system loader](https://github.com/google/iree/pull/8655/commits/6bd8b26be05e5cd974dd8767fe498a7df3f9e286) This is for benchmarks using the `dylib-sync` driver as opposed to `dylib`.  The `dylib-sync` was only trying to load embedded modules, so this makes it try also loading system-linked modules.
7. [Build Android benchmark modules with system linker (so Tracy works)](https://github.com/google/iree/pull/8655/commits/388805d2564a2e13d34596c0447e0162cb5f8016): actually enable the `IREE_BYTECODE_MODULE_FORCE_SYSTEM_DYLIB_LINKER` option introduced earlier, in Android benchmarks.  (Dilemma: also enable it in some Android tests so that any regression with system linker is caught in more than just buildkite builds? At the expense of reducing test coverage for embedded-linker, which is default?)