### PR TITLE
fix data dace in iree_task_queue_initialize

### DIFF
--- a/iree/task/queue.c
+++ b/iree/task/queue.c
@@ -10,7 +10,7 @@
 #include <string.h>
 
 void iree_task_queue_initialize(iree_task_queue_t* out_queue) {
-  memset(out_queue, 0, sizeof(*out_queue));
+  memset(&out_queue->list, 0, sizeof(out_queue->list));
   iree_slim_mutex_initialize(&out_queue->mutex);
   iree_task_list_initialize(&out_queue->list);
 }


### PR DESCRIPTION
[TSan report](https://gist.github.com/bjacob/b835f742022ed03d5e1a4550a4bebae4)

`iree_task_queue_initialize` was memset'ing the whole `out_queue`. That non-atomic write to `out_queue->mutex` was racing with the atomic read on it perform by `iree_slim_mutex_lock` called by `iree_task_queue_try_steal` on another thread.

So this is limiting the non-atomic write of zeros to the remainder of `out_queue`, which happens to be just `out_queue->list`. If we want to zero all of `out_queue` (maybe to have a guarantee that if `iree_task_queue_t` gains new fields, we don't forget to zero them), then we will need to make that write atomic. Moreover, as the TSan report shows an atomic read contending with it, it won't be just a `relaxed` atomic.