### PR TITLE
Sanitize module names during input conversion.

### DIFF
--- a/iree/compiler/InputConversion/Common/BUILD
+++ b/iree/compiler/InputConversion/Common/BUILD
@@ -47,6 +47,7 @@ cc_library(
         "IREEImportPublic.cpp",
         "Passes.cpp",
         "QuantizedMatmulToMatmul.cpp",
+        "SanitizeModuleNames.cpp",
         "TopLevelSCFToCFG.cpp",
     ],
     hdrs = [

--- a/iree/compiler/InputConversion/Common/CMakeLists.txt
+++ b/iree/compiler/InputConversion/Common/CMakeLists.txt
@@ -42,6 +42,7 @@ iree_cc_library(
     "IREEImportPublic.cpp"
     "Passes.cpp"
     "QuantizedMatmulToMatmul.cpp"
+    "SanitizeModuleNames.cpp"
     "TopLevelSCFToCFG.cpp"
   DEPS
     ::PassHeaders

--- a/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
+++ b/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
@@ -17,9 +17,7 @@
 #include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
 #include "iree/compiler/InputConversion/Common/PassDetail.h"
 #include "iree/compiler/InputConversion/Common/Passes.h"
-#include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/SCF/SCF.h"
 #include "mlir/IR/BuiltinDialect.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
@@ -325,33 +323,34 @@ void IREEImportPublicPass::runOnOperation() {
                                              specific_benefit);
   patterns.insert<GlobalOpPattern>(typeConverter, &getContext(), 0);
 
-#define ONETOONE(SrcOpTy, TargetOpTy)             \
+#define ONE_TO_ONE(SrcOpTy, TargetOpTy)           \
   patterns.insert<OneToOneConverionPattern>(      \
       typeConverter, SrcOpTy::getOperationName(), \
       TargetOpTy::getOperationName(), &getContext(), specific_benefit)
 
-  ONETOONE(IREE::Input::BufferViewRankOp, IREE::HAL::BufferViewRankOp);
-  ONETOONE(IREE::Input::BufferViewDimOp, IREE::HAL::BufferViewDimOp);
-  ONETOONE(IREE::Input::ListCreateOp, IREE::Util::ListCreateOp);
-  ONETOONE(IREE::Input::ListSizeOp, IREE::Util::ListSizeOp);
-  ONETOONE(IREE::Input::ListResizeOp, IREE::Util::ListResizeOp);
-  ONETOONE(IREE::Input::ListGetOp, IREE::Util::ListGetOp);
-  ONETOONE(IREE::Input::ListSetOp, IREE::Util::ListSetOp);
-  ONETOONE(IREE::Input::NullOp, IREE::Util::NullOp);
-  ONETOONE(IREE::Input::TensorCloneOp, IREE::Flow::TensorCloneOp);
-  ONETOONE(IREE::Input::TensorLoadOp, IREE::Flow::TensorLoadOp);
-  ONETOONE(IREE::Input::TensorReshapeOp, IREE::Flow::TensorReshapeOp);
-  ONETOONE(IREE::Input::TensorSliceOp, IREE::Flow::TensorSliceOp);
-  ONETOONE(IREE::Input::TensorSplatOp, IREE::Flow::TensorSplatOp);
-  ONETOONE(IREE::Input::TensorStoreOp, IREE::Flow::TensorStoreOp);
-  ONETOONE(IREE::Input::TensorUpdateOp, IREE::Flow::TensorUpdateOp);
-  ONETOONE(IREE::Input::TensorTraceOp, IREE::Flow::TensorTraceOp);
-  ONETOONE(IREE::Input::GlobalAddressOp, IREE::Util::GlobalAddressOp);
-  ONETOONE(IREE::Input::GlobalLoadOp, IREE::Util::GlobalLoadOp);
-  ONETOONE(IREE::Input::GlobalLoadIndirectOp, IREE::Util::GlobalLoadIndirectOp);
-  ONETOONE(IREE::Input::GlobalStoreOp, IREE::Util::GlobalStoreOp);
-  ONETOONE(IREE::Input::GlobalStoreIndirectOp,
-           IREE::Util::GlobalStoreIndirectOp);
+  ONE_TO_ONE(IREE::Input::BufferViewRankOp, IREE::HAL::BufferViewRankOp);
+  ONE_TO_ONE(IREE::Input::BufferViewDimOp, IREE::HAL::BufferViewDimOp);
+  ONE_TO_ONE(IREE::Input::ListCreateOp, IREE::Util::ListCreateOp);
+  ONE_TO_ONE(IREE::Input::ListSizeOp, IREE::Util::ListSizeOp);
+  ONE_TO_ONE(IREE::Input::ListResizeOp, IREE::Util::ListResizeOp);
+  ONE_TO_ONE(IREE::Input::ListGetOp, IREE::Util::ListGetOp);
+  ONE_TO_ONE(IREE::Input::ListSetOp, IREE::Util::ListSetOp);
+  ONE_TO_ONE(IREE::Input::NullOp, IREE::Util::NullOp);
+  ONE_TO_ONE(IREE::Input::TensorCloneOp, IREE::Flow::TensorCloneOp);
+  ONE_TO_ONE(IREE::Input::TensorLoadOp, IREE::Flow::TensorLoadOp);
+  ONE_TO_ONE(IREE::Input::TensorReshapeOp, IREE::Flow::TensorReshapeOp);
+  ONE_TO_ONE(IREE::Input::TensorSliceOp, IREE::Flow::TensorSliceOp);
+  ONE_TO_ONE(IREE::Input::TensorSplatOp, IREE::Flow::TensorSplatOp);
+  ONE_TO_ONE(IREE::Input::TensorStoreOp, IREE::Flow::TensorStoreOp);
+  ONE_TO_ONE(IREE::Input::TensorUpdateOp, IREE::Flow::TensorUpdateOp);
+  ONE_TO_ONE(IREE::Input::TensorTraceOp, IREE::Flow::TensorTraceOp);
+  ONE_TO_ONE(IREE::Input::GlobalAddressOp, IREE::Util::GlobalAddressOp);
+  ONE_TO_ONE(IREE::Input::GlobalLoadOp, IREE::Util::GlobalLoadOp);
+  ONE_TO_ONE(IREE::Input::GlobalLoadIndirectOp,
+             IREE::Util::GlobalLoadIndirectOp);
+  ONE_TO_ONE(IREE::Input::GlobalStoreOp, IREE::Util::GlobalStoreOp);
+  ONE_TO_ONE(IREE::Input::GlobalStoreIndirectOp,
+             IREE::Util::GlobalStoreIndirectOp);
 
   if (failed(applyFullConversion(getOperation(), target, std::move(patterns))))
     signalPassFailure();

--- a/iree/compiler/InputConversion/Common/Passes.cpp
+++ b/iree/compiler/InputConversion/Common/Passes.cpp
@@ -21,6 +21,7 @@ namespace {
 
 void buildCommonInputConversionPassPipeline(OpPassManager &passManager) {
   passManager.addPass(createIREEImportPublicPass());
+  passManager.addPass(createSanitizeModuleNamesPass());
 }
 
 void registerCommonInputConversionPasses() {

--- a/iree/compiler/InputConversion/Common/Passes.cpp
+++ b/iree/compiler/InputConversion/Common/Passes.cpp
@@ -27,7 +27,7 @@ void registerCommonInputConversionPasses() {
   // Generated passes.
   registerPasses();
 
-  PassPipelineRegistration<> mhlo(
+  PassPipelineRegistration<> common(
       "iree-common-input-transformation-pipeline",
       "Runs the common input transformation pipeline",
       [](OpPassManager &passManager) {

--- a/iree/compiler/InputConversion/Common/Passes.h
+++ b/iree/compiler/InputConversion/Common/Passes.h
@@ -26,10 +26,10 @@ void buildCommonInputConversionPassPipeline(OpPassManager &passManager);
 // Passes
 //===----------------------------------------------------------------------===//
 
-std::unique_ptr<OperationPass<func::FuncOp>> createTopLevelSCFToCFGPass();
 std::unique_ptr<OperationPass<ModuleOp>> createIREEImportPublicPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createLinalgQuantizedMatmulToMatmulPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createTopLevelSCFToCFGPass();
 
 //===----------------------------------------------------------------------===//
 // Register all Passes

--- a/iree/compiler/InputConversion/Common/Passes.h
+++ b/iree/compiler/InputConversion/Common/Passes.h
@@ -29,6 +29,7 @@ void buildCommonInputConversionPassPipeline(OpPassManager &passManager);
 std::unique_ptr<OperationPass<ModuleOp>> createIREEImportPublicPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createLinalgQuantizedMatmulToMatmulPass();
+std::unique_ptr<OperationPass<ModuleOp>> createSanitizeModuleNamesPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createTopLevelSCFToCFGPass();
 
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/InputConversion/Common/Passes.td
+++ b/iree/compiler/InputConversion/Common/Passes.td
@@ -9,12 +9,6 @@
 
 include "mlir/Pass/PassBase.td"
 
-def TopLevelSCFToCFG :
-    Pass<"iree-top-level-scf-to-cfg", "FuncOp"> {
-  let summary = "Converts non-nested SCF constructs to CFG (not traversing into opaque operations).";
-  let constructor = "mlir::iree_compiler::createTopLevelSCFToCFGPass()";
-}
-
 def IREEImportPublic :
     Pass<"iree-import-public", "ModuleOp"> {
   let summary = "Imports IREE public dialect to internal implementation.";
@@ -26,6 +20,12 @@ def LinalgQuantizedMatmulToMatmulPass
   let summary = "lower quantized_matmul to matmul";
   let constructor = "mlir::iree_compiler::createLinalgQuantizedMatmulToMatmulPass()";
   // let dependentDialects = ["mlir::linalg::LinalgDialect"];
+}
+
+def TopLevelSCFToCFG :
+    Pass<"iree-top-level-scf-to-cfg", "FuncOp"> {
+  let summary = "Converts non-nested SCF constructs to CFG (not traversing into opaque operations).";
+  let constructor = "mlir::iree_compiler::createTopLevelSCFToCFGPass()";
 }
 
 #endif // IREE_COMPILER_INPUTCONVERSION_COMMON_PASSES

--- a/iree/compiler/InputConversion/Common/Passes.td
+++ b/iree/compiler/InputConversion/Common/Passes.td
@@ -22,6 +22,12 @@ def LinalgQuantizedMatmulToMatmulPass
   // let dependentDialects = ["mlir::linalg::LinalgDialect"];
 }
 
+def SanitizeModuleNames :
+    Pass<"iree-sanitize-module-names", "ModuleOp"> {
+  let summary = "Sanitizes module names for uniformity across target implementations.";
+  let constructor = "mlir::iree_compiler::createSanitizeModuleNamesPass()";
+}
+
 def TopLevelSCFToCFG :
     Pass<"iree-top-level-scf-to-cfg", "FuncOp"> {
   let summary = "Converts non-nested SCF constructs to CFG (not traversing into opaque operations).";

--- a/iree/compiler/InputConversion/Common/SanitizeModuleNames.cpp
+++ b/iree/compiler/InputConversion/Common/SanitizeModuleNames.cpp
@@ -1,0 +1,47 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/InputConversion/Common/PassDetail.h"
+#include "iree/compiler/InputConversion/Common/Passes.h"
+#include "mlir/IR/BuiltinDialect.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+
+struct SanitizeModuleNamesPass
+    : public SanitizeModuleNamesBase<SanitizeModuleNamesPass> {
+  void runOnOperation() override {
+    // MLIR identifiers must match this regex:
+    //   (letter|[_]) (letter|digit|[_$.])*
+    // https://mlir.llvm.org/docs/LangRef/#identifiers-and-keywords
+    //
+    // IREE VM modules use the `.` (period) character for namespacing, so
+    // replace any occurrences of `.` with `_`.
+
+    auto moduleOp = getOperation();
+    auto optionalName = moduleOp.getName();
+    if (!optionalName.hasValue()) return;
+    auto name = optionalName.getValue();
+    if (!name.contains('.')) return;
+
+    std::string sanitizedName(name);
+    std::replace(sanitizedName.begin(), sanitizedName.end(), '.', '_');
+    moduleOp.setName(sanitizedName);
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>> createSanitizeModuleNamesPass() {
+  return std::make_unique<SanitizeModuleNamesPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/InputConversion/Common/test/BUILD
+++ b/iree/compiler/InputConversion/Common/test/BUILD
@@ -20,8 +20,8 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         [
             "iree_import_public.mlir",
-            "top_level_scf_to_cfg.mlir",
             "linalg_quantized_matmul_to_matmul.mlir",
+            "top_level_scf_to_cfg.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/iree/compiler/InputConversion/Common/test/BUILD
+++ b/iree/compiler/InputConversion/Common/test/BUILD
@@ -21,6 +21,7 @@ iree_lit_test_suite(
         [
             "iree_import_public.mlir",
             "linalg_quantized_matmul_to_matmul.mlir",
+            "sanitize_module_names.mlir",
             "top_level_scf_to_cfg.mlir",
         ],
         include = ["*.mlir"],

--- a/iree/compiler/InputConversion/Common/test/CMakeLists.txt
+++ b/iree/compiler/InputConversion/Common/test/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_lit_test_suite(
   SRCS
     "iree_import_public.mlir"
     "linalg_quantized_matmul_to_matmul.mlir"
+    "sanitize_module_names.mlir"
     "top_level_scf_to_cfg.mlir"
   TOOLS
     FileCheck

--- a/iree/compiler/InputConversion/Common/test/sanitize_module_names.mlir
+++ b/iree/compiler/InputConversion/Common/test/sanitize_module_names.mlir
@@ -1,0 +1,24 @@
+// RUN: iree-opt -split-input-file -iree-sanitize-module-names %s | FileCheck %s
+
+// CHECK-LABEL: module @letters
+builtin.module @letters {}
+
+// -----
+
+// CHECK-LABEL: module @digits0123456789
+builtin.module @digits0123456789 {}
+
+// -----
+
+// CHECK-LABEL: module @u_n_d_e_r_s_c_o_r_e_s
+builtin.module @u_n_d_e_r_s_c_o_r_e_s {}
+
+// -----
+
+// CHECK-LABEL: module @dollar$$signs$$are$$okay
+builtin.module @dollar$$signs$$are$$okay {}
+
+// -----
+
+// CHECK-LABEL: module @periods_change_to_underscores
+builtin.module @periods.change.to.underscores {}


### PR DESCRIPTION
Some programs coming through the new JAX frontend are including `.` characters in module names, like:

```mlir
module @xla_computation_inference_fn.396 { func @main() }
```

This conflicts with how the IREE VM uses `.` characters for namespacing, leading to runtime name resolution errors [like this one discussed on Discord](https://discord.com/channels/689900678990135345/782059441641881630/954154767238713344).

With this PR all `.` characters in module names are replaced with `_`. I also audited the other characters supported by MLIR itself and I _think_ we're in an okay spot for handling other module and function names that frontends may generate. There is still room for frameworks and bindings to generate their own naming rules if they want to sidecar that data inside an attribute or some other mechanism.