### PR TITLE
Limiting buffer host visibility where not required.

### DIFF
--- a/bindings/python/iree/runtime/array_interop.py
+++ b/bindings/python/iree/runtime/array_interop.py
@@ -185,9 +185,9 @@ def asdevicearray(device: HalDevice,
                   dtype=None,
                   *,
                   implicit_host_transfer: bool = False,
-                  memory_type=MemoryType.DEVICE_LOCAL |
-                  MemoryType.DEVICE_VISIBLE,
-                  allowed_usage=BufferUsage.ALL,
+                  memory_type=MemoryType.DEVICE_LOCAL,
+                  allowed_usage=(BufferUsage.DISPATCH | BufferUsage.TRANSFER |
+                                 BufferUsage.MAPPING),
                   element_type: Optional[HalElementType] = None) -> DeviceArray:
   """Helper to create a DeviceArray from an arbitrary array like.
 

--- a/bindings/python/iree/runtime/function.py
+++ b/bindings/python/iree/runtime/function.py
@@ -295,9 +295,9 @@ ABI_TYPE_TO_DTYPE = {
 
 # When we get an ndarray as an argument and are implicitly mapping it to a
 # buffer view, flags for doing so.
-IMPLICIT_BUFFER_ARG_MEMORY_TYPE = (MemoryType.DEVICE_LOCAL |
-                                   MemoryType.DEVICE_VISIBLE)
-IMPLICIT_BUFFER_ARG_USAGE = BufferUsage.ALL
+IMPLICIT_BUFFER_ARG_MEMORY_TYPE = MemoryType.DEVICE_LOCAL
+IMPLICIT_BUFFER_ARG_USAGE = (BufferUsage.DISPATCH | BufferUsage.TRANSFER |
+                             BufferUsage.MAPPING)
 
 
 def _is_ndarray_descriptor(desc):

--- a/bindings/python/iree/runtime/hal.cc
+++ b/bindings/python/iree/runtime/hal.cc
@@ -347,14 +347,15 @@ void SetupHalBindings(pybind11::module m) {
       .value("TRANSFER", IREE_HAL_BUFFER_USAGE_TRANSFER)
       .value("MAPPING", IREE_HAL_BUFFER_USAGE_MAPPING)
       .value("DISPATCH", IREE_HAL_BUFFER_USAGE_DISPATCH)
-      .value("ALL", IREE_HAL_BUFFER_USAGE_ALL)
       .export_values()
       .def("__or__",
            [](enum iree_hal_buffer_usage_bits_t self,
-              enum iree_hal_buffer_usage_bits_t other) { return self | other; })
+              enum iree_hal_buffer_usage_bits_t other) {
+             return (enum iree_hal_buffer_usage_bits_t)(self | other);
+           })
       .def("__and__", [](enum iree_hal_buffer_usage_bits_t self,
                          enum iree_hal_buffer_usage_bits_t other) {
-        return self & other;
+        return (enum iree_hal_buffer_usage_bits_t)(self & other);
       });
 
   py::enum_<enum iree_hal_memory_access_bits_t>(m, "MemoryAccess")

--- a/bindings/python/iree/runtime/invoke.cc
+++ b/bindings/python/iree/runtime/invoke.cc
@@ -194,9 +194,11 @@ class InvokeStatics {
             }
 
             retained_bv = c.allocator().AllocateBufferCopy(
-                IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
-                    IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-                IREE_HAL_BUFFER_USAGE_ALL, host_array, hal_element_type);
+                IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+                IREE_HAL_BUFFER_USAGE_DISPATCH |
+                    IREE_HAL_BUFFER_USAGE_TRANSFER |
+                    IREE_HAL_BUFFER_USAGE_MAPPING,
+                host_array, hal_element_type);
             bv = py::cast<HalBufferView *>(retained_bv);
           }
 
@@ -399,9 +401,10 @@ class InvokeStatics {
 
       // Put it on the device.
       py::object retained_bv = c.allocator().AllocateBufferCopy(
-          IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
-              IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-          IREE_HAL_BUFFER_USAGE_ALL, host_array, hal_element_type);
+          IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+          IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER |
+              IREE_HAL_BUFFER_USAGE_MAPPING,
+          host_array, hal_element_type);
       HalBufferView *bv = py::cast<HalBufferView *>(retained_bv);
 
       // TODO: If adding further manipulation here, please make this common

--- a/bindings/python/iree/runtime/vm_test.py
+++ b/bindings/python/iree/runtime/vm_test.py
@@ -95,9 +95,10 @@ class VmTest(absltest.TestCase):
       lst = iree.runtime.VmVariantList(5)
       ary1 = np.asarray([1, 2, 3, 4], dtype=dt)
       bv1 = self.device.allocator.allocate_buffer_copy(
-          memory_type=iree.runtime.MemoryType.DEVICE_LOCAL |
-          iree.runtime.MemoryType.DEVICE_VISIBLE,
-          allowed_usage=iree.runtime.BufferUsage.ALL,
+          memory_type=iree.runtime.MemoryType.DEVICE_LOCAL,
+          allowed_usage=(iree.runtime.BufferUsage.DISPATCH |
+                         iree.runtime.BufferUsage.TRANSFER |
+                         iree.runtime.BufferUsage.MAPPING),
           buffer=ary1,
           element_type=et)
       lst.push_buffer_view(bv1)

--- a/bindings/tflite/tensor.c
+++ b/bindings/tflite/tensor.c
@@ -141,7 +141,9 @@ iree_status_t _TfLiteTensorReallocateIfNeeded(
               (iree_hal_buffer_params_t){
                   .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
                           IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
-                  .usage = IREE_HAL_BUFFER_USAGE_ALL,
+                  .usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
+                           IREE_HAL_BUFFER_USAGE_TRANSFER |
+                           IREE_HAL_BUFFER_USAGE_MAPPING,
               },
               allocation_size, iree_const_byte_span_empty(), &tensor->buffer));
 

--- a/experimental/web/sample_static/main.c
+++ b/experimental/web/sample_static/main.c
@@ -124,8 +124,7 @@ int run_sample(iree_sample_state_t* state, float* image_data) {
         IREE_ARRAYSIZE(buffer_shape), IREE_HAL_ELEMENT_TYPE_FLOAT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
-            .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
-                    IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+            .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
             .usage =
                 IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER,
         },

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/allocator_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/allocator_ops.mlir
@@ -3,8 +3,8 @@
 // CHECK-LABEL: vm.func private @allocatorAllocate
 func.func @allocatorAllocate(%arg0 : !hal.allocator) -> !hal.buffer {
   %c1024 = arith.constant 1024 : index
-  // CHECK: %ref = vm.call @hal.allocator.allocate(%arg0, %c6, %c14, %c1024) : (!vm.ref<!hal.allocator>, i32, i32, i32) -> !vm.ref<!hal.buffer>
-  %0 = hal.allocator.allocate<%arg0 : !hal.allocator> type("HostLocal") usage("All") : !hal.buffer{%c1024}
+  // CHECK: %ref = vm.call @hal.allocator.allocate(%arg0, %c6, %c10, %c1024) : (!vm.ref<!hal.allocator>, i32, i32, i32) -> !vm.ref<!hal.buffer>
+  %0 = hal.allocator.allocate<%arg0 : !hal.allocator> type("HostLocal") usage("Dispatch|Transfer") : !hal.buffer{%c1024}
   return %0 : !hal.buffer
 }
 

--- a/iree/compiler/Dialect/HAL/IR/HALBase.td
+++ b/iree/compiler/Dialect/HAL/IR/HALBase.td
@@ -52,7 +52,6 @@ def HAL_BufferUsage_Constant  : BitEnumAttrCase<"Constant", 0x0001>;  // C
 def HAL_BufferUsage_Transfer  : BitEnumAttrCase<"Transfer", 0x0002>;  // T
 def HAL_BufferUsage_Mapping   : BitEnumAttrCase<"Mapping",  0x0004>;  // M
 def HAL_BufferUsage_Dispatch  : BitEnumAttrCase<"Dispatch", 0x0008>;  // D
-def HAL_BufferUsage_All       : BitEnumAttrCase<"All",      0x000E>;
 def HAL_BufferUsageBitfieldAttr :
     BitEnumAttr<"BufferUsageBitfield", "valid BufferUsage", [
       HAL_BufferUsage_None,
@@ -60,7 +59,6 @@ def HAL_BufferUsageBitfieldAttr :
       HAL_BufferUsage_Transfer,
       HAL_BufferUsage_Mapping,
       HAL_BufferUsage_Dispatch,
-      HAL_BufferUsage_All,
     ]> {
   let cppNamespace = "mlir::iree_compiler::IREE::HAL";
 }

--- a/iree/compiler/Dialect/HAL/Transforms/test/convert_to_hal.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/convert_to_hal.mlir
@@ -67,7 +67,7 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
 
     // CHECK: %[[RESULT_BUFFER:.+]] = hal.allocator.allocate<%[[ALLOCATOR]] : !hal.allocator>
     // CHECK-SAME: type("HostVisible|DeviceVisible|DeviceLocal")
-    // CHECK-SAME: usage("Transfer|Mapping|Dispatch|All")
+    // CHECK-SAME: usage("Transfer|Mapping|Dispatch")
     // CHECK-SAME: : !hal.buffer{%c16}
     %result_resource = stream.resource.alloc uninitialized : !stream.resource<external>{%c16}
 

--- a/iree/hal/allocator.h
+++ b/iree/hal/allocator.h
@@ -53,7 +53,7 @@ typedef struct iree_hal_buffer_params_t {
   // limit the allowed usage bits to precisely what the actual usage will be to
   // avoid additional copies, synchronization, and expensive emulation.
   //
-  // If 0 then the usage will be set as IREE_HAL_BUFFER_USAGE_ALL.
+  // If 0 then the usage will default to all usage modes.
   iree_hal_buffer_usage_t usage;
 
   // Specifies the access allowed to the memory via the HAL APIs.
@@ -95,8 +95,13 @@ typedef struct iree_hal_buffer_params_t {
 // Canonicalizes |params| fields when zero initialization is used.
 static inline void iree_hal_buffer_params_canonicalize(
     iree_hal_buffer_params_t* params) {
-  if (!params->usage) params->usage = IREE_HAL_BUFFER_USAGE_ALL;
-  if (!params->access) params->access = IREE_HAL_MEMORY_ACCESS_ALL;
+  if (!params->usage) {
+    params->usage =
+        IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER;
+  }
+  if (!params->access) {
+    params->access = IREE_HAL_MEMORY_ACCESS_ALL;
+  }
   if (!params->queue_affinity) {
     params->queue_affinity = IREE_HAL_QUEUE_AFFINITY_ANY;
   }
@@ -106,7 +111,10 @@ static inline void iree_hal_buffer_params_canonicalize(
 static inline iree_hal_buffer_params_t iree_hal_buffer_params_with_usage(
     const iree_hal_buffer_params_t params, iree_hal_buffer_usage_t usage) {
   iree_hal_buffer_params_t result = params;
-  if (!result.usage) result.usage = IREE_HAL_BUFFER_USAGE_ALL;
+  if (!result.usage) {
+    result.usage =
+        IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER;
+  }
   result.usage |= usage;
   return result;
 }

--- a/iree/hal/buffer.c
+++ b/iree/hal/buffer.c
@@ -59,7 +59,6 @@ IREE_API_EXPORT iree_string_view_t iree_hal_buffer_usage_format(
     iree_hal_buffer_usage_t value, iree_bitfield_string_temp_t* out_temp) {
   static const iree_bitfield_string_mapping_t mappings[] = {
       // Combined:
-      {IREE_HAL_BUFFER_USAGE_ALL, IREE_SVL("ALL")},
       // Separate:
       {IREE_HAL_BUFFER_USAGE_CONSTANT, IREE_SVL("CONSTANT")},
       {IREE_HAL_BUFFER_USAGE_TRANSFER, IREE_SVL("TRANSFER")},

--- a/iree/hal/buffer.h
+++ b/iree/hal/buffer.h
@@ -152,11 +152,6 @@ enum iree_hal_buffer_usage_bits_t {
   // The buffer can be provided as an input or output to an executable.
   // Buffers of this type may be directly used by drivers during dispatch.
   IREE_HAL_BUFFER_USAGE_DISPATCH = 1u << 3,
-
-  // Buffer may be used for any operation.
-  IREE_HAL_BUFFER_USAGE_ALL = IREE_HAL_BUFFER_USAGE_TRANSFER |
-                              IREE_HAL_BUFFER_USAGE_MAPPING |
-                              IREE_HAL_BUFFER_USAGE_DISPATCH,
 };
 typedef uint32_t iree_hal_buffer_usage_t;
 

--- a/iree/hal/cts/allocator_test.h
+++ b/iree/hal/cts/allocator_test.h
@@ -73,7 +73,7 @@ TEST_P(allocator_test, BaselineBufferCompatibility) {
 
 TEST_P(allocator_test, AllocateBuffer) {
   iree_hal_buffer_params_t params = {0};
-  params.type = IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
+  params.type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
   params.usage = IREE_HAL_BUFFER_USAGE_TRANSFER;
   iree_hal_buffer_t* buffer = NULL;
   IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(
@@ -96,7 +96,7 @@ TEST_P(allocator_test, AllocateBuffer) {
 // practice so we should at least be able to create them without errors.
 TEST_P(allocator_test, AllocateEmptyBuffer) {
   iree_hal_buffer_params_t params = {0};
-  params.type = IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
+  params.type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
   params.usage = IREE_HAL_BUFFER_USAGE_TRANSFER;
   iree_hal_buffer_t* buffer = NULL;
   IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(

--- a/iree/hal/cts/command_buffer_dispatch_test.h
+++ b/iree/hal/cts/command_buffer_dispatch_test.h
@@ -80,8 +80,7 @@ TEST_P(command_buffer_dispatch_test, DispatchAbs) {
 
   // Create input and output buffers.
   iree_hal_buffer_params_t input_params = {0};
-  input_params.type =
-      IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
+  input_params.type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
   input_params.usage =
       IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER;
   iree_hal_buffer_view_t* input_buffer_view = NULL;
@@ -95,8 +94,9 @@ TEST_P(command_buffer_dispatch_test, DispatchAbs) {
   iree_hal_buffer_params_t output_params = {0};
   output_params.type =
       IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
-  output_params.usage =
-      IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_MAPPING;
+  output_params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
+                        IREE_HAL_BUFFER_USAGE_TRANSFER |
+                        IREE_HAL_BUFFER_USAGE_MAPPING;
   iree_hal_buffer_t* output_buffer = NULL;
   IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(
       device_allocator_, output_params, sizeof(float),

--- a/iree/hal/cts/command_buffer_test.h
+++ b/iree/hal/cts/command_buffer_test.h
@@ -33,7 +33,9 @@ class command_buffer_test : public CtsTestBase {
     iree_hal_buffer_params_t params = {0};
     params.type =
         IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
-    params.usage = IREE_HAL_BUFFER_USAGE_ALL;
+    params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
+                   IREE_HAL_BUFFER_USAGE_TRANSFER |
+                   IREE_HAL_BUFFER_USAGE_MAPPING;
     iree_hal_buffer_t* device_buffer = NULL;
     IREE_CHECK_OK(iree_hal_allocator_allocate_buffer(
         iree_hal_device_allocator(device_), params, buffer_size,
@@ -139,7 +141,9 @@ TEST_P(command_buffer_test, CopyWholeBuffer) {
   iree_hal_buffer_params_t host_params = {0};
   host_params.type =
       IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
-  host_params.usage = IREE_HAL_BUFFER_USAGE_ALL;
+  host_params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
+                      IREE_HAL_BUFFER_USAGE_TRANSFER |
+                      IREE_HAL_BUFFER_USAGE_MAPPING;
   iree_hal_buffer_t* host_buffer = nullptr;
   IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(
       device_allocator_, host_params, kDefaultAllocationSize,
@@ -151,7 +155,9 @@ TEST_P(command_buffer_test, CopyWholeBuffer) {
   iree_hal_buffer_params_t device_params = {0};
   device_params.type =
       IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
-  device_params.usage = IREE_HAL_BUFFER_USAGE_ALL;
+  device_params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
+                        IREE_HAL_BUFFER_USAGE_TRANSFER |
+                        IREE_HAL_BUFFER_USAGE_MAPPING;
   iree_hal_buffer_t* device_buffer = nullptr;
   IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(
       device_allocator_, device_params, kDefaultAllocationSize,
@@ -193,7 +199,9 @@ TEST_P(command_buffer_test, CopySubBuffer) {
   iree_hal_buffer_params_t device_params = {0};
   device_params.type =
       IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
-  device_params.usage = IREE_HAL_BUFFER_USAGE_ALL;
+  device_params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
+                        IREE_HAL_BUFFER_USAGE_TRANSFER |
+                        IREE_HAL_BUFFER_USAGE_MAPPING;
   iree_hal_buffer_t* device_buffer = NULL;
   IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(
       device_allocator_, device_params, kDefaultAllocationSize,
@@ -208,7 +216,9 @@ TEST_P(command_buffer_test, CopySubBuffer) {
   iree_hal_buffer_params_t host_params = {0};
   host_params.type =
       IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
-  host_params.usage = IREE_HAL_BUFFER_USAGE_ALL;
+  host_params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
+                      IREE_HAL_BUFFER_USAGE_TRANSFER |
+                      IREE_HAL_BUFFER_USAGE_MAPPING;
   std::vector<uint8_t> host_buffer_data(kDefaultAllocationSize, i8_val);
   iree_hal_buffer_t* host_buffer = NULL;
   IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(

--- a/iree/modules/check/check_test.cc
+++ b/iree/modules/check/check_test.cc
@@ -83,7 +83,9 @@ class CheckTest : public ::testing::Test {
     iree_hal_buffer_params_t params = {0};
     params.type =
         IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-    params.usage = IREE_HAL_BUFFER_USAGE_ALL;
+    params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
+                   IREE_HAL_BUFFER_USAGE_TRANSFER |
+                   IREE_HAL_BUFFER_USAGE_MAPPING;
     IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer(
         allocator_, shape.data(), shape.size(), IREE_HAL_ELEMENT_TYPE_INT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR, params,
@@ -103,7 +105,9 @@ class CheckTest : public ::testing::Test {
     iree_hal_buffer_params_t params = {0};
     params.type =
         IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
-    params.usage = IREE_HAL_BUFFER_USAGE_ALL;
+    params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
+                   IREE_HAL_BUFFER_USAGE_TRANSFER |
+                   IREE_HAL_BUFFER_USAGE_MAPPING;
     IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer(
         allocator_, shape.data(), shape.size(), IREE_HAL_ELEMENT_TYPE_FLOAT_16,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR, params,
@@ -123,7 +127,9 @@ class CheckTest : public ::testing::Test {
     iree_hal_buffer_params_t params = {0};
     params.type =
         IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
-    params.usage = IREE_HAL_BUFFER_USAGE_ALL;
+    params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
+                   IREE_HAL_BUFFER_USAGE_TRANSFER |
+                   IREE_HAL_BUFFER_USAGE_MAPPING;
     IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer(
         allocator_, shape.data(), shape.size(), IREE_HAL_ELEMENT_TYPE_FLOAT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR, params,
@@ -143,7 +149,9 @@ class CheckTest : public ::testing::Test {
     iree_hal_buffer_params_t params = {0};
     params.type =
         IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
-    params.usage = IREE_HAL_BUFFER_USAGE_ALL;
+    params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
+                   IREE_HAL_BUFFER_USAGE_TRANSFER |
+                   IREE_HAL_BUFFER_USAGE_MAPPING;
     IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer(
         allocator_, shape.data(), shape.size(), IREE_HAL_ELEMENT_TYPE_FLOAT_64,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR, params,

--- a/iree/runtime/demo/hello_world_explained.c
+++ b/iree/runtime/demo/hello_world_explained.c
@@ -203,12 +203,12 @@ static iree_status_t iree_runtime_demo_perform_mul(
           IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
           (iree_hal_buffer_params_t){
               // Where to allocate (host or device):
-              .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
-                      IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+              .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
               // Access to allow to this memory (this is .rodata so READ only):
               .access = IREE_HAL_MEMORY_ACCESS_READ,
               // Intended usage of the buffer (transfers, dispatches, etc):
-              .usage = IREE_HAL_BUFFER_USAGE_ALL,
+              .usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
+                       IREE_HAL_BUFFER_USAGE_TRANSFER,
           },
           // The actual heap buffer to wrap or clone and its allocator:
           iree_make_const_byte_span(arg0_data, sizeof(arg0_data)),
@@ -236,10 +236,10 @@ static iree_status_t iree_runtime_demo_perform_mul(
           IREE_HAL_ELEMENT_TYPE_FLOAT_32,
           IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
           (iree_hal_buffer_params_t){
-              .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
-                      IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+              .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
               .access = IREE_HAL_MEMORY_ACCESS_READ,
-              .usage = IREE_HAL_BUFFER_USAGE_ALL,
+              .usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
+                       IREE_HAL_BUFFER_USAGE_TRANSFER,
           },
           iree_make_const_byte_span(arg1_data, sizeof(arg1_data)), &arg1);
     }

--- a/iree/runtime/demo/hello_world_terse.c
+++ b/iree/runtime/demo/hello_world_terse.c
@@ -85,10 +85,10 @@ static void iree_runtime_demo_perform_mul(iree_runtime_session_t* session) {
       IREE_ARRAYSIZE(arg0_shape), IREE_HAL_ELEMENT_TYPE_FLOAT_32,
       IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
       (iree_hal_buffer_params_t){
-          .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
-                  IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+          .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
           .access = IREE_HAL_MEMORY_ACCESS_READ,
-          .usage = IREE_HAL_BUFFER_USAGE_ALL,
+          .usage =
+              IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER,
       },
       iree_make_const_byte_span(arg0_data, sizeof(arg0_data)), &arg0));
   IREE_CHECK_OK(iree_hal_buffer_view_fprint(
@@ -108,10 +108,10 @@ static void iree_runtime_demo_perform_mul(iree_runtime_session_t* session) {
       IREE_ARRAYSIZE(arg1_shape), IREE_HAL_ELEMENT_TYPE_FLOAT_32,
       IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
       (iree_hal_buffer_params_t){
-          .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
-                  IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+          .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
           .access = IREE_HAL_MEMORY_ACCESS_READ,
-          .usage = IREE_HAL_BUFFER_USAGE_ALL,
+          .usage =
+              IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER,
       },
       iree_make_const_byte_span(arg1_data, sizeof(arg1_data)), &arg1));
   IREE_CHECK_OK(iree_hal_buffer_view_fprint(

--- a/iree/samples/custom_modules/custom_modules_test.cc
+++ b/iree/samples/custom_modules/custom_modules_test.cc
@@ -136,7 +136,8 @@ TEST_F(CustomModulesTest, PrintTensor) {
   iree_hal_buffer_params_t params = {0};
   params.type =
       IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
-  params.usage = IREE_HAL_BUFFER_USAGE_ALL;
+  params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
+                 IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_MAPPING;
   iree_hal_buffer_view_t* buffer_view = nullptr;
   IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer(
       hal_allocator_, kShape, IREE_ARRAYSIZE(kShape),
@@ -184,7 +185,8 @@ TEST_F(CustomModulesTest, RoundTripTensor) {
   iree_hal_buffer_params_t params = {0};
   params.type =
       IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
-  params.usage = IREE_HAL_BUFFER_USAGE_ALL;
+  params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
+                 IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_MAPPING;
   iree_hal_buffer_view_t* buffer_view = nullptr;
   IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer(
       hal_allocator_, kShape, IREE_ARRAYSIZE(kShape),

--- a/iree/samples/dynamic_shapes/main.c
+++ b/iree/samples/dynamic_shapes/main.c
@@ -24,9 +24,9 @@ iree_status_t reduce_sum_1d(iree_runtime_session_t* session, const int* values,
         IREE_ARRAYSIZE(arg0_shape), IREE_HAL_ELEMENT_TYPE_SINT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
-            .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
-                    IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-            .usage = IREE_HAL_BUFFER_USAGE_ALL,
+            .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+            .usage =
+                IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER,
         },
         iree_make_const_byte_span((void*)values, sizeof(int) * values_length),
         &arg0);
@@ -74,9 +74,9 @@ iree_status_t reduce_sum_2d(iree_runtime_session_t* session, const int* values,
         IREE_ARRAYSIZE(arg0_shape), IREE_HAL_ELEMENT_TYPE_SINT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
-            .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
-                    IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-            .usage = IREE_HAL_BUFFER_USAGE_ALL,
+            .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+            .usage =
+                IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER,
         },
         iree_make_const_byte_span((void*)values, sizeof(int) * values_length),
         &arg0);
@@ -115,9 +115,9 @@ iree_status_t add_one(iree_runtime_session_t* session, const int* values,
         IREE_ARRAYSIZE(arg0_shape), IREE_HAL_ELEMENT_TYPE_SINT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
-            .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
-                    IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-            .usage = IREE_HAL_BUFFER_USAGE_ALL,
+            .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+            .usage =
+                IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER,
         },
         iree_make_const_byte_span((void*)values, sizeof(int) * values_length),
         &arg0);

--- a/iree/samples/simple_embedding/simple_embedding.c
+++ b/iree/samples/simple_embedding/simple_embedding.c
@@ -83,22 +83,18 @@ iree_status_t Run() {
       iree_hal_device_allocator(device), shape, IREE_ARRAYSIZE(shape),
       IREE_HAL_ELEMENT_TYPE_FLOAT_32, IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
       (iree_hal_buffer_params_t){
-          .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
-                  IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
-          .usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
-                   IREE_HAL_BUFFER_USAGE_TRANSFER |
-                   IREE_HAL_BUFFER_USAGE_MAPPING,
+          .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+          .usage =
+              IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER,
       },
       iree_make_const_byte_span(kFloat4, sizeof(kFloat4)), &arg0_buffer_view));
   IREE_RETURN_IF_ERROR(iree_hal_buffer_view_allocate_buffer(
       iree_hal_device_allocator(device), shape, IREE_ARRAYSIZE(shape),
       IREE_HAL_ELEMENT_TYPE_FLOAT_32, IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
       (iree_hal_buffer_params_t){
-          .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
-                  IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
-          .usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
-                   IREE_HAL_BUFFER_USAGE_TRANSFER |
-                   IREE_HAL_BUFFER_USAGE_MAPPING,
+          .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+          .usage =
+              IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER,
       },
       iree_make_const_byte_span(kFloat2, sizeof(kFloat2)), &arg1_buffer_view));
 

--- a/iree/samples/static_library/static_library_demo.c
+++ b/iree/samples/static_library/static_library_demo.c
@@ -124,9 +124,9 @@ iree_status_t Run() {
         iree_hal_device_allocator(device), shape, IREE_ARRAYSIZE(shape),
         IREE_HAL_ELEMENT_TYPE_FLOAT_32, IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
-            .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
-                    IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-            .usage = IREE_HAL_BUFFER_USAGE_ALL,
+            .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+            .usage =
+                IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER,
         },
         iree_make_const_byte_span((void*)kFloat4,
                                   sizeof(float) * kElementCount),
@@ -137,9 +137,9 @@ iree_status_t Run() {
         iree_hal_device_allocator(device), shape, IREE_ARRAYSIZE(shape),
         IREE_HAL_ELEMENT_TYPE_FLOAT_32, IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
-            .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
-                    IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-            .usage = IREE_HAL_BUFFER_USAGE_ALL,
+            .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+            .usage =
+                IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER,
         },
         iree_make_const_byte_span((void*)kFloat2,
                                   sizeof(float) * kElementCount),

--- a/iree/samples/variables_and_state/main.c
+++ b/iree/samples/variables_and_state/main.c
@@ -52,9 +52,9 @@ iree_status_t counter_set_value(iree_runtime_session_t* session,
         /*shape_rank=*/0, IREE_HAL_ELEMENT_TYPE_SINT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
-            .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
-                    IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-            .usage = IREE_HAL_BUFFER_USAGE_ALL,
+            .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+            .usage =
+                IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER,
         },
         iree_make_const_byte_span((void*)arg0_data, sizeof(arg0_data)), &arg0);
   }
@@ -85,9 +85,9 @@ iree_status_t counter_add_to_value(iree_runtime_session_t* session, int x) {
         /*shape_rank=*/0, IREE_HAL_ELEMENT_TYPE_SINT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
-            .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
-                    IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-            .usage = IREE_HAL_BUFFER_USAGE_ALL,
+            .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+            .usage =
+                IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER,
         },
         iree_make_const_byte_span((void*)arg0_data, sizeof(arg0_data)), &arg0);
   }

--- a/iree/samples/vulkan/vulkan_inference_gui.cc
+++ b/iree/samples/vulkan/vulkan_inference_gui.cc
@@ -361,7 +361,9 @@ extern "C" int iree_main(int argc, char** argv) {
                 IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE);
         iree_hal_buffer_usage_t input_buffer_usage =
             static_cast<iree_hal_buffer_usage_t>(
-                IREE_HAL_BUFFER_USAGE_ALL | IREE_HAL_BUFFER_USAGE_CONSTANT);
+                IREE_HAL_BUFFER_USAGE_DISPATCH |
+                IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_MAPPING |
+                IREE_HAL_BUFFER_USAGE_CONSTANT);
         iree_hal_buffer_params_t buffer_params;
         buffer_params.type = input_memory_type;
         buffer_params.usage = input_buffer_usage;

--- a/iree/tools/iree-e2e-matmul-test.c
+++ b/iree/tools/iree-e2e-matmul-test.c
@@ -517,7 +517,9 @@ static iree_status_t allocate_buffer_like(iree_hal_allocator_t* hal_allocator,
       (iree_hal_buffer_params_t){
           .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
                   IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-          .usage = IREE_HAL_BUFFER_USAGE_ALL,
+          .usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
+                   IREE_HAL_BUFFER_USAGE_TRANSFER |
+                   IREE_HAL_BUFFER_USAGE_MAPPING,
       },
       iree_const_byte_span_empty(), dst);
 }
@@ -543,7 +545,9 @@ static iree_status_t copy_buffer(iree_hal_allocator_t* hal_allocator,
       (iree_hal_buffer_params_t){
           .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
                   IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-          .usage = IREE_HAL_BUFFER_USAGE_ALL,
+          .usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
+                   IREE_HAL_BUFFER_USAGE_TRANSFER |
+                   IREE_HAL_BUFFER_USAGE_MAPPING,
       },
       src_span, dst);
 }

--- a/iree/tools/utils/image_util.c
+++ b/iree/tools/utils/image_util.c
@@ -139,10 +139,10 @@ iree_status_t iree_tools_utils_buffer_view_from_image(
         allocator, shape, shape_rank, element_type,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
-            .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
-                    IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+            .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
             .access = IREE_HAL_MEMORY_ACCESS_READ,
-            .usage = IREE_HAL_BUFFER_USAGE_ALL,
+            .usage =
+                IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER,
         },
         iree_make_const_byte_span(pixel_data, element_byte * buffer_length),
         out_buffer_view);

--- a/iree/tools/utils/trace_replay.c
+++ b/iree/tools/utils/trace_replay.c
@@ -713,9 +713,9 @@ static iree_status_t iree_trace_replay_parse_hal_buffer(
   IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
       iree_hal_device_allocator(replay->device),
       (iree_hal_buffer_params_t){
-          .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
-                  IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
-          .usage = IREE_HAL_BUFFER_USAGE_ALL,
+          .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+          .usage =
+              IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER,
       },
       allocation_size, iree_const_byte_span_empty(), &buffer));
 
@@ -792,11 +792,9 @@ static iree_status_t iree_trace_replay_parse_hal_buffer_view(
         iree_hal_device_allocator(replay->device), shape, shape_rank,
         element_type, encoding_type,
         (iree_hal_buffer_params_t){
-            .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
-                    IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
-            .usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
-                     IREE_HAL_BUFFER_USAGE_TRANSFER |
-                     IREE_HAL_BUFFER_USAGE_MAPPING,
+            .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+            .usage =
+                IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER,
         },
         iree_trace_replay_generate_hal_buffer_callback, &params, &buffer_view));
   } else {
@@ -804,11 +802,9 @@ static iree_status_t iree_trace_replay_parse_hal_buffer_view(
         iree_hal_device_allocator(replay->device), shape, shape_rank,
         element_type, encoding_type,
         (iree_hal_buffer_params_t){
-            .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
-                    IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
-            .usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
-                     IREE_HAL_BUFFER_USAGE_TRANSFER |
-                     IREE_HAL_BUFFER_USAGE_MAPPING,
+            .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+            .usage =
+                IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER,
         },
         iree_const_byte_span_empty(), &buffer_view));
   }


### PR DESCRIPTION
Future changes will remove the requirement that backends support concurrent host and device visibility and will be easier to enforce if we don't have a bunch of places asking for it when they don't need it.

The python side needs work still - it's assuming mappable memory is always available.