### PR TITLE
Rename FuncOp into func::FuncOp

### DIFF
--- a/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
+++ b/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
@@ -47,7 +47,7 @@ class WrapEntryPointsPass
     auto moduleOp = getOperation();
 
     SmallVector<func::FuncOp, 4> entryFuncOps;
-    for (auto funcOp : moduleOp.getOps<FuncOp>()) {
+    for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {
       if (funcOp.isPublic() && !funcOp->hasAttr("iree.abi.stub")) {
         entryFuncOps.push_back(funcOp);
       }
@@ -103,7 +103,7 @@ class WrapEntryPointsPass
   //
   // NOTE: today we only support a single entry point; with minor tweaks we
   // could fix this up to support multiple if we wanted.
-  func::FuncOp createWrapperFunc(FuncOp entryFuncOp) {
+  func::FuncOp createWrapperFunc(func::FuncOp entryFuncOp) {
     // Convert argument types to those required by the binding ABI.
     //
     // NOTE: this is where we could change our signature to provide additional
@@ -121,8 +121,8 @@ class WrapEntryPointsPass
     auto wrapperFuncType =
         FunctionType::get(entryFuncOp.getContext(), inputTypes, resultTypes);
 
-    auto wrapperFuncOp = FuncOp::create(entryFuncOp.getLoc(),
-                                        entryFuncOp.getName(), wrapperFuncType);
+    auto wrapperFuncOp = func::FuncOp::create(
+        entryFuncOp.getLoc(), entryFuncOp.getName(), wrapperFuncType);
 
     SmallVector<DictionaryAttr, 4> argAttrDict;
     entryFuncOp.getAllArgAttrs(argAttrDict);

--- a/iree/compiler/Bindings/TFLite/Transforms/WrapEntryPoints.cpp
+++ b/iree/compiler/Bindings/TFLite/Transforms/WrapEntryPoints.cpp
@@ -66,8 +66,8 @@ class WrapEntryPointsPass
   void runOnOperation() override {
     auto moduleOp = getOperation();
 
-    SmallVector<FuncOp, 4> entryFuncOps;
-    for (auto funcOp : moduleOp.getOps<FuncOp>()) {
+    SmallVector<func::FuncOp, 4> entryFuncOps;
+    for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {
       if (funcOp.isPublic() && !funcOp->hasAttr("iree.abi.stub")) {
         entryFuncOps.push_back(funcOp);
       }
@@ -434,7 +434,7 @@ class WrapEntryPointsPass
                                   ArrayRef<DynamicDims> outputDynamicDims,
                                   mlir::func::FuncOp calculateShapeFuncOp,
                                   OpBuilder &moduleBuilder) {
-    auto queryFuncOp = moduleBuilder.create<FuncOp>(
+    auto queryFuncOp = moduleBuilder.create<func::FuncOp>(
         loc, namePrefix.str() + "_query_output_shape",
         moduleBuilder.getFunctionType(/*inputs=*/
                                       TypeRange{

--- a/iree/compiler/Codegen/Common/BufferizeCopyOnlyDispatchesPass.cpp
+++ b/iree/compiler/Codegen/Common/BufferizeCopyOnlyDispatchesPass.cpp
@@ -228,7 +228,7 @@ void BufferizeCopyOnlyDispatchesPass::runOnOperation() {
   }
 
   SmallVector<Operation *> copyOnlyFunctions;
-  auto funcOps = module.getOps<FuncOp>();
+  auto funcOps = module.getOps<func::FuncOp>();
   for (auto funcOp : funcOps) {
     /// Check if the dispatch has all sources for `flow.dispatch.tensor.store`
     /// operations coming from `flow.dispatch.tensor.load` operations. If so,

--- a/iree/compiler/Codegen/Common/CleanupBufferAllocViewPass.cpp
+++ b/iree/compiler/Codegen/Common/CleanupBufferAllocViewPass.cpp
@@ -129,7 +129,8 @@ struct CleanupBufferAllocViewPass
 
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>> createCleanupBufferAllocViewPass() {
+std::unique_ptr<OperationPass<func::FuncOp>>
+createCleanupBufferAllocViewPass() {
   return std::make_unique<CleanupBufferAllocViewPass>();
 }
 

--- a/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
+++ b/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
@@ -271,7 +271,7 @@ static LogicalResult modifyResultToUseStoreBuffer(
 /// Main entry point to convert dispatch region to use destination passing
 /// style.
 static LogicalResult convertToDestinationPassingStyle(OpBuilder &b,
-                                                      FuncOp funcOp) {
+                                                      func::FuncOp funcOp) {
   BufferizationPlan plan;
   if (failed(createTensorEquivalenceClasses(funcOp, plan))) {
     return failure();
@@ -382,7 +382,7 @@ struct AdaptLinalgInputOperandToOutputOperand
 }  // namespace
 
 void ConvertToDestinationPassingStylePass::runOnOperation() {
-  FuncOp funcOp = getOperation();
+  func::FuncOp funcOp = getOperation();
   MLIRContext *context = &getContext();
 
   {
@@ -409,7 +409,7 @@ void ConvertToDestinationPassingStylePass::runOnOperation() {
   }
 }
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 createConvertToDestinationPassingStylePass() {
   return std::make_unique<ConvertToDestinationPassingStylePass>();
 }

--- a/iree/compiler/Codegen/Common/FoldAffineMinInDistributedLoops.cpp
+++ b/iree/compiler/Codegen/Common/FoldAffineMinInDistributedLoops.cpp
@@ -134,7 +134,7 @@ void populateFoldAffineMinInDistributedLoopsPatterns(
       patterns.getContext());
 }
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 createFoldAffineMinInDistributedLoopsPass() {
   return std::make_unique<FoldAffineMinInDistributedLoopsPass>();
 }

--- a/iree/compiler/Codegen/Common/ForOpCanonicalizationPass.cpp
+++ b/iree/compiler/Codegen/Common/ForOpCanonicalizationPass.cpp
@@ -226,7 +226,7 @@ struct ForOpCanonicalizationPass
   }
 
   void runOnOperation() override {
-    FuncOp fn = getOperation();
+    func::FuncOp fn = getOperation();
     RewritePatternSet patterns(&getContext());
     patterns.insert<CanonicalizeForOpInductionVarShape,
                     PackForOpInductionVarVector>(fn.getContext());
@@ -238,7 +238,7 @@ struct ForOpCanonicalizationPass
 
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>> createForOpCanonicalizationPass() {
+std::unique_ptr<OperationPass<func::FuncOp>> createForOpCanonicalizationPass() {
   return std::make_unique<ForOpCanonicalizationPass>();
 }
 

--- a/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -157,13 +157,13 @@ void addIREEComprehensiveBufferizePasses(
   passManager.addPass(createIREEComprehensiveBufferizePass(
       allocationFn, deallocationFn, memCpyFn));
   passManager.addPass(memref::createResolveShapedTypeResultDimsPass());
-  passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
-  passManager.addNestedPass<FuncOp>(createCSEPass());
+  passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  passManager.addNestedPass<func::FuncOp>(createCSEPass());
   // There are redundant memcpy (with linalg.generic form) ops created, which
   // can be deleted by canonicalizer. We have to run it again because the
   // memrefs are unified in CSE pass, so we can truely remove redundant memcpy.
-  passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
-  passManager.addNestedPass<FuncOp>(createCleanupBufferAllocViewPass());
+  passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  passManager.addNestedPass<func::FuncOp>(createCleanupBufferAllocViewPass());
 }
 
 }  // namespace iree_compiler

--- a/iree/compiler/Codegen/Common/InsertDistributionInfoPass.cpp
+++ b/iree/compiler/Codegen/Common/InsertDistributionInfoPass.cpp
@@ -89,7 +89,7 @@ static SmallVector<int64_t> getWorkloadPerWorkgroup(
 /// Defines the workgroup count region if the tile size for the distributed
 /// loops are known.
 static LogicalResult defineWorkgroupCountRegion(
-    FuncOp entryPointFn, ArrayRef<int64_t> workloadPerWorkgroup) {
+    func::FuncOp entryPointFn, ArrayRef<int64_t> workloadPerWorkgroup) {
   if (workloadPerWorkgroup.size() > kNumMaxParallelDims) {
     // For now error out here.
     return entryPointFn.emitOpError(
@@ -121,7 +121,7 @@ static LogicalResult defineWorkgroupCountRegion(
 // TODO(ravishankarm): The workload_per_wg field should be deprecated. This
 // is just transition before all dependencies on it can be removed.
 static LogicalResult updateTranslationInfoAttr(
-    FuncOp entryPointFn, ArrayRef<int64_t> workloadPerWorkgroup) {
+    func::FuncOp entryPointFn, ArrayRef<int64_t> workloadPerWorkgroup) {
   auto entryPointOp = getEntryPoint(entryPointFn);
   if (!entryPointOp) {
     return entryPointFn.emitOpError("expected entry point function");
@@ -156,7 +156,7 @@ struct InsertDistributionInfoPass
 
 void InsertDistributionInfoPass::runOnOperation() {
   MLIRContext *context = &getContext();
-  FuncOp funcOp = getOperation();
+  func::FuncOp funcOp = getOperation();
   if (!isEntryPoint(funcOp)) return;
 
   SmallVector<Operation *> computeOps;
@@ -189,7 +189,8 @@ void InsertDistributionInfoPass::runOnOperation() {
   }
 }
 
-std::unique_ptr<OperationPass<FuncOp>> createInsertDistributionInfoPass() {
+std::unique_ptr<OperationPass<func::FuncOp>>
+createInsertDistributionInfoPass() {
   return std::make_unique<InsertDistributionInfoPass>();
 }
 

--- a/iree/compiler/Codegen/Common/MemrefCopyToLinalg.cpp
+++ b/iree/compiler/Codegen/Common/MemrefCopyToLinalg.cpp
@@ -49,7 +49,7 @@ struct MemrefCopyToLinalgPass
 
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>> createMemrefCopyToLinalgPass() {
+std::unique_ptr<OperationPass<func::FuncOp>> createMemrefCopyToLinalgPass() {
   return std::make_unique<MemrefCopyToLinalgPass>();
 }
 

--- a/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
+++ b/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
@@ -39,7 +39,7 @@ static bool allUsesAreStores(Operation* op, std::vector<Operation*>& uses) {
 
 // Track temporary allocations that are never read from. If this is the case
 // it means both the allocations and associated stores can be removed.
-static void eraseDeadAllocAndStores(FuncOp funcOp) {
+static void eraseDeadAllocAndStores(func::FuncOp funcOp) {
   std::vector<Operation*> opToErase;
   funcOp.walk([&](memref::AllocOp op) {
     if (allUsesAreStores(op, opToErase)) {
@@ -75,7 +75,7 @@ class TransposeUnitDimToShapeCast
   }
 };
 
-static LogicalResult loopInvariantCodeMotion(FuncOp funcOp) {
+static LogicalResult loopInvariantCodeMotion(func::FuncOp funcOp) {
   // Walk through all loops in a function in innermost-loop-first order. This
   // way, we first LICM from the inner loop, and place the ops in
   // the outer loop, which in turn can be further LICM'ed.
@@ -89,7 +89,7 @@ static LogicalResult loopInvariantCodeMotion(FuncOp funcOp) {
 struct OptimizeVectorTransferPass
     : public OptimizeVectorTransferBase<OptimizeVectorTransferPass> {
   void runOnOperation() override {
-    FuncOp funcOp = getOperation();
+    func::FuncOp funcOp = getOperation();
     // Generate vector.shape_cast for dropping leading one dimensions in vector
     // ops. This increases the chance that we can forward more transfer writes
     // to transfer reads.
@@ -131,7 +131,8 @@ struct OptimizeVectorTransferPass
 
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>> createOptimizeVectorTransferPass() {
+std::unique_ptr<OperationPass<func::FuncOp>>
+createOptimizeVectorTransferPass() {
   return std::make_unique<OptimizeVectorTransferPass>();
 }
 

--- a/iree/compiler/Codegen/Common/RemoveTrivialLoops.cpp
+++ b/iree/compiler/Codegen/Common/RemoveTrivialLoops.cpp
@@ -91,7 +91,7 @@ static bool isWorkgroupLoop(const LoopTilingAndDistributionInfo &info) {
 /// Infer the number of workgroups by looking at the tiled loop and the number
 /// of element per workgroups.
 static SmallVector<int64_t> getNumWorkgroup(
-    FuncOp funcOp, IREE::HAL::ExecutableEntryPointOp entryPointOp) {
+    func::FuncOp funcOp, IREE::HAL::ExecutableEntryPointOp entryPointOp) {
   auto allLoops = getTiledAndDistributedLoopInfo(funcOp);
   auto wgLoops =
       llvm::to_vector<3>(llvm::make_filter_range(allLoops, isWorkgroupLoop));
@@ -132,7 +132,7 @@ static SmallVector<int64_t> getNumWorkgroup(
   return numWorkgroups;
 }
 
-static LogicalResult removeOneTripTiledLoops(FuncOp funcOp,
+static LogicalResult removeOneTripTiledLoops(func::FuncOp funcOp,
                                              ArrayRef<int64_t> workgroupSize,
                                              ArrayRef<int64_t> numWorkgroups) {
   auto getWorkgroupRangeFn = [numWorkgroups, workgroupSize](
@@ -152,7 +152,7 @@ namespace {
 class RemoveSingleIterationLoopPass final
     : public RemoveSingleIterationLoopBase<RemoveSingleIterationLoopPass> {
   void runOnOperation() override {
-    FuncOp funcOp = getOperation();
+    func::FuncOp funcOp = getOperation();
     auto entryPointOp = getEntryPoint(funcOp);
     if (!entryPointOp) return;
 
@@ -166,7 +166,8 @@ class RemoveSingleIterationLoopPass final
 };
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>> createRemoveSingleIterationLoopPass() {
+std::unique_ptr<OperationPass<func::FuncOp>>
+createRemoveSingleIterationLoopPass() {
   return std::make_unique<RemoveSingleIterationLoopPass>();
 }
 

--- a/iree/compiler/Codegen/Common/RewriteLinalgDestructiveUpdatesPass.cpp
+++ b/iree/compiler/Codegen/Common/RewriteLinalgDestructiveUpdatesPass.cpp
@@ -33,7 +33,7 @@ struct RewriteLinalgDestructiveUpdatesPass
 
 void RewriteLinalgDestructiveUpdatesPass::runOnOperation() {
   MLIRContext *context = &getContext();
-  FuncOp funcOp = getOperation();
+  func::FuncOp funcOp = getOperation();
   if (!isEntryPoint(funcOp)) return;
 
   // Rewrite destructive updates and ensure no remaining store remains to the
@@ -58,7 +58,7 @@ void RewriteLinalgDestructiveUpdatesPass::runOnOperation() {
   }
 }
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 createRewriteLinalgDestructiveUpdatesPass() {
   return std::make_unique<RewriteLinalgDestructiveUpdatesPass>();
 }

--- a/iree/compiler/Codegen/Common/SetNumWorkgroupsPass.cpp
+++ b/iree/compiler/Codegen/Common/SetNumWorkgroupsPass.cpp
@@ -82,7 +82,7 @@ void SetNumWorkgroupsPass::runOnOperation() {
 
   llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> entryPoints =
       getAllEntryPoints(module);
-  for (auto funcOp : module.getOps<FuncOp>()) {
+  for (auto funcOp : module.getOps<func::FuncOp>()) {
     auto entryPointOp = entryPoints.lookup(funcOp.getName());
     if (!entryPointOp) continue;
 

--- a/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -149,7 +149,7 @@ struct TileAndDistributeToWorkgroupsPass
 
 void TileAndDistributeToWorkgroupsPass::runOnOperation() {
   MLIRContext *context = &getContext();
-  FuncOp funcOp = getOperation();
+  func::FuncOp funcOp = getOperation();
   if (!isEntryPoint(funcOp)) return;
 
   SmallVector<Operation *> computeOps;
@@ -253,7 +253,7 @@ void TileAndDistributeToWorkgroupsPass::runOnOperation() {
   }
 }
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 createTileAndDistributeToWorkgroupsPass() {
   return std::make_unique<TileAndDistributeToWorkgroupsPass>();
 }

--- a/iree/compiler/Codegen/Common/TypePropagationPass.cpp
+++ b/iree/compiler/Codegen/Common/TypePropagationPass.cpp
@@ -379,7 +379,7 @@ struct TypePropagationPass : public TypePropagationBase<TypePropagationPass> {
 };
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>> createTypePropagationPass() {
+std::unique_ptr<OperationPass<func::FuncOp>> createTypePropagationPass() {
   return std::make_unique<TypePropagationPass>();
 }
 

--- a/iree/compiler/Codegen/Common/VectorizeConv.cpp
+++ b/iree/compiler/Codegen/Common/VectorizeConv.cpp
@@ -381,7 +381,8 @@ void populateLinalgToVectorVectorizeConvPatterns(MLIRContext *context,
   patterns.insert<VectorizeLinalgConv, VectorizeLinalgDepthwiseConv>(context);
 }
 
-std::unique_ptr<OperationPass<FuncOp>> createLinalgToVectorVectorizeConvPass() {
+std::unique_ptr<OperationPass<func::FuncOp>>
+createLinalgToVectorVectorizeConvPass() {
   return std::make_unique<LinalgToVectorVectorizeConvPass>();
 }
 

--- a/iree/compiler/Codegen/Common/VectorizeMMT4d.cpp
+++ b/iree/compiler/Codegen/Common/VectorizeMMT4d.cpp
@@ -163,7 +163,7 @@ void populateLinalgToVectorVectorizeMMT4dPatterns(MLIRContext *context,
   patterns.insert<VectorizeMMT4DOp>(context);
 }
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 createLinalgToVectorVectorizeMMT4dPass() {
   return std::make_unique<LinalgToVectorVectorizeMMT4dPass>();
 }

--- a/iree/compiler/Codegen/Dialect/LoweringConfig.h
+++ b/iree/compiler/Codegen/Dialect/LoweringConfig.h
@@ -50,7 +50,8 @@ IREE::Codegen::TranslationInfoAttr getTranslationInfo(
     IREE::HAL::ExecutableEntryPointOp entryPointOp);
 /// Returns the translation info for the `funcOp` (by looking at the entry
 /// point). Returns `nullptr` on failure.
-inline IREE::Codegen::TranslationInfoAttr getTranslationInfo(FuncOp funcOp) {
+inline IREE::Codegen::TranslationInfoAttr getTranslationInfo(
+    func::FuncOp funcOp) {
   auto entryPointOp = getEntryPoint(funcOp);
   if (!entryPointOp) return nullptr;
   return getTranslationInfo(entryPointOp);
@@ -80,7 +81,7 @@ inline void setTranslationInfo(
 /// is already set on the entry point op and is incompatible with what is being
 /// set.
 inline void setTranslationInfo(
-    FuncOp entryPointFn,
+    func::FuncOp entryPointFn,
     IREE::Codegen::DispatchLoweringPassPipeline passPipeline,
     ArrayRef<int64_t> workloadPerWorkgroup, ArrayRef<int64_t> workgroupSize) {
   auto entryPointOp = getEntryPoint(entryPointFn);
@@ -113,7 +114,7 @@ void setLoweringConfig(Operation *op, IREE::Codegen::LoweringConfigAttr config);
 /// tile sizes to use for the operation, and pass pipeline to use for the
 /// translation.
 inline LogicalResult setOpConfigAndEntryPointFnTranslation(
-    FuncOp entryPointFn, Operation *op, TileSizesListTypeRef tileSizes,
+    func::FuncOp entryPointFn, Operation *op, TileSizesListTypeRef tileSizes,
     IREE::Codegen::DispatchLoweringPassPipeline passPipeline,
     ArrayRef<int64_t> workgroupSize = {}) {
   MLIRContext *context = entryPointFn.getContext();

--- a/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -633,7 +633,7 @@ class ConvertHALEntryPointFuncOp : public ConvertToLLVMPattern {
   LogicalResult matchAndRewrite(
       Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
-    auto stdFuncOp = cast<FuncOp>(op);
+    auto stdFuncOp = cast<func::FuncOp>(op);
     if (!stdFuncOp.isPublic()) return failure();
     FunctionType fnType = stdFuncOp.getFunctionType();
     if (fnType.getNumInputs() != 0 || fnType.getNumResults() != 0) {
@@ -971,7 +971,7 @@ void ConvertToLLVMPass::runOnOperation() {
   target.addIllegalOp<UnrealizedConversionCastOp>();
 
   // Don't apply patterns to private function (e.g num_workgroups func).
-  target.addDynamicallyLegalOp<FuncOp>([&](FuncOp funcOp) {
+  target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp funcOp) {
     if (isEntryPoint(funcOp)) return false;
     return true;
   });
@@ -980,7 +980,7 @@ void ConvertToLLVMPass::runOnOperation() {
                                     IREE::Util::UtilDialect,
                                     IREE::HAL::HALDialect, math::MathDialect>(
       [&](Operation *op) {
-        auto funcParent = op->getParentOfType<FuncOp>();
+        auto funcParent = op->getParentOfType<func::FuncOp>();
         if (!funcParent) return false;
         if (isEntryPoint(funcParent)) return false;
         return true;

--- a/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileFuseAndVectorizeLinalgTensorOps.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileFuseAndVectorizeLinalgTensorOps.cpp
@@ -74,7 +74,7 @@ struct LLVMCPUTileFuseAndVectorizePass
   bool lowerToVectors;
 };
 
-LogicalResult applyTileAndFuseCanonicalizationPatterns(FuncOp funcOp) {
+LogicalResult applyTileAndFuseCanonicalizationPatterns(func::FuncOp funcOp) {
   auto context = funcOp.getContext();
   RewritePatternSet patterns(context);
   linalg::populateLinalgTilingCanonicalizationPatterns(patterns);
@@ -395,8 +395,8 @@ void LLVMCPUTileFuseAndVectorizePass::runOnOperation() {
   }
 }
 
-std::unique_ptr<OperationPass<FuncOp>> createLLVMCPUTileFuseAndVectorizePass(
-    bool lowerToVectors) {
+std::unique_ptr<OperationPass<func::FuncOp>>
+createLLVMCPUTileFuseAndVectorizePass(bool lowerToVectors) {
   return std::make_unique<LLVMCPUTileFuseAndVectorizePass>(lowerToVectors);
 }
 

--- a/iree/compiler/Codegen/LLVMCPU/LLVMCPUUnfuseFMAOps.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/LLVMCPUUnfuseFMAOps.cpp
@@ -60,7 +60,7 @@ void LLVMCPUUnfuseFMAOpsPass::runOnOperation() {
   }
 }
 
-std::unique_ptr<OperationPass<FuncOp>> createLLVMCPUUnfuseFMAOpsPass() {
+std::unique_ptr<OperationPass<func::FuncOp>> createLLVMCPUUnfuseFMAOpsPass() {
   return std::make_unique<LLVMCPUUnfuseFMAOpsPass>();
 }
 

--- a/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -166,12 +166,13 @@ LogicalResult verifyDoubleTilingExpertPassPipelineConfig(
 
 void addSingleTilingExpertPassPipeline(OpPassManager &passManager) {
   // Do first level of tiling and distribution.
-  passManager.addNestedPass<FuncOp>(createInsertDistributionInfoPass());
-  passManager.addNestedPass<FuncOp>(createTileAndDistributeToWorkgroupsPass());
+  passManager.addNestedPass<func::FuncOp>(createInsertDistributionInfoPass());
+  passManager.addNestedPass<func::FuncOp>(
+      createTileAndDistributeToWorkgroupsPass());
   passManager.addPass(createCanonicalizerPass());
   passManager.addPass(createCSEPass());
 
-  passManager.addNestedPass<FuncOp>(
+  passManager.addNestedPass<func::FuncOp>(
       createConvertToDestinationPassingStylePass());
   passManager.addPass(createCanonicalizerPass());
   // Add the sandbox single tiling expert to tile and vectorize.
@@ -179,7 +180,7 @@ void addSingleTilingExpertPassPipeline(OpPassManager &passManager) {
     LinalgSingleTilingExpertPassOptions options;
     options.vectorize = true;
     options.tilingLevel = static_cast<int64_t>(TilingLevel::L1Tiles);
-    passManager.addNestedPass<FuncOp>(
+    passManager.addNestedPass<func::FuncOp>(
         createLinalgSingleTilingExpertPass(options));
   }
 
@@ -195,7 +196,7 @@ void addSingleTilingExpertPassPipeline(OpPassManager &passManager) {
 
   // Add the vector lowering expert.
   {
-    OpPassManager &nestedFuncPassManager = passManager.nest<FuncOp>();
+    OpPassManager &nestedFuncPassManager = passManager.nest<func::FuncOp>();
     LinalgVectorLoweringPassOptions options;
     addLowerToVectorTransforms(nestedFuncPassManager, options);
   }
@@ -203,8 +204,9 @@ void addSingleTilingExpertPassPipeline(OpPassManager &passManager) {
 
 void addCPUBufferOpsTileAndVectorizePipeline(OpPassManager &passManager) {
   // Do first level of tiling and distribution.
-  passManager.addNestedPass<FuncOp>(createInsertDistributionInfoPass());
-  passManager.addNestedPass<FuncOp>(createTileAndDistributeToWorkgroupsPass());
+  passManager.addNestedPass<func::FuncOp>(createInsertDistributionInfoPass());
+  passManager.addNestedPass<func::FuncOp>(
+      createTileAndDistributeToWorkgroupsPass());
   passManager.addPass(createCanonicalizerPass());
   passManager.addPass(createCSEPass());
 
@@ -212,26 +214,27 @@ void addCPUBufferOpsTileAndVectorizePipeline(OpPassManager &passManager) {
   // of a correctness issue. See Issue #8579.
 
   // Run IREE specific passes before vector lowering expert.
-  passManager.addNestedPass<FuncOp>(createRemoveSingleIterationLoopPass());
+  passManager.addNestedPass<func::FuncOp>(
+      createRemoveSingleIterationLoopPass());
 }
 
 void addDoubleTilingExpertPassPipeline(OpPassManager &passManager) {
-  passManager.addNestedPass<FuncOp>(
+  passManager.addNestedPass<func::FuncOp>(
       createConvertToDestinationPassingStylePass());
 
   passManager.addPass(createCanonicalizerPass());
 
   // Do first level of tiling and distribution.
-  passManager.addNestedPass<FuncOp>(createInsertDistributionInfoPass());
+  passManager.addNestedPass<func::FuncOp>(createInsertDistributionInfoPass());
   {
     LinalgFusePassOptions options;
     options.tilingLevel =
         static_cast<int64_t>(StrategyTilingLevel::WorkGroupTiles);
     options.doIREEDistribution = true;
-    passManager.addNestedPass<FuncOp>(createLinalgFusePass(options));
-    passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
-    passManager.addNestedPass<FuncOp>(createCSEPass());
-    passManager.addNestedPass<FuncOp>(
+    passManager.addNestedPass<func::FuncOp>(createLinalgFusePass(options));
+    passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+    passManager.addNestedPass<func::FuncOp>(createCSEPass());
+    passManager.addNestedPass<func::FuncOp>(
         createRewriteLinalgDestructiveUpdatesPass());
   }
 
@@ -243,9 +246,9 @@ void addDoubleTilingExpertPassPipeline(OpPassManager &passManager) {
     LinalgFusePassOptions options;
     options.tilingLevel =
         static_cast<int64_t>(StrategyTilingLevel::ParallelTiles);
-    passManager.addNestedPass<FuncOp>(createLinalgFusePass(options));
-    passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
-    passManager.addNestedPass<FuncOp>(createCSEPass());
+    passManager.addNestedPass<func::FuncOp>(createLinalgFusePass(options));
+    passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+    passManager.addNestedPass<func::FuncOp>(createCSEPass());
   }
 
   // Add the sandbox single tiling expert to tile and vectorize.
@@ -263,10 +266,10 @@ void addDoubleTilingExpertPassPipeline(OpPassManager &passManager) {
     // options.packPaddings = {1, 1, 0};
     options.tilingLevel =
         static_cast<int64_t>(StrategyTilingLevel::ReductionTiles);
-    passManager.addNestedPass<FuncOp>(
+    passManager.addNestedPass<func::FuncOp>(
         createLinalgSingleTilingExpertPass(options));
-    passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
-    passManager.addNestedPass<FuncOp>(createCSEPass());
+    passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+    passManager.addNestedPass<func::FuncOp>(createCSEPass());
   }
 
   BufferizationOptions::AllocationFn allocationFn =
@@ -278,11 +281,12 @@ void addDoubleTilingExpertPassPipeline(OpPassManager &passManager) {
                                       memcpyFn);
 
   // Run IREE specific passes before vector lowering expert.
-  passManager.addNestedPass<FuncOp>(createRemoveSingleIterationLoopPass());
+  passManager.addNestedPass<func::FuncOp>(
+      createRemoveSingleIterationLoopPass());
 
   // Add the vector lowering expert.
   {
-    OpPassManager &nestedFuncPassManager = passManager.nest<FuncOp>();
+    OpPassManager &nestedFuncPassManager = passManager.nest<func::FuncOp>();
     LinalgVectorLoweringPassOptions options;
     options.splitVectorTransfersTo = "linalg-copy";
     addLowerToVectorTransforms(nestedFuncPassManager, options);
@@ -290,22 +294,22 @@ void addDoubleTilingExpertPassPipeline(OpPassManager &passManager) {
 }
 
 void addConvTileAndDecomposeExpertPassPipeline(OpPassManager &passManager) {
-  passManager.addNestedPass<FuncOp>(
+  passManager.addNestedPass<func::FuncOp>(
       createConvertToDestinationPassingStylePass());
 
   passManager.addPass(createCanonicalizerPass());
 
   // Do first level of tiling and distribution.
-  passManager.addNestedPass<FuncOp>(createInsertDistributionInfoPass());
+  passManager.addNestedPass<func::FuncOp>(createInsertDistributionInfoPass());
   {
     LinalgFusePassOptions options;
     options.tilingLevel =
         static_cast<int64_t>(StrategyTilingLevel::WorkGroupTiles);
     options.doIREEDistribution = true;
-    passManager.addNestedPass<FuncOp>(createLinalgFusePass(options));
-    passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
-    passManager.addNestedPass<FuncOp>(createCSEPass());
-    passManager.addNestedPass<FuncOp>(
+    passManager.addNestedPass<func::FuncOp>(createLinalgFusePass(options));
+    passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+    passManager.addNestedPass<func::FuncOp>(createCSEPass());
+    passManager.addNestedPass<func::FuncOp>(
         createRewriteLinalgDestructiveUpdatesPass());
   }
 
@@ -317,9 +321,9 @@ void addConvTileAndDecomposeExpertPassPipeline(OpPassManager &passManager) {
     LinalgFusePassOptions options;
     options.tilingLevel =
         static_cast<int64_t>(StrategyTilingLevel::ParallelTiles);
-    passManager.addNestedPass<FuncOp>(createLinalgFusePass(options));
-    passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
-    passManager.addNestedPass<FuncOp>(createCSEPass());
+    passManager.addNestedPass<func::FuncOp>(createLinalgFusePass(options));
+    passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+    passManager.addNestedPass<func::FuncOp>(createCSEPass());
   }
 
   // Add the sandbox single tiling expert to tile and vectorize.
@@ -330,10 +334,10 @@ void addConvTileAndDecomposeExpertPassPipeline(OpPassManager &passManager) {
     options.vectorizePadding = true;
     options.tilingLevel =
         static_cast<int64_t>(StrategyTilingLevel::ReductionTiles);
-    passManager.addNestedPass<FuncOp>(
+    passManager.addNestedPass<func::FuncOp>(
         createLinalgSingleTilingExpertPass(options));
-    passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
-    passManager.addNestedPass<FuncOp>(createCSEPass());
+    passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+    passManager.addNestedPass<func::FuncOp>(createCSEPass());
   }
 
   BufferizationOptions::AllocationFn allocationFn =
@@ -345,11 +349,12 @@ void addConvTileAndDecomposeExpertPassPipeline(OpPassManager &passManager) {
                                       memcpyFn);
 
   // Run IREE specific passes before vector lowering expert.
-  passManager.addNestedPass<FuncOp>(createRemoveSingleIterationLoopPass());
+  passManager.addNestedPass<func::FuncOp>(
+      createRemoveSingleIterationLoopPass());
 
   // Add the vector lowering expert.
   {
-    OpPassManager &nestedFuncPassManager = passManager.nest<FuncOp>();
+    OpPassManager &nestedFuncPassManager = passManager.nest<func::FuncOp>();
     LinalgVectorLoweringPassOptions options;
     options.splitVectorTransfersTo = "shuffle";
     addLowerToVectorTransforms(nestedFuncPassManager, options);
@@ -359,16 +364,17 @@ void addConvTileAndDecomposeExpertPassPipeline(OpPassManager &passManager) {
 void addTileFuseAndVectorizePassPipeline(OpPassManager &passManager,
                                          bool lowerToVectors) {
   // Do first level of tile and distribute to workgroups.
-  passManager.addNestedPass<FuncOp>(createInsertDistributionInfoPass());
-  passManager.addNestedPass<FuncOp>(createTileAndDistributeToWorkgroupsPass());
+  passManager.addNestedPass<func::FuncOp>(createInsertDistributionInfoPass());
+  passManager.addNestedPass<func::FuncOp>(
+      createTileAndDistributeToWorkgroupsPass());
   passManager.addPass(createCanonicalizerPass());
   passManager.addPass(createCSEPass());
 
   // Tile and vectorize linalg ops on tensors.
-  passManager.addNestedPass<FuncOp>(
+  passManager.addNestedPass<func::FuncOp>(
       createLLVMCPUTileFuseAndVectorizePass(lowerToVectors));
-  passManager.addNestedPass<FuncOp>(createCSEPass());
-  passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
+  passManager.addNestedPass<func::FuncOp>(createCSEPass());
+  passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
 
   // Use stack allocation on CPU side.
 
@@ -383,17 +389,18 @@ void addTileFuseAndVectorizePassPipeline(OpPassManager &passManager,
   // addIREEComprehensiveBufferizePasses(passManager, std::move(callbacks));
 
   addLinalgBufferizePasses(passManager, cpuAllocationFunction);
-  passManager.addNestedPass<FuncOp>(createCSEPass());
-  passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
+  passManager.addNestedPass<func::FuncOp>(createCSEPass());
+  passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
 
-  passManager.addNestedPass<FuncOp>(createForOpCanonicalizationPass());
-  passManager.addNestedPass<FuncOp>(createOptimizeVectorTransferPass());
+  passManager.addNestedPass<func::FuncOp>(createForOpCanonicalizationPass());
+  passManager.addNestedPass<func::FuncOp>(createOptimizeVectorTransferPass());
 }
 
 void addCPUDefaultPassPipeline(OpPassManager &passManager) {
   // Do first level of tile and distribute to workgroups.
-  passManager.addNestedPass<FuncOp>(createInsertDistributionInfoPass());
-  passManager.addNestedPass<FuncOp>(createTileAndDistributeToWorkgroupsPass());
+  passManager.addNestedPass<func::FuncOp>(createInsertDistributionInfoPass());
+  passManager.addNestedPass<func::FuncOp>(
+      createTileAndDistributeToWorkgroupsPass());
   passManager.addPass(createCanonicalizerPass());
   passManager.addPass(createCSEPass());
   // Use stack allocation on CPU side.
@@ -425,19 +432,19 @@ void addLinalgTransformInterpPasses(OpPassManager &passManager) {
 
 static void addLowerToLLVMPasses(OpPassManager &passManager) {
   // LinalgExt -> SCF
-  passManager.addNestedPass<FuncOp>(
+  passManager.addNestedPass<func::FuncOp>(
       IREE::LinalgExt::createLinalgExtToLoopsPass());
 
   // Linalg -> SCF
-  passManager.addNestedPass<FuncOp>(createMemrefCopyToLinalgPass());
-  passManager.addNestedPass<FuncOp>(createConvertLinalgToLoopsPass());
-  passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
-  passManager.addNestedPass<FuncOp>(createCSEPass());
+  passManager.addNestedPass<func::FuncOp>(createMemrefCopyToLinalgPass());
+  passManager.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
+  passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  passManager.addNestedPass<func::FuncOp>(createCSEPass());
 
   // SCF -> STD
-  passManager.addNestedPass<FuncOp>(createConvertSCFToCFPass());
-  passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
-  passManager.addNestedPass<FuncOp>(createCSEPass());
+  passManager.addNestedPass<func::FuncOp>(createConvertSCFToCFPass());
+  passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  passManager.addNestedPass<func::FuncOp>(createCSEPass());
 
   if (clCheckIRBeforeLLVMConversion) {
     passManager.addPass(createLLVMCPUCheckIRBeforeLLVMConversionPass());
@@ -447,11 +454,12 @@ static void addLowerToLLVMPasses(OpPassManager &passManager) {
   passManager.addPass(createFoldTensorExtractOpPass());
 
   // math dialect elementry functions -> polynomial form.
-  passManager.addNestedPass<FuncOp>(createPolynomialApproximationPass());
+  passManager.addNestedPass<func::FuncOp>(createPolynomialApproximationPass());
 
   // (HAL, IREE, Linalg, STD) -> LLVM
-  passManager.addNestedPass<FuncOp>(arith::createArithmeticExpandOpsPass());
-  passManager.addNestedPass<FuncOp>(memref::createExpandOpsPass());
+  passManager.addNestedPass<func::FuncOp>(
+      arith::createArithmeticExpandOpsPass());
+  passManager.addNestedPass<func::FuncOp>(memref::createExpandOpsPass());
   passManager.addPass(createConvertToLLVMPass());
   passManager.addPass(createReconcileUnrealizedCastsPass());
 
@@ -464,7 +472,7 @@ static void addLowerToLLVMPasses(OpPassManager &passManager) {
 }
 
 void buildLLVMCPUCodegenPassPipeline(OpPassManager &passManager) {
-  passManager.nest<ModuleOp>().nest<FuncOp>().addPass(
+  passManager.nest<ModuleOp>().nest<func::FuncOp>().addPass(
       createTypePropagationPass());
   passManager.nest<ModuleOp>().addPass(createBufferizeCopyOnlyDispatchesPass());
   passManager.addPass(createLLVMCPULowerExecutableTargetPass());

--- a/iree/compiler/Codegen/LLVMCPU/VectorContractCustomKernels.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/VectorContractCustomKernels.cpp
@@ -1195,7 +1195,8 @@ void populateVectorContractCustomKernelsPatterns(
   }
 }
 
-std::unique_ptr<OperationPass<FuncOp>> createVectorContractCustomKernelsPass() {
+std::unique_ptr<OperationPass<func::FuncOp>>
+createVectorContractCustomKernelsPass() {
   return std::make_unique<VectorContractCustomKernelsPass>();
 }
 

--- a/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
@@ -141,7 +141,7 @@ struct ConvertSharedMemAllocOp : public OpRewritePattern<memref::AllocOp> {
     }
     // In CUDA workgroup memory is represented by a global variable.
     MemRefType allocType = allocOp.getType();
-    auto funcOp = allocOp->getParentOfType<FuncOp>();
+    auto funcOp = allocOp->getParentOfType<func::FuncOp>();
     auto moduleOp = funcOp->getParentOfType<ModuleOp>();
     SymbolTable symbolTable(moduleOp);
     OpBuilder::InsertionGuard guard(rewriter);

--- a/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
@@ -100,7 +100,7 @@ struct ConvertToNVVMPass : public ConvertToNVVMBase<ConvertToNVVMPass> {
       LLVMConversionTarget target(getContext());
       populateFuncToLLVMFuncOpConversionPattern(converter, llvmPatterns);
       configureGpuToNVVMConversionLegality(target);
-      target.addDynamicallyLegalOp<FuncOp>([&](FuncOp funcOp) {
+      target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp funcOp) {
         if (isEntryPoint(funcOp)) return false;
         return true;
       });

--- a/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -92,7 +92,7 @@ struct ConvertToROCDLPass : public ConvertToROCDLBase<ConvertToROCDLPass> {
       LLVMConversionTarget target(getContext());
       populateFuncToLLVMFuncOpConversionPattern(converter, llvmPatterns);
       configureGpuToROCDLConversionLegality(target);
-      target.addDynamicallyLegalOp<FuncOp>([&](FuncOp funcOp) {
+      target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp funcOp) {
         if (isEntryPoint(funcOp)) return false;
         return true;
       });

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPUDistributeSharedMemoryCopy.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPUDistributeSharedMemoryCopy.cpp
@@ -202,7 +202,7 @@ class LLVMGPUDistributeSharedMemoryCopyPass
     registry.insert<vector::VectorDialect, scf::SCFDialect>();
   }
   void runOnOperation() override {
-    FuncOp funcOp = getOperation();
+    func::FuncOp funcOp = getOperation();
     auto entryPointOp = getEntryPoint(funcOp);
     if (!entryPointOp) return;
     auto workgroupSize = getWorkgroupSize(entryPointOp);
@@ -291,7 +291,7 @@ class LLVMGPUDistributeSharedMemoryCopyPass
 
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 createLLVMGPUDistributeSharedMemoryCopy() {
   return std::make_unique<LLVMGPUDistributeSharedMemoryCopyPass>();
 }

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPUMultiBuffering.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPUMultiBuffering.cpp
@@ -41,7 +41,7 @@ struct LLVMGPUMultiBufferingPass
 };
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>> createLLVMGPUMultiBuffering(
+std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUMultiBuffering(
     unsigned numBuffers) {
   return std::make_unique<LLVMGPUMultiBufferingPass>(numBuffers);
 }

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPUPipelining.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPUPipelining.cpp
@@ -155,7 +155,7 @@ struct LLVMGPUPipeliningPass
 };
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>> createLLVMGPUPipeliningPass(
+std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUPipeliningPass(
     unsigned depth) {
   return std::make_unique<LLVMGPUPipeliningPass>(depth);
 }

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
@@ -158,7 +158,7 @@ struct LLVMGPUTensorCoreVectorizationPass
 };
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 createLLVMGPUTensorCoreVectorizationPass() {
   return std::make_unique<LLVMGPUTensorCoreVectorizationPass>();
 }

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
@@ -182,7 +182,7 @@ static Optional<Value> allocateWorkgroupMemory(
     OpBuilder &b, memref::SubViewOp subview,
     ArrayRef<Value> boundingSubViewSize, DataLayout &layout) {
   OpBuilder::InsertionGuard guard(b);
-  FuncOp funcOp = subview->getParentOfType<FuncOp>();
+  func::FuncOp funcOp = subview->getParentOfType<func::FuncOp>();
   if (!funcOp) {
     subview.emitError("expected op to be within std.func");
     return llvm::None;
@@ -364,7 +364,7 @@ struct LLVMGPUTileAndDistributePass
 };
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>> createLLVMGPUTileAndDistribute(
+std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUTileAndDistribute(
     bool distributeToWarp) {
   return std::make_unique<LLVMGPUTileAndDistributePass>(distributeToWarp);
 }

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -26,7 +26,7 @@ struct LLVMGPUVectorLoweringPass
     registry.insert<vector::VectorDialect>();
   }
   void runOnOperation() override {
-    FuncOp funcOp = getOperation();
+    func::FuncOp funcOp = getOperation();
     RewritePatternSet vectorToLoopsPatterns(&getContext());
     VectorTransferToSCFOptions vectorToSCFOptions;
     vectorToSCFOptions.enableFullUnroll();
@@ -42,7 +42,7 @@ struct LLVMGPUVectorLoweringPass
 };
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>> createLLVMGPUVectorLoweringPass() {
+std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUVectorLoweringPass() {
   return std::make_unique<LLVMGPUVectorLoweringPass>();
 }
 

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
@@ -16,7 +16,7 @@ namespace iree_compiler {
 
 /// Helper to convert copy to shared memory to async copy. This creates groups
 /// of consecutive copies and emit wait operation right after.
-static void createAsyncGroups(FuncOp funcOp) {
+static void createAsyncGroups(func::FuncOp funcOp) {
   llvm::SmallSetVector<vector::TransferWriteOp, 16> copyToSharedMem;
   // Look for all the copy that can be converted to async copy ops.
   funcOp.walk([&](vector::TransferWriteOp writeOp) {
@@ -236,7 +236,7 @@ struct LLVMGPUVectorToGPUPass
 };
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>> createLLVMGPUVectorToGPU() {
+std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUVectorToGPU() {
   return std::make_unique<LLVMGPUVectorToGPUPass>();
 }
 

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorization.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorization.cpp
@@ -182,7 +182,7 @@ struct LLVMGPUVectorizationPass
 };
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>> createLLVMGPUVectorizationPass() {
+std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUVectorizationPass() {
   return std::make_unique<LLVMGPUVectorizationPass>();
 }
 

--- a/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -38,8 +38,8 @@ static Value gpuAllocationFunction(OpBuilder &builder, Location loc,
 }
 
 static void tileAndBufferize(OpPassManager &pm) {
-  pm.addNestedPass<FuncOp>(createInsertDistributionInfoPass());
-  pm.addNestedPass<FuncOp>(createTileAndDistributeToWorkgroupsPass());
+  pm.addNestedPass<func::FuncOp>(createInsertDistributionInfoPass());
+  pm.addNestedPass<func::FuncOp>(createTileAndDistributeToWorkgroupsPass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
@@ -57,22 +57,22 @@ void addGPUVectorizationPassPipeline(OpPassManager &pm) {
   tileAndBufferize(pm);
 
   // Distribute linalg onto threads within the workgroup.
-  pm.addNestedPass<FuncOp>(createLLVMGPUTileAndDistribute());
+  pm.addNestedPass<func::FuncOp>(createLLVMGPUTileAndDistribute());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
-  pm.addNestedPass<FuncOp>(createRemoveSingleIterationLoopPass());
+  pm.addNestedPass<func::FuncOp>(createRemoveSingleIterationLoopPass());
 
   // Linalg -> vector
-  pm.addNestedPass<FuncOp>(createLLVMGPUVectorizationPass());
-  pm.addNestedPass<FuncOp>(createCanonicalizerPass());
-  pm.addNestedPass<FuncOp>(createCSEPass());
-  pm.addNestedPass<FuncOp>(createOptimizeVectorTransferPass());
+  pm.addNestedPass<func::FuncOp>(createLLVMGPUVectorizationPass());
+  pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  pm.addNestedPass<func::FuncOp>(createCSEPass());
+  pm.addNestedPass<func::FuncOp>(createOptimizeVectorTransferPass());
 }
 
 void addGPUMatmulSimtPassPipeline(OpPassManager &pm) {
-  pm.addNestedPass<FuncOp>(createInsertDistributionInfoPass());
-  pm.addNestedPass<FuncOp>(createTileAndDistributeToWorkgroupsPass());
+  pm.addNestedPass<func::FuncOp>(createInsertDistributionInfoPass());
+  pm.addNestedPass<func::FuncOp>(createTileAndDistributeToWorkgroupsPass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
@@ -82,64 +82,64 @@ void addGPUMatmulSimtPassPipeline(OpPassManager &pm) {
   pm.addPass(createCSEPass());
 
   // Distribute linalg onto threads within the workgroup.
-  pm.addNestedPass<FuncOp>(createLLVMGPUTileAndDistribute());
-  pm.addNestedPass<FuncOp>(createMemrefCopyToLinalgPass());
-  pm.addNestedPass<FuncOp>(createLLVMGPUDistributeSharedMemoryCopy());
+  pm.addNestedPass<func::FuncOp>(createLLVMGPUTileAndDistribute());
+  pm.addNestedPass<func::FuncOp>(createMemrefCopyToLinalgPass());
+  pm.addNestedPass<func::FuncOp>(createLLVMGPUDistributeSharedMemoryCopy());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
-  pm.addNestedPass<FuncOp>(createRemoveSingleIterationLoopPass());
+  pm.addNestedPass<func::FuncOp>(createRemoveSingleIterationLoopPass());
 
   // Linalg -> vector
-  pm.addNestedPass<FuncOp>(createLLVMGPUVectorizationPass());
-  pm.addNestedPass<FuncOp>(createCanonicalizerPass());
-  pm.addNestedPass<FuncOp>(createCSEPass());
-  pm.addNestedPass<FuncOp>(createOptimizeVectorTransferPass());
+  pm.addNestedPass<func::FuncOp>(createLLVMGPUVectorizationPass());
+  pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  pm.addNestedPass<func::FuncOp>(createCSEPass());
+  pm.addNestedPass<func::FuncOp>(createOptimizeVectorTransferPass());
 
   // Pipeline memory operations.
-  pm.addNestedPass<FuncOp>(createLLVMGPUPipeliningPass());
+  pm.addNestedPass<func::FuncOp>(createLLVMGPUPipeliningPass());
 }
 
 void addGPUMatmulTensorCorePassPipeline(OpPassManager &pm) {
   tileAndBufferize(pm);
 
   // Distribute linalg onto warps within the workgroup.
-  pm.addNestedPass<FuncOp>(
+  pm.addNestedPass<func::FuncOp>(
       createLLVMGPUTileAndDistribute(/*distributeToWarp=*/true));
   if (pipelineDepth > 1)
-    pm.addNestedPass<FuncOp>(createLLVMGPUMultiBuffering(pipelineDepth));
-  pm.addNestedPass<FuncOp>(createMemrefCopyToLinalgPass());
-  pm.addNestedPass<FuncOp>(createLLVMGPUDistributeSharedMemoryCopy());
+    pm.addNestedPass<func::FuncOp>(createLLVMGPUMultiBuffering(pipelineDepth));
+  pm.addNestedPass<func::FuncOp>(createMemrefCopyToLinalgPass());
+  pm.addNestedPass<func::FuncOp>(createLLVMGPUDistributeSharedMemoryCopy());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
-  pm.addNestedPass<FuncOp>(createRemoveSingleIterationLoopPass());
+  pm.addNestedPass<func::FuncOp>(createRemoveSingleIterationLoopPass());
 
   // Linalg -> vector
-  pm.addNestedPass<FuncOp>(createLLVMGPUTensorCoreVectorizationPass());
-  pm.addNestedPass<FuncOp>(createCanonicalizerPass());
-  pm.addNestedPass<FuncOp>(createCSEPass());
-  pm.addNestedPass<FuncOp>(createOptimizeVectorTransferPass());
+  pm.addNestedPass<func::FuncOp>(createLLVMGPUTensorCoreVectorizationPass());
+  pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  pm.addNestedPass<func::FuncOp>(createCSEPass());
+  pm.addNestedPass<func::FuncOp>(createOptimizeVectorTransferPass());
 
   // Vector -> MMA ops
-  pm.addNestedPass<FuncOp>(memref::createFoldSubViewOpsPass());
-  pm.addNestedPass<FuncOp>(createLLVMGPUVectorToGPU());
+  pm.addNestedPass<func::FuncOp>(memref::createFoldSubViewOpsPass());
+  pm.addNestedPass<func::FuncOp>(createLLVMGPUVectorToGPU());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
   // Pipeline memory operations.
-  pm.addNestedPass<FuncOp>(createLLVMGPUPipeliningPass(pipelineDepth));
+  pm.addNestedPass<func::FuncOp>(createLLVMGPUPipeliningPass(pipelineDepth));
 }
 
 void addGPUSimpleDistributePassPipeline(OpPassManager &pm) {
   tileAndBufferize(pm);
 
   // Distribute linalg onto threads within the workgroup.
-  pm.addNestedPass<FuncOp>(createLLVMGPUTileAndDistribute());
+  pm.addNestedPass<func::FuncOp>(createLLVMGPUTileAndDistribute());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
-  pm.addNestedPass<FuncOp>(createRemoveSingleIterationLoopPass());
+  pm.addNestedPass<func::FuncOp>(createRemoveSingleIterationLoopPass());
 }
 
 static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
@@ -148,30 +148,30 @@ static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
   pm.addPass(createCSEPass());
 
   // LinalgExt -> SCF
-  pm.addNestedPass<FuncOp>(IREE::LinalgExt::createLinalgExtToLoopsPass());
+  pm.addNestedPass<func::FuncOp>(IREE::LinalgExt::createLinalgExtToLoopsPass());
 
   // Linalg -> SCF
-  pm.addNestedPass<FuncOp>(createMemrefCopyToLinalgPass());
-  pm.addNestedPass<FuncOp>(createConvertLinalgToLoopsPass());
-  pm.addNestedPass<FuncOp>(createCanonicalizerPass());
-  pm.addNestedPass<FuncOp>(createCSEPass());
+  pm.addNestedPass<func::FuncOp>(createMemrefCopyToLinalgPass());
+  pm.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
+  pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  pm.addNestedPass<func::FuncOp>(createCSEPass());
 
   // Handled tensor-type constants.
   pm.addPass(arith::createConstantBufferizePass());
   pm.addPass(createFoldTensorExtractOpPass());
 
-  pm.addNestedPass<FuncOp>(createLLVMGPUVectorLoweringPass());
+  pm.addNestedPass<func::FuncOp>(createLLVMGPUVectorLoweringPass());
 
   // SCF -> STD
-  pm.addNestedPass<FuncOp>(createConvertSCFToCFPass());
-  pm.addNestedPass<FuncOp>(createCanonicalizerPass());
-  pm.addNestedPass<FuncOp>(createCSEPass());
+  pm.addNestedPass<func::FuncOp>(createConvertSCFToCFPass());
+  pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  pm.addNestedPass<func::FuncOp>(createCSEPass());
 
   // math dialect elementry functions -> polynomial form.
-  pm.addNestedPass<FuncOp>(createPolynomialApproximationPass());
+  pm.addNestedPass<func::FuncOp>(createPolynomialApproximationPass());
 
-  pm.addNestedPass<FuncOp>(arith::createArithmeticExpandOpsPass());
-  pm.addNestedPass<FuncOp>(memref::createExpandOpsPass());
+  pm.addNestedPass<func::FuncOp>(arith::createArithmeticExpandOpsPass());
+  pm.addNestedPass<func::FuncOp>(memref::createExpandOpsPass());
   pm.addPass(createLowerAffinePass());
 
   // Strip out the debug info for the kernel as CUDA driver doesn't diggest PTX
@@ -187,7 +187,7 @@ static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
 }
 
 void buildLLVMGPUTransformPassPipeline(OpPassManager &pm, bool useROCM) {
-  pm.nest<ModuleOp>().nest<FuncOp>().addPass(createTypePropagationPass());
+  pm.nest<ModuleOp>().nest<func::FuncOp>().addPass(createTypePropagationPass());
   pm.nest<ModuleOp>().addPass(createBufferizeCopyOnlyDispatchesPass());
   pm.addPass(createLLVMGPULowerExecutableTargetPass());
   OpPassManager &nestedModulePM = pm.nest<ModuleOp>();

--- a/iree/compiler/Codegen/Passes.h
+++ b/iree/compiler/Codegen/Passes.h
@@ -58,7 +58,7 @@ void addIREEComprehensiveBufferizePasses(
 
 /// Pass to perform canonicalizations/cleanups related to HAL interface/buffer
 /// allocations and view operations.
-std::unique_ptr<OperationPass<FuncOp>> createCleanupBufferAllocViewPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createCleanupBufferAllocViewPass();
 
 /// Pass to bufferize dispatches that are copying from one interface to another.
 /// This will create a `linalg.generic` op which is a copy that can then be
@@ -76,7 +76,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createDemoteF32ToF16Pass();
 std::unique_ptr<OperationPass<ModuleOp>> createFlattenMemRefSubspanPass();
 
 /// Creates a pass to to fold `affine.min` ops in tiled and distributed loops.
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 createFoldAffineMinInDistributedLoopsPass();
 
 /// After running the upstream TensorConstantBufferize pass, remove tensor_loads
@@ -86,7 +86,7 @@ std::unique_ptr<OperationPass<>> createFoldTensorExtractOpPass();
 
 /// An ad-hoc pass to canonicalize selected loop carried dependencies on
 /// scf.for.
-std::unique_ptr<OperationPass<FuncOp>> createForOpCanonicalizationPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createForOpCanonicalizationPass();
 
 /// Pass to perform linalg on tensor bufferization. The function passed into the
 /// pass through the `allocationFn` argument is invoked whenever a new buffer is
@@ -96,7 +96,7 @@ std::unique_ptr<OperationPass<FuncOp>> createForOpCanonicalizationPass();
 /// the default allocator generates an `std.alloc` instruction with the
 /// allocated MemRefType having no stride map (i.e. default row-major striding)
 /// and default memory space.
-std::unique_ptr<OperationPass<FuncOp>> createLinalgBufferizePass(
+std::unique_ptr<OperationPass<func::FuncOp>> createLinalgBufferizePass(
     WorkgroupMemoryAllocationFn allocationFn = nullptr);
 std::unique_ptr<OperationPass<ModuleOp>> createIREEComprehensiveBufferizePass(
     Optional<BufferizationOptions::AllocationFn> allocationFn = None,
@@ -104,41 +104,44 @@ std::unique_ptr<OperationPass<ModuleOp>> createIREEComprehensiveBufferizePass(
     Optional<BufferizationOptions::MemCpyFn> memCpyFn = None);
 
 /// Creates a pass to remove single iteration distributed loops.
-std::unique_ptr<OperationPass<FuncOp>> createRemoveSingleIterationLoopPass();
+std::unique_ptr<OperationPass<func::FuncOp>>
+createRemoveSingleIterationLoopPass();
 
 /// Converts entry point function within dispatch regions to use
 /// destination-passing style, which is better suited for the upstream
 /// comprehensive bufferization pass.
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 createConvertToDestinationPassingStylePass();
 
 /// Creates a pass to vectorize a very specific form of linalg.conv ops.
-std::unique_ptr<OperationPass<FuncOp>> createLinalgToVectorVectorizeConvPass();
+std::unique_ptr<OperationPass<func::FuncOp>>
+createLinalgToVectorVectorizeConvPass();
 
 /// Creates a pass to vectorize a very specific form of linalg.conv ops.
-std::unique_ptr<OperationPass<FuncOp>> createLinalgToVectorVectorizeMMT4dPass();
+std::unique_ptr<OperationPass<func::FuncOp>>
+createLinalgToVectorVectorizeMMT4dPass();
 
 /// Creates a pass to vectorize a very specific form of tensor.pad ops with
 /// control flows.
-std::unique_ptr<OperationPass<FuncOp>> createVectorizePadPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createVectorizePadPass();
 
 /// Pass to optimize vector transfer_read and transfer_write.
-std::unique_ptr<OperationPass<FuncOp>> createOptimizeVectorTransferPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createOptimizeVectorTransferPass();
 
 /// Pass to insert workgroup count region and update translation info.
-std::unique_ptr<OperationPass<FuncOp>> createInsertDistributionInfoPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createInsertDistributionInfoPass();
 
 /// Pass to tile and distribute to workgroups.
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 createTileAndDistributeToWorkgroupsPass();
 
 /// Pass to rewrite Linalg destructive updates, see DestructiveUpdateUtils.h for
 /// more details.
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 createRewriteLinalgDestructiveUpdatesPass();
 
 /// Pass to propagate type to avoid generating load/stores of illegal types.
-std::unique_ptr<OperationPass<FuncOp>> createTypePropagationPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createTypePropagationPass();
 
 /// Sets the number of workgroups to use for each entry point in the dispatch
 /// region.
@@ -146,13 +149,13 @@ std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
 createSetNumWorkgroupsPass(ArrayRef<int64_t> workgroupSize = {});
 
 /// Pass to optimize vector transfer_read and transfer_write.
-std::unique_ptr<OperationPass<FuncOp>> createOptimizeVectorTransferPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createOptimizeVectorTransferPass();
 
 /// Pass to convert math operations to their polynomial approximation.
 std::unique_ptr<OperationPass<>> createPolynomialApproximationPass();
 
 /// Creates a pass to convert memref.copy to linalg op.
-std::unique_ptr<OperationPass<FuncOp>> createMemrefCopyToLinalgPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createMemrefCopyToLinalgPass();
 
 //----------------------------------------------------------------------------//
 // Common codegen patterns.
@@ -207,14 +210,15 @@ std::unique_ptr<OperationPass<ModuleOp>>
 createLLVMCPUSynchronizeSymbolVisibilityPass();
 
 /// Multi-level tiling, fusing and vectorization of linalg ops on tensors.
-std::unique_ptr<OperationPass<FuncOp>> createLLVMCPUTileFuseAndVectorizePass(
-    bool lowerToVectors = true);
+std::unique_ptr<OperationPass<func::FuncOp>>
+createLLVMCPUTileFuseAndVectorizePass(bool lowerToVectors = true);
 
 /// Replaces llvm.intr.fma with its unfused mul and add ops.
-std::unique_ptr<OperationPass<FuncOp>> createLLVMCPUUnfuseFMAOpsPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createLLVMCPUUnfuseFMAOpsPass();
 
 /// A pass that converts certain vector.contract ops to custom kernels.
-std::unique_ptr<OperationPass<FuncOp>> createVectorContractCustomKernelsPass();
+std::unique_ptr<OperationPass<func::FuncOp>>
+createVectorContractCustomKernelsPass();
 
 //------------------------------------------------------------------------------
 // LLVMCPU Codegen specific patterns.
@@ -325,7 +329,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createConvertToNVVMPass();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertToROCDLPass();
 
 /// Perform tiling and distribution to threads.
-std::unique_ptr<OperationPass<FuncOp>> createLLVMGPUTileAndDistribute(
+std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUTileAndDistribute(
     bool distributeToWarp = false);
 
 /// Create pass calling the dynamic pipeline for LLVMGPU.
@@ -333,29 +337,29 @@ std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
 createLLVMGPULowerExecutableTargetPass();
 
 /// Convert Linalg ops to Vector.
-std::unique_ptr<OperationPass<FuncOp>> createLLVMGPUVectorizationPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUVectorizationPass();
 
 /// Convert Linalg ops to Vector and prepare converstion to GPU MMA ops.
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 createLLVMGPUTensorCoreVectorizationPass();
 
 /// Lower vector ops before convertion to LLVM.
-std::unique_ptr<OperationPass<FuncOp>> createLLVMGPUVectorLoweringPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUVectorLoweringPass();
 
 /// Convert shared memory copies to distributed transfer_read/transfer_write.
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 createLLVMGPUDistributeSharedMemoryCopy();
 
 /// Apply software pipelining.
-std::unique_ptr<OperationPass<FuncOp>> createLLVMGPUPipeliningPass(
+std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUPipeliningPass(
     unsigned depth = 1);
 
 /// Apply multi-buffering transformation.
-std::unique_ptr<OperationPass<FuncOp>> createLLVMGPUMultiBuffering(
+std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUMultiBuffering(
     unsigned numBuffers = 5);
 
 /// Converts vector ops to gpu dialect.
-std::unique_ptr<OperationPass<FuncOp>> createLLVMGPUVectorToGPU();
+std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUVectorToGPU();
 
 //------------------------------------------------------------------------------
 // SPIR-V Passes
@@ -390,7 +394,8 @@ void addSPIRVTileAndVectorizeToCooperativeOpsPassPipeline(OpPassManager &pm);
 std::unique_ptr<OperationPass<ModuleOp>> createConvertToSPIRVPass();
 
 /// Creates a pass to fold processor ID uses where possible.
-std::unique_ptr<OperationPass<FuncOp>> createSPIRVFoldProcessorIDUsesPass();
+std::unique_ptr<OperationPass<func::FuncOp>>
+createSPIRVFoldProcessorIDUsesPass();
 
 /// Main pass to lower executables to scalar + vector code on SPIR-V path.
 /// Invokes one of the pass pipelines that translate the executable to
@@ -402,25 +407,26 @@ createSPIRVLowerExecutableTargetPass();
 std::unique_ptr<OperationPass<ModuleOp>> createSPIRVInitConfigPass();
 
 /// Pass to tile and distribute Linalg ops with buffer semantics to invocations.
-std::unique_ptr<OperationPass<FuncOp>> createSPIRVTileAndDistributePass();
+std::unique_ptr<OperationPass<func::FuncOp>> createSPIRVTileAndDistributePass();
 
 /// Pass to tile Linalg ops with buffer semantics to subgroups and vectorize to
 /// vector ops suitable for lowering to SPIR-V cooperative ops.
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 createSPIRVTileAndVectorizeToCooperativeOpsPass();
 
 /// Pass to convert vector read/write/arithmetic operations to the corresponding
 /// cooperative matrix ops when possible.
-std::unique_ptr<OperationPass<FuncOp>> createSPIRVVectorToCooperativeOpsPass();
+std::unique_ptr<OperationPass<func::FuncOp>>
+createSPIRVVectorToCooperativeOpsPass();
 
 /// Pass to tile Linalg ops with tensor semantics to invocations.
-std::unique_ptr<OperationPass<FuncOp>> createSPIRVTilePass();
+std::unique_ptr<OperationPass<func::FuncOp>> createSPIRVTilePass();
 
 /// Pass to distribute tiled loop nests to invocations.
-std::unique_ptr<OperationPass<FuncOp>> createSPIRVDistributePass();
+std::unique_ptr<OperationPass<func::FuncOp>> createSPIRVDistributePass();
 
 /// Pass to vectorize Linalg ops with buffer semantics.
-std::unique_ptr<OperationPass<FuncOp>> createSPIRVVectorizePass();
+std::unique_ptr<OperationPass<func::FuncOp>> createSPIRVVectorizePass();
 
 /// Converts memref of scalar to memref of vector of efficent size. This will
 /// allow to convert memory accesses to vector load/store in SPIR-V without
@@ -428,13 +434,14 @@ std::unique_ptr<OperationPass<FuncOp>> createSPIRVVectorizePass();
 std::unique_ptr<OperationPass<ModuleOp>> createSPIRVVectorizeLoadStore();
 
 /// Fuses tensor.pad ops into their consumer ops' tiled loop nests.
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 createSPIRVFuseTensorPadWithConsumerPass();
 
 // Uses `tensor.pad` ops as anchors to create separate fast and slow paths
 // inside the kernel. The fast path is for inner tiles where we don't need
 // padding, while the slow path is for boundary tiles where we do need padding.
-std::unique_ptr<OperationPass<FuncOp>> createSPIRVCreateFastSlowPathPass();
+std::unique_ptr<OperationPass<func::FuncOp>>
+createSPIRVCreateFastSlowPathPass();
 
 //----------------------------------------------------------------------------//
 // SPIRV Codegen Pass Pipelines.

--- a/iree/compiler/Codegen/Passes.td
+++ b/iree/compiler/Codegen/Passes.td
@@ -94,7 +94,7 @@ def OptimizeVectorTransfer :
 }
 
 def InsertDistributionInfo :
-    Pass<"iree-codegen-insert-distribution-info", "FuncOp"> {
+    Pass<"iree-codegen-insert-distribution-info", "func::FuncOp"> {
   let summary = "Insert the workgroup count region and translation info";
   let constructor = "mlir::iree_compiler::createInsertDistributionInfoPass()";
 }

--- a/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -94,8 +94,8 @@ InterfaceResourceMap createResourceVariables(mlir::ModuleOp module) {
   SymbolTable symbolTable(module);
   InterfaceResourceMap interfaceToResourceVars;
 
-  auto fns = llvm::to_vector<1>(module.getOps<FuncOp>());
-  for (FuncOp func : llvm::reverse(fns)) {
+  auto fns = llvm::to_vector<1>(module.getOps<func::FuncOp>());
+  for (func::FuncOp func : llvm::reverse(fns)) {
     // Collect all interface ops and their (set, binding) pairs in this
     // function. Use SmallVector here for a deterministic order.
     SmallVector<IREE::HAL::InterfaceBindingSubspanOp, 8> subspanOps;
@@ -305,7 +305,7 @@ void ConvertToSPIRVPass::runOnOperation() {
 
   llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> entryPoints =
       getAllEntryPoints(moduleOp);
-  for (auto funcOp : moduleOp.getOps<FuncOp>()) {
+  for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {
     auto entryPointOp = entryPoints.lookup(funcOp.getName());
     if (!entryPointOp) continue;
     // TODO(ravishankarm): This needs to be removed after ConvertToGPU is
@@ -400,14 +400,14 @@ void ConvertToSPIRVPass::runOnOperation() {
   // Disallow all other ops.
   target->markUnknownOpDynamicallyLegal([](Operation *) { return false; });
 
-  SmallVector<FuncOp, 1> functions;
-  for (FuncOp fn : moduleOp.getOps<FuncOp>()) {
+  SmallVector<func::FuncOp, 1> functions;
+  for (func::FuncOp fn : moduleOp.getOps<func::FuncOp>()) {
     if (!fn.isPublic()) continue;
     functions.push_back(fn);
   }
 
   FrozenRewritePatternSet frozenPatterns(std::move(patterns));
-  for (FuncOp fn : functions) {
+  for (func::FuncOp fn : functions) {
     if (failed(applyFullConversion(fn, *target, frozenPatterns))) {
       return signalPassFailure();
     }

--- a/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -156,7 +156,7 @@ LogicalResult setConvOpConfig(linalg::LinalgOp linalgOp,
     return success();
   }
 
-  auto funcOp = linalgOp->getParentOfType<FuncOp>();
+  auto funcOp = linalgOp->getParentOfType<func::FuncOp>();
   return setOpConfigAndEntryPointFnTranslation(funcOp, linalgOp, tileSizes,
                                                pipeline, workgroupSize);
 }
@@ -267,7 +267,8 @@ LogicalResult setMatmulOpConfig(linalg::LinalgOp op,
   tileSizes.push_back(invocationTileSizes);
   tileSizes.push_back(reductionTileSizes);
   return setOpConfigAndEntryPointFnTranslation(
-      op->getParentOfType<FuncOp>(), op, tileSizes, pipeline, workgroupSize);
+      op->getParentOfType<func::FuncOp>(), op, tileSizes, pipeline,
+      workgroupSize);
 }
 
 }  // namespace detail
@@ -306,7 +307,8 @@ static LogicalResult setFftOpConfig(spirv::ResourceLimitsAttr limits,
   }
   TileSizesListType tileSizes = {workgroupTileSize};
   return setOpConfigAndEntryPointFnTranslation(
-      op->getParentOfType<FuncOp>(), op, tileSizes, pipeline, workgroupSize);
+      op->getParentOfType<func::FuncOp>(), op, tileSizes, pipeline,
+      workgroupSize);
 }
 
 //===----------------------------------------------------------------------===//
@@ -316,7 +318,7 @@ static LogicalResult setFftOpConfig(spirv::ResourceLimitsAttr limits,
 static LogicalResult setDefaultOpConfig(spirv::ResourceLimitsAttr limits,
                                         Operation *op) {
   LLVM_DEBUG(llvm::dbgs() << "Using default config for op: " << *op << "\n");
-  FuncOp funcOp = op->getParentOfType<FuncOp>();
+  func::FuncOp funcOp = op->getParentOfType<func::FuncOp>();
   auto interfaceOp = cast<IREE::Flow::PartitionableLoopsInterface>(*op);
   auto partitionedLoops =
       interfaceOp.getPartitionableLoops(kNumMaxParallelDims);
@@ -588,7 +590,7 @@ LogicalResult initSPIRVLaunchConfig(ModuleOp module) {
   spirv::TargetEnv targetEnv(targetEnvAttr);
   spirv::ResourceLimitsAttr limits = targetEnv.getResourceLimits();
 
-  for (auto funcOp : module.getOps<FuncOp>()) {
+  for (auto funcOp : module.getOps<func::FuncOp>()) {
     auto entryPointOp = entryPointOps.lookup(funcOp.getName());
     if (!entryPointOp) continue;
 

--- a/iree/compiler/Codegen/SPIRV/NVIDIAConfig.cpp
+++ b/iree/compiler/Codegen/SPIRV/NVIDIAConfig.cpp
@@ -105,7 +105,8 @@ static LogicalResult setOpConfig(const spirv::TargetEnv &targetEnv,
   tileSizes.push_back({coopMatSize->m, coopMatSize->n, coopMatSize->k});
 
   return setOpConfigAndEntryPointFnTranslation(
-      op->getParentOfType<FuncOp>(), op, tileSizes, pipeline, workgroupSize);
+      op->getParentOfType<func::FuncOp>(), op, tileSizes, pipeline,
+      workgroupSize);
 }
 
 LogicalResult setNVIDIACodeGenConfig(const spirv::TargetEnv &targetEnv,

--- a/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -55,26 +55,27 @@ void addSPIRVBufferizePasses(OpPassManager &passManager,
   // becuase of dim op usage. This avoids bufferizing those compute ops just for
   // their shape dimensions.
   passManager.addPass(memref::createResolveShapedTypeResultDimsPass());
-  passManager.addNestedPass<FuncOp>(createLinalgBufferizePass(allocationFn));
+  passManager.addNestedPass<func::FuncOp>(
+      createLinalgBufferizePass(allocationFn));
   // Distribute immediately after bufferization to avoid losing attribute
   // annotations in subsequent transformations. This is a bit fragile right now
   // but we expect upstream for loops to eventually recognize distribution as a
   // first-class attribute then we don't need this.
-  passManager.addNestedPass<FuncOp>(createSPIRVDistributePass());
+  passManager.addNestedPass<func::FuncOp>(createSPIRVDistributePass());
   passManager.addPass(memref::createResolveShapedTypeResultDimsPass());
-  passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
-  passManager.addNestedPass<FuncOp>(createCSEPass());
-  passManager.addNestedPass<FuncOp>(createCleanupBufferAllocViewPass());
+  passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  passManager.addNestedPass<func::FuncOp>(createCSEPass());
+  passManager.addNestedPass<func::FuncOp>(createCleanupBufferAllocViewPass());
 }
 
 /// Adds passes to materialize structured ops as loops. This replaces structured
 /// ops with loop nests containing payloads, so it should be invoked after
 /// tiling and vectorization and before buffer transformations.
 static void addLoopMaterializationPasses(OpPassManager &pm) {
-  pm.addNestedPass<FuncOp>(IREE::LinalgExt::createLinalgExtToLoopsPass());
-  pm.addNestedPass<FuncOp>(createMemrefCopyToLinalgPass());
-  pm.addNestedPass<FuncOp>(createConvertLinalgToLoopsPass());
-  pm.addNestedPass<FuncOp>(createRemoveSingleIterationLoopPass());
+  pm.addNestedPass<func::FuncOp>(IREE::LinalgExt::createLinalgExtToLoopsPass());
+  pm.addNestedPass<func::FuncOp>(createMemrefCopyToLinalgPass());
+  pm.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
+  pm.addNestedPass<func::FuncOp>(createRemoveSingleIterationLoopPass());
 }
 
 /// Adds passes to lowering MemRefs. This folds MemRef subviews, flattens n-D
@@ -86,14 +87,14 @@ static void addMemRefLoweringPasses(OpPassManager &pm) {
   pm.addPass(createCSEPass());
 
   // math dialect elementry functions -> polynomial form.
-  pm.addNestedPass<FuncOp>(createPolynomialApproximationPass());
+  pm.addNestedPass<func::FuncOp>(createPolynomialApproximationPass());
 
   // Fold load/store from/to subview ops into the original memref when possible.
   // In SPIR-V we don't use memref descriptor so it's not possible to handle
   // subview ops.
   pm.addPass(memref::createFoldSubViewOpsPass());
-  pm.addNestedPass<FuncOp>(arith::createArithmeticExpandOpsPass());
-  pm.addNestedPass<FuncOp>(memref::createExpandOpsPass());
+  pm.addNestedPass<func::FuncOp>(arith::createArithmeticExpandOpsPass());
+  pm.addNestedPass<func::FuncOp>(memref::createExpandOpsPass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
@@ -102,7 +103,7 @@ static void addMemRefLoweringPasses(OpPassManager &pm) {
   pm.addPass(createSPIRVVectorizeLoadStore());
 
   // Perform optimizations that need to across the scf.for region boundary.
-  pm.addNestedPass<FuncOp>(createForOpCanonicalizationPass());
+  pm.addNestedPass<func::FuncOp>(createForOpCanonicalizationPass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
@@ -136,25 +137,25 @@ static void addSPIRVLoweringPasses(OpPassManager &pm) {
 //===----------------------------------------------------------------------===//
 
 void addSPIRVTileAndVectorizePassPipeline(OpPassManager &pm) {
-  pm.addNestedPass<FuncOp>(createInsertDistributionInfoPass());
-  pm.addNestedPass<FuncOp>(createTileAndDistributeToWorkgroupsPass());
-  pm.addNestedPass<FuncOp>(createSPIRVFuseTensorPadWithConsumerPass());
+  pm.addNestedPass<func::FuncOp>(createInsertDistributionInfoPass());
+  pm.addNestedPass<func::FuncOp>(createTileAndDistributeToWorkgroupsPass());
+  pm.addNestedPass<func::FuncOp>(createSPIRVFuseTensorPadWithConsumerPass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
-  pm.addNestedPass<FuncOp>(createFoldAffineMinInDistributedLoopsPass());
+  pm.addNestedPass<func::FuncOp>(createFoldAffineMinInDistributedLoopsPass());
   pm.addPass(memref::createResolveShapedTypeResultDimsPass());
 
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
   // Tile to GPU invocations and vectorize.
-  pm.addNestedPass<FuncOp>(createSPIRVCreateFastSlowPathPass());
-  pm.addNestedPass<FuncOp>(createSPIRVTilePass());
+  pm.addNestedPass<func::FuncOp>(createSPIRVCreateFastSlowPathPass());
+  pm.addNestedPass<func::FuncOp>(createSPIRVTilePass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
-  pm.addNestedPass<FuncOp>(createSPIRVVectorizePass());
-  pm.addNestedPass<FuncOp>(createForOpCanonicalizationPass());
+  pm.addNestedPass<func::FuncOp>(createSPIRVVectorizePass());
+  pm.addNestedPass<func::FuncOp>(createForOpCanonicalizationPass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
@@ -166,12 +167,12 @@ void addSPIRVTileAndVectorizePassPipeline(OpPassManager &pm) {
 
   // Perform various vector-level cross-op optimizations like load-store
   // forwarding, shape casting and casting op cancelling.
-  pm.addNestedPass<FuncOp>(createOptimizeVectorTransferPass());
+  pm.addNestedPass<func::FuncOp>(createOptimizeVectorTransferPass());
 }
 
 void addSPIRVTileAndVectorizeToCooperativeOpsPassPipeline(OpPassManager &pm) {
-  pm.addNestedPass<FuncOp>(createInsertDistributionInfoPass());
-  pm.addNestedPass<FuncOp>(createTileAndDistributeToWorkgroupsPass());
+  pm.addNestedPass<func::FuncOp>(createInsertDistributionInfoPass());
+  pm.addNestedPass<func::FuncOp>(createTileAndDistributeToWorkgroupsPass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
@@ -181,24 +182,25 @@ void addSPIRVTileAndVectorizeToCooperativeOpsPassPipeline(OpPassManager &pm) {
   pm.addPass(createCSEPass());
 
   // Tile and distribute to GPU subgroups and vectorize.
-  pm.addNestedPass<FuncOp>(createSPIRVTileAndVectorizeToCooperativeOpsPass());
+  pm.addNestedPass<func::FuncOp>(
+      createSPIRVTileAndVectorizeToCooperativeOpsPass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
   // Perform various vector-level cross-op optimizations like load-store
   // forwarding, shape casting and casting op cancelling.
-  pm.addNestedPass<FuncOp>(createOptimizeVectorTransferPass());
+  pm.addNestedPass<func::FuncOp>(createOptimizeVectorTransferPass());
 
   // Fold subview ops is reqiured for converting vector transfer ops into SPIR-V
   // cooperative ops in the next step.
   pm.addPass(memref::createFoldSubViewOpsPass());
 
-  pm.addNestedPass<FuncOp>(createSPIRVVectorToCooperativeOpsPass());
+  pm.addNestedPass<func::FuncOp>(createSPIRVVectorToCooperativeOpsPass());
 }
 
 void addSPIRVTileAndDistributePassPipeline(OpPassManager &pm) {
-  pm.addNestedPass<FuncOp>(createInsertDistributionInfoPass());
-  pm.addNestedPass<FuncOp>(createTileAndDistributeToWorkgroupsPass());
+  pm.addNestedPass<func::FuncOp>(createInsertDistributionInfoPass());
+  pm.addNestedPass<func::FuncOp>(createTileAndDistributeToWorkgroupsPass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
@@ -208,7 +210,7 @@ void addSPIRVTileAndDistributePassPipeline(OpPassManager &pm) {
   pm.addPass(createCSEPass());
 
   // Tile and distribute to GPU invocations.
-  pm.addNestedPass<FuncOp>(createSPIRVTileAndDistributePass());
+  pm.addNestedPass<func::FuncOp>(createSPIRVTileAndDistributePass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
@@ -232,13 +234,13 @@ void addSPIRVTileAndDistributeCopyPassPipeline(OpPassManager &pm) {
   addLinalgBufferizePasses(pm, gpuAllocationFunction);
   pm.addPass(createSPIRVInitConfigPass());
 
-  pm.addNestedPass<FuncOp>(createInsertDistributionInfoPass());
-  pm.addNestedPass<FuncOp>(createTileAndDistributeToWorkgroupsPass());
+  pm.addNestedPass<func::FuncOp>(createInsertDistributionInfoPass());
+  pm.addNestedPass<func::FuncOp>(createTileAndDistributeToWorkgroupsPass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
   // Tile and distribute to GPU invocations.
-  pm.addNestedPass<FuncOp>(createSPIRVTileAndDistributePass());
+  pm.addNestedPass<func::FuncOp>(createSPIRVTileAndDistributePass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
@@ -250,7 +252,7 @@ void addSPIRVTileAndDistributeCopyPassPipeline(OpPassManager &pm) {
 //===----------------------------------------------------------------------===//
 
 void buildSPIRVCodegenPassPipeline(OpPassManager &pm) {
-  pm.nest<ModuleOp>().nest<FuncOp>().addPass(createTypePropagationPass());
+  pm.nest<ModuleOp>().nest<func::FuncOp>().addPass(createTypePropagationPass());
   pm.nest<ModuleOp>().addPass(createBufferizeCopyOnlyDispatchesPass());
   pm.addPass(createSPIRVLowerExecutableTargetPass());
 

--- a/iree/compiler/Codegen/SPIRV/SPIRVCreateFastSlowPath.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVCreateFastSlowPath.cpp
@@ -137,7 +137,7 @@ struct SPIRVCreateFastSlowPathPass final
     : public SPIRVCreateFastSlowPathBase<SPIRVCreateFastSlowPathPass> {
   void runOnOperation() override {
     MLIRContext *context = &getContext();
-    FuncOp funcOp = getOperation();
+    func::FuncOp funcOp = getOperation();
 
     {
       RewritePatternSet patterns(context);
@@ -162,7 +162,8 @@ struct SPIRVCreateFastSlowPathPass final
 
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>> createSPIRVCreateFastSlowPathPass() {
+std::unique_ptr<OperationPass<func::FuncOp>>
+createSPIRVCreateFastSlowPathPass() {
   return std::make_unique<SPIRVCreateFastSlowPathPass>();
 }
 

--- a/iree/compiler/Codegen/SPIRV/SPIRVDistribute.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVDistribute.cpp
@@ -84,7 +84,7 @@ struct SPIRVDistributePass final
 
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>> createSPIRVDistributePass() {
+std::unique_ptr<OperationPass<func::FuncOp>> createSPIRVDistributePass() {
   return std::make_unique<SPIRVDistributePass>();
 }
 

--- a/iree/compiler/Codegen/SPIRV/SPIRVFuseTensorPadWithConsumer.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVFuseTensorPadWithConsumer.cpp
@@ -20,7 +20,7 @@ struct SPIRVFuseTensorPadWithConsumerPass final
           SPIRVFuseTensorPadWithConsumerPass> {
   void runOnOperation() override {
     MLIRContext *context = &getContext();
-    FuncOp funcOp = getOperation();
+    func::FuncOp funcOp = getOperation();
 
     RewritePatternSet patterns(context);
     patterns.insert<linalg::ExtractSliceOfPadTensorSwapPattern>(
@@ -33,7 +33,7 @@ struct SPIRVFuseTensorPadWithConsumerPass final
 
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 createSPIRVFuseTensorPadWithConsumerPass() {
   return std::make_unique<SPIRVFuseTensorPadWithConsumerPass>();
 }

--- a/iree/compiler/Codegen/SPIRV/SPIRVTile.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVTile.cpp
@@ -167,7 +167,7 @@ class SPIRVTilePass final : public SPIRVTileBase<SPIRVTilePass> {
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();
-    FuncOp funcOp = getOperation();
+    func::FuncOp funcOp = getOperation();
 
     // Try to find computation ops which we will use as anchor to tile and fuse
     // again. If there are `scf.if` ops, we have both a fast and slow paths for
@@ -338,7 +338,7 @@ class SPIRVTilePass final : public SPIRVTileBase<SPIRVTilePass> {
 };
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>> createSPIRVTilePass() {
+std::unique_ptr<OperationPass<func::FuncOp>> createSPIRVTilePass() {
   return std::make_unique<SPIRVTilePass>();
 }
 

--- a/iree/compiler/Codegen/SPIRV/SPIRVTileAndDistribute.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVTileAndDistribute.cpp
@@ -174,7 +174,7 @@ class SPIRVTileAndDistributePass
 
 void SPIRVTileAndDistributePass::runOnOperation() {
   MLIRContext *context = &getContext();
-  FuncOp funcOp = getOperation();
+  func::FuncOp funcOp = getOperation();
   auto entryPointOp = getEntryPoint(funcOp);
   if (!entryPointOp) return;
 
@@ -248,7 +248,8 @@ void SPIRVTileAndDistributePass::runOnOperation() {
 // Pass entry point and registration
 //===----------------------------------------------------------------------===//
 
-std::unique_ptr<OperationPass<FuncOp>> createSPIRVTileAndDistributePass() {
+std::unique_ptr<OperationPass<func::FuncOp>>
+createSPIRVTileAndDistributePass() {
   return std::make_unique<SPIRVTileAndDistributePass>();
 }
 

--- a/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
@@ -276,7 +276,7 @@ class SPIRVTileAndVectorizeToCooperativeOpsPass final
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();
-    FuncOp funcOp = getOperation();
+    func::FuncOp funcOp = getOperation();
 
     // First we need to discover the CodeGen lowering configuration. It was
     // decided earlier and attached to a linalg op as an attribute.
@@ -411,7 +411,7 @@ class SPIRVTileAndVectorizeToCooperativeOpsPass final
 
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 createSPIRVTileAndVectorizeToCooperativeOpsPass() {
   return std::make_unique<SPIRVTileAndVectorizeToCooperativeOpsPass>();
 }

--- a/iree/compiler/Codegen/SPIRV/SPIRVVectorToCooperativeOps.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVVectorToCooperativeOps.cpp
@@ -200,7 +200,7 @@ struct SPIRVVectorToCooperativeOpsPass final
     : public SPIRVVectorToCooperativeOpsBase<SPIRVVectorToCooperativeOpsPass> {
   void runOnOperation() override {
     MLIRContext *context = &getContext();
-    FuncOp funcOp = getOperation();
+    func::FuncOp funcOp = getOperation();
 
     spirv::TargetEnvAttr targetAttr = getSPIRVTargetEnvAttr(funcOp);
     SPIRVTypeConverter typeConverter(targetAttr);
@@ -280,7 +280,8 @@ struct SPIRVVectorToCooperativeOpsPass final
 
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>> createSPIRVVectorToCooperativeOpsPass() {
+std::unique_ptr<OperationPass<func::FuncOp>>
+createSPIRVVectorToCooperativeOpsPass() {
   return std::make_unique<SPIRVVectorToCooperativeOpsPass>();
 }
 

--- a/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
@@ -103,7 +103,7 @@ class SPIRVVectorizePass : public SPIRVVectorizeBase<SPIRVVectorizePass> {
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();
-    FuncOp funcOp = getOperation();
+    func::FuncOp funcOp = getOperation();
 
     {
       RewritePatternSet patterns(context);
@@ -202,7 +202,7 @@ class SPIRVVectorizePass : public SPIRVVectorizeBase<SPIRVVectorizePass> {
 
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>> createSPIRVVectorizePass() {
+std::unique_ptr<OperationPass<func::FuncOp>> createSPIRVVectorizePass() {
   return std::make_unique<SPIRVVectorizePass>();
 }
 

--- a/iree/compiler/Codegen/SPIRV/SPIRVVectorizePad.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVVectorizePad.cpp
@@ -246,7 +246,7 @@ void populateVectorizePadPatterns(RewritePatternSet &patterns,
   patterns.add<VectorizePadWithConditions>(patterns.getContext(), baseBenefit);
 }
 
-std::unique_ptr<OperationPass<FuncOp>> createVectorizePadPass() {
+std::unique_ptr<OperationPass<func::FuncOp>> createVectorizePadPass() {
   return std::make_unique<TensorToVectorVectorizePadPass>();
 }
 

--- a/iree/compiler/Codegen/Sandbox/LinalgTensorCodegenDriver.cpp
+++ b/iree/compiler/Codegen/Sandbox/LinalgTensorCodegenDriver.cpp
@@ -52,7 +52,7 @@ static bool getTilingOptionsFromConfig(int64_t tilingLevel,
 /// Default method to initialize the tiling options for fusion in IREE. These
 /// could be ovveridden by the command line options if specified.
 static FailureOr<LinalgTilingAndFusionOptions> getTileAndFuseOptionsFromConfig(
-    FuncOp funcOp, int64_t tilingLevel) {
+    func::FuncOp funcOp, int64_t tilingLevel) {
   SmallVector<Operation *> computeOps;
   SmallVector<mlir::iree_compiler::LoopTilingAndDistributionInfo> tiledLoops;
   mlir::iree_compiler::IREE::Codegen::LoweringConfigAttr loweringConfig;
@@ -201,7 +201,7 @@ static Value getNeutralOfLinalgOp(OpBuilder &b, OpOperand &op) {
 /// For now this just fuses everything.
 // TODO: finer control.
 void LinalgFusePass::runOnOperation() {
-  FuncOp funcOp = getOperation();
+  func::FuncOp funcOp = getOperation();
 
   // Set up tiling and vectorization options.
   FailureOr<LinalgTilingAndFusionOptions> defaultTilingOptions =
@@ -259,7 +259,7 @@ void LinalgFusePass::runOnOperation() {
       .vectorizeIf(vectorize, "", nullptr, vectorizePadding);
 
   // Created a nested OpPassManager and run.
-  OpPassManager dynamicPM(FuncOp::getOperationName());
+  OpPassManager dynamicPM(func::FuncOp::getOperationName());
   strategy.configurePassPipeline(dynamicPM, funcOp.getContext());
 
   if (failed(runPipeline(dynamicPM, funcOp))) {
@@ -268,7 +268,7 @@ void LinalgFusePass::runOnOperation() {
 }
 
 void LinalgSingleTilingExpertPass::runOnOperation() {
-  FuncOp funcOp = getOperation();
+  func::FuncOp funcOp = getOperation();
 
   // Set up tiling and vectorization options.
   LinalgTilingOptions tilingOptions;
@@ -329,7 +329,7 @@ void LinalgSingleTilingExpertPass::runOnOperation() {
                    nullptr, vectorizePadding);
 
   // Created a nested OpPassManager and run.
-  OpPassManager dynamicPM(FuncOp::getOperationName());
+  OpPassManager dynamicPM(func::FuncOp::getOperationName());
   strategy.configurePassPipeline(dynamicPM, funcOp.getContext());
   if (failed(runPipeline(dynamicPM, funcOp))) {
     return signalPassFailure();
@@ -410,8 +410,8 @@ void LinalgVectorLoweringPass::runOnOperation() {
   CodegenStrategy strategy;
   strategy.vectorLowering(vectorLoweringOptions);
   // Created a nested OpPassManager and run.
-  OpPassManager dynamicPM(FuncOp::getOperationName());
-  FuncOp funcOp = getOperation();
+  OpPassManager dynamicPM(func::FuncOp::getOperationName());
+  func::FuncOp funcOp = getOperation();
   strategy.configurePassPipeline(dynamicPM, funcOp.getContext());
   if (failed(runPipeline(dynamicPM, funcOp))) {
     return signalPassFailure();
@@ -500,41 +500,46 @@ void OutlineOneParentLoopPass::runOnOperation() {
   });
 }
 
-std::unique_ptr<OperationPass<FuncOp>> mlir::createLinalgFusePass() {
+std::unique_ptr<OperationPass<func::FuncOp>> mlir::createLinalgFusePass() {
   return std::make_unique<LinalgFusePass>();
 }
-std::unique_ptr<OperationPass<FuncOp>> mlir::createLinalgFusePass(
+std::unique_ptr<OperationPass<func::FuncOp>> mlir::createLinalgFusePass(
     const mlir::LinalgFusePassOptions &options) {
   return std::make_unique<LinalgFusePass>(options);
 }
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 mlir::createLinalgSingleTilingExpertPass() {
   return std::make_unique<LinalgSingleTilingExpertPass>();
 }
-std::unique_ptr<OperationPass<FuncOp>> mlir::createLinalgSingleTilingExpertPass(
+std::unique_ptr<OperationPass<func::FuncOp>>
+mlir::createLinalgSingleTilingExpertPass(
     const LinalgSingleTilingExpertPassOptions &passOptions) {
   return std::make_unique<LinalgSingleTilingExpertPass>(passOptions);
 }
 
-std::unique_ptr<OperationPass<FuncOp>> mlir::createLinalgVectorLoweringPass(
-    int64_t vectorLoweringStage) {
+std::unique_ptr<OperationPass<func::FuncOp>>
+mlir::createLinalgVectorLoweringPass(int64_t vectorLoweringStage) {
   return std::make_unique<LinalgVectorLoweringPass>(vectorLoweringStage);
 }
-std::unique_ptr<OperationPass<FuncOp>> mlir::createLinalgVectorLoweringPass(
+std::unique_ptr<OperationPass<func::FuncOp>>
+mlir::createLinalgVectorLoweringPass(
     const LinalgVectorLoweringPassOptions &options) {
   return std::make_unique<LinalgVectorLoweringPass>(options);
 }
 
-std::unique_ptr<OperationPass<FuncOp>> mlir::createUnrollOneVectorOpPass() {
+std::unique_ptr<OperationPass<func::FuncOp>>
+mlir::createUnrollOneVectorOpPass() {
   return std::make_unique<UnrollOneVectorOpPass>();
 }
 
-std::unique_ptr<OperationPass<FuncOp>> mlir::createUnrollOneParentLoopPass() {
+std::unique_ptr<OperationPass<func::FuncOp>>
+mlir::createUnrollOneParentLoopPass() {
   return std::make_unique<UnrollOneParentLoopPass>();
 }
 
-std::unique_ptr<OperationPass<FuncOp>> mlir::createOutlineOneParentLoopPass() {
+std::unique_ptr<OperationPass<func::FuncOp>>
+mlir::createOutlineOneParentLoopPass() {
   return std::make_unique<OutlineOneParentLoopPass>();
 }
 
@@ -557,7 +562,7 @@ void mlir::addLowerToVectorTransforms(OpPassManager &passManager,
 // backend pipelines
 //===----------------------------------------------------------------------===//
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 mlir::iree_compiler::createLinalgFusePass(int64_t tilingLevel, bool vectorize) {
   return std::make_unique<LinalgFusePass>(tilingLevel, vectorize);
 }

--- a/iree/compiler/Codegen/Sandbox/Passes.h
+++ b/iree/compiler/Codegen/Sandbox/Passes.h
@@ -29,8 +29,8 @@ struct LinalgFusePassOptions {
 };
 
 /// Creates a pass to drive tile + fuse transformations of `LinalgOp`s.
-std::unique_ptr<OperationPass<FuncOp>> createLinalgFusePass();
-std::unique_ptr<OperationPass<FuncOp>> createLinalgFusePass(
+std::unique_ptr<OperationPass<func::FuncOp>> createLinalgFusePass();
+std::unique_ptr<OperationPass<func::FuncOp>> createLinalgFusePass(
     const LinalgFusePassOptions &options);
 
 /// Struct to control pass options for `LinalgSingleTilingExpert` pass.
@@ -54,8 +54,9 @@ struct LinalgSingleTilingExpertPassOptions {
 };
 
 /// Creates a pass to drive one level tiling + vectorization of `LinalgOp`s.
-std::unique_ptr<OperationPass<FuncOp>> createLinalgSingleTilingExpertPass();
-std::unique_ptr<OperationPass<FuncOp>> createLinalgSingleTilingExpertPass(
+std::unique_ptr<OperationPass<func::FuncOp>>
+createLinalgSingleTilingExpertPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createLinalgSingleTilingExpertPass(
     const LinalgSingleTilingExpertPassOptions &passOptions);
 
 /// Struct to control pass options for `LinalgVectorLoweringPass` pass.
@@ -72,20 +73,20 @@ struct LinalgVectorLoweringPassOptions {
 
 /// Creates a pass to drive the lowering of vector operations in a staged
 /// manner.
-std::unique_ptr<OperationPass<FuncOp>> createLinalgVectorLoweringPass(
+std::unique_ptr<OperationPass<func::FuncOp>> createLinalgVectorLoweringPass(
     int64_t vectorLoweringStage = 0);
-std::unique_ptr<OperationPass<FuncOp>> createLinalgVectorLoweringPass(
+std::unique_ptr<OperationPass<func::FuncOp>> createLinalgVectorLoweringPass(
     const LinalgVectorLoweringPassOptions &options);
 
 /// Create a pass to drive the unrolling of a single vector op.
-std::unique_ptr<OperationPass<FuncOp>> createUnrollOneVectorOpPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createUnrollOneVectorOpPass();
 
 /// Create a pass to drive the unrolling of a single parent loop of an op.
-std::unique_ptr<OperationPass<FuncOp>> createUnrollOneParentLoopPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createUnrollOneParentLoopPass();
 
 /// Create a pass to drive the outlining of the region of a single parent loop
 /// of an op.
-std::unique_ptr<OperationPass<FuncOp>> createOutlineOneParentLoopPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createOutlineOneParentLoopPass();
 
 //===----------------------------------------------------------------------===//
 // Transforms that tie together individual drivers.
@@ -105,13 +106,13 @@ namespace iree_compiler {
 /// Creates a pass to drive tile + fuse transformations of `LinalgOp`s with
 /// additional parameters that allow controlling the value of the pass options
 /// when building the pipeline.
-std::unique_ptr<OperationPass<FuncOp>> createLinalgFusePass(int64_t tilingLevel,
-                                                            bool vectorize);
+std::unique_ptr<OperationPass<func::FuncOp>> createLinalgFusePass(
+    int64_t tilingLevel, bool vectorize);
 
 /// Creates a pass to drive one level tiling + vectorization of `LinalgOp`s with
 /// additional parameters that allow controlling the value of the pass options
 /// when building the pipeline.
-std::unique_ptr<OperationPass<FuncOp>> createLinalgSingleTilingExpertPass(
+std::unique_ptr<OperationPass<func::FuncOp>> createLinalgSingleTilingExpertPass(
     int64_t tilingLevel, bool vectorize);
 
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Codegen/Sandbox/Passes.td
+++ b/iree/compiler/Codegen/Sandbox/Passes.td
@@ -9,7 +9,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def LinalgFuse : Pass<"linalg-fuse", "FuncOp"> {
+def LinalgFuse : Pass<"linalg-fuse", "func::FuncOp"> {
   let summary = "Pass to tile and fuse linalg operations.";
   let constructor = "mlir::createLinalgFusePass()";
   let options = [
@@ -56,7 +56,7 @@ def LinalgFuse : Pass<"linalg-fuse", "FuncOp"> {
 }
 
 def LinalgSingleTilingExpert
-    : Pass<"linalg-single-tiling-expert-driver", "FuncOp"> {
+    : Pass<"linalg-single-tiling-expert-driver", "func::FuncOp"> {
   let summary = "Pass to drive transformations on Linalg on tensors.";
   let constructor = "mlir::createLinalgSingleTilingExpertPass()";
   let options = [
@@ -121,7 +121,7 @@ def LinalgSingleTilingExpert
   ];
 }
 
-def LinalgVectorLowering : Pass<"linalg-vector-lowering", "FuncOp"> {
+def LinalgVectorLowering : Pass<"linalg-vector-lowering", "func::FuncOp"> {
   let summary = "Run transformations that lower high-level vectors.";
   let constructor = "mlir::createLinalgVectorLoweringPass()";
   let options = [
@@ -176,7 +176,7 @@ def LinalgVectorLowering : Pass<"linalg-vector-lowering", "FuncOp"> {
   ];
 }
 
-def UnrollOneVectorOp : Pass<"unroll-one-vector-op", "FuncOp"> {
+def UnrollOneVectorOp : Pass<"unroll-one-vector-op", "func::FuncOp"> {
   let summary = "Pass to unroll a vector op to a target size.";
   let constructor = "mlir::createUnrollOneVectorOpPass()";
   let options = [
@@ -199,7 +199,7 @@ def UnrollOneVectorOp : Pass<"unroll-one-vector-op", "FuncOp"> {
   ];
 }
 
-def UnrollOneParentLoop : Pass<"unroll-one-parent-loop", "FuncOp"> {
+def UnrollOneParentLoop : Pass<"unroll-one-parent-loop", "func::FuncOp"> {
   let summary = "Pass to unroll the k^th parent loop of an op by some amount.";
   let constructor = "mlir::createUnrollOneParentLoopPass()";
   let options = [
@@ -222,7 +222,7 @@ def UnrollOneParentLoop : Pass<"unroll-one-parent-loop", "FuncOp"> {
   ];
 }
 
-def OutlineOneParentLoop : Pass<"outline-one-parent-loop", "FuncOp"> {
+def OutlineOneParentLoop : Pass<"outline-one-parent-loop", "func::FuncOp"> {
   let summary = "Pass to outline the k^th parent loop of an op.";
   let constructor = "mlir::createOutlineOneParentLoopPass()";
   let options = [

--- a/iree/compiler/ConstEval/JitGlobals.cpp
+++ b/iree/compiler/ConstEval/JitGlobals.cpp
@@ -42,7 +42,7 @@ struct ProgramExtractor {
     Type globalType = globalOp.type();
     auto funcType =
         builder.getType<FunctionType>(TypeRange{}, TypeRange{globalType});
-    auto funcOp = FuncOp::create(loc, name, funcType);
+    auto funcOp = func::FuncOp::create(loc, name, funcType);
     StringAttr funcSymbolName = targetSymbolTable.insert(funcOp);
     Block *entryBlock = funcOp.addEntryBlock();
 

--- a/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
@@ -194,7 +194,8 @@ class CUDATargetBackend final : public TargetBackend {
 
     // Remove all the functions that are not part of the CUDA kernel.
     // TODO: Find a better solution to handle this.
-    auto illegalFuncOps = llvm::to_vector<4>(innerModuleOp.getOps<FuncOp>());
+    auto illegalFuncOps =
+        llvm::to_vector<4>(innerModuleOp.getOps<func::FuncOp>());
     for (auto funcOp : illegalFuncOps) {
       funcOp.erase();
     }

--- a/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTarget.cpp
@@ -104,7 +104,8 @@ class ROCMTargetBackend final : public TargetBackend {
 
     // Remove all the functions that are not part of the ROCM kernel.
     // TODO: Find a better solution to handle this.
-    auto illegalFuncOps = llvm::to_vector<4>(innerModuleOp.getOps<FuncOp>());
+    auto illegalFuncOps =
+        llvm::to_vector<4>(innerModuleOp.getOps<func::FuncOp>());
     for (auto funcOp : illegalFuncOps) {
       funcOp.erase();
     }

--- a/iree/compiler/Dialect/HAL/Transforms/BenchmarkBatchDispatches.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/BenchmarkBatchDispatches.cpp
@@ -18,7 +18,8 @@ namespace {
 
 // A pass converting the IREE flow dialect into the IREE HAL dialect.
 class BenchmarkBatchDispatchesPass
-    : public PassWrapper<BenchmarkBatchDispatchesPass, OperationPass<FuncOp>> {
+    : public PassWrapper<BenchmarkBatchDispatchesPass,
+                         OperationPass<func::FuncOp>> {
  public:
   explicit BenchmarkBatchDispatchesPass(unsigned repeatCount)
       : repeatCount_(repeatCount) {}
@@ -37,7 +38,7 @@ class BenchmarkBatchDispatchesPass
   }
 
   void runOnOperation() override {
-    FuncOp f = getOperation();
+    func::FuncOp f = getOperation();
     SmallVector<HAL::CommandBufferDispatchOp> ops;
     f.walk([&](HAL::CommandBufferDispatchOp op) { ops.push_back(op); });
 

--- a/iree/compiler/Dialect/Modules/VMVX/Conversion/HALToVMVX/ConvertHALToVMVX.cpp
+++ b/iree/compiler/Dialect/Modules/VMVX/Conversion/HALToVMVX/ConvertHALToVMVX.cpp
@@ -63,7 +63,7 @@ enum EntryArgOrdinals {
 ///       %workgroup_count_y: index,
 ///       %workgroup_count_z: index
 ///   )
-LogicalResult updateHALToVMVXEntryFuncOp(FuncOp funcOp,
+LogicalResult updateHALToVMVXEntryFuncOp(func::FuncOp funcOp,
                                          TypeConverter &typeConverter) {
   auto originalType = funcOp.getFunctionType();
   if (originalType.getNumInputs() != 0 || originalType.getNumResults() != 0) {

--- a/iree/compiler/Dialect/Modules/VMVX/Transforms/Conversion.cpp
+++ b/iree/compiler/Dialect/Modules/VMVX/Transforms/Conversion.cpp
@@ -53,7 +53,7 @@ class ConversionPass
     typeConverter.addConversion([](Type type) { return type; });
 
     // Run a pre-pass that updates the entry function signature.
-    for (auto funcOp : getOperation().getOps<FuncOp>()) {
+    for (auto funcOp : getOperation().getOps<func::FuncOp>()) {
       if (funcOp.isPublic()) {
         if (failed(updateHALToVMVXEntryFuncOp(funcOp, typeConverter))) {
           return signalPassFailure();

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
@@ -64,10 +64,10 @@ constexpr const char *kRetainedAttributes[] = {
     "noinline",
 };
 
-class FuncOpConversion : public OpConversionPattern<FuncOp> {
+class FuncOpConversion : public OpConversionPattern<func::FuncOp> {
   using OpConversionPattern::OpConversionPattern;
   LogicalResult matchAndRewrite(
-      FuncOp srcOp, OpAdaptor adaptor,
+      func::FuncOp srcOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     FunctionType srcFuncType = srcOp.getFunctionType();
     TypeConverter::SignatureConversion signatureConversion(

--- a/iree/compiler/Dialect/VM/Target/C/TranslateToCpp.cpp
+++ b/iree/compiler/Dialect/VM/Target/C/TranslateToCpp.cpp
@@ -412,7 +412,7 @@ static LogicalResult printOperation(CppEmitter &emitter, ModuleOp moduleOp) {
   return success();
 }
 
-static LogicalResult printOperation(CppEmitter &emitter, FuncOp functionOp) {
+static LogicalResult printOperation(CppEmitter &emitter, func::FuncOp functionOp) {
   // We need to declare variables at top if the function has multiple blocks.
   if (!emitter.shouldDeclareVariablesAtTop() &&
       functionOp.getBlocks().size() > 1) {
@@ -754,7 +754,7 @@ LogicalResult CppEmitter::emitOperation(Operation &op, bool trailingSemicolon) {
               [&](auto op) { return printOperation(*this, op); })
           // Standard ops.
           .Case<cf::BranchOp, mlir::func::CallOp, cf::CondBranchOp, mlir::func::ConstantOp,
-                FuncOp, ModuleOp, func::ReturnOp>(
+                func::FuncOp, ModuleOp, func::ReturnOp>(
               [&](auto op) { return printOperation(*this, op); })
           .Default([&](Operation *) {
             return op.emitOpError("unable to find printer for op");

--- a/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
+++ b/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
@@ -137,10 +137,10 @@ class TensorToBufferViewPattern
   }
 };
 
-class BuiltinFuncOpPattern : public OpConversionPattern<FuncOp> {
-  using OpConversionPattern<FuncOp>::OpConversionPattern;
+class BuiltinFuncOpPattern : public OpConversionPattern<func::FuncOp> {
+  using OpConversionPattern<func::FuncOp>::OpConversionPattern;
   LogicalResult matchAndRewrite(
-      FuncOp srcOp, OpAdaptor adaptor,
+      func::FuncOp srcOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     FunctionType srcFuncType = srcOp.getFunctionType();
     TypeConverter::SignatureConversion signatureConversion(
@@ -166,8 +166,8 @@ class BuiltinFuncOpPattern : public OpConversionPattern<FuncOp> {
     auto newFuncType = mlir::FunctionType::get(
         srcOp.getContext(), signatureConversion.getConvertedTypes(),
         convertedResultTypes);
-    auto newFuncOp =
-        rewriter.create<FuncOp>(srcOp.getLoc(), srcOp.getName(), newFuncType);
+    auto newFuncOp = rewriter.create<func::FuncOp>(
+        srcOp.getLoc(), srcOp.getName(), newFuncType);
     rewriter.inlineRegionBefore(srcOp.getBody(), newFuncOp.getBody(),
                                 newFuncOp.end());
 
@@ -296,7 +296,7 @@ void IREEImportPublicPass::runOnOperation() {
     return true;
   };
 
-  target.addDynamicallyLegalOp<FuncOp>([&](FuncOp funcOp) {
+  target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp funcOp) {
     for (Type type : funcOp.getFunctionType().getInputs()) {
       if (isIllegalType(type)) return false;
     }

--- a/iree/compiler/InputConversion/Common/Passes.td
+++ b/iree/compiler/InputConversion/Common/Passes.td
@@ -16,7 +16,7 @@ def IREEImportPublic :
 }
 
 def LinalgQuantizedMatmulToMatmulPass
-    : Pass<"iree-linalg-quantized-matmul-to-matmul", "FuncOp"> {
+    : Pass<"iree-linalg-quantized-matmul-to-matmul", "func::FuncOp"> {
   let summary = "lower quantized_matmul to matmul";
   let constructor = "mlir::iree_compiler::createLinalgQuantizedMatmulToMatmulPass()";
   // let dependentDialects = ["mlir::linalg::LinalgDialect"];
@@ -29,7 +29,7 @@ def SanitizeModuleNames :
 }
 
 def TopLevelSCFToCFG :
-    Pass<"iree-top-level-scf-to-cfg", "FuncOp"> {
+    Pass<"iree-top-level-scf-to-cfg", "func::FuncOp"> {
   let summary = "Converts non-nested SCF constructs to CFG (not traversing into opaque operations).";
   let constructor = "mlir::iree_compiler::createTopLevelSCFToCFGPass()";
 }

--- a/iree/compiler/InputConversion/Common/QuantizedMatmulToMatmul.cpp
+++ b/iree/compiler/InputConversion/Common/QuantizedMatmulToMatmul.cpp
@@ -225,7 +225,7 @@ struct LinalgQuantizedMatmulToMatmulPass
 
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 createLinalgQuantizedMatmulToMatmulPass() {
   return std::make_unique<LinalgQuantizedMatmulToMatmulPass>();
 }

--- a/iree/compiler/InputConversion/Common/TopLevelSCFToCFG.cpp
+++ b/iree/compiler/InputConversion/Common/TopLevelSCFToCFG.cpp
@@ -46,7 +46,7 @@ void TopLevelSCFToCFGPass::runOnOperation() {
     signalPassFailure();
 }
 
-std::unique_ptr<OperationPass<FuncOp>> createTopLevelSCFToCFGPass() {
+std::unique_ptr<OperationPass<func::FuncOp>> createTopLevelSCFToCFGPass() {
   return std::make_unique<TopLevelSCFToCFGPass>();
 }
 

--- a/iree/compiler/InputConversion/MHLO/ConvertComplexToReal.cpp
+++ b/iree/compiler/InputConversion/MHLO/ConvertComplexToReal.cpp
@@ -424,7 +424,7 @@ struct TestMHLOConvertComplexToRealPass
 
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 createTestMHLOConvertComplexToRealPass() {
   return std::make_unique<TestMHLOConvertComplexToRealPass>();
 }

--- a/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
+++ b/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
@@ -574,7 +574,8 @@ struct ConvertMHLOToLinalgExtPass
 };
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>> createConvertMHLOToLinalgExtPass() {
+std::unique_ptr<OperationPass<func::FuncOp>>
+createConvertMHLOToLinalgExtPass() {
   return std::make_unique<ConvertMHLOToLinalgExtPass>();
 }
 

--- a/iree/compiler/InputConversion/MHLO/FlattenTuplesInCFG.cpp
+++ b/iree/compiler/InputConversion/MHLO/FlattenTuplesInCFG.cpp
@@ -234,7 +234,7 @@ bool convertOperation(Operation *op, OpBuilder &builder,
   return false;
 }
 
-bool convertFunction(FuncOp oldFunction, FuncOp newFunction) {
+bool convertFunction(func::FuncOp oldFunction, func::FuncOp newFunction) {
   OpBuilder builder(newFunction.getBody());
   BlockAndValueMapping mapping;
 
@@ -285,9 +285,9 @@ class FlattenTuplesInCFGPass
     // Build a list of (oldFunction, newFunction) for all functions we need to
     // replace. This will ensure that when we go to convert function bodies we
     // have only new functions defined.
-    std::vector<std::pair<FuncOp, FuncOp>> convertedFunctions;
+    std::vector<std::pair<func::FuncOp, func::FuncOp>> convertedFunctions;
 
-    for (auto oldFunction : module.getOps<FuncOp>()) {
+    for (auto oldFunction : module.getOps<func::FuncOp>()) {
       auto oldFunctionType = oldFunction.getFunctionType();
       llvm::SmallVector<Type, 10> newInputTypes;
       untupleTypes(oldFunctionType.getInputs(), &newInputTypes);
@@ -298,8 +298,8 @@ class FlattenTuplesInCFGPass
       auto newFunctionType =
           builder.getFunctionType(newInputTypes, newResultTypes);
       auto newFunction =
-          FuncOp::create(oldFunction.getLoc(), oldFunction.getName(),
-                         newFunctionType, oldFunction->getDialectAttrs());
+          func::FuncOp::create(oldFunction.getLoc(), oldFunction.getName(),
+                               newFunctionType, oldFunction->getDialectAttrs());
       convertedFunctions.push_back({oldFunction, newFunction});
 
       // Perform the actual body conversion now that we have proper signatures.

--- a/iree/compiler/InputConversion/MHLO/LegalizeInputTypes.cpp
+++ b/iree/compiler/InputConversion/MHLO/LegalizeInputTypes.cpp
@@ -199,7 +199,8 @@ static LogicalResult convertFunc(mlir::func::FuncOp oldFuncOp,
     return oldFuncOp.emitOpError() << "unable to legalize result types";
   }
 
-  auto newFuncOp = cast<FuncOp>(moduleBuilder.cloneWithoutRegions(*oldFuncOp));
+  auto newFuncOp =
+      cast<func::FuncOp>(moduleBuilder.cloneWithoutRegions(*oldFuncOp));
   newFuncOp.setType(FunctionType::get(
       oldFuncOp.getContext(), signature.getConvertedTypes(), convertedResults));
 

--- a/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
+++ b/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
@@ -217,10 +217,10 @@ struct FftOpConversion : public OpConversionPattern<mhlo::FftOp> {
 };
 
 // We need to convert func ops in order to convert types.
-class BuiltinFuncOpPattern : public OpConversionPattern<FuncOp> {
-  using OpConversionPattern<FuncOp>::OpConversionPattern;
+class BuiltinFuncOpPattern : public OpConversionPattern<func::FuncOp> {
+  using OpConversionPattern<func::FuncOp>::OpConversionPattern;
   LogicalResult matchAndRewrite(
-      FuncOp srcOp, OpAdaptor adaptor,
+      func::FuncOp srcOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     FunctionType srcFuncType = srcOp.getFunctionType();
     TypeConverter::SignatureConversion signatureConversion(
@@ -348,7 +348,7 @@ struct ConvertMHLOToLinalgOnTensorsPass
     target.addIllegalDialect<mhlo::MhloDialect>();
 
     // Functions must have legal types.
-    target.addDynamicallyLegalOp<FuncOp>([&](FuncOp funcOp) {
+    target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp funcOp) {
       for (Type type : funcOp.getFunctionType().getInputs()) {
         if (isIllegalType(type)) return false;
       }
@@ -387,7 +387,7 @@ void populateMHLOToLinalgOnTensorsConversionPatterns(
       typeConverter, context, PatternBenefit(1000));
 }
 
-std::unique_ptr<OperationPass<FuncOp>> createMHLOToLinalgOnTensorsPass() {
+std::unique_ptr<OperationPass<func::FuncOp>> createMHLOToLinalgOnTensorsPass() {
   return std::make_unique<ConvertMHLOToLinalgOnTensorsPass>();
 }
 

--- a/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
+++ b/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
@@ -871,7 +871,8 @@ struct MHLOToMHLOPreprocessingPass
 
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>> createMHLOToMHLOPreprocessingPass() {
+std::unique_ptr<OperationPass<func::FuncOp>>
+createMHLOToMHLOPreprocessingPass() {
   return std::make_unique<MHLOToMHLOPreprocessingPass>();
 }
 

--- a/iree/compiler/InputConversion/MHLO/Passes.cpp
+++ b/iree/compiler/InputConversion/MHLO/Passes.cpp
@@ -41,18 +41,18 @@ void buildMHLOInputConversionPassPipeline(OpPassManager &passManager) {
   // Currently we don't handle SCF ops well and have to convert them all to CFG.
   // In the future it would be nice if we could have all of flow be both scf
   // and cfg compatible.
-  passManager.addNestedPass<FuncOp>(createTopLevelSCFToCFGPass());
+  passManager.addNestedPass<func::FuncOp>(createTopLevelSCFToCFGPass());
 
-  passManager.addNestedPass<FuncOp>(createMHLOToMHLOPreprocessingPass());
-  passManager.addNestedPass<FuncOp>(mlir::createCanonicalizerPass());
+  passManager.addNestedPass<func::FuncOp>(createMHLOToMHLOPreprocessingPass());
+  passManager.addNestedPass<func::FuncOp>(mlir::createCanonicalizerPass());
 
   // Various shape functions may have been materialized in the `shape.shape_of`
   // style of treating shapes as tensors. We prefer to legalize these to
   // scalar ops as early as possible to avoid having them persist as tensor
   // computations.
-  passManager.addNestedPass<FuncOp>(createShapeToShapeLowering());
+  passManager.addNestedPass<func::FuncOp>(createShapeToShapeLowering());
   passManager.addPass(createConvertShapeToStandardPass());
-  passManager.addNestedPass<FuncOp>(mlir::createCanonicalizerPass());
+  passManager.addNestedPass<func::FuncOp>(mlir::createCanonicalizerPass());
 
   // We also don't handle calls well on the old codepath; until we remove the
   // use of the CFG we can continue inlining.
@@ -67,18 +67,18 @@ void buildMHLOInputConversionPassPipeline(OpPassManager &passManager) {
 
   // Perform initial cleanup. createLegalizeInputTypes could rewrite types. In
   // this context, some operations could be folded away.
-  passManager.addNestedPass<FuncOp>(mlir::createCanonicalizerPass());
-  passManager.addNestedPass<FuncOp>(mlir::createCSEPass());
+  passManager.addNestedPass<func::FuncOp>(mlir::createCanonicalizerPass());
+  passManager.addNestedPass<func::FuncOp>(mlir::createCSEPass());
 
   // Convert to Linalg. After this point, MHLO will be eliminated.
-  passManager.addNestedPass<FuncOp>(createConvertMHLOToLinalgExtPass());
-  passManager.addNestedPass<FuncOp>(createMHLOToLinalgOnTensorsPass());
+  passManager.addNestedPass<func::FuncOp>(createConvertMHLOToLinalgExtPass());
+  passManager.addNestedPass<func::FuncOp>(createMHLOToLinalgOnTensorsPass());
   // Ensure conversion completed.
   passManager.addPass(createReconcileUnrealizedCastsPass());
 
   // Note that some MHLO ops are left by the above and must resolve via
   // canonicalization. See comments in the above pass and find a better way.
-  passManager.addNestedPass<FuncOp>(mlir::createCanonicalizerPass());
+  passManager.addNestedPass<func::FuncOp>(mlir::createCanonicalizerPass());
 
   //----------------------------------------------------------------------------
   // Entry dialect cleanup
@@ -87,9 +87,10 @@ void buildMHLOInputConversionPassPipeline(OpPassManager &passManager) {
 }
 
 void buildXLACleanupPassPipeline(OpPassManager &passManager) {
-  passManager.addNestedPass<FuncOp>(mhlo::createLegalizeControlFlowPass());
+  passManager.addNestedPass<func::FuncOp>(
+      mhlo::createLegalizeControlFlowPass());
   passManager.addPass(createFlattenTuplesInCFGPass());
-  passManager.addNestedPass<FuncOp>(mlir::createCanonicalizerPass());
+  passManager.addNestedPass<func::FuncOp>(mlir::createCanonicalizerPass());
 }
 
 namespace {

--- a/iree/compiler/InputConversion/TOSA/Passes.cpp
+++ b/iree/compiler/InputConversion/TOSA/Passes.cpp
@@ -33,25 +33,28 @@ void buildTOSAInputConversionPassPipeline(OpPassManager &passManager) {
   // Currently we don't handle SCF ops well and have to convert them all to CFG.
   // In the future it would be nice if we could have all of flow be both scf
   // and cfg compatible.
-  passManager.addNestedPass<FuncOp>(tosa::createTosaToSCF());
-  passManager.addNestedPass<FuncOp>(createTopLevelSCFToCFGPass());
+  passManager.addNestedPass<func::FuncOp>(tosa::createTosaToSCF());
+  passManager.addNestedPass<func::FuncOp>(createTopLevelSCFToCFGPass());
 
   // We also don't handle calls well on the old codepath; until we remove the
   // use of the CFG we can continue inlining.
   passManager.addPass(mlir::createInlinerPass());
 
-  passManager.addNestedPass<FuncOp>(tosa::createTosaMakeBroadcastablePass());
-  passManager.addNestedPass<FuncOp>(tosa::createTosaToStandard());
-  passManager.addNestedPass<FuncOp>(mlir::createCanonicalizerPass());
+  passManager.addNestedPass<func::FuncOp>(
+      tosa::createTosaMakeBroadcastablePass());
+  passManager.addNestedPass<func::FuncOp>(tosa::createTosaToStandard());
+  passManager.addNestedPass<func::FuncOp>(mlir::createCanonicalizerPass());
 
   tosa::addTosaToLinalgPasses(passManager);
-  passManager.addNestedPass<FuncOp>(tosa::createTosaToStandard());
+  passManager.addNestedPass<func::FuncOp>(tosa::createTosaToStandard());
 
-  passManager.addNestedPass<FuncOp>(IREE::Flow::createStripSignednessPass());
-  passManager.addNestedPass<FuncOp>(mlir::createCanonicalizerPass());
+  passManager.addNestedPass<func::FuncOp>(
+      IREE::Flow::createStripSignednessPass());
+  passManager.addNestedPass<func::FuncOp>(mlir::createCanonicalizerPass());
 
-  passManager.addNestedPass<FuncOp>(createLinalgQuantizedMatmulToMatmulPass());
-  passManager.addNestedPass<FuncOp>(mlir::createCanonicalizerPass());
+  passManager.addNestedPass<func::FuncOp>(
+      createLinalgQuantizedMatmulToMatmulPass());
+  passManager.addNestedPass<func::FuncOp>(mlir::createCanonicalizerPass());
 
   //----------------------------------------------------------------------------
   // Entry dialect cleanup

--- a/iree/compiler/Pipelines/Pipelines.cpp
+++ b/iree/compiler/Pipelines/Pipelines.cpp
@@ -42,7 +42,7 @@ void buildIREEVMTransformPassPipeline(
       MHLO::buildMHLOInputConversionPassPipeline(passManager);
       break;
     case InputDialectOptions::Type::tmtensor:
-      passManager.addNestedPass<FuncOp>(
+      passManager.addNestedPass<func::FuncOp>(
           TMTensor::createConvertTMTensorToLinalgExtPass());
       break;
     case InputDialectOptions::Type::xla:


### PR DESCRIPTION
FuncOp is moving into func Dialect. Fixing the places where FuncOp is
used in iree compiler.