### PR TITLE
UnixLinker: trim toolnames (Apple) and generate shared lib (non-Apple)

### DIFF
--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/UnixLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/UnixLinkerTool.cpp
@@ -28,10 +28,34 @@ class UnixLinkerTool : public LinkerTool {
     if (!toolPath.empty()) return toolPath;
 
     // No explicit linker specified, search the environment for common tools.
-    toolPath = findToolInEnvironment({"ld", "ld.gold", "ld.lld"});
+    // We want LLD:
+    // * On Apple, we want the system linker, which is named `ld`
+    if (targetIsApple()) {
+      // On macOS, the standard system linker is `ld`, and it's
+      // unconditionally what we want to use.
+      toolPath = findToolInEnvironment({"ld"});
+    } else {
+      // On Linux, the only linker basename that's standard is `ld` but it could
+      // be any of ld.bfd, ld.gold, ld.lld, which are inequivalent in the way
+      // explained in the comment below on the -shared flag. We specifically
+      // want ld.lld here, however we still search for `ld` as a fallback name,
+      // in case the linker would be ld.lld but would be installed only under
+      // the name `ld`.
+      //
+      // Having `ld` as a fallback name also makes sense (at least
+      // theoretically) on "generic Unix": `ld` is the standard name of the
+      // system linker, and `-static -shared` should in theory be supported by
+      // the system linker (as suggested by both the FreeBSD and GNU man pages
+      // for ld).
+      //
+      // On the other hand, on Linux where the possible fallbacks are ld.bfd or
+      // ld.gold, we are specifically not interested in falling back on any
+      // of these, at least given current behavior.
+      toolPath = findToolInEnvironment({"ld.lld", "ld"});
+    }
     if (!toolPath.empty()) return toolPath;
 
-    llvm::errs() << "No Unix linker tool specified or discovered\n";
+    llvm::errs() << "No Unix linker tool found in environment.\n";
     return "";
   }
 
@@ -54,7 +78,7 @@ class UnixLinkerTool : public LinkerTool {
         "-o " + artifacts.libraryFile.path,
     };
 
-    if (targetTriple.isOSDarwin() || targetTriple.isiOS()) {
+    if (targetIsApple()) {
       // Statically link all dependencies so we don't have any runtime deps.
       // We cannot have any imports in the module we produce.
       flags.push_back("-static");
@@ -73,6 +97,27 @@ class UnixLinkerTool : public LinkerTool {
       // Statically link all dependencies so we don't have any runtime deps.
       // We cannot have any imports in the module we produce.
       flags.push_back("-static");
+
+      // Generate a dynamic library (ELF type: ET_DYN), otherwise dlopen()
+      // won't succeed on it. This is not incompatible with -static. The GNU
+      // man page for ld, `man ld`, says the following:
+      //
+      //   -static
+      //       Do not link against shared libraries. [...] This option can be
+      //       used with -shared. Doing so means that a shared library is
+      //       being created but that all of the library's external references
+      //       must be resolved by pulling in entries from static libraries.
+      //
+      // While that much is said in the GNU ld man page, the reality is that
+      // out of ld.bfd, ld.gold and ld.lld, only ld.lld actually implements
+      // that. Meanwhile, ld.bfd interprets -static -shared as just -static,
+      // and ld.gold rejects -static -shared outright as "incompatible".
+      //
+      // So here we are effectively relying on the linker being ld.lld, which
+      // is the case because we are using Android NDK clang, which execs
+      // Android NDK ld, which is ld.lld, see strace results mentioned in
+      // AndroidLinkerTool class comment.
+      flags.push_back("-shared");
     }
 
     // Strip debug information (only, no relocations) when not requested.
@@ -89,6 +134,11 @@ class UnixLinkerTool : public LinkerTool {
     auto commandLine = llvm::join(flags, " ");
     if (failed(runLinkCommand(commandLine))) return llvm::None;
     return artifacts;
+  }
+
+ private:
+  bool targetIsApple() const {
+    return targetTriple.isOSDarwin() || targetTriple.isiOS();
   }
 };
 

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/UnixLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/UnixLinkerTool.cpp
@@ -112,11 +112,6 @@ class UnixLinkerTool : public LinkerTool {
       // out of ld.bfd, ld.gold and ld.lld, only ld.lld actually implements
       // that. Meanwhile, ld.bfd interprets -static -shared as just -static,
       // and ld.gold rejects -static -shared outright as "incompatible".
-      //
-      // So here we are effectively relying on the linker being ld.lld, which
-      // is the case because we are using Android NDK clang, which execs
-      // Android NDK ld, which is ld.lld, see strace results mentioned in
-      // AndroidLinkerTool class comment.
       flags.push_back("-shared");
     }
 


### PR DESCRIPTION
(Part 5/7 of tracy fixes, PR https://github.com/google/iree/pull/8655)

- On Apple, now that it's clear that we're only searching the environment for a system linker, it's also clear that we only need to search for ld.
- Outside of Apple, similarly to the Android situation before PR #8665, we weren't so far generating a shared object. Doing so makes us explicitly require LLD so we trim the toolnames list accordingly.

@powderluv please take a look - is this breaking some Apple target? Also I hope that #8670 didn't break anything (so if things are broken before this PR, that might be the culprit).