### PR TITLE
Fix trace capture with `benchmark_min_time` flag.

### DIFF
--- a/build_tools/benchmarks/run_benchmarks_on_android.py
+++ b/build_tools/benchmarks/run_benchmarks_on_android.py
@@ -390,15 +390,21 @@ def run_benchmarks_for_category(
         # certain amount of seconds---Pixel 4 seems to have an issue that will
         # make the trace collection step get stuck. Instead wait for the
         # benchmark result to be available.
+        print("XXX adb_start_cmd has returned. process is running...")
         while True:
+          print(f"XXX blocking on readline()... note: process.poll() returns {process.poll()}")
           line = process.stdout.readline()  # pytype: disable=attribute-error
+          print(f"XXX readline() returned this line: {line}")
           if line == "" and process.poll() is not None:  # Process completed
+            print("XXX raising exception")
             raise ValueError("Cannot find benchmark result line in the log!")
           if verbose:
             print(line.strip())
           # Result available
           if re.match(r"^BM_.+/real_time", line) is not None:
+            print("XXX matched line, break")
             break
+        print("XXX after the while loop")
 
         # Now it's okay to collect the trace via the capture tool. This will
         # send the signal to let the previously waiting benchmark tool to

--- a/build_tools/benchmarks/run_benchmarks_on_android.py
+++ b/build_tools/benchmarks/run_benchmarks_on_android.py
@@ -108,9 +108,10 @@ def adb_push_to_tmp_dir(content: str,
   """
   filename = os.path.basename(content)
   android_path = os.path.join(ANDROID_TMP_DIR, relative_dir, filename)
-  execute_cmd(["adb", "push", "-p",
-               os.path.abspath(content), android_path],
-              verbose=verbose)
+  execute_cmd(
+      ["adb", "push", os.path.abspath(content), android_path],
+      verbose=verbose,
+      stdout=subprocess.DEVNULL)
   return android_path
 
 


### PR DESCRIPTION
The handling of the `benchmark_min_time` flag was inside the `if` branch that's specific to running "normal benchmarking" as opposed to "capture trace", but it should apply equally to both.