### PR TITLE
Fix memory handling problem in matmul_test and renable cuda tests

### DIFF
--- a/iree/test/e2e/matmul/BUILD
+++ b/iree/test/e2e/matmul/BUILD
@@ -115,59 +115,57 @@ py_binary(
     "small",
 ]]
 
-# TODO(8784): enable when the runner does not require managed memory.
-# [iree_generated_trace_runner_test(
-#     name = "e2e_matmul_direct_f32_gpu_large_%s" % compilation_info,
-#     generator = ":generate_e2e_matmul_tests",
-#     generator_args = [
-#         "--lhs_rhs_type=f32",
-#         "--shapes=gpu_large",
-#         "--compilation_info=%s" % compilation_info,
-#     ],
-#     tags = [
-#         # CUDA cuInit fails with sanitizer on.
-#         "noasan",
-#         "nomsan",
-#         "notsan",
-#         "noubsan",
-#         "requires-gpu-nvidia",
-#     ],
-#     target_backends_and_drivers = [
-#         ("cuda", "cuda"),
-#     ],
-#     trace_runner = "//iree/tools:iree-e2e-matmul-test",
-# ) for compilation_info in [
-#     "LLVMGPUMatmulSimt",
-# ]]
+[iree_generated_trace_runner_test(
+    name = "e2e_matmul_direct_f32_gpu_large_%s" % compilation_info,
+    generator = ":generate_e2e_matmul_tests",
+    generator_args = [
+        "--lhs_rhs_type=f32",
+        "--shapes=gpu_large",
+        "--compilation_info=%s" % compilation_info,
+    ],
+    tags = [
+        # CUDA cuInit fails with sanitizer on.
+        "noasan",
+        "nomsan",
+        "notsan",
+        "noubsan",
+        "requires-gpu-nvidia",
+    ],
+    target_backends_and_drivers = [
+        ("cuda", "cuda"),
+    ],
+    trace_runner = "//iree/tools:iree-e2e-matmul-test",
+) for compilation_info in [
+    "LLVMGPUMatmulSimt",
+]]
 
