### PR TITLE
Remove default assignee for issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,6 @@ name: Bug report
 about: Create a report to help us improve
 title: ''
 labels: "bug \U0001F41E, help wanted"
-assignees: GMNGeoffrey
 
 ---
 


### PR DESCRIPTION
I'm going on vacation, so this system for making sure issues don't get
lost will not continue working. Issues have mostly been taken care of
without intervention from me, so I'm not sure how much this was helping
anyway.