### PR TITLE
Use upstream tile, fuse, and distribution for codegen driver approaches.

### DIFF
--- a/iree/compiler/Codegen/Common/BUILD
+++ b/iree/compiler/Codegen/Common/BUILD
@@ -51,6 +51,7 @@ cc_library(
         "OptimizeVectorTransferPass.cpp",
         "PolynomialApproximationPass.cpp",
         "RemoveTrivialLoops.cpp",
+        "RewriteLinalgDestructiveUpdatesPass.cpp",
         "SetNumWorkgroupsPass.cpp",
         "TileAndDistributeToWorkgroupsPass.cpp",
         "TypePropagationPass.cpp",

--- a/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -43,6 +43,7 @@ iree_cc_library(
     "OptimizeVectorTransferPass.cpp"
     "PolynomialApproximationPass.cpp"
     "RemoveTrivialLoops.cpp"
+    "RewriteLinalgDestructiveUpdatesPass.cpp"
     "SetNumWorkgroupsPass.cpp"
     "TileAndDistributeToWorkgroupsPass.cpp"
     "TypePropagationPass.cpp"

--- a/iree/compiler/Codegen/Common/RewriteLinalgDestructiveUpdatesPass.cpp
+++ b/iree/compiler/Codegen/Common/RewriteLinalgDestructiveUpdatesPass.cpp
@@ -1,0 +1,67 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/DestructiveUpdateUtils.h"
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Passes.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/Dialect/MemRef/Transforms/Passes.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-codegen-rewrite-linalg-destructive-updates"
+
+namespace mlir {
+namespace iree_compiler {
+namespace {
+struct RewriteLinalgDestructiveUpdatesPass
+    : public RewriteLinalgDestructiveUpdatesBase<
+          RewriteLinalgDestructiveUpdatesPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry
+        .insert<AffineDialect, IREE::Flow::FlowDialect, linalg::LinalgDialect,
+                scf::SCFDialect, tensor::TensorDialect>();
+  }
+
+  void runOnOperation() override;
+};
+}  // namespace
+
+void RewriteLinalgDestructiveUpdatesPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  FuncOp funcOp = getOperation();
+  if (!isEntryPoint(funcOp)) return;
+
+  // Rewrite destructive updates and ensure no remaining store remains to the
+  // full output.
+
+  // TODO(#...): Use of the destructive update rewrite is a hack! There needs to
+  // be a way to generate loops as we need, and use the tiled op generation
+  // implementation. This should be possible after moving everything to use the
+  // `TilingInterface`.
+  if (failed(rewriteLinalgDestructiveUpdates(funcOp))) {
+    funcOp->emitError("Failed to rewrite destructive updates in:\n")
+        << *funcOp.getOperation();
+    return signalPassFailure();
+  }
+
+  // After rewriting destructive updates, there might be uses of compute
+  // operations only in `tensor.dim` ops. Resolve these.
+  RewritePatternSet resolveDimOps(context);
+  memref::populateResolveRankedShapeTypeResultDimsPatterns(resolveDimOps);
+  if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(resolveDimOps)))) {
+    return signalPassFailure();
+  }
+}
+
+std::unique_ptr<OperationPass<FuncOp>>
+createRewriteLinalgDestructiveUpdatesPass() {
+  return std::make_unique<RewriteLinalgDestructiveUpdatesPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Codegen/Common/test/BUILD
+++ b/iree/compiler/Codegen/Common/test/BUILD
@@ -34,6 +34,7 @@ iree_lit_test_suite(
             "linalg_bufferize.mlir",
             "remove_dead_allocs.mlir",
             "remove_trivial_loops.mlir",
+            "rewrite_linalg_destructive_updates.mlir",
             "tile_and_distribute_to_workgroups.mlir",
             "transpose_canonicalization.mlir",
             "type_propagation.mlir",

--- a/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -29,6 +29,7 @@ iree_lit_test_suite(
     "linalg_bufferize.mlir"
     "remove_dead_allocs.mlir"
     "remove_trivial_loops.mlir"
+    "rewrite_linalg_destructive_updates.mlir"
     "tile_and_distribute_to_workgroups.mlir"
     "transpose_canonicalization.mlir"
     "type_propagation.mlir"

--- a/iree/compiler/Codegen/Common/test/rewrite_linalg_destructive_updates.mlir
+++ b/iree/compiler/Codegen/Common/test/rewrite_linalg_destructive_updates.mlir
@@ -1,0 +1,42 @@
+// RUN: iree-opt -iree-codegen-rewrite-linalg-destructive-updates %s | FileCheck %s
+
+func @matmul() {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c786432 = arith.constant 786432 : index
+  %c0 = arith.constant 0 : index
+  %c384 = arith.constant 384 : index
+  %c128 = arith.constant 128 : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:128x1536xf32>
+  %1 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c786432) alignment(64) : !flow.dispatch.tensor<readonly:1536x384xf32>
+  %2 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:128x384xf32>
+  %3 = flow.dispatch.tensor.load %2, offsets = [0, 0], sizes = [128, 384], strides = [1, 1] : !flow.dispatch.tensor<writeonly:128x384xf32> -> tensor<128x384xf32>
+  %4 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [128, 1536], strides = [1, 1] : !flow.dispatch.tensor<readonly:128x1536xf32> -> tensor<128x1536xf32>
+  %5 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [1536, 384], strides = [1, 1] : !flow.dispatch.tensor<readonly:1536x384xf32> -> tensor<1536x384xf32>
+  %workgroup_id_x = hal.interface.workgroup.id[0] : index
+  %workgroup_count_x = hal.interface.workgroup.count[0] : index
+  %workgroup_id_y = hal.interface.workgroup.id[1] : index
+  %workgroup_count_y = hal.interface.workgroup.count[1] : index
+  %6 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_id_y]
+  %7 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_count_y]
+  %8 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_id_x]
+  %9 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_count_x]
+  %10 = scf.for %arg0 = %6 to %c128 step %7 iter_args(%arg1 = %3) -> (tensor<128x384xf32>) {
+    %11 = tensor.extract_slice %4[%arg0, 0] [64, 1536] [1, 1] : tensor<128x1536xf32> to tensor<64x1536xf32>
+    %12 = scf.for %arg2 = %8 to %c384 step %9 iter_args(%arg3 = %arg1) -> (tensor<128x384xf32>) {
+      %13 = tensor.extract_slice %5[0, %arg2] [1536, 64] [1, 1] : tensor<1536x384xf32> to tensor<1536x64xf32>
+      %14 = tensor.extract_slice %arg3[%arg0, %arg2] [64, 64] [1, 1] : tensor<128x384xf32> to tensor<64x64xf32>
+      %15 = linalg.fill ins(%cst : f32) outs(%14 : tensor<64x64xf32>) -> tensor<64x64xf32>
+      %16 = linalg.matmul {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 0], [8, 32, 0], [0, 0, 16]]>} ins(%11, %13 : tensor<64x1536xf32>, tensor<1536x64xf32>) outs(%15 : tensor<64x64xf32>) -> tensor<64x64xf32>
+      %17 = tensor.insert_slice %16 into %arg3[%arg0, %arg2] [64, 64] [1, 1] : tensor<64x64xf32> into tensor<128x384xf32>
+      scf.yield %17 : tensor<128x384xf32>
+    }
+    scf.yield %12 : tensor<128x384xf32>
+  }
+  flow.dispatch.tensor.store %10, %2, offsets = [0, 0], sizes = [128, 384], strides = [1, 1] : tensor<128x384xf32> -> !flow.dispatch.tensor<writeonly:128x384xf32>
+  return
+}
+// CHECK-LABEL: func @matmul
+// CHECK:         scf.for
+// CHECK:           scf.for
+// CHECK:             %[[MATMUL:.+]] = linalg.matmul
+// CHECK:             flow.dispatch.tensor.store %[[MATMUL]]

