### PR TITLE
Tag host-cpu tests as "local"

### DIFF
--- a/iree/test/e2e/xla_ops/BUILD
+++ b/iree/test/e2e/xla_ops/BUILD
@@ -537,6 +537,9 @@ iree_check_single_backend_test_suite(
         "-iree-llvm-target-cpu-features=host",
     ],
     driver = "dylib",
+    # Building and testing must be on the same architecture, which doesn't work
+    # with remote execution in general.
+    tags = ["local"],
     target_backend = "dylib-llvm-aot",
 )
 

--- a/iree/test/e2e/xla_ops/CMakeLists.txt
+++ b/iree/test/e2e/xla_ops/CMakeLists.txt
@@ -492,6 +492,8 @@ iree_check_single_backend_test_suite(
   COMPILER_FLAGS
     "-iree-input-type=mhlo"
     "-iree-llvm-target-cpu-features=host"
+  LABELS
+    "local"
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###


### PR DESCRIPTION
With remote execution, build and test actions may easily run on
different architectures, but these tests specifically target the
architecture on which they were built.