### PR TITLE
[CUDA] Add pass to try to reduce shared memory bank conflicts

### DIFF
--- a/iree/compiler/Codegen/LLVMGPU/BUILD
+++ b/iree/compiler/Codegen/LLVMGPU/BUILD
@@ -21,6 +21,7 @@ cc_library(
         "LLVMGPULowerExecutableTarget.cpp",
         "LLVMGPUMultiBuffering.cpp",
         "LLVMGPUPipelining.cpp",
+        "LLVMGPUReduceBankConflicts.cpp",
         "LLVMGPUTensorCoreVectorization.cpp",
         "LLVMGPUTileAndDistribute.cpp",
         "LLVMGPUUtils.cpp",

--- a/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -26,6 +26,7 @@ iree_cc_library(
     "LLVMGPULowerExecutableTarget.cpp"
     "LLVMGPUMultiBuffering.cpp"
     "LLVMGPUPipelining.cpp"
+    "LLVMGPUReduceBankConflicts.cpp"
     "LLVMGPUTensorCoreVectorization.cpp"
     "LLVMGPUTileAndDistribute.cpp"
     "LLVMGPUUtils.cpp"

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPUReduceBankConflicts.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPUReduceBankConflicts.cpp
@@ -97,7 +97,7 @@ struct LLVMGPUReduceBankConflictsPass
 }  // namespace
 
 std::unique_ptr<OperationPass<func::FuncOp>>
-createLLVMGPUReduceBankConflicts() {
+createLLVMGPUReduceSharedMemoryBankConflicts() {
   return std::make_unique<LLVMGPUReduceBankConflictsPass>();
 }
 

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPUReduceBankConflicts.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPUReduceBankConflicts.cpp
@@ -1,0 +1,105 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Passes.h"
+#include "mlir/Dialect/GPU/Passes.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+/// Replace the uses of `oldOp` with the given `val` and for subview uses
+/// propagate the type change. Changing the memref type may require propagating
+/// it through subview ops so we cannot just do a replaceAllUse but need to
+/// propagate the type change and erase old subview ops.
+static void replaceUsesAndPropagateType(Operation *oldOp, Value val,
+                                        OpBuilder &builder) {
+  SmallVector<Operation *> opToDelete;
+  SmallVector<OpOperand *> operandsToReplace;
+  for (OpOperand &use : oldOp->getUses()) {
+    auto subviewUse = dyn_cast<memref::SubViewOp>(use.getOwner());
+    if (!subviewUse) {
+      // Save the operand to and replace outside the loop to not invalidate the
+      // iterator.
+      operandsToReplace.push_back(&use);
+      continue;
+    }
+    builder.setInsertionPoint(subviewUse);
+    Type newType = memref::SubViewOp::inferRankReducedResultType(
+        subviewUse.getType().getRank(), val.getType().cast<MemRefType>(),
+        extractFromI64ArrayAttr(subviewUse.static_offsets()),
+        extractFromI64ArrayAttr(subviewUse.static_sizes()),
+        extractFromI64ArrayAttr(subviewUse.static_strides()));
+    Value newSubview = builder.create<memref::SubViewOp>(
+        subviewUse->getLoc(), newType.cast<MemRefType>(), val,
+        subviewUse.getMixedOffsets(), subviewUse.getMixedSizes(),
+        subviewUse.getMixedStrides());
+    replaceUsesAndPropagateType(subviewUse, newSubview, builder);
+    opToDelete.push_back(use.getOwner());
+  }
+  for (OpOperand *operand : operandsToReplace) operand->set(val);
+  // Clean up old subview ops.
+  for (Operation *op : opToDelete) op->erase();
+}
+
+/// Padd out the inner dimension of the allocOp in order reduce the chances to
+/// have bank conflicts when reading 2D shapes within shared memory.
+static void padAlloc(memref::AllocOp allocOp) {
+  int64_t innerDim = allocOp.getType().getShape().back();
+  if (ShapedType::isDynamic(innerDim)) return;
+  Type elType = allocOp.getType().getElementType();
+  unsigned bitwidth =
+      mlir::DataLayout::closest(allocOp).getTypeSizeInBits(elType);
+  // Pad with 128bits==16bytes so that accesses are still aligned on 16bytes.
+  int64_t paddingSize = 128 / bitwidth;
+  SmallVector<int64_t> shape = llvm::to_vector(allocOp.getType().getShape());
+  shape.back() = shape.back() + paddingSize;
+  MemRefType allocType = MemRefType::get(
+      shape, elType, {}, allocOp.getType().getMemorySpaceAsInt());
+  OpBuilder builder(allocOp);
+  Location loc = allocOp.getLoc();
+  Value paddedAlloc = builder.create<memref::AllocOp>(loc, allocType);
+  SmallVector<int64_t> offsets(shape.size(), 0);
+  SmallVector<int64_t> strides(shape.size(), 1);
+  Value subview = builder.create<memref::SubViewOp>(
+      loc, paddedAlloc, offsets, allocOp.getType().getShape(), strides);
+  replaceUsesAndPropagateType(allocOp, subview, builder);
+  allocOp->erase();
+}
+
+namespace {
+
+/// Pass to reduce the number of bank conflicts when accessing shared memory in
+/// a 2D manner. This is a simple version just padding allocation.
+/// This doesn't fully remove bank conflicts and increase the shared memory
+/// usage. In order to get better memory access patterns we should do shared
+/// memory swizzling which requires more complex transformations. This pass can
+/// be removed once the better solution is implemented.
+struct LLVMGPUReduceBankConflictsPass
+    : public LLVMGPUReduceBankConflictsBase<LLVMGPUReduceBankConflictsPass> {
+  void runOnOperation() override {
+    auto funcOp = getOperation();
+    SmallVector<memref::AllocOp> sharedMemAllocs;
+    // Collect all the alloc operations.
+    funcOp.walk([&](memref::AllocOp allocOp) {
+      if (allocOp.getType().getMemorySpaceAsInt() ==
+          gpu::GPUDialect::getWorkgroupAddressSpace()) {
+        sharedMemAllocs.push_back(allocOp);
+      }
+    });
+    for (memref::AllocOp alloc : sharedMemAllocs) padAlloc(alloc);
+  }
+};
+}  // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createLLVMGPUReduceBankConflicts() {
+  return std::make_unique<LLVMGPUReduceBankConflictsPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -88,6 +88,7 @@ void addGPUMatmulSimtPassPipeline(OpPassManager &pm) {
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
+  pm.addNestedPass<func::FuncOp>(createLLVMGPUReduceBankConflicts());
   pm.addNestedPass<func::FuncOp>(createRemoveSingleIterationLoopPass());
 
   // Linalg -> vector
@@ -113,6 +114,7 @@ void addGPUMatmulTensorCorePassPipeline(OpPassManager &pm) {
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
+  pm.addNestedPass<func::FuncOp>(createLLVMGPUReduceBankConflicts());
   pm.addNestedPass<func::FuncOp>(createRemoveSingleIterationLoopPass());
 
   // Linalg -> vector

--- a/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -88,7 +88,8 @@ void addGPUMatmulSimtPassPipeline(OpPassManager &pm) {
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
-  pm.addNestedPass<func::FuncOp>(createLLVMGPUReduceBankConflicts());
+  pm.addNestedPass<func::FuncOp>(
+      createLLVMGPUReduceSharedMemoryBankConflicts());
   pm.addNestedPass<func::FuncOp>(createRemoveSingleIterationLoopPass());
 
   // Linalg -> vector
@@ -114,7 +115,8 @@ void addGPUMatmulTensorCorePassPipeline(OpPassManager &pm) {
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
-  pm.addNestedPass<func::FuncOp>(createLLVMGPUReduceBankConflicts());
+  pm.addNestedPass<func::FuncOp>(
+      createLLVMGPUReduceSharedMemoryBankConflicts());
   pm.addNestedPass<func::FuncOp>(createRemoveSingleIterationLoopPass());
 
   // Linalg -> vector

--- a/iree/compiler/Codegen/LLVMGPU/test/BUILD
+++ b/iree/compiler/Codegen/LLVMGPU/test/BUILD
@@ -25,6 +25,7 @@ iree_lit_test_suite(
             "distribute_wg_copy.mlir",
             "gpu_set_num_workgroups.mlir",
             "nvvm_pipeline_test.mlir",
+            "reduce_bank_conflicts.mlir",
             "rocdl_pipeline_test.mlir",
             "illegal_configuration.mlir",
             "legalize.mlir",

--- a/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_lit_test_suite(
     "illegal_configuration.mlir"
     "legalize.mlir"
     "nvvm_pipeline_test.mlir"
+    "reduce_bank_conflicts.mlir"
     "rocdl_pipeline_test.mlir"
     "tensorcore_vectorization.mlir"
     "vector_to_gpu.mlir"

--- a/iree/compiler/Codegen/LLVMGPU/test/reduce_bank_conflicts.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/reduce_bank_conflicts.mlir
@@ -1,0 +1,22 @@
+// RUN: iree-opt %s -iree-llvmgpu-reduce-bank-conflicts  | FileCheck %s
+
+#map = affine_map<(d0, d1, d2) -> (d0 * 2048 + d1 * 64 + d2)>
+// CHECK-DAG: #[[$MAP:.*]] = affine_map<(d0, d1, d2) -> (d0 * 2176 + d1 * 68 + d2)>
+
+// CHECK-LABEL: func @pad_alloc
+func.func @pad_alloc(%a: memref<1024x1024xf32>) {
+// CHECK: %[[A:.*]] = memref.alloc() : memref<4x32x68xf32, 3>
+  %0 = memref.alloc() : memref<4x32x64xf32, 3>
+// CHECK: %[[S1:.*]] = memref.subview %[[A]][0, 0, 0] [4, 32, 64] [1, 1, 1] : memref<4x32x68xf32, 3> to memref<4x32x64xf32, #[[$MAP]], 3>
+// CHECK: %[[S2:.*]] = memref.subview %[[S1]][0, 0, 0] [1, 32, 64] [1, 1, 1] : memref<4x32x64xf32, #[[$MAP]], 3> to memref<1x32x64xf32, #[[$MAP]], 3>
+  %1 = memref.subview %0[0, 0, 0] [1, 32, 64] [1, 1, 1] :
+    memref<4x32x64xf32, 3> to memref<1x32x64xf32, #map, 3>
+  %c0 = arith.constant 0 : index
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %2 = vector.transfer_read %a[%c0, %c0], %cst_0 {in_bounds = [true]} :
+    memref<1024x1024xf32>, vector<4xf32>
+// CHECK: vector.transfer_write %{{.*}}, %[[S2]][%{{.*}}, %{{.*}}, %{{.*}}] {in_bounds = [true]} : vector<4xf32>, memref<1x32x64xf32, #[[$MAP]], 3>    
+  vector.transfer_write %2, %1[%c0, %c0, %c0] {in_bounds = [true]} : 
+    vector<4xf32>, memref<1x32x64xf32, #map, 3>
+  return
+}

--- a/iree/compiler/Codegen/Passes.h
+++ b/iree/compiler/Codegen/Passes.h
@@ -369,8 +369,10 @@ std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUPipeliningPass(
 std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUMultiBuffering(
     unsigned numBuffers = 5);
 
-/// Apply transformation to reduce the number of bank conflicts.
-std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUReduceBankConflicts();
+/// Apply transformation to reduce the number of bank conflicts when accessing
+/// shared memory.
+std::unique_ptr<OperationPass<func::FuncOp>>
+createLLVMGPUReduceSharedMemoryBankConflicts();
 
 /// Converts vector ops to gpu dialect.
 std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUVectorToGPU();

--- a/iree/compiler/Codegen/Passes.h
+++ b/iree/compiler/Codegen/Passes.h
@@ -369,6 +369,9 @@ std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUPipeliningPass(
 std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUMultiBuffering(
     unsigned numBuffers = 5);
 
+/// Apply transformation to reduce the number of bank conflicts.
+std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUReduceBankConflicts();
+
 /// Converts vector ops to gpu dialect.
 std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUVectorToGPU();
 

--- a/iree/compiler/Codegen/Passes.td
+++ b/iree/compiler/Codegen/Passes.td
@@ -315,6 +315,12 @@ def LLVMGPUMultiBuffering :
   let constructor = "mlir::iree_compiler::createLLVMGPUMultiBuffering()";
 }
 
+def LLVMGPUReduceBankConflicts :
+    Pass<"iree-llvmgpu-reduce-bank-conflicts", "func::FuncOp"> {
+  let summary = "Pass try reduce the number of bank conflicts.";
+  let constructor = "mlir::iree_compiler::createLLVMGPUReduceBankConflicts()";
+}
+
 def LLVMGPUVectorToGPU :
     Pass<"iree-llvmgpu-vector-to-gpu", "func::FuncOp"> {
   let summary = "Pass to convert vector to gpu.";

--- a/iree/compiler/Codegen/Passes.td
+++ b/iree/compiler/Codegen/Passes.td
@@ -318,7 +318,7 @@ def LLVMGPUMultiBuffering :
 def LLVMGPUReduceBankConflicts :
     Pass<"iree-llvmgpu-reduce-bank-conflicts", "func::FuncOp"> {
   let summary = "Pass try reduce the number of bank conflicts.";
-  let constructor = "mlir::iree_compiler::createLLVMGPUReduceBankConflicts()";
+  let constructor = "mlir::iree_compiler::createLLVMGPUReduceSharedMemoryBankConflicts()";
 }
 
 def LLVMGPUVectorToGPU :


### PR DESCRIPTION
Stop gap solution to reduce the number of bank conflicts in cuda gemm kernels. A better solution will be implemented later but this allows to get a performance boost on current gemm implementation.