### PR TITLE
Adding a comment and print to iree-benchmark-module.

### DIFF
--- a/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -43,9 +43,8 @@ static llvm::cl::opt<unsigned> benchmarkDispatchRepeatCount{
     "iree-hal-benchmark-dispatch-repeat-count",
     llvm::cl::desc(
         "The number of times to repeat each hal.command_buffer.dispatch op. "
-        "(Not that this simply duplicates the dispatch op and inserts "
-        "barriers. It's meant for command buffers having linear dispatch "
-        "structures.)"),
+        "This simply duplicates the dispatch op and inserts barriers. It's "
+        "meant for command buffers having linear dispatch structures."),
     llvm::cl::init(1)};
 
 }  // namespace


### PR DESCRIPTION
IREE is not a BLAS library, and iree-benchmark-module is not the same as a BLAS library microbenchmark.