### PR TITLE
Fix rewriting logic in CaptureDispatchDynamicDims

### DIFF
--- a/integrations/tensorflow/test/iree_tf_tests/uncategorized/llvmaot__fill.run
+++ b/integrations/tensorflow/test/iree_tf_tests/uncategorized/llvmaot__fill.run
@@ -1,3 +1,2 @@
 # REQUIRES: llvmaot
 # RUN: %PYTHON -m iree_tf_tests.uncategorized.fill_test --target_backends=iree_llvmaot -artifacts_dir=%t
-# XFAIL: *

--- a/integrations/tensorflow/test/iree_tf_tests/uncategorized/vulkan__fill.run
+++ b/integrations/tensorflow/test/iree_tf_tests/uncategorized/vulkan__fill.run
@@ -1,3 +1,2 @@
 # REQUIRES: vulkan
 # RUN: %PYTHON -m iree_tf_tests.uncategorized.fill_test --target_backends=iree_vulkan -artifacts_dir=%t
-# XFAIL: *

--- a/iree/compiler/Dialect/Flow/Transforms/test/capture_dispatch_dynamic_dims.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/capture_dispatch_dynamic_dims.mlir
@@ -20,6 +20,26 @@ func.func @captureDims(%arg0: tensor<?x?xf32>, %arg0_dim0: index, %arg0_dim1: in
 
 // -----
 
+// Check the rewriting logic for when two dimensions are captured for a single
+// operand tensor.
+
+// CHECK-LABEL: @capture2DimsForOneTensor
+// CHECK-SAME: (%[[ARG0:.+]]: tensor<?x?xf32>, %[[ARG0_DIM0:.+]]: index, %[[ARG0_DIM1:.+]]: index, %[[RET0_DIM0:.+]]: index, %[[RET0_DIM1:.+]]: index)
+func @capture2DimsForOneTensor(%arg0: tensor<?x?xf32>, %arg0_dim0: index, %arg0_dim1: index, %ret0_dim0: index, %ret0_dim1: index) {
+  %c1 = arith.constant 1 : index
+  // CHECK: flow.dispatch.workgroups[%c1, %c1, %c1](%[[ARG0]], %[[ARG0_DIM0]], %[[ARG0_DIM1]], %[[RET0_DIM0]], %[[RET0_DIM1]])
+  %0 = flow.dispatch.workgroups[%c1, %c1, %c1](%arg0) : (tensor<?x?xf32>{%arg0_dim0, %arg0_dim1}) -> tensor<?x?xf32>{%ret0_dim0, %ret0_dim1} =
+      // CHECK-NEXT: (%[[ARG0_CAPTURE:.+]]: !flow.dispatch.tensor<readonly:?x?xf32>, %[[ARG0_DIM0_CAPTURE:.+]]: index, %[[ARG0_DIM1_CAPTURE:.+]]: index, %[[RET0_DIM0_CAPTURE:.+]]: index, %[[RET0_DIM1_CAPTURE:.+]]: index, %[[RET0_CAPTURE:.+]]: !flow.dispatch.tensor<writeonly:?x?xf32>)
+      (%arg0_capture: !flow.dispatch.tensor<readonly:?x?xf32>, %ret0_capture: !flow.dispatch.tensor<writeonly:?x?xf32>) {
+    // CHECK-DAG: = flow.dispatch.tie_shape %[[ARG0_CAPTURE]] : !flow.dispatch.tensor<readonly:?x?xf32>{%[[ARG0_DIM0_CAPTURE]], %[[ARG0_DIM1_CAPTURE]]}
+    // CHECK-DAG: = flow.dispatch.tie_shape %[[RET0_CAPTURE]] : !flow.dispatch.tensor<writeonly:?x?xf32>{%[[RET0_DIM0_CAPTURE]], %[[RET0_DIM1_CAPTURE]]}
+    flow.return
+  }
+  return
+}
+
+// -----
+
 // Tests dim capture on tied operands.
 
 // CHECK-LABEL: @capturedTiedDims


### PR DESCRIPTION
It previously was using a ValueRange pointing into a stale
updated-in-place operand list.

Fixes #8718