### PR TITLE
[spirv] Support scalarizing non-minor-identity transfer write

### DIFF
--- a/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -462,7 +462,7 @@ struct ScalarizeVectorTransferWrite final
     auto addMap = AffineMap::get(0, 2, {sym0 + sym1}, context);
 
     // The result vector is 1-D and we have a projected permutation.
-    unsigned dimPos = map.getResult(0).cast<AffineDimExpr>().getPosition();
+    unsigned dimPos = map.getDimPosition(0);
 
     auto indices = llvm::to_vector<4>(writeOp.getIndices());
     Value oldIndex = indices[dimPos];

--- a/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -451,8 +451,8 @@ struct ScalarizeVectorTransferWrite final
   LogicalResult matchAndRewrite(vector::TransferWriteOp writeOp,
                                 PatternRewriter &rewriter) const override {
     VectorType vectorType = writeOp.getVectorType();
-    if (vectorType.getRank() != 1 ||
-        !writeOp.getPermutationMap().isMinorIdentity())
+    auto map = writeOp.getPermutationMap();
+    if (vectorType.getRank() != 1 || !map.isProjectedPermutation())
       return failure();
 
     Location loc = writeOp.getLoc();
@@ -461,11 +461,15 @@ struct ScalarizeVectorTransferWrite final
     bindSymbols(context, sym0, sym1);
     auto addMap = AffineMap::get(0, 2, {sym0 + sym1}, context);
 
+    // The result vector is 1-D and we have a projected permutation.
+    unsigned dimPos = map.getResult(0).cast<AffineDimExpr>().getPosition();
+
+    auto indices = llvm::to_vector<4>(writeOp.getIndices());
+    Value oldIndex = indices[dimPos];
     for (int i = 0; i < vectorType.getDimSize(0); ++i) {
       Value iVal = rewriter.create<arith::ConstantIndexOp>(loc, i);
-      auto indices = llvm::to_vector<4>(writeOp.getIndices());
-      indices.back() = rewriter.create<AffineApplyOp>(
-          loc, addMap, ValueRange{indices.back(), iVal});
+      indices[dimPos] = rewriter.create<AffineApplyOp>(
+          loc, addMap, ValueRange{oldIndex, iVal});
       Value scalar =
           rewriter.create<vector::ExtractOp>(loc, writeOp.getVector(), i);
       rewriter.create<memref::StoreOp>(loc, scalar, writeOp.getSource(),

--- a/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ops.mlir
@@ -79,7 +79,7 @@ hal.executable @tensor_insert {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 1, 64], [0, 1, 1, 1]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 2, 32, 1], [0, 1, 1, 1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
 //      CHECK: hal.executable.entry_point public @copy
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]


### PR DESCRIPTION
We are scalarizing the transfer write ops anyway, don't need to
require minor identity access permutation map. Weaken that to
projected permutation.

Fixes https://github.com/google/iree/issues/8580