### PR TITLE
Fix web sample warnings and use IREE_DEFAULT_COPTS warnings/errors.

### DIFF
--- a/experimental/web/sample_dynamic/CMakeLists.txt
+++ b/experimental/web/sample_dynamic/CMakeLists.txt
@@ -21,6 +21,8 @@ target_sources(${_NAME}
 )
 set_target_properties(${_NAME} PROPERTIES OUTPUT_NAME "web-sample-dynamic-sync")
 
+target_compile_options(${_NAME} PRIVATE ${IREE_DEFAULT_COPTS})
+
 # Note: we have to be very careful about dependencies here.
 #
 # The general purpose libraries link in multiple executable loaders and HAL
@@ -46,6 +48,6 @@ target_link_options(${_NAME} PRIVATE
   "-gseparate-dwarf"
   #
   # Dynamic linking: https://emscripten.org/docs/compiling/Dynamic-Linking.html
-  "-sMAIN_MODULE"
+  "-sMAIN_MODULE=2"
   # "-sALLOW_TABLE_GROWTH"
 )

--- a/experimental/web/sample_static/CMakeLists.txt
+++ b/experimental/web/sample_static/CMakeLists.txt
@@ -36,6 +36,8 @@ target_sources(${_NAME}
 )
 set_target_properties(${_NAME} PROPERTIES OUTPUT_NAME "web-sample-static-sync")
 
+target_compile_options(${_NAME} PRIVATE ${IREE_DEFAULT_COPTS})
+
 # Note: we have to be very careful about dependencies here.
 #
 # The general purpose libraries link in multiple executable loaders and HAL
@@ -77,6 +79,8 @@ target_sources(${_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/mnist_bytecode.c
 )
 set_target_properties(${_NAME} PROPERTIES OUTPUT_NAME "web-sample-static-multithreaded")
+
+target_compile_options(${_NAME} PRIVATE ${IREE_DEFAULT_COPTS})
 
 # Note: we have to be very careful about dependencies here.
 #

--- a/experimental/web/sample_static/device_multithreaded.c
+++ b/experimental/web/sample_static/device_multithreaded.c
@@ -17,7 +17,7 @@ iree_status_t create_device_with_static_loader(iree_allocator_t host_allocator,
   iree_hal_task_device_params_initialize(&params);
 
   // Register the statically linked executable library.
-  const iree_hal_executable_library_query_fn_t* libraries[] = {
+  const iree_hal_executable_library_query_fn_t libraries[] = {
       mnist_linked_llvm_library_query,
   };
   iree_hal_executable_loader_t* library_loader = NULL;

--- a/experimental/web/sample_static/device_sync.c
+++ b/experimental/web/sample_static/device_sync.c
@@ -14,7 +14,7 @@ iree_status_t create_device_with_static_loader(iree_allocator_t host_allocator,
   iree_hal_sync_device_params_initialize(&params);
 
   // Register the statically linked executable library.
-  const iree_hal_executable_library_query_fn_t* libraries[] = {
+  const iree_hal_executable_library_query_fn_t libraries[] = {
       mnist_linked_llvm_library_query,
   };
   iree_hal_executable_loader_t* library_loader = NULL;

--- a/experimental/web/sample_static/main.c
+++ b/experimental/web/sample_static/main.c
@@ -69,7 +69,6 @@ iree_sample_state_t* setup_sample() {
 
   iree_runtime_session_options_t session_options;
   iree_runtime_session_options_initialize(&session_options);
-  iree_runtime_session_t* session = NULL;
   if (iree_status_is_ok(status)) {
     status = iree_runtime_session_create_with_device(
         state->instance, &session_options, state->device,


### PR DESCRIPTION
Tested on Windows with emsdk 3.1.8

---

Warnings are now treated as errors thanks to applying `IREE_DEFAULT_COPTS`. I hesitate to use an internal IREE CMake variable in a sample, but the convenience seems worth it here. Anyone forking this can just set the options they want.

---

Mismatched pointer type was from https://github.com/google/iree/pull/8436 (since these don't build/test on presubmit and warnings were not treated as errors before). These samples now match https://github.com/google/iree/blob/2cf4a787ad631be33b092eaf65223252fd63eab8/iree/samples/static_library/static_library_demo.c#L33-L41

---

The `-sMAIN_MODULE=2` change is to fix this warning:

```
[10/10] Linking C executable experimental\web\sample_dynamic\web-sample-dynamic-sync.js
emcc: warning: EXPORTED_FUNCTIONS is not valid with LINKABLE set (normally due to SIDE_MODULE=1/MAIN_MODULE=1) since all functions are exported this mode.  To export only a subset use SIDE_MODULE=2/MAIN_MODULE=2 [-Wunused-command-line-argument]
```

See the docs: https://emscripten.org/docs/compiling/Dynamic-Linking.html#code-size. Setting to `2` enables DCE and `EXPORTED_FUNCTIONS` again (we tightly control the symbols we need so the default export all behavior isn't what we want).