### PR TITLE
Fix scalarize_dyn_dims composition.

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.td
@@ -105,18 +105,39 @@ def TileOp : Linalg_Transform_Operation<"tile",
 
   let arguments = (ins PDL_Operation:$target,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$sizes,
-                   DefaultValuedAttr<I64ArrayAttr, "{}">:$interchange,
-                   DefaultValuedAttr<BoolAttr, "false">:$scalarize_dyn_dims);
+                   DefaultValuedAttr<I64ArrayAttr, "{}">:$interchange);
   let results = (outs PDL_Operation:$tiled_linalg_op,
                       Variadic<PDL_Operation>:$loops);
 
   let hasCustomAssemblyFormat = 1;
-  let hasVerifier = 1;
 
   let extraClassDeclaration = [{
     ::mlir::LogicalResult apply(
         ::mlir::linalg::transform::TransformResults &transformResults,
         ::mlir::linalg::transform::TransformState &state);
+  }];
+}
+
+def ScalarizeOp : Linalg_Transform_Operation<"scalarize",
+    [TransformOpInterface, TargetableSingleOperandTransformOpTrait]> {
+  let description = [{Indicates that ops of a specific kind in the given
+    function should be scalarized (i.e. their dynamic dimensions tiled by 1).
+    
+    This operation returns the tiled op but not the loops.
+
+    We make this design choice because it is hard to know ahead of time the 
+    number of loops that will be produced (it depends on the number of 
+    dynamic dimensions after multiple transformations have been applied).
+  }];
+
+  let arguments = (ins PDL_Operation:$target);
+  let results = (outs PDL_Operation:$tiled_linalg_op);
+
+  let assemblyFormat = "$target attr-dict";
+
+  let extraClassDeclaration = [{
+    ::mlir::FailureOr<::mlir::linalg::LinalgOp> applyToOne(
+        ::mlir::linalg::LinalgOp target);
   }];
 }
 

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/LinalgTransformOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/LinalgTransformOps.cpp
@@ -170,13 +170,9 @@ LogicalResult transform::TileOp::apply(TransformResults &transformResults,
     if (i)
       ++numExpectedLoops;
 
-  // "scalarize_dyn_dims" actually sets the same lambda as the tile sizes and
-  // asserts that it is not already set.
-  if (!tileSizes.empty() || !scalarize_dyn_dims())
+  if (!tileSizes.empty())
     tilingOptions.setTileSizes(tileSizes);
   tilingOptions.setInterchange(extractUIntArray(interchange()));
-  if (scalarize_dyn_dims())
-    tilingOptions.scalarizeDynamicDims();
   LinalgTilingPattern pattern(getContext(), tilingOptions);
   auto functionalTile =
       [&](LinalgOp op, PatternRewriter &rewriter) -> FailureOr<TiledLinalgOp> {
@@ -195,15 +191,6 @@ LogicalResult transform::TileOp::apply(TransformResults &transformResults,
 
     tiledLinalgOps.push_back(tiled->op);
 
-    // Scalarizing dynamic dimensions is a special case where it is hard to
-    // know in advance how many loops we will need. The loop information is
-    // also rarely relevant.
-    // Instead, only returned the tiled op.
-    // TODO: this seems to warrant its own transformation rather than keep
-    // fused into tiling.
-    if (scalarize_dyn_dims())
-      continue;
-
     if (tiled->loops.size() != numExpectedLoops) {
       // Not enough loops were generated. This usually means that the input size
       // was smaller than the tiling size.
@@ -219,15 +206,6 @@ LogicalResult transform::TileOp::apply(TransformResults &transformResults,
   transformResults.set(tiled_linalg_op().cast<OpResult>(), tiledLinalgOps);
   for (unsigned int i = 0; i < numExpectedLoops; ++i) {
     transformResults.set(getOperation()->getOpResult(i + 1), loops[i]);
-  }
-  return success();
-}
-
-LogicalResult transform::TileOp::verify() {
-  if (!sizes().empty() && scalarize_dyn_dims()) {
-    return emitOpError() << sizesAttrName() << " and "
-                         << scalarize_dyn_dimsAttrName()
-                         << " attributes are mutually exclusive";
   }
   return success();
 }
@@ -262,6 +240,24 @@ void transform::TileOp::print(OpAsmPrinter &p) {
   p << ' ';
   p << target();
   p.printOptionalAttrDict((*this)->getAttrs());
+}
+
+//===---------------------------------------------------------------------===//
+// ScalarizeOp
+//===---------------------------------------------------------------------===//
+
+FailureOr<LinalgOp> transform::ScalarizeOp::applyToOne(LinalgOp target) {
+  LinalgTilingOptions tilingOptions;
+  tilingOptions.scalarizeDynamicDims();
+  // Tiling with "scalarize_dyn_dims" actually sets the same lambda as the tile
+  // sizes and asserts that it is not already set.
+  SmallVector<int64_t> emptyTileSizes;
+  LinalgTilingPattern pattern(getContext(), tilingOptions);
+  auto maybeTiledLinalgOp =
+      functional::applyReturningPatternAt(pattern, target);
+  if (failed(maybeTiledLinalgOp))
+    return failure();
+  return maybeTiledLinalgOp->op;
 }
 
 //===---------------------------------------------------------------------===//

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/Transforms/TransformInterpreter.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/Transforms/TransformInterpreter.cpp
@@ -165,7 +165,7 @@ static LogicalResult executeSequence(linalg::transform::SequenceOp sequence,
     if (failed(executeTransform(&transform, state))) {
       std::string str;
       llvm::raw_string_ostream ss(str);
-      ss << "failed to apply: " << transform << "\nto\n" << containerOp;
+      ss << "failed to apply: " << transform << "\nto\n" << *containerOp;
       ss.flush();
       return transform.emitError() << str;
     }

--- a/llvm-external-projects/iree-dialects/python/iree/compiler/dialects/_iree_linalg_transform_ops_ext.py
+++ b/llvm-external-projects/iree-dialects/python/iree/compiler/dialects/_iree_linalg_transform_ops_ext.py
@@ -177,12 +177,10 @@ class TileOp:
                *,
                sizes: IntListArg = None,
                interchange: IntListArg = None,
-               scalarize_dyn_dims: BoolArg = None,
                loc=None,
                ip=None):
     sizes = _ensure_int_array_attr(sizes, [])
     interchange = _ensure_int_array_attr(interchange, [])
-    scalarize_dyn_dims = _ensure_bool_attr(scalarize_dyn_dims, False)
     operation_type = pdl.OperationType.get()
     tile_size_zero = _ensure_int_attr(0)
     # Number of loops = number of tile sizes != 0
@@ -191,9 +189,21 @@ class TileOp:
                      target,
                      sizes,
                      interchange,
-                     scalarize_dyn_dims,
                      loc=loc,
                      ip=ip)
+
+
+class ScalarizeOp:
+  """Specialization for the ScalarizeOp class."""
+
+  def __init__(self,
+               target: Union[ir.Value, ir.Operation, ir.OpView],
+               *,
+               loc=None,
+               ip=None):
+    operation_type = pdl.OperationType.get()
+
+    super().__init__(operation_type, target, loc=loc, ip=ip)
 
 
 class PeelLoopOp:

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/double-tiling.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/double-tiling.mlir
@@ -37,8 +37,8 @@ pdl.pattern @pdl_target: benefit(1) {
 }
 iree_linalg_transform.sequence {
   %0 = match @pdl_target
-  %1, %loops1:3 = tile %0 {interchange = [0, 2, 1], scalarize_dyn_dims = false, sizes = [32, 32, 32]}
-  %2, %loops2:3 = tile %1 {interchange = [0, 1, 2], scalarize_dyn_dims = false, sizes = [4, 4, 1]}
+  %1, %loops1:3 = tile %0 {interchange = [0, 2, 1], sizes = [32, 32, 32]}
+  %2, %loops2:3 = tile %1 {interchange = [0, 1, 2], sizes = [4, 4, 1]}
   %3 = pad %2 {padding_values=["0.0", "0.0", "0.0"], pack_paddings = [1, 1, 1], hoist_paddings = [6, 6, 0], transpose_paddings = [[1, 0], [0, 1]]}
   %4 = vectorize %3  {vectorize_padding = true}
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/invalid.mlir
@@ -22,14 +22,6 @@ iree_linalg_transform.sequence {
 
 iree_linalg_transform.sequence {
   %0 = match @match
-  // expected-error@below {{"sizes" and "scalarize_dyn_dims" attributes are mutually exclusive}}
-  tile %0 {sizes = [1,2,3], scalarize_dyn_dims = true}
-}
-
-// -----
-
-iree_linalg_transform.sequence {
-  %0 = match @match
   // expected-error@below {{expects iterator_interchange to be a permutation, found [1, 1]}}
   interchange %0 {iterator_interchange = [1, 1]}
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/scalarize.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/scalarize.mlir
@@ -1,0 +1,31 @@
+// RUN: iree-dialects-opt -linalg-interp-transforms %s | FileCheck %s
+
+func @fun_to_benchmark(%arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32>) -> 
+    tensor<128x128xf32> attributes {passthrough = ["noinline", ["target-cpu", "skylake-avx512"], ["prefer-vector-width", "512"]]} {
+
+  // With scalarization we expect vectorization to still work albeit with a leading
+  // `1` dimension.
+  // CHECK: vector.contract {{.*}} : vector<1x32xf32>, vector<32x16xf32> into vector<1x16xf32>
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<128x128xf32>, tensor<128x128xf32>) 
+                    outs(%arg2 : tensor<128x128xf32>) -> tensor<128x128xf32>
+  return %0 : tensor<128x128xf32>
+}
+
+pdl.pattern @isa_linalg.matmul : benefit(1) {
+  %0 = operands
+  %1 = types
+  %2 = operation "linalg.matmul"(%0 : !pdl.range<value>)  -> (%1 : !pdl.range<type>)
+  rewrite %2 with "iree_linalg_transform.apply"
+}
+
+iree_linalg_transform.sequence {
+  %0 = match @isa_linalg.matmul
+  %tiled_linalg_op, %loops:3 = tile %0 {interchange = [1, 0, 2], scalarize_dyn_dims = false, sizes = [6, 16, 32]}
+  %1 = peel_loop %loops#0
+
+  // This test checks the proper handling of the scalarize dims attribute.
+  // The first dimension does not divide but we can always scalarize a `?` into `1`
+  // and enable vectorization of a lower-rank op this way.
+  %tiled_linalg_op_0 = tile %tiled_linalg_op {interchange = [], scalarize_dyn_dims = true, sizes = []}
+  vectorize {vectorize_padding = false}
+}

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/scalarize.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/scalarize.mlir
@@ -2,7 +2,6 @@
 
 func @fun_to_benchmark(%arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32>) -> 
     tensor<128x128xf32> attributes {passthrough = ["noinline", ["target-cpu", "skylake-avx512"], ["prefer-vector-width", "512"]]} {
-
   // With scalarization we expect vectorization to still work albeit with a leading
   // `1` dimension.
   // CHECK: vector.contract {{.*}} : vector<1x32xf32>, vector<32x16xf32> into vector<1x16xf32>
@@ -20,12 +19,11 @@ pdl.pattern @isa_linalg.matmul : benefit(1) {
 
 iree_linalg_transform.sequence {
   %0 = match @isa_linalg.matmul
-  %tiled_linalg_op, %loops:3 = tile %0 {interchange = [1, 0, 2], scalarize_dyn_dims = false, sizes = [6, 16, 32]}
+  %tiled_linalg_op, %loops:3 = tile %0 {interchange = [1, 0, 2], sizes = [6, 16, 32]}
   %1 = peel_loop %loops#0
-
   // This test checks the proper handling of the scalarize dims attribute.
   // The first dimension does not divide but we can always scalarize a `?` into `1`
   // and enable vectorization of a lower-rank op this way.
-  %tiled_linalg_op_0 = tile %tiled_linalg_op {interchange = [], scalarize_dyn_dims = true, sizes = []}
+  %tiled_linalg_op_0 = scalarize %tiled_linalg_op
   vectorize {vectorize_padding = false}
 }


### PR DESCRIPTION
Previously, tiling with the scalarize_dyn_dims would systematically crash because it
expected `0` loops to be produced (i.e. because the tile size must be empty).
In reality, this will always produce as many loops as there are dynamic dims in the op.

Change the behavior to only return the op and always return `0` loops.

Subsequently, introduce a ScalarizeOp and move the TileOp.scalarize logic to it. 
This improves separation of concerns.