### PR TITLE
add IREE_BYTECODE_MODULE_FORCE_SYSTEM_DYLIB_LINKER

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ option(IREE_BUILD_DOCS "Builds IREE docs." OFF)
 option(IREE_BUILD_SAMPLES "Builds IREE sample projects." ON)
 option(IREE_BUILD_TRACY "Builds tracy server tools." OFF)
 
+option(IREE_BYTECODE_MODULE_FORCE_SYSTEM_DYLIB_LINKER "Use the system linker when generating IREE modules in tests/samples/benchmarks (useful for Tracy)." OFF)
+
 # Properties controlling version and naming of release artifacts.
 set(IREE_RELEASE_PACKAGE_SUFFIX "" CACHE STRING "Suffix to append to distributed package names")
 set(IREE_RELEASE_VERSION "0.1a1" CACHE STRING "Version to embed in distributed packages")

--- a/build_tools/cmake/iree_benchmark_suite.cmake
+++ b/build_tools/cmake/iree_benchmark_suite.cmake
@@ -181,6 +181,11 @@ function(iree_benchmark_suite)
       # The full list of translation flags.
       set(_TRANSLATION_ARGS "--iree-mlir-to-vm-bytecode-module")
       list(APPEND _TRANSLATION_ARGS "--iree-hal-target-backends=${_RULE_TARGET_BACKEND}")
+      if (IREE_BYTECODE_MODULE_FORCE_SYSTEM_DYLIB_LINKER)
+        # Honor this option here --- it's only an accident that we're not
+        # currently using iree_bytecode_module here.
+        list(APPEND _TRANSLATION_ARGS "-iree-llvm-link-embedded=false")
+      endif()
       list(SORT _RULE_TRANSLATION_FLAGS)
       list(APPEND _TRANSLATION_ARGS ${_RULE_TRANSLATION_FLAGS})
 

--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -116,6 +116,10 @@ function(iree_bytecode_module)
     # Note: -iree-llvm-system-linker-path is left unspecified.
   endif()
 
+  if (IREE_BYTECODE_MODULE_FORCE_SYSTEM_DYLIB_LINKER)
+    list(APPEND _TRANSLATION_ARGS "-iree-llvm-link-embedded=false")
+  endif()
+
   # Depending on the binary instead of the target here given we might not have
   # a target in this CMake invocation when cross-compiling.
   add_custom_command(


### PR DESCRIPTION
(Part 2/7 of tracy fixes, PR #8655)

This allows Tracy to see into module code in benchmarks on platforms,
at least Android and Unix, where it can't decipher embedded modules.

While the motivation here is about benchmarks, the new CMake option
added here also controls test modules (not just benchmark modules). That
is for two reasons:
* It's good to be testing the same code paths as one is benchmarking.
* Just like this is useful for Tracy, this could also conceivably be
  useful for any other debugging tool, such as GDB, that one may need to
  run tests in, and which unlike profilers may be useful on more than
  just benchmarks.

Note: @benvanik has already sent [this comment](https://github.com/google/iree/pull/8655#issuecomment-1080877654) on an earlier draft, resulting in the current naming and the comment in `iree_benchmark_suite.cmake` about how that should be using `iree_bytecode_module`.