### PR TITLE
Adding -iree-hal-dump-executable-sources-to= flag.

### DIFF
--- a/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
+++ b/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
@@ -27,8 +27,14 @@ void TargetOptions::bindOptions(OptionsBinder &binder) {
   // first.
   binder.list<std::string>(
       "iree-hal-target-backends", targets,
-      llvm::cl::desc("Target backends for executable compilation"),
+      llvm::cl::desc("Target backends for executable compilation."),
       llvm::cl::ZeroOrMore, llvm::cl::cat(halTargetOptionsCategory));
+
+  binder.opt<std::string>(
+      "iree-hal-dump-executable-sources-to", sourceListingPath,
+      llvm::cl::desc("Path to write individual hal.executable input "
+                     "source listings into (- for stdout)."),
+      llvm::cl::cat(halTargetOptionsCategory));
 }
 
 // Renames |op| within |moduleOp| with a new name that is unique within both

--- a/iree/compiler/Dialect/HAL/Target/TargetBackend.h
+++ b/iree/compiler/Dialect/HAL/Target/TargetBackend.h
@@ -25,10 +25,14 @@ namespace iree_compiler {
 namespace IREE {
 namespace HAL {
 
+// TODO(benvanik): remove this and replace with the pass pipeline options.
 // Controls executable translation targets.
 struct TargetOptions {
   // TODO(benvanik): multiple targets of the same type, etc.
   std::vector<std::string> targets;
+
+  // A path to write individual executable source listings into.
+  std::string sourceListingPath;
 
   // TODO(benvanik): flags for debug/optimization/etc.
   // The intent is that we can have a global debug/-ON flag that then each

--- a/iree/compiler/Dialect/HAL/Transforms/BUILD
+++ b/iree/compiler/Dialect/HAL/Transforms/BUILD
@@ -16,6 +16,7 @@ cc_library(
         "AssignTargetDevices.cpp",
         "BenchmarkBatchDispatches.cpp",
         "ConvertToHAL.cpp",
+        "DumpExecutableSources.cpp",
         "ElideRedundantCommands.cpp",
         "InlineDeviceSwitches.cpp",
         "LinkExecutables.cpp",

--- a/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_cc_library(
     "AssignTargetDevices.cpp"
     "BenchmarkBatchDispatches.cpp"
     "ConvertToHAL.cpp"
+    "DumpExecutableSources.cpp"
     "ElideRedundantCommands.cpp"
     "InlineDeviceSwitches.cpp"
     "LinkExecutables.cpp"

--- a/iree/compiler/Dialect/HAL/Transforms/DumpExecutableSources.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/DumpExecutableSources.cpp
@@ -1,0 +1,100 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <memory>
+#include <utility>
+
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Dialect/HAL/Transforms/Passes.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/ToolOutputFile.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/FileUtilities.h"
+#include "mlir/Transforms/LocationSnapshot.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace HAL {
+
+static void dumpExecutableToStream(IREE::HAL::ExecutableOp executableOp,
+                                   StringRef fileName, llvm::raw_ostream &os) {
+  OpPrintingFlags flags;
+  flags.useLocalScope();
+  mlir::generateLocationsFromIR(os, fileName, executableOp, flags);
+  os << "\n";  // newline at end of file
+}
+
+class DumpExecutableSourcesPass
+    : public PassWrapper<DumpExecutableSourcesPass, OperationPass<ModuleOp>> {
+ public:
+  DumpExecutableSourcesPass() = default;
+  DumpExecutableSourcesPass(const DumpExecutableSourcesPass &pass) {}
+  DumpExecutableSourcesPass(StringRef path) { this->path = path.str(); }
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<IREE::HAL::HALDialect>();
+  }
+
+  StringRef getArgument() const override {
+    return "iree-hal-dump-executable-sources";
+  }
+
+  StringRef getDescription() const override {
+    return "Dumps individual hal.executable source listings to a path.";
+  }
+
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+    auto moduleName = moduleOp.getName().getValueOr("module");
+
+    // Help people out and mkdir if needed.
+    if (!path.empty() && path != "-") {
+      llvm::sys::fs::create_directories(path);
+    }
+
+    for (auto executableOp : moduleOp.getOps<IREE::HAL::ExecutableOp>()) {
+      auto fileName =
+          (moduleName + "_" + executableOp.getName() + ".mlir").str();
+      if (path.empty() || path == "-") {
+        dumpExecutableToStream(executableOp, fileName, llvm::outs());
+      } else {
+        auto filePath =
+            (path + llvm::sys::path::get_separator() + fileName).str();
+        std::string error;
+        auto file = mlir::openOutputFile(filePath, &error);
+        if (!file) {
+          executableOp.emitError()
+              << "while dumping to " << path << ": " << error;
+          return signalPassFailure();
+        }
+        dumpExecutableToStream(executableOp, fileName, file->os());
+        file->keep();
+      }
+    }
+  }
+
+ private:
+  Option<std::string> path{
+      *this, "path",
+      llvm::cl::desc("Path to write hal.executable source files into.")};
+};
+
+std::unique_ptr<OperationPass<ModuleOp>> createDumpExecutableSourcesPass(
+    StringRef path) {
+  return std::make_unique<DumpExecutableSourcesPass>(path);
+}
+
+static PassRegistration<DumpExecutableSourcesPass> pass([] {
+  return std::make_unique<DumpExecutableSourcesPass>();
+});
+
+}  // namespace HAL
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -117,6 +117,15 @@ void buildHALTransformPassPipeline(OpPassManager &passManager,
   // device communicate across the ABI boundary.
   passManager.addPass(createMaterializeInterfacesPass());
 
+  // Dump a source listing of each hal.executable and update the source
+  // locations in the IR. This will allow us to easily inspect each executable
+  // and give downstream tools that can display source information something
+  // more useful and slim than the entire original source model.
+  if (!targetOptions.sourceListingPath.empty()) {
+    passManager.addPass(
+        createDumpExecutableSourcesPass(targetOptions.sourceListingPath));
+  }
+
   // TODO(benvanik): move translation after conversion; today translation
   // inserts the workgroup count logic we need to convert but we could instead
   // insert placeholder ops that are expanded after translation.

--- a/iree/compiler/Dialect/HAL/Transforms/Passes.h
+++ b/iree/compiler/Dialect/HAL/Transforms/Passes.h
@@ -45,7 +45,7 @@ void registerHALTransformPassPipeline();
 //===----------------------------------------------------------------------===//
 
 // Converts input flow/std/etc dialects to the IREE HAL dialect.
-std::unique_ptr<OperationPass<ModuleOp>> createConvertToHALPass();
+std::unique_ptr<OperationPass<mlir::ModuleOp>> createConvertToHALPass();
 
 //===----------------------------------------------------------------------===//
 // Device management
@@ -54,29 +54,35 @@ std::unique_ptr<OperationPass<ModuleOp>> createConvertToHALPass();
 // Verifies that the target execution environment is valid.
 // #hal.device.target and #hal.executable.target attribute placement and
 // definition will be checked as well along with other structural requirements.
-std::unique_ptr<OperationPass<ModuleOp>> createVerifyTargetEnvironmentPass();
+std::unique_ptr<OperationPass<mlir::ModuleOp>>
+createVerifyTargetEnvironmentPass();
 
 // Assigns the HAL devices the module will target to the given list of targets.
-std::unique_ptr<OperationPass<ModuleOp>> createAssignTargetDevicesPass(
+std::unique_ptr<OperationPass<mlir::ModuleOp>> createAssignTargetDevicesPass(
     ArrayRef<std::string> targets);
 
 // Outlines hal.device.switch conditions into functions and inlines conditions.
 std::unique_ptr<OperationPass<void>> createInlineDeviceSwitchesPass();
 
 // Finds hal.device.query ops and creates variables initialized on startup.
-std::unique_ptr<OperationPass<ModuleOp>> createMemoizeDeviceQueriesPass();
+std::unique_ptr<OperationPass<mlir::ModuleOp>> createMemoizeDeviceQueriesPass();
 
 //===----------------------------------------------------------------------===//
 // Executable translation
 //===----------------------------------------------------------------------===//
 
 // Packs stream.executable operands into i32 push constants.
-std::unique_ptr<OperationPass<ModuleOp>> createPackDispatchOperandsPass();
+std::unique_ptr<OperationPass<mlir::ModuleOp>> createPackDispatchOperandsPass();
 
 // Defines hal.executables and hal.interfaces for flow.executable ops based on
 // usage within the module. Target backends are queried to check for support and
 // device placements are made.
-std::unique_ptr<OperationPass<ModuleOp>> createMaterializeInterfacesPass();
+std::unique_ptr<OperationPass<mlir::ModuleOp>>
+createMaterializeInterfacesPass();
+
+// Dumps individual hal.executable source listings to |path|.
+std::unique_ptr<OperationPass<mlir::ModuleOp>> createDumpExecutableSourcesPass(
+    StringRef path);
 
 // Translates hal.executable.variant ops via a nested translation pipeline.
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableOp>>
@@ -97,7 +103,8 @@ std::unique_ptr<OperationPass<mlir::ModuleOp>> createLinkTargetExecutablesPass(
     StringRef target);
 
 // Resolves hal.executable.entry_point references to ordinals.
-std::unique_ptr<OperationPass<ModuleOp>> createResolveEntryPointOrdinalsPass();
+std::unique_ptr<OperationPass<mlir::ModuleOp>>
+createResolveEntryPointOrdinalsPass();
 
 // Converts hal.executable.variants to one or more hal.executable.binary ops.
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableOp>>
@@ -117,8 +124,8 @@ std::unique_ptr<OperationPass<func::FuncOp>> createPackAllocationsPass();
 // Finds all resource lookups (such as hal.executable.lookup), materializes
 // their cache storage and initialization, and rewrites the lookups to
 // references.
-std::unique_ptr<OperationPass<ModuleOp>> createMaterializeResourceCachesPass(
-    TargetOptions targetOptions);
+std::unique_ptr<OperationPass<mlir::ModuleOp>>
+createMaterializeResourceCachesPass(TargetOptions targetOptions);
 
 // Eliminates redundant 'load's of variables within functions with no 'store'.
 // TODO(#1124): replace with memory side effects once supported upstream.
@@ -142,6 +149,7 @@ inline void registerHALPasses() {
   createAssignTargetDevicesPass({});
   createBenchmarkBatchDispatchesPass(/*repeatCount=*/1);
   createConvertToHALPass();
+  createDumpExecutableSourcesPass("");
   createElideRedundantCommandsPass();
   createInlineDeviceSwitchesPass();
   createLinkExecutablesPass();

--- a/iree/compiler/Dialect/HAL/Transforms/test/BUILD
+++ b/iree/compiler/Dialect/HAL/Transforms/test/BUILD
@@ -20,6 +20,7 @@ iree_lit_test_suite(
             "assign_target_devices.mlir",
             "benchmark_batch_dispatches.mlir",
             "convert_to_hal.mlir",
+            "dump_executable_sources.mlir",
             "elide_redundant_commands.mlir",
             "inline_device_switches.mlir",
             "materialize_interfaces.mlir",

--- a/iree/compiler/Dialect/HAL/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Transforms/test/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     "assign_target_devices.mlir"
     "benchmark_batch_dispatches.mlir"
     "convert_to_hal.mlir"
+    "dump_executable_sources.mlir"
     "elide_redundant_commands.mlir"
     "inline_device_switches.mlir"
     "materialize_interfaces.mlir"

--- a/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_sources.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_sources.mlir
@@ -1,0 +1,60 @@
+// RUN: iree-opt -split-input-file -iree-hal-dump-executable-sources %s | FileCheck %s
+
+// Tests dumping executable sources to stdout - it's more common to use files
+// but this is much easier to test with lit.
+
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm", "embedded-elf-x86_64">
+#device_target_cpu = #hal.device.target<"cpu", {
+  executable_targets = [#executable_target_embedded_elf_x86_64_]
+}>
+#executable_layout = #hal.executable.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+
+module attributes {hal.device.targets = [#device_target_cpu]}  {
+
+  // CHECK: hal.executable private @ex0
+  hal.executable private @ex0 {
+    // We expect local outputs with attributes inlined:
+    // CHECK-NEXT: hal.executable.variant {{.+}}, target = <"llvm"
+    hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
+      hal.executable.entry_point public @dispatch0 ordinal(0) layout(#executable_layout) {
+        translation_info = #iree_codegen.translation_info<CPUDefault, workload_per_wg = [4]>
+      } {
+      ^bb0(%arg0: index, %arg1: index, %arg2: index):  // no predecessors
+        %c1 = arith.constant 1 : index
+        %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 4)>()[%arg0]
+        hal.return %0, %c1, %c1 : index, index, index
+      }
+      builtin.module {
+        func.func @dispatch0() {
+          func.return
+        }
+      }
+    }
+  }
+
+  // CHECK: hal.executable private @ex1
+  hal.executable private @ex1 {
+    hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
+      hal.executable.entry_point public @dispatch1 ordinal(0) layout(#executable_layout) {
+        translation_info = #iree_codegen.translation_info<CPUDefault, workload_per_wg = [4]>
+      } {
+      ^bb0(%arg0: index, %arg1: index, %arg2: index):  // no predecessors
+        %c1 = arith.constant 1 : index
+        %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 4)>()[%arg0]
+        hal.return %0, %c1, %c1 : index, index, index
+      }
+      builtin.module {
+        func.func @dispatch1() {
+          func.return
+        }
+      }
+    }
+  }
+
+}

--- a/iree/compiler/Dialect/HAL/Transforms/test/verify_target_environment.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/verify_target_environment.mlir
@@ -1,26 +1,54 @@
 // RUN: iree-opt -split-input-file -iree-hal-verify-target-environment %s -verify-diagnostics | FileCheck %s
 
 // expected-error@+1 {{no HAL target devices specified}}
-module @module {}
+module @module {
+  func.func private @func() -> ()
+}
 
 // -----
 
 // expected-error@+1 {{no HAL target devices specified}}
-module @module attributes {hal.device.targets = []} {}
+module @module attributes {hal.device.targets = []} {
+  func.func private @func() -> ()
+}
 
 // -----
 
 // expected-error@+1 {{invalid target attr type}}
-module @module attributes {hal.device.targets = ["wrong_type"]} {}
+module @module attributes {hal.device.targets = ["wrong_type"]} {
+  func.func private @func() -> ()
+}
 
 // -----
 
 // expected-error@+1 {{unregistered target backend "foo"}}
-module @module attributes {hal.device.targets = [#hal.device.target<"foo">]} {}
+module @module attributes {hal.device.targets = [#hal.device.target<"foo">]} {
+  func.func private @func() -> ()
+}
 
 // -----
 
+// Valid input with proper attributes.
+
+// CHECK: #device_target_vmvx = #hal.device.target<"vmvx">
 #device_target_vmvx = #hal.device.target<"vmvx">
 
 // CHECK: module @module attributes {hal.device.targets = [#device_target_vmvx]}
-module @module attributes {hal.device.targets = [#device_target_vmvx]} {}
+module @module attributes {hal.device.targets = [#device_target_vmvx]} {
+  func.func private @func() -> ()
+}
+
+// -----
+
+// Modules without anything that needs an environment are OK.
+
+#executable_target = #hal.executable.target<"llvm", "embedded-elf-arm_64", {}>
+
+// CHECK: module @module
+module @module {
+  // CHECK-NEXT: hal.executable private @exe
+  hal.executable private @exe {
+    // CHECK-NEXT: hal.executable.variant public @embedded_elf_arm_64
+    hal.executable.variant public @embedded_elf_arm_64, target = #executable_target {}
+  }
+}


### PR DESCRIPTION
This will dump all hal.executable files to their own mlir files, which
can then be compiled individually with `iree-translate -iree-mlir-to-hal-executable`.

Fixes #8676.