### PR TITLE
Disabling CUDA e2e matmul tests pending #8784.

### DIFF
--- a/iree/test/e2e/matmul/BUILD
+++ b/iree/test/e2e/matmul/BUILD
@@ -115,57 +115,59 @@ py_binary(
     "small",
 ]]
 
-[iree_generated_trace_runner_test(
-    name = "e2e_matmul_direct_f32_gpu_large_%s" % compilation_info,
-    generator = ":generate_e2e_matmul_tests",
-    generator_args = [
-        "--lhs_rhs_type=f32",
-        "--shapes=gpu_large",
-        "--compilation_info=%s" % compilation_info,
-    ],
-    tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
-        "requires-gpu-nvidia",
-    ],
-    target_backends_and_drivers = [
-        ("cuda", "cuda"),
-    ],
-    trace_runner = "//iree/tools:iree-e2e-matmul-test",
-) for compilation_info in [
-    "LLVMGPUMatmulSimt",
-]]
+# TODO(8784): enable when the runner does not require managed memory.
+# [iree_generated_trace_runner_test(
+#     name = "e2e_matmul_direct_f32_gpu_large_%s" % compilation_info,
+#     generator = ":generate_e2e_matmul_tests",
+#     generator_args = [
+#         "--lhs_rhs_type=f32",
+#         "--shapes=gpu_large",
+#         "--compilation_info=%s" % compilation_info,
+#     ],
+#     tags = [
+#         # CUDA cuInit fails with sanitizer on.
+#         "noasan",
+#         "nomsan",
+#         "notsan",
+#         "noubsan",
+#         "requires-gpu-nvidia",
+#     ],
+#     target_backends_and_drivers = [
+#         ("cuda", "cuda"),
+#     ],
+#     trace_runner = "//iree/tools:iree-e2e-matmul-test",
+# ) for compilation_info in [
+#     "LLVMGPUMatmulSimt",
+# ]]
 
-# Testing Ampere+ tensorcore path.
-[iree_generated_trace_runner_test(
-    name = "e2e_matmul_direct_f32_gpu_large_%s" % compilation_info,
-    compiler_flags = [
-        "--iree-cuda-llvm-target-arch=sm_80",
-    ],
-    generator = ":generate_e2e_matmul_tests",
-    generator_args = [
-        "--lhs_rhs_type=f32",
-        "--shapes=gpu_large",
-        "--compilation_info=%s" % compilation_info,
-    ],
-    tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
-        "requires-gpu-nvidia",
-    ],
-    target_backends_and_drivers = [
-        ("cuda", "cuda"),
-    ],
-    trace_runner = "//iree/tools:iree-e2e-matmul-test",
-) for compilation_info in [
-    "LLVMGPUMatmulTensorCore",
-]]
+# TODO(8784): enable when the runner does not require managed memory.
+# # Testing Ampere+ tensorcore path.
+# [iree_generated_trace_runner_test(
+#     name = "e2e_matmul_direct_f32_gpu_large_%s" % compilation_info,
+#     compiler_flags = [
+#         "--iree-cuda-llvm-target-arch=sm_80",
+#     ],
+#     generator = ":generate_e2e_matmul_tests",
+#     generator_args = [
+#         "--lhs_rhs_type=f32",
+#         "--shapes=gpu_large",
+#         "--compilation_info=%s" % compilation_info,
+#     ],
+#     tags = [
+#         # CUDA cuInit fails with sanitizer on.
+#         "noasan",
+#         "nomsan",
+#         "notsan",
+#         "noubsan",
+#         "requires-gpu-nvidia",
+#     ],
+#     target_backends_and_drivers = [
+#         ("cuda", "cuda"),
+#     ],
+#     trace_runner = "//iree/tools:iree-e2e-matmul-test",
+# ) for compilation_info in [
+#     "LLVMGPUMatmulTensorCore",
+# ]]
 
 [iree_generated_trace_runner_test(
     name = "e2e_matmul_direct_%s_large_split_k" % lhs_rhs_type,
@@ -186,7 +188,8 @@ py_binary(
         "requires-gpu-nvidia",
     ],
     target_backends_and_drivers = [
-        ("cuda", "cuda"),
+        # TODO(8784): enable when the runner does not require managed memory.
+        # ("cuda", "cuda"),
         ("dylib-llvm-aot", "dylib"),
     ],
     trace_runner = "//iree/tools:iree-e2e-matmul-test",

--- a/iree/test/e2e/matmul/CMakeLists.txt
+++ b/iree/test/e2e/matmul/CMakeLists.txt
@@ -176,54 +176,6 @@ iree_generated_trace_runner_test(
 
 iree_generated_trace_runner_test(
   NAME
-    e2e_matmul_direct_f32_gpu_large_LLVMGPUMatmulSimt
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f32"
-    "--shapes=gpu_large"
-    "--compilation_info=LLVMGPUMatmulSimt"
-  TRACE_RUNNER
-    iree_tools_iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "cuda"
-  DRIVERS
-    "cuda"
-  LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
-    "requires-gpu-nvidia"
-)
-
-iree_generated_trace_runner_test(
-  NAME
-    e2e_matmul_direct_f32_gpu_large_LLVMGPUMatmulTensorCore
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f32"
-    "--shapes=gpu_large"
-    "--compilation_info=LLVMGPUMatmulTensorCore"
-  TRACE_RUNNER
-    iree_tools_iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "cuda"
-  DRIVERS
-    "cuda"
-  COMPILER_FLAGS
-    "--iree-cuda-llvm-target-arch=sm_80"
-  LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
-    "requires-gpu-nvidia"
-)
-
-iree_generated_trace_runner_test(
-  NAME
     e2e_matmul_direct_f32_large_split_k
   GENERATOR
     "generate_e2e_matmul_tests.py"
@@ -233,10 +185,8 @@ iree_generated_trace_runner_test(
   TRACE_RUNNER
     iree_tools_iree-e2e-matmul-test
   TARGET_BACKENDS
-    "cuda"
     "dylib-llvm-aot"
   DRIVERS
-    "cuda"
     "dylib"
   COMPILER_FLAGS
     "-iree-flow-split-matmul-reduction=4"


### PR DESCRIPTION
The test currently requires mappable memory and that's not guaranteed.