### PR TITLE
Add config class to represent the parameters of benchmark script

### DIFF
--- a/build_tools/benchmarks/common/CMakeLists.txt
+++ b/build_tools/benchmarks/common/CMakeLists.txt
@@ -24,10 +24,19 @@ iree_py_test(
     "common_arguments_test.py"
 )
 
+iree_py_test(
+  NAME
+    benchmark_config_test
+  SRCS
+    "benchmark_config_test.py"
+)
+
 # TODO(#8708): Temporary solution to fix python path for tests.
 set_property(TEST "build_tools/benchmarks/common/linux_device_utils_test"
     APPEND PROPERTY ENVIRONMENT "PYTHONPATH=${BENCHMARKS_TOOL_PYTHON_DIR}:$ENV{PYTHONPATH}")
 set_property(TEST "build_tools/benchmarks/common/common_arguments_test"
+  APPEND PROPERTY ENVIRONMENT "PYTHONPATH=${BENCHMARKS_TOOL_PYTHON_DIR}:$ENV{PYTHONPATH}")
+set_property(TEST "build_tools/benchmarks/common/benchmark_config_test"
   APPEND PROPERTY ENVIRONMENT "PYTHONPATH=${BENCHMARKS_TOOL_PYTHON_DIR}:$ENV{PYTHONPATH}")
 
 endif()

--- a/build_tools/benchmarks/common/benchmark_config.py
+++ b/build_tools/benchmarks/common/benchmark_config.py
@@ -1,0 +1,121 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# All benchmarks' relative path against root build directory.
+
+from argparse import Namespace
+from dataclasses import dataclass
+from typing import Optional
+import os
+
+BENCHMARK_SUITE_REL_PATH = "benchmark_suites"
+BENCHMARK_RESULTS_REL_PATH = "benchmark-results"
+CAPTURES_REL_PATH = "captures"
+
+
+@dataclass
+class TraceCaptureConfig:
+  """Represents the settings for capturing traces during the benchamrks.
+
+    traced_benchmark_tool_dir: the path to the tracing-enabled benchmark tool
+      directory.
+    trace_capture_tool: the path to the tool for collecting captured traces.
+    capture_tarball: the path of capture tar archive.
+    capture_tmp_dir: the temporary directory to store captured traces.
+  """
+
+  traced_benchmark_tool_dir: str
+  trace_capture_tool: str
+  capture_tarball: str
+  capture_tmp_dir: str
+
+
+@dataclass
+class BenchmarkConfig:
+  """Represents the settings to run benchmarks.
+
+    root_benchmark_dir: the root directory containing the built benchmark
+      suites.
+    benchmark_results_dir: the directory to store benchmark results files.
+    normal_benchmark_tool_dir: the path to the non-traced benchmark tool
+      directory.
+    trace_capture_config: the config for capturing traces. Set if and only if
+      the traces need to be captured.
+    driver_filter: filter benchmarks to those whose driver matches this regex
+      (or all if this is None).
+    model_name_filter: filter benchmarks to those whose model name matches this
+      regex (or all if this is None).
+    mode_filter: filter benchmarks to those whose benchmarking mode matches this
+      regex (or all if this is None).
+    keep_going: whether to proceed if an individual run fails. Exceptions will
+      logged and returned.
+    benchmark_min_time: min number of seconds to run the benchmark for, if
+      specified. Otherwise, the benchmark will be repeated a fixed number of
+      times.
+  """
+
+  root_benchmark_dir: str
+  benchmark_results_dir: str
+
+  normal_benchmark_tool_dir: Optional[str] = None
+  trace_capture_config: Optional[TraceCaptureConfig] = None
+
+  driver_filter: Optional[str] = None
+  model_name_filter: Optional[str] = None
+  mode_filter: Optional[str] = None
+
+  keep_going: bool = False
+  benchmark_min_time: float = 0
+
+  @staticmethod
+  def build_from_args(args: Namespace, git_commit_hash: str):
+    """Build config from command arguments.
+    
+    Args:
+      args: the command arguments.
+      git_commit_hash: the commit hash to separete different benchmark runs in
+        the temporary directory.
+    """
+
+    def real_path_or_none(path: str) -> Optional[str]:
+      return os.path.realpath(path) if path else None
+
+    if not args.normal_benchmark_tool_dir and not args.traced_benchmark_tool_dir:
+      raise ValueError(
+          "At least one of --normal_benchmark_tool_dir or --traced_benchmark_tool_dir should be specified."
+      )
+    if not ((args.traced_benchmark_tool_dir is None) ==
+            (args.trace_capture_tool is None) ==
+            (args.capture_tarball is None)):
+      raise ValueError(
+          "The following 3 flags should be simultaneously all specified or all unspecified: --traced_benchmark_tool_dir, --trace_capture_tool, --capture_tarball"
+      )
+
+    per_commit_tmp_dir = os.path.realpath(
+        os.path.join(args.tmp_dir, git_commit_hash))
+
+    if args.traced_benchmark_tool_dir is None:
+      trace_capture_config = None
+    else:
+      trace_capture_config = TraceCaptureConfig(
+          traced_benchmark_tool_dir=real_path_or_none(
+              args.traced_benchmark_tool_dir),
+          trace_capture_tool=real_path_or_none(args.trace_capture_tool),
+          capture_tarball=real_path_or_none(args.capture_tarball),
+          capture_tmp_dir=os.path.join(per_commit_tmp_dir, CAPTURES_REL_PATH))
+
+    build_dir = os.path.realpath(args.build_dir)
+    return BenchmarkConfig(
+        root_benchmark_dir=os.path.join(build_dir, BENCHMARK_SUITE_REL_PATH),
+        benchmark_results_dir=os.path.join(per_commit_tmp_dir,
+                                           BENCHMARK_RESULTS_REL_PATH),
+        normal_benchmark_tool_dir=real_path_or_none(
+            args.normal_benchmark_tool_dir),
+        trace_capture_config=trace_capture_config,
+        driver_filter=args.driver_filter_regex,
+        model_name_filter=args.model_name_regex,
+        mode_filter=args.mode_regex,
+        keep_going=args.keep_going,
+        benchmark_min_time=args.benchmark_min_time)

