### PR TITLE
Explicitly find linker in either environment or own build/install dir

### DIFF
--- a/iree/compiler/Dialect/HAL/Target/LLVM/LinkerTool.h
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LinkerTool.h
@@ -105,10 +105,16 @@ class LinkerTool {
   // Runs the given command line on the shell, logging failures.
   LogicalResult runLinkCommand(std::string commandLine, StringRef env = "");
 
+  // Returns the path to the first tool in |toolNames| found in the executable
+  // directory (plus some hard-coded relative paths from there, reflecting our
+  // build structure with the LLVM submodule) or empty string if no tool was
+  // found.
+  std::string findToolFromExecutableDir(
+      SmallVector<std::string> toolNames) const;
+
   // Returns the path to the first tool in |toolNames| found in the environment,
   // or empty string if no tool was found.
-  std::string findToolInEnvironment(
-      SmallVector<std::string, 4> toolNames) const;
+  std::string findToolInEnvironment(SmallVector<std::string> toolNames) const;
 
   llvm::Triple targetTriple;
   LLVMTargetOptions targetOptions;

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/EmbeddedLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/EmbeddedLinkerTool.cpp
@@ -56,13 +56,13 @@ class EmbeddedLinkerTool : public LinkerTool {
     // No explicit linker specified, search the install or build dir.
     const SmallVector<std::string> &toolNames{"iree-lld", "lld", "ld.lld",
                                               "lld-link"};
-    const std::string &executableDirPath = findToolFromExecutableDir(toolNames);
+    std::string executableDirPath = findToolFromExecutableDir(toolNames);
     if (!executableDirPath.empty()) return executableDirPath;
 
     // Currently fall back on searching the environment. This shouldn't be
     // needed as we are building lld in the LLVM submodule of IREE, but it
     // currently required on a few of our CI bots.
-    const std::string &environmentPath = findToolInEnvironment(toolNames);
+    std::string environmentPath = findToolInEnvironment(toolNames);
     if (!environmentPath.empty()) return environmentPath;
 
     llvm::errs()

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/EmbeddedLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/EmbeddedLinkerTool.cpp
@@ -53,9 +53,16 @@ class EmbeddedLinkerTool : public LinkerTool {
     char *envVarPath = std::getenv("IREE_LLVMAOT_EMBEDDED_LINKER_PATH");
     if (envVarPath && envVarPath[0] != '\0') return std::string(envVarPath);
 
-    // No explicit linker specified, search the environment for common tools.
-    std::string environmentPath =
-        findToolInEnvironment({"iree-lld", "lld", "ld.lld", "lld-link"});
+    // No explicit linker specified, search the install or build dir.
+    const SmallVector<std::string> &toolNames{"iree-lld", "lld", "ld.lld",
+                                              "lld-link"};
+    const std::string &executableDirPath = findToolFromExecutableDir(toolNames);
+    if (!executableDirPath.empty()) return executableDirPath;
+
+    // Currently fall back on searching the environment. This shouldn't be
+    // needed as we are building lld in the LLVM submodule of IREE, but it
+    // currently required on a few of our CI bots.
+    const std::string &environmentPath = findToolInEnvironment(toolNames);
     if (!environmentPath.empty()) return environmentPath;
 
     llvm::errs()

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/WasmLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/WasmLinkerTool.cpp
@@ -50,8 +50,9 @@ class WasmLinkerTool : public LinkerTool {
       return std::string(linkerPath);
     }
 
-    // No explicit linker specified, search the environment for common tools.
-    std::string toolPath = findToolInEnvironment(
+    // No explicit linker specified, search the environment (i.e. our own build
+    // or install directories) for common tools.
+    const std::string &toolPath = findToolFromExecutableDir(
         {"wasm-ld", "iree-lld", "lld", "ld.lld", "lld-link"});
     if (!toolPath.empty()) return toolPath;
 

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/WasmLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/WasmLinkerTool.cpp
@@ -52,7 +52,7 @@ class WasmLinkerTool : public LinkerTool {
 
     // No explicit linker specified, search the environment (i.e. our own build
     // or install directories) for common tools.
-    const std::string &toolPath = findToolFromExecutableDir(
+    std::string toolPath = findToolFromExecutableDir(
         {"wasm-ld", "iree-lld", "lld", "ld.lld", "lld-link"});
     if (!toolPath.empty()) return toolPath;
 

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/WindowsLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/WindowsLinkerTool.cpp
@@ -26,8 +26,9 @@ class WindowsLinkerTool : public LinkerTool {
     auto toolPath = LinkerTool::getSystemToolPath();
     if (!toolPath.empty()) return toolPath;
 
-    // No explicit linker specified, search the environment for common tools.
-    toolPath = findToolInEnvironment({"lld-link"});
+    // No explicit linker specified, search the executable directory (i.e. our
+    // own build or install directories) for common tools.
+    toolPath = findToolFromExecutableDir({"lld-link"});
     if (!toolPath.empty()) return toolPath;
 
     llvm::errs() << "No Windows linker tool specified or discovered\n";


### PR DESCRIPTION
(Part 4/7 of tracy fixes, PR https://github.com/google/iree/pull/8655)

While working on the next commit in this series, on UnixLinkerTool which handles both Apple and general-Unix cases, I realized that we had a bit too much magic nestled in findToolInEnvironment: having it search both our own executable dir and the environment made for confusing call sites where it wasn't clear when we're interested in one or the other. This would be useful if we actually needed to search both, but in practice, it seems that each call site knows which or the two cases it falls in (own executable dir or environment) so this makes code more explicit in this respect and allows the following commit to be less error-prone.

I had to reinstate searching the environment in EmbeddedLinkerTool because two of the CI builds failed to find the linker without that. I guess it's good that we discovered that.

I dropped some explicit inline storage size hints in SmallVector's -- rewrote `SmallVector<std::string, 4>` to just `SmallVector<std::string>` -- because otherwise i had to propagate that (can't pass a `Smallvector<T, N>` to a function that expects a `SmallVector<T, K>`) and that felt like premature optimization.