### PR TITLE
Update iree-flow-trace-dispatch-tensors flag name.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -27,7 +27,7 @@ static llvm::cl::opt<bool> clExportBenchmarkFuncs(
 
 // TODO(ravishankarm): Change to a pipeline option.
 static llvm::cl::opt<bool> clTraceDispatchTensors(
-    "iree-flow-trace-dispatch-tensors2",
+    "iree-flow-trace-dispatch-tensors",
     llvm::cl::desc(
         "Trace runtime input/output tensors for each dispatch function."),
     llvm::cl::init(false));

--- a/iree/test/e2e/regression/trace_dispatch_tensors.mlir
+++ b/iree/test/e2e/regression/trace_dispatch_tensors.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-run-mlir --iree-input-type=mhlo -iree-hal-target-backends=vmvx -iree-flow-trace-dispatch-tensors2 %s 2>&1 | FileCheck %s
+// RUN: iree-run-mlir --iree-input-type=mhlo -iree-hal-target-backends=vmvx -iree-flow-trace-dispatch-tensors %s 2>&1 | FileCheck %s
 
 func.func @two_dispatch() -> (tensor<5x5xf32>, tensor<3x5xf32>) {
   %0 = util.unfoldable_constant dense<1.0> : tensor<5x3xf32>


### PR DESCRIPTION
The v1 flag was removed, so we can correct v2 flag name.