--- a/iree/compiler/Codegen/LLVMCPU/test/illegal_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/illegal_configuration.mlir
@@ -31,7 +31,7 @@ hal.executable private @matmul_tensors {
 
 // -----
 
-#config = #iree_codegen.lowering_config<tile_sizes = [[4, 8], [8, 8, 0], [0, 0, 8]], native_vector_size = [0, 0, 4]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[4, 8, 0], [8, 8, 0], [0, 0, 8]], native_vector_size = [0, 0, 4]>
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
@@ -93,7 +93,7 @@ hal.executable private @matmul_tensors {
 
 // -----
 
-#config = #iree_codegen.lowering_config<tile_sizes = [[64, 64], [8, 0, 0], [0, 16, 16]]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 0], [8, 0, 0], [0, 16, 16]]>
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [

--- a/iree/compiler/Codegen/Passes.h
+++ b/iree/compiler/Codegen/Passes.h
@@ -132,6 +132,11 @@ std::unique_ptr<OperationPass<FuncOp>> createInsertDistributionInfoPass();
 std::unique_ptr<OperationPass<FuncOp>>
 createTileAndDistributeToWorkgroupsPass();
 
+/// Pass to rewrite Linalg destructive updates, see DestructiveUpdateUtils.h for
+/// more details.
+std::unique_ptr<OperationPass<FuncOp>>
+createRewriteLinalgDestructiveUpdatesPass();
+
 /// Pass to propagate type to avoid generating load/stores of illegal types.
 std::unique_ptr<OperationPass<FuncOp>> createTypePropagationPass();
 

--- a/iree/compiler/Codegen/Passes.td
+++ b/iree/compiler/Codegen/Passes.td
@@ -105,6 +105,11 @@ def TileAndDistributeToWorkgroups :
   let constructor = "mlir::iree_compiler::createTileAndDistributeToWorkgroupsPass()";
 }
 
+def RewriteLinalgDestructiveUpdates :
+    Pass<"iree-codegen-rewrite-linalg-destructive-updates", "func::FuncOp"> {
+  let summary = "Rewrites Linalg destructive updates";
+  let constructor = "mlir::iree_compiler::createRewriteLinalgDestructiveUpdatesPass()";
+}
 def TypePropagation :
     Pass<"iree-codegen-type-propagation", "func::FuncOp"> {
   let summary = "Propogate the type of tensor to avoid load/stores of illegal bit widths";

--- a/iree/compiler/Codegen/Sandbox/LinalgTensorCodegenDriver.cpp
+++ b/iree/compiler/Codegen/Sandbox/LinalgTensorCodegenDriver.cpp
@@ -112,6 +112,7 @@ struct LinalgFusePass : public LinalgFuseBase<LinalgFusePass> {
     this->vectorize = options.vectorize;
     this->vectorizePadding = options.vectorizePadding;
     this->tilingLevel = options.tilingLevel;
+    this->doIREEDistribution = options.doIREEDistribution;
   }
   void runOnOperation() override;
 };
@@ -216,6 +217,10 @@ void LinalgFusePass::runOnOperation() {
   }
   tilingOptions.tileInterchange = {tileInterchange.begin(),
                                    tileInterchange.end()};
+  if (doIREEDistribution) {
+    tilingOptions.setDistributionOptions(
+        ::mlir::iree_compiler::getIREELinalgLoopDistributionOptions());
+  }
 
   // Set up padding options.
   // TODO: Replace the lambdas by either functions defined in MLIR core or even

--- a/iree/compiler/Codegen/Sandbox/Passes.h
+++ b/iree/compiler/Codegen/Sandbox/Passes.h
@@ -7,6 +7,7 @@
 #ifndef IREE_CODEGEN_SANDBOX_PASSES_H_
 #define IREE_CODEGEN_SANDBOX_PASSES_H_
 
+#include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {
@@ -24,6 +25,7 @@ struct LinalgFusePassOptions {
   bool vectorize = false;
   bool vectorizePadding = false;
   int64_t tilingLevel = -1;
+  bool doIREEDistribution = false;
 };
 
 /// Creates a pass to drive tile + fuse transformations of `LinalgOp`s.

--- a/iree/compiler/Codegen/Sandbox/Passes.td
+++ b/iree/compiler/Codegen/Sandbox/Passes.td
@@ -43,7 +43,9 @@ def LinalgFuse : Pass<"linalg-fuse", "FuncOp"> {
 
     // IREE specific options
     Option<"tilingLevel", "tiling-level", "int64_t", /*default=*/"-1",
-      "Use default tiling level used to retrieve the configuration from lowering_config">
+      "Use default tiling level used to retrieve the configuration from lowering_config">,
+    Option<"doIREEDistribution", "do-iree-distribution", "bool", /*default=*/"false",
+      "Apply IREE distribution during tiling">,
   ];
   let dependentDialects = [
     "::mlir::arith::ArithmeticDialect", "::mlir::AffineDialect",

--- a/iree/compiler/Codegen/Utils/Utils.h
+++ b/iree/compiler/Codegen/Utils/Utils.h
@@ -13,6 +13,7 @@
 #include "llvm/ADT/Triple.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/SCF/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
 
@@ -149,6 +150,10 @@ SmallVector<LoopTilingAndDistributionInfo> getTiledAndDistributedLoopInfo(
 
 Operation *createLinalgCopyOp(OpBuilder &b, Location loc, Value from, Value to,
                               ArrayRef<NamedAttribute> attributes = {});
+
+/// Returns the option that distributes the ops using the flow workgroup
+/// ID/Count operations.
+linalg::LinalgLoopDistributionOptions getIREELinalgLoopDistributionOptions();
 }  // namespace iree_compiler
 }  // namespace mlir
 

--- a/iree/compiler/Dialect/Flow/Transforms/SplitReduction.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/SplitReduction.cpp
@@ -95,6 +95,12 @@ struct SplitReductionPass : public SplitReductionBase<SplitReductionPass> {
                                             std::move(patterns)))) {
       return signalPassFailure();
     }
