### PR TITLE
Lock the mutex around the condvar destruction

### DIFF
--- a/iree/base/internal/synchronization.c
+++ b/iree/base/internal/synchronization.c
@@ -569,7 +569,9 @@ void iree_notification_deinitialize(iree_notification_t* notification) {
 #if IREE_SYNCHRONIZATION_DISABLE_UNSAFE
   // No-op.
 #elif !defined(IREE_PLATFORM_HAS_FUTEX)
+  pthread_mutex_lock(&notification->mutex);
   pthread_cond_destroy(&notification->cond);
+  pthread_mutex_unlock(&notification->mutex);
   pthread_mutex_destroy(&notification->mutex);
 #endif  // IREE_PLATFORM_HAS_FUTEX
 }


### PR DESCRIPTION
This fixes a race condition reported by TSan, [TSan report](https://gist.github.com/bjacob/29dc59ccfa86bc09c5b75fe7ae933ded)

I was hoping that this would be what @ScottTodd had [observed](https://discord.com/channels/689900678990135345/689957613152239638/958508447639433287) as an intermittent failure on CI.... but Ben points out that as I'm running with TSan, [this line](https://github.com/google/iree/blob/504ec77a85996c2c9a602030ad61f343eb543f5c/iree/base/internal/synchronization.h#L61) implies that I'm on a non-default (non-futex) path, so not was CI is running 🙁 