### PR TITLE
VM::Conversion: add arith::populateArithmeticExpandOpsPatterns

### DIFF
--- a/iree/compiler/Dialect/VM/Transforms/BUILD
+++ b/iree/compiler/Dialect/VM/Transforms/BUILD
@@ -39,6 +39,7 @@ cc_library(
         "@llvm-project//mlir:AffineToStandardTransforms",
         "@llvm-project//mlir:AffineTransforms",
         "@llvm-project//mlir:AffineUtils",
+        "@llvm-project//mlir:ArithmeticTransforms",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:MathDialect",

--- a/iree/compiler/Dialect/VM/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Transforms/CMakeLists.txt
@@ -30,6 +30,7 @@ iree_cc_library(
     MLIRAffineToStandard
     MLIRAffineTransforms
     MLIRAffineUtils
+    MLIRArithmeticTransforms
     MLIRFunc
     MLIRIR
     MLIRMath

--- a/iree/compiler/Dialect/VM/Transforms/Conversion.cpp
+++ b/iree/compiler/Dialect/VM/Transforms/Conversion.cpp
@@ -21,6 +21,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arithmetic/Transforms/Passes.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -120,6 +121,7 @@ class ConversionPass
                                    conversionPatterns);
     populateUtilToVMPatterns(context, conversionTarget, typeConverter,
                              conversionPatterns);
+    arith::populateArithmeticExpandOpsPatterns(conversionPatterns);
     populateStandardToVMPatterns(context, typeConverter, conversionPatterns);
     populateMathToVMPatterns(context, typeConverter, conversionPatterns);
     populateMemRefToVMPatterns(context, conversionTarget, typeConverter,


### PR DESCRIPTION
This fixes the arith.floordivsi case in #8715, and should fix a number
of other ops if we encounter them.

Fixes #8715