-# TODO(8784): enable when the runner does not require managed memory.
-# # Testing Ampere+ tensorcore path.
-# [iree_generated_trace_runner_test(
-#     name = "e2e_matmul_direct_f32_gpu_large_%s" % compilation_info,
-#     compiler_flags = [
-#         "--iree-cuda-llvm-target-arch=sm_80",
-#     ],
-#     generator = ":generate_e2e_matmul_tests",
-#     generator_args = [
-#         "--lhs_rhs_type=f32",
-#         "--shapes=gpu_large",
-#         "--compilation_info=%s" % compilation_info,
-#     ],
-#     tags = [
-#         # CUDA cuInit fails with sanitizer on.
-#         "noasan",
-#         "nomsan",
-#         "notsan",
-#         "noubsan",
-#         "requires-gpu-nvidia",
-#     ],
-#     target_backends_and_drivers = [
-#         ("cuda", "cuda"),
-#     ],
-#     trace_runner = "//iree/tools:iree-e2e-matmul-test",
-# ) for compilation_info in [
-#     "LLVMGPUMatmulTensorCore",
-# ]]
+# Testing Ampere+ tensorcore path.
+[iree_generated_trace_runner_test(
+    name = "e2e_matmul_direct_f32_gpu_large_%s" % compilation_info,
+    compiler_flags = [
+        "--iree-cuda-llvm-target-arch=sm_80",
+    ],
+    generator = ":generate_e2e_matmul_tests",
+    generator_args = [
+        "--lhs_rhs_type=f32",
+        "--shapes=gpu_large",
+        "--compilation_info=%s" % compilation_info,
+    ],
+    tags = [
+        # CUDA cuInit fails with sanitizer on.
+        "noasan",
+        "nomsan",
+        "notsan",
+        "noubsan",
+        "requires-gpu-nvidia",
+    ],
+    target_backends_and_drivers = [
+        ("cuda", "cuda"),
+    ],
+    trace_runner = "//iree/tools:iree-e2e-matmul-test",
+) for compilation_info in [
+    "LLVMGPUMatmulTensorCore",
+]]
 
 [iree_generated_trace_runner_test(
     name = "e2e_matmul_direct_%s_large_split_k" % lhs_rhs_type,
@@ -188,8 +186,7 @@ py_binary(
         "requires-gpu-nvidia",
     ],
     target_backends_and_drivers = [
-        # TODO(8784): enable when the runner does not require managed memory.
-        # ("cuda", "cuda"),
+        ("cuda", "cuda"),
         ("dylib-llvm-aot", "dylib"),
     ],
     trace_runner = "//iree/tools:iree-e2e-matmul-test",

--- a/iree/test/e2e/matmul/CMakeLists.txt
+++ b/iree/test/e2e/matmul/CMakeLists.txt
@@ -176,6 +176,54 @@ iree_generated_trace_runner_test(
 
 iree_generated_trace_runner_test(
   NAME
+    e2e_matmul_direct_f32_gpu_large_LLVMGPUMatmulSimt
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--shapes=gpu_large"
+    "--compilation_info=LLVMGPUMatmulSimt"
+  TRACE_RUNNER
+    iree_tools_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "cuda"
+  DRIVERS
+    "cuda"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-nvidia"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_direct_f32_gpu_large_LLVMGPUMatmulTensorCore
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--shapes=gpu_large"
+    "--compilation_info=LLVMGPUMatmulTensorCore"
+  TRACE_RUNNER
+    iree_tools_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "cuda"
+  DRIVERS
+    "cuda"
+  COMPILER_FLAGS
+    "--iree-cuda-llvm-target-arch=sm_80"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-nvidia"
+)
+
+iree_generated_trace_runner_test(
+  NAME
     e2e_matmul_direct_f32_large_split_k
   GENERATOR
     "generate_e2e_matmul_tests.py"
@@ -185,8 +233,10 @@ iree_generated_trace_runner_test(
   TRACE_RUNNER
     iree_tools_iree-e2e-matmul-test
   TARGET_BACKENDS
+    "cuda"
     "dylib-llvm-aot"
   DRIVERS
+    "cuda"
     "dylib"
   COMPILER_FLAGS
     "-iree-flow-split-matmul-reduction=4"

--- a/iree/tools/iree-e2e-matmul-test.c
+++ b/iree/tools/iree-e2e-matmul-test.c
@@ -515,29 +515,20 @@ static iree_status_t allocate_buffer_like(iree_hal_allocator_t* hal_allocator,
       iree_hal_buffer_view_element_type(src),
       iree_hal_buffer_view_encoding_type(src),
       (iree_hal_buffer_params_t){
-          .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
-                  IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-          .usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
-                   IREE_HAL_BUFFER_USAGE_TRANSFER |
-                   IREE_HAL_BUFFER_USAGE_MAPPING,
+          .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL,
+          .usage =
+              IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_MAPPING,
       },
       iree_const_byte_span_empty(), dst);
 }
 
-// Performs a deep copy of |src| into |dst|. Takes care of allocating |dst|.
-static iree_status_t copy_buffer(iree_hal_allocator_t* hal_allocator,
-                                 iree_hal_buffer_view_t* src,
-                                 iree_hal_buffer_view_t** dst) {
-  // TODO(benvanik): change this to use iree_hal_buffer_map_copy. Or
-  // something. I can't understand what all this code is doing.
-  iree_hal_buffer_mapping_t src_mapping = {{0}};
-  IREE_RETURN_IF_ERROR(iree_hal_buffer_map_range(
-      iree_hal_buffer_view_buffer(src), IREE_HAL_MAPPING_MODE_PERSISTENT,
-      IREE_HAL_MEMORY_ACCESS_READ, 0, IREE_WHOLE_BUFFER, &src_mapping));
-  iree_const_byte_span_t src_span;
-  src_span.data = src_mapping.contents.data;
-  src_span.data_length = src_mapping.contents.data_length;
-  return iree_hal_buffer_view_allocate_buffer(
+// Performs a deep copy of |src| into a host local |dst| buffer. Takes care of
+// allocating |dst|.
+static iree_status_t clone_buffer(iree_hal_device_t* device,
+                                  iree_hal_allocator_t* hal_allocator,
+                                  iree_hal_buffer_view_t* src,
+                                  iree_hal_buffer_view_t** dst) {
+  iree_status_t status = iree_hal_buffer_view_allocate_buffer(
       hal_allocator, iree_hal_buffer_view_shape_dims(src),
       iree_hal_buffer_view_shape_rank(src),
       iree_hal_buffer_view_element_type(src),
@@ -545,16 +536,25 @@ static iree_status_t copy_buffer(iree_hal_allocator_t* hal_allocator,
       (iree_hal_buffer_params_t){
           .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
                   IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-          .usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
-                   IREE_HAL_BUFFER_USAGE_TRANSFER |
-                   IREE_HAL_BUFFER_USAGE_MAPPING,
+          .usage =
+              IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_MAPPING,
       },
-      src_span, dst);
+      iree_const_byte_span_empty(), dst);
+  if (iree_status_is_ok(status)) {
+    // TODO: move to using d2h version after refactoring the code to not use
+    // `iree_hal_buffer_view_t` for host buffers.
+    status = iree_hal_device_transfer_d2d(
+        device, iree_hal_buffer_view_buffer(src), 0,
+        iree_hal_buffer_view_buffer(*dst), 0,
+        iree_hal_buffer_view_byte_length(src),
+        IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT, iree_infinite_timeout());
+  }
+  return status;
 }
 
 static iree_status_t copy_list_of_buffer_views(
-    iree_hal_allocator_t* hal_allocator, iree_vm_list_t* src,
-    iree_vm_list_t** dst) {
+    iree_hal_device_t* device, iree_hal_allocator_t* hal_allocator,
+    iree_vm_list_t* src, iree_vm_list_t** dst) {
   iree_vm_type_def_t elem_type;
   IREE_RETURN_IF_ERROR(iree_vm_list_element_type(src, &elem_type));
   iree_host_size_t size = iree_vm_list_size(src);
@@ -565,7 +565,8 @@ static iree_status_t copy_list_of_buffer_views(
     iree_hal_buffer_view_t* src_elem;
     IREE_RETURN_IF_ERROR(iree_get_buffer_view_list_item(src, i, &src_elem));
     iree_hal_buffer_view_t* dst_elem;
-    IREE_RETURN_IF_ERROR(copy_buffer(hal_allocator, src_elem, &dst_elem));
+    IREE_RETURN_IF_ERROR(
+        clone_buffer(device, hal_allocator, src_elem, &dst_elem));
     iree_vm_ref_t dst_elem_ref = {0};
     IREE_RETURN_IF_ERROR(iree_vm_ref_wrap_assign(
         dst_elem, iree_hal_buffer_view_type_id(), &dst_elem_ref));
@@ -643,14 +644,15 @@ static iree_status_t replay_event_call(iree_trace_replay_t* replay,
   IREE_RETURN_IF_ERROR(iree_trace_replay_event_call_prepare(
       replay, document, event_node, &function, &input_list));
 
-  // Perform a deep copy of the input list to pass to the test function.
+  // Perform a deep copy of the input list into a host local buffer
+  // and keep it for verification.
   // Rationale: the test function may mutate some of the input list elements,
   // e.g. input-output parameters. For instance, the accumulator input of a
   // linalg.matmul. We need to preserve the original test inputs to run the
   // reference matmul on and to use in test failure logs.
-  iree_vm_list_t* copy_of_input_list = NULL;
-  IREE_CHECK_OK(copy_list_of_buffer_views(device_allocator, input_list,
-                                          &copy_of_input_list));
+  iree_vm_list_t* host_copy_of_input_list = NULL;
+  IREE_CHECK_OK(copy_list_of_buffer_views(
+      replay->device, device_allocator, input_list, &host_copy_of_input_list));
 
   // Invoke the function to produce the actual result.
   iree_vm_list_t* output_list = NULL;
@@ -659,12 +661,17 @@ static iree_status_t replay_event_call(iree_trace_replay_t* replay,
                                     replay->host_allocator, &output_list));
   IREE_CHECK_OK(iree_vm_invoke(
       replay->context, function, IREE_VM_INVOCATION_FLAG_NONE, /*policy=*/NULL,
-      copy_of_input_list, output_list, replay->host_allocator));
+      input_list, output_list, replay->host_allocator));
 
   // Get the actual_result buffer from the output_list.
   iree_hal_buffer_view_t* actual_result;
   IREE_RETURN_IF_ERROR(
       iree_get_buffer_view_list_item(output_list, 0, &actual_result));
+
+  // Copy the results to a host local buffer to be able to map it.
+  iree_hal_buffer_view_t* host_copy_actual_result = NULL;
+  clone_buffer(replay->device, device_allocator, actual_result,
+               &host_copy_actual_result);
 
   // Allocate an expected_result buffer, with same shape as actual_result.
   iree_hal_buffer_view_t* expected_result;
@@ -672,16 +679,19 @@ static iree_status_t replay_event_call(iree_trace_replay_t* replay,
       allocate_buffer_like(device_allocator, actual_result, &expected_result));
 
   // Use the reference matmul implementation to fill expected_result
-  IREE_RETURN_IF_ERROR(reference_matmul(input_list, expected_result));
+  IREE_RETURN_IF_ERROR(
+      reference_matmul(host_copy_of_input_list, expected_result));
 
   // Check that actual_result and expected_result agree.
-  IREE_CHECK_OK(iree_check_matmul(input_list, actual_result, expected_result));
+  IREE_CHECK_OK(iree_check_matmul(host_copy_of_input_list,
+                                  host_copy_actual_result, expected_result));
 
   // Clean up.
   iree_vm_list_release(input_list);
-  iree_vm_list_release(copy_of_input_list);
+  iree_vm_list_release(host_copy_of_input_list);
   iree_vm_list_release(output_list);  // releases actual_result
   iree_hal_buffer_view_release(expected_result);
+  iree_hal_buffer_view_release(host_copy_actual_result);
 
   return iree_ok_status();
 }


### PR DESCRIPTION
This is a minimal fix for matmul test, use the host local copy for all
the reference checks as it is allows to be mapped. Since a large portion
of the code relies on mapping the buffer during verification it is
simpler to keep it that way. This could be refactored to not need the
mapping but in order to keep the fix simple this is left untouched.