### PR TITLE
[spirv] Invoke TransposeOp canonicalization after vectorization

### DIFF
--- a/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
@@ -116,6 +116,7 @@ class SPIRVVectorizePass : public SPIRVVectorizeBase<SPIRVVectorizePass> {
       RewritePatternSet foldPatterns(context);
       // Fold consumer add ops into the contraction op itself.
       vector::ContractionOp::getCanonicalizationPatterns(foldPatterns, context);
+      vector::TransposeOp::getCanonicalizationPatterns(foldPatterns, context);
       if (failed(
               applyPatternsAndFoldGreedily(funcOp, std::move(foldPatterns)))) {
         return signalPassFailure();


### PR DESCRIPTION
This is needed to fold `transpose(broadcast(<scalar>))` patterns
before further vector-level transformations.

Fixes https://github.com/google/iree/issues/8689