### PR TITLE
[NFC] Apply some cleanups to HAL::EntryPointOp

### DIFF
--- a/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -25,9 +25,7 @@
 namespace mlir {
 namespace iree_compiler {
 
-namespace {
-
-}  // namespace
+namespace {}  // namespace
 
 LogicalResult defineWorkgroupCountRegion(
     OpBuilder &builder, func::FuncOp funcOp,
@@ -45,7 +43,7 @@ LogicalResult defineWorkgroupCountRegion(
   auto clonedOp = builder.create<IREE::HAL::ExecutableEntryPointOp>(
       loc, entryPointOp.sym_nameAttr(), entryPointOp.ordinalAttr(),
       entryPointOp.layoutAttr(), entryPointOp.workgroup_sizeAttr(),
-      entryPointOp.workgroup_local_memoryAttr(), 1);
+      entryPointOp.workgroup_local_memoryAttr());
   // Copy over all attributes
   for (auto attr : entryPointOp->getAttrs()) {
     if (attr.getName() != entryPointOp.sym_nameAttrName() &&
@@ -56,10 +54,12 @@ LogicalResult defineWorkgroupCountRegion(
       clonedOp->setAttr(attr.getName(), attr.getValue());
     }
   }
-  Region *region = clonedOp.getBody();
-  Block *entryBlock = builder.createBlock(region);
+  Region &region = clonedOp.workgroup_count_region();
+  Block *entryBlock = builder.createBlock(&region);
   // Add 3 index arguments for the workload.
   auto indexType = builder.getIndexType();
+  assert(IREE::HAL::ExecutableEntryPointOp::getNumWorkgroupDims() == 3 &&
+         "expected 3 dims");
   std::array<Value, 3> workload = {entryBlock->addArgument(indexType, loc),
                                    entryBlock->addArgument(indexType, loc),
                                    entryBlock->addArgument(indexType, loc)};

--- a/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/ConvertStreamToHAL.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/ConvertStreamToHAL.cpp
@@ -781,8 +781,8 @@ struct CmdDispatchOpPattern
       Location loc, IREE::HAL::ExecutableOp executableOp,
       IREE::HAL::ExecutableEntryPointOp entryPointOp, ValueRange workload,
       OpBuilder &builder) {
-    Region *region = entryPointOp.getBody();
-    if (region) {
+    Block *body = entryPointOp.getWorkgroupCountBody();
+    if (body) {
       return calculateDispatchWorkgroupCountFromRegion(loc, entryPointOp,
                                                        workload, builder);
     }
@@ -811,7 +811,7 @@ struct CmdDispatchOpPattern
       Location loc, IREE::HAL::ExecutableEntryPointOp entryPointOp,
       ValueRange workload, OpBuilder &builder) {
     // TODO(benvanik): replace with region inlining util.
-    Block *body = entryPointOp.getBlock();
+    Block *body = entryPointOp.getWorkgroupCountBody();
     BlockAndValueMapping bvm;
     for (auto args : llvm::enumerate(workload)) {
       bvm.map(body->getArgument(args.index()), args.value());

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -1521,10 +1521,10 @@ def HAL_ExecutableEntryPointOp : HAL_Op<"executable.entry_point", [
     An entry point exported by the executable with statically-available
     information describing the IO interface it uses and other dispatch metadata.
 
-    The optional `workgroup_count_region` region represents the
-    computation that returns the number of workgroups to use. The
-    arguments to the region represents the workload along x, y and
-    z. It returns the number of workgroups along x, y, and z.
+    The `workgroup_count_region` region represents the computation that returns
+    the number of workgroups to use.
+    The arguments to the region represents the workload along x, y and z.
+    It returns the number of workgroups along x, y, and z.
 
     TODO(ravishankarm): In reality there is no need to define what the
     arguments represent. They could be any values that are needed to
@@ -1542,7 +1542,7 @@ def HAL_ExecutableEntryPointOp : HAL_Op<"executable.entry_point", [
     OptionalAttr<IndexAttr>:$workgroup_local_memory
   );
 
-  let regions = (region VariadicRegion<SizedRegion<1>>:$workgroup_count_region);
+  let regions = (region AnyRegion:$workgroup_count_region);
 
   let builders = [
     OpBuilder<(ins
@@ -1553,32 +1553,21 @@ def HAL_ExecutableEntryPointOp : HAL_Op<"executable.entry_point", [
       "::mlir::IntegerAttr":$workgroup_local_memory
     ), [{
       build($_builder, $_state, nullptr, sym_name, ordinal, layout,
-            workgroup_size, workgroup_local_memory, 0);
+            workgroup_size, workgroup_local_memory);
     }]>,
-    OpBuilder<(ins
-      "::mlir::StringAttr":$sym_name,
-      "::mlir::IntegerAttr":$ordinal,
-      "IREE::HAL::ExecutableLayoutAttr":$layout,
-      "::mlir::ArrayAttr":$workgroup_size,
-      "::mlir::IntegerAttr":$workgroup_local_memory,
-      "int":$workgroup_count_regionCount
-    ), [{
-      build($_builder, $_state, nullptr, sym_name, ordinal, layout,
-            workgroup_size, workgroup_local_memory, workgroup_count_regionCount);
-    }]>
   ];
 
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    Region *getBody() {
-      auto regions = workgroup_count_region();
-      if (!regions.empty()) return &regions.front();
-      return nullptr;
-    }
-    Block* getBlock() {
-      if (Region *region = getBody()) return &region->front();
-      return nullptr;
+    /// For now assume that the workload is at max 3D.
+    /// Arguments to the region are workload along x, y and z.
+    // TODO: Propogate this and avoid magic constants.
+    static int64_t getNumWorkgroupDims() { return 3; }
+
+    Block* getWorkgroupCountBody() {
+      if (workgroup_count_region().empty()) return nullptr;
+      return &workgroup_count_region().front();
     }
   }];
 }


### PR DESCRIPTION
In particular, the usage of variadic regions seems unnecessary.
In the future when we want multiple regions, we can add them with a specific name.

This simplifies the code around region/block logic, as well as builders.