### PR TITLE
more data races in HALDispatchABI constructor

### DIFF
--- a/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -108,6 +108,8 @@ class HALDispatchABI {
   static LLVM::LLVMStructType getEnvironmentType(
       MLIRContext *context, LLVMTypeConverter *typeConverter,
       LLVM::LLVMStructType processorType) {
+    static llvm::sys::Mutex mutex;
+    llvm::sys::ScopedLock lock(mutex);
     auto structType = LLVM::LLVMStructType::getIdentified(
         context, "iree_hal_executable_environment_v0_t");
     if (structType.isInitialized()) return structType;
@@ -162,6 +164,8 @@ class HALDispatchABI {
   // Returns a Type representing iree_hal_executable_dispatch_state_v0_t.
   static LLVM::LLVMStructType getDispatchStateType(
       MLIRContext *context, LLVMTypeConverter *typeConverter) {
+    static llvm::sys::Mutex mutex;
+    llvm::sys::ScopedLock lock(mutex);
     auto structType = LLVM::LLVMStructType::getIdentified(
         context, "iree_hal_executable_dispatch_state_v0_t");
     if (structType.isInitialized()) return structType;
@@ -225,6 +229,8 @@ class HALDispatchABI {
   // Returns a Type representing iree_hal_executable_workgroup_state_v0_t.
   static LLVM::LLVMStructType getWorkgroupStateType(
       MLIRContext *context, LLVMTypeConverter *typeConverter) {
+    static llvm::sys::Mutex mutex;
+    llvm::sys::ScopedLock lock(mutex);
     auto structType = LLVM::LLVMStructType::getIdentified(
         context, "iree_hal_executable_workgroup_state_v0_t");
     if (structType.isInitialized()) return structType;


### PR DESCRIPTION
[TSAN report](https://gist.github.com/bjacob/8df729620ae119b88a060eb3e9c38c46)

This is similar to #8590. Just more similar instances in the same file -- while #8590 fixed `getProcessorType`, a similar race existed in the other functions below creating Types.

Question: is there also a potential race in `HALDispatchABI::getInputTypes`? TSAN didn't observe anything here so far.