### PR TITLE
Use official github.ref_name to refer to the current branch in builds

### DIFF
--- a/.github/workflows/oneshot_candidate_release.yml
+++ b/.github/workflows/oneshot_candidate_release.yml
@@ -29,7 +29,7 @@ jobs:
         uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
-          branch: ${{ env.ref }}
+          branch: ${{ github.ref_name }}
           tags: true
 
       - name: Create Release

--- a/.github/workflows/schedule_candidate_release.yml
+++ b/.github/workflows/schedule_candidate_release.yml
@@ -34,7 +34,7 @@ jobs:
         uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
-          branch: ${{ env.ref }}
+          branch: ${{ github.ref_name }}
           tags: true
 
       - name: Create Release


### PR DESCRIPTION
Use the official env var ${{ github.ref_name }} referencing the current branch.
https://docs.github.com/en/actions/learn-github-actions/contexts#github-context

Tested on a local branch: https://github.com/NodLabs/SHARK/actions/runs/2097947669 