--- a/build_tools/benchmarks/common/benchmark_config.py
+++ b/build_tools/benchmarks/common/benchmark_config.py
@@ -5,10 +5,11 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # All benchmarks' relative path against root build directory.
 
+import os
+
 from argparse import Namespace
 from dataclasses import dataclass
 from typing import Optional
-import os
 
 BENCHMARK_SUITE_REL_PATH = "benchmark_suites"
 BENCHMARK_RESULTS_REL_PATH = "benchmark-results"
@@ -17,7 +18,7 @@ CAPTURES_REL_PATH = "captures"
 
 @dataclass
 class TraceCaptureConfig:
-  """Represents the settings for capturing traces during the benchamrks.
+  """Represents the settings for capturing traces during benchamrking.
 
     traced_benchmark_tool_dir: the path to the tracing-enabled benchmark tool
       directory.

--- a/build_tools/benchmarks/common/benchmark_config_test.py
+++ b/build_tools/benchmarks/common/benchmark_config_test.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import stat
+import unittest
+import tempfile
+import os
+
+from common.common_arguments import build_common_argument_parser
+from common.benchmark_config import BenchmarkConfig, TraceCaptureConfig
+
+
+class BenchmarkConfigTest(unittest.TestCase):
+
+  def setUp(self):
+    self.build_dir = tempfile.TemporaryDirectory()
+    self.tmp_dir = tempfile.TemporaryDirectory()
+    self.normal_tool_dir = os.path.join(self.build_dir.name, "normal_tool")
+    os.mkdir(self.normal_tool_dir)
+    self.traced_tool_dir = os.path.join(self.build_dir.name, "traced_tool")
+    os.mkdir(self.traced_tool_dir)
+    self.trace_capture_tool = tempfile.NamedTemporaryFile()
+    os.chmod(self.trace_capture_tool.name, stat.S_IEXEC)
+
+  def tearDown(self):
+    self.tmp_dir.cleanup()
+    self.build_dir.cleanup()
+
+  def test_build_from_args(self):
+    args = build_common_argument_parser().parse_args([
+        f"--tmp_dir={self.tmp_dir.name}",
+        f"--normal_benchmark_tool_dir={self.normal_tool_dir}",
+        f"--traced_benchmark_tool_dir={self.traced_tool_dir}",
+        f"--trace_capture_tool={self.trace_capture_tool.name}",
+        f"--capture_tarball=capture.tar", f"--driver_filter_regex=a",
+        f"--model_name_regex=b", f"--mode_regex=c", f"--keep_going",
+        f"--benchmark_min_time=10", self.build_dir.name
+    ])
+
+    config = BenchmarkConfig.build_from_args(args=args, git_commit_hash="abcd")
+
+    per_commit_tmp_dir = os.path.join(self.tmp_dir.name, "abcd")
+    expected_trace_capture_config = TraceCaptureConfig(
+        traced_benchmark_tool_dir=self.traced_tool_dir,
+        trace_capture_tool=self.trace_capture_tool.name,
+        capture_tarball=os.path.realpath("capture.tar"),
+        capture_tmp_dir=os.path.join(per_commit_tmp_dir, "captures"))
+    self.assertEqual(
+        config,
+        BenchmarkConfig(root_benchmark_dir=os.path.join(self.build_dir.name,
+                                                        "benchmark_suites"),
+                        benchmark_results_dir=os.path.join(
+                            per_commit_tmp_dir, "benchmark-results"),
+                        normal_benchmark_tool_dir=self.normal_tool_dir,
+                        trace_capture_config=expected_trace_capture_config,
+                        driver_filter="a",
+                        model_name_filter="b",
+                        mode_filter="c",
+                        keep_going=True,
+                        benchmark_min_time=10))
+
+  def test_build_from_args_benchmark_only(self):
+    args = build_common_argument_parser().parse_args([
+        f"--tmp_dir={self.tmp_dir.name}",
+        f"--normal_benchmark_tool_dir={self.normal_tool_dir}",
+        self.build_dir.name
+    ])
+
+    config = BenchmarkConfig.build_from_args(args=args, git_commit_hash="abcd")
+
+    self.assertIsNone(config.trace_capture_config)
+
+  def test_build_from_args_invalid_capture_args(self):
+    args = build_common_argument_parser().parse_args([
+        f"--tmp_dir={self.tmp_dir.name}",
+        f"--normal_benchmark_tool_dir={self.normal_tool_dir}",
+        f"--traced_benchmark_tool_dir={self.traced_tool_dir}",
+        self.build_dir.name
+    ])
+
+    self.assertRaises(
+        ValueError,
+        lambda: BenchmarkConfig.build_from_args(args=args,
+                                                git_commit_hash="abcd"))
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
Add config class to load and store all benchmark settings from command arguments. This will help us pass the benchmark settings through functions without having a long list of function parameter.