### PR TITLE
Add a oneshot build and allow building on a branch

### DIFF
--- a/.github/workflows/oneshot_candidate_release.yml
+++ b/.github/workflows/oneshot_candidate_release.yml
@@ -1,17 +1,12 @@
-name: Schedule candidate release
+name: Oneshot candidate release
 
 on:
-  schedule:
-    - cron: '0 10 * * *'
-
   workflow_dispatch:
 
 jobs:
   tag_release:
     name: "Tag candidate release"
     runs-on: ubuntu-18.04
-    # Don't run this in everyone's forks.
-    if: github.repository == 'google/iree'
     steps:
       - name: Checking out repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Allow oneshot to build from Nod.ai's fork too.

Also remove hardcode for "main" branch

TEST=Able to build on custom shark branch
https://github.com/NodLabs/SHARK/actions/runs/2080070703