+
+    // Remove all the markers at the end.
+    auto funcOp = getOperation();
+    funcOp->walk([&](linalg::LinalgOp op) {
+      op->removeAttr(linalg::LinalgTransforms::kLinalgTransformMarker);
+    });
   }
 };
 

--- a/iree/test/e2e/regression/lowering_config.mlir
+++ b/iree/test/e2e/regression/lowering_config.mlir
@@ -1,9 +1,9 @@
 #compilation0 = #iree_codegen.compilation_info<
-    lowering_config = <tile_sizes = [[32, 32], [8, 8, 0], [0, 0, 8]]>,
+    lowering_config = <tile_sizes = [[32, 32, 0], [8, 8, 0], [0, 0, 8]]>,
     translation_info = <CPUDoubleTilingExpert>,
     workgroup_size = []>
 #compilation1 = #iree_codegen.compilation_info<
-    lowering_config = <tile_sizes = [[64, 64], [4, 4, 0], [0, 0, 4]]>,
+    lowering_config = <tile_sizes = [[64, 64, 0], [4, 4, 0], [0, 0, 4]]>,
     translation_info = <CPUDoubleTilingExpert>,
     workgroup_size = []>
 func @lowering_config_test() {

--- a/iree/test/e2e/xla_ops/reduce_window.mlir
+++ b/iree/test/e2e/xla_ops/reduce_window.mlir
@@ -81,3 +81,18 @@ func @reduce_window_max_with_padding_4x6xf32() {
   check.expect_almost_eq_const(%res, dense<[[[[3.0], [6.0]], [[15.0], [18.0]], [[21.0], [24.0]]]]> : tensor<1x3x2x1xf32>) : tensor<1x3x2x1xf32>
   return
 }
+
+func @cumsum_f32() {
+  %0 = mhlo.constant dense<0.000000e+00> : tensor<f32>
+  %1 = util.unfoldable_constant dense<1.0> : tensor<2x2x2xf32>
+  %res = "mhlo.reduce_window"(%1, %0) ({
+  ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
+    %4 = mhlo.add %arg1, %arg2 : tensor<f32>
+    "mhlo.return"(%4) : (tensor<f32>) -> ()
+  }) {padding = dense<[[1, 0], [0, 0], [0, 0]]> : tensor<3x2xi64>,
+      window_dimensions = dense<[2, 1, 1]> : tensor<3xi64>,
+      window_strides = dense<1> : tensor<3xi64>
+  } : (tensor<2x2x2xf32>, tensor<f32>) -> tensor<2x2x2xf32>
+  check.expect_almost_eq_const(%res, dense<[[[1.0, 1.0], [1.0, 1.0]], [[2.0, 2.0], [2.0, 2.0]]]> : tensor<2x2x2xf32>) : tensor<2x2x2xf32>
+  return
+}


### PR DESCRIPTION
This adds RewriteLinalgDestructiveUpdates pass, and one e2e cumsum integration tests.

This also contains a fix-up for removing split-k marker.