### PR TITLE
Fixes configurations for matvec and dot. 

### DIFF
--- a/iree/test/e2e/cpu_specific/BUILD
+++ b/iree/test/e2e/cpu_specific/BUILD
@@ -7,6 +7,7 @@
 # Tests for end-to-end IREE support specific to the CUDA backend to be able to
 # incrementally enable features.
 
+load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 load("//build_tools/bazel:iree_check_test.bzl", "iree_check_single_backend_test_suite")
 
 package(
@@ -17,9 +18,14 @@ package(
 
 iree_check_single_backend_test_suite(
     name = "check_dylib-llvm-aot_dylib",
-    srcs = [
-        "dot_exp.mlir",
-    ],
+    srcs = enforce_glob(
+        # keep sorted
+        [
+            "dot_exp.mlir",
+            "tests.mlir",
+        ],
+        include = ["*.mlir"],
+    ),
     compiler_flags = [
         "-iree-input-type=mhlo",
     ],

--- a/iree/test/e2e/cpu_specific/CMakeLists.txt
+++ b/iree/test/e2e/cpu_specific/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_check_single_backend_test_suite(
     check_dylib-llvm-aot_dylib
   SRCS
     "dot_exp.mlir"
+    "tests.mlir"
   TARGET_BACKEND
     "dylib-llvm-aot"
   DRIVER

--- a/iree/test/e2e/cpu_specific/tests.mlir
+++ b/iree/test/e2e/cpu_specific/tests.mlir
@@ -1,0 +1,8 @@
+// TODO(#8782): Delete the test.
+func.func @matvec() {
+  %lhs = util.unfoldable_constant dense<1.0> : tensor<250x1024xf32>
+  %rhs = util.unfoldable_constant dense<0.5> : tensor<1024xf32>
+  %res = "mhlo.dot"(%lhs, %rhs) : (tensor<250x1024xf32>, tensor<1024xf32>) -> tensor<250xf32>
+  check.expect_almost_eq_const(%res, dense<512.0> : tensor<250xf32>) : tensor<250xf32>
+  return
+}

--- a/iree/test/e2e/xla_ops/dot.mlir
+++ b/iree/test/e2e/xla_ops/dot.mlir
@@ -50,3 +50,19 @@ func.func @large() {
   check.expect_almost_eq_const(%res, dense<409.596> : tensor<250x500xf32>) : tensor<250x500xf32>
   return
 }
+
+func.func @matvec() {
+  %lhs = util.unfoldable_constant dense<1.0> : tensor<250x1024xf32>
+  %rhs = util.unfoldable_constant dense<0.5> : tensor<1024xf32>
+  %res = "mhlo.dot"(%lhs, %rhs) : (tensor<250x1024xf32>, tensor<1024xf32>) -> tensor<250xf32>
+  check.expect_almost_eq_const(%res, dense<512.0> : tensor<250xf32>) : tensor<250xf32>
+  return
+}
+
+func.func @dot() {
+  %lhs = util.unfoldable_constant dense<1.0> : tensor<1024xf32>
+  %rhs = util.unfoldable_constant dense<0.5> : tensor<1024xf32>
+  %res = "mhlo.dot"(%lhs, %rhs) : (tensor<1024xf32>, tensor<1024xf32>) -> tensor<f32>
+  check.expect_almost_eq_const(%res, dense<512.0> : tensor<f32>) : tensor<f32>
+  return
+}

--- a/iree/test/e2e/xla_ops/dot.mlir
+++ b/iree/test/e2e/xla_ops/dot.mlir
@@ -51,13 +51,14 @@ func.func @large() {
   return
 }
 
-func.func @matvec() {
-  %lhs = util.unfoldable_constant dense<1.0> : tensor<250x1024xf32>
-  %rhs = util.unfoldable_constant dense<0.5> : tensor<1024xf32>
-  %res = "mhlo.dot"(%lhs, %rhs) : (tensor<250x1024xf32>, tensor<1024xf32>) -> tensor<250xf32>
-  check.expect_almost_eq_const(%res, dense<512.0> : tensor<250xf32>) : tensor<250xf32>
-  return
-}
+// TODO(#8782): Enable the test.
+// func.func @matvec() {
+//   %lhs = util.unfoldable_constant dense<1.0> : tensor<250x1024xf32>
+//   %rhs = util.unfoldable_constant dense<0.5> : tensor<1024xf32>
+//   %res = "mhlo.dot"(%lhs, %rhs) : (tensor<250x1024xf32>, tensor<1024xf32>) -> tensor<250xf32>
+//   check.expect_almost_eq_const(%res, dense<512.0> : tensor<250xf32>) : tensor<250xf32>
+//   return
+// }
 
 func.func @dot() {
   %lhs = util.unfoldable_constant dense<1.0> : tensor<1024xf32>


### PR DESCRIPTION
In the past, we only considered contraction ops that have at least
three loops. The PR accounts matvec and dot cases.

For now, set the limit to having a single reduction loop and it's
expected to be the innermost loop. This condition can be relaxed if
there are needs.

Fixes https://github.com/google/iree/issues/8713