### PR TITLE
[spirv] Fix fp16 vectorization flow

### DIFF
--- a/iree/compiler/Codegen/SPIRV/MaliConfig.cpp
+++ b/iree/compiler/Codegen/SPIRV/MaliConfig.cpp
@@ -34,7 +34,7 @@ LogicalResult setMaliCodeGenConfig(const spirv::TargetEnv &targetEnv,
         std::array<int64_t, 3> threadMNK;
         auto inputType = op.inputs()[0].getType().template cast<ShapedType>();
         if (inputType.getElementType().isF16()) {
-          threadMNK = {8, 8, 4};
+          threadMNK = {2, 8, 8};
         } else {
           threadMNK = {6, 4, 4};
         }

--- a/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -101,6 +101,9 @@ static void addMemRefLoweringPasses(OpPassManager &pm) {
   // Turn scalar load/store from memrefs into vectorized ones if possible. This
   // gives better memory access patterns, which is very important for perf.
   pm.addPass(createSPIRVVectorizeLoadStore());
+  // Perform various vector-level cross-op optimizations like load-store
+  // forwarding, shape casting and casting op cancelling.
+  pm.addNestedPass<func::FuncOp>(createOptimizeVectorTransferPass());
 
   // Perform optimizations that need to across the scf.for region boundary.
   pm.addNestedPass<func::FuncOp>(createForOpCanonicalizationPass());

--- a/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
@@ -21,8 +21,11 @@
 #include "mlir/Dialect/Linalg/Transforms/Hoisting.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/SPIRV/IR/TargetAndABI.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h"
 #include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/Interfaces/VectorInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -33,16 +36,33 @@ namespace mlir {
 namespace iree_compiler {
 namespace {
 
-int getNativeVectorSize(int64_t size) {
+int getComputeVectorSize(int64_t size) {
   // Try to use 4 first, and then 2, and then 1.
   return size % 4 == 0 ? 4 : (size % 2 == 0 ? 2 : 1);
+}
+
+int getMemoryVectorSize(Value source, Type scalarType, int64_t size) {
+  int bitwidth = scalarType.getIntOrFloatBitWidth();
+  while (auto sliceOp = source.getDefiningOp<tensor::ExtractSliceOp>())
+    source = sliceOp.source();
+  if (!matchPattern(source, m_Constant())) {
+    // If we are not reading from a constant array that is embedded in the
+    // kernel, try to use a large vector size matching the bitwidth to read in
+    // 128-bit chunks. This helps with memory access performance. Such vector
+    // sizes are not native in SPIR-V though; this relies on following passes to
+    // bitcast them to 32-bit 4-element vectors to be valid.
+    if (bitwidth <= 8 && size % 16 == 0) return 16;
+    if (bitwidth <= 16 && size % 8 == 0) return 8;
+  }
+  if (bitwidth <= 32 && size % 4 == 0) return 4;
+  return size % 2 == 0 ? 2 : 1;
 }
 
 Optional<SmallVector<int64_t, 4>> getNativeVectorShape(Operation *op) {
   if (OpTrait::hasElementwiseMappableTraits(op) && op->getNumResults() == 1) {
     if (auto vecType = op->getResultTypes()[0].dyn_cast<VectorType>()) {
       SmallVector<int64_t, 4> nativeSize(vecType.getRank(), 1);
-      nativeSize.back() = getNativeVectorSize(vecType.getShape().back());
+      nativeSize.back() = getComputeVectorSize(vecType.getShape().back());
       return nativeSize;
     }
   } else if (auto vtOp = dyn_cast<VectorTransferOpInterface>(op)) {
@@ -53,7 +73,8 @@ Optional<SmallVector<int64_t, 4>> getNativeVectorShape(Operation *op) {
       if (auto dimExpr = dim.value().dyn_cast<AffineDimExpr>()) {
         if (dimExpr.getPosition() == vtOp.permutation_map().getNumDims() - 1) {
           nativeSize[dim.index()] =
-              getNativeVectorSize(vecType.getShape()[dim.index()]);
+              getMemoryVectorSize(vtOp.source(), vecType.getElementType(),
+                                  vecType.getShape()[dim.index()]);
         }
       }
     }
@@ -105,20 +126,13 @@ class SPIRVVectorizePass : public SPIRVVectorizeBase<SPIRVVectorizePass> {
     MLIRContext *context = &getContext();
     func::FuncOp funcOp = getOperation();
 
+    // First apply vectorization to generate vectors of the original tensor
+    // shape.
     {
       RewritePatternSet patterns(context);
       populateVectorizationPatterns(patterns);
       populateLinalgToVectorVectorizeConvPatterns(context, patterns);
       if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
-        return signalPassFailure();
-      }
-
-      RewritePatternSet foldPatterns(context);
-      // Fold consumer add ops into the contraction op itself.
-      vector::ContractionOp::getCanonicalizationPatterns(foldPatterns, context);
-      vector::TransposeOp::getCanonicalizationPatterns(foldPatterns, context);
-      if (failed(
-              applyPatternsAndFoldGreedily(funcOp, std::move(foldPatterns)))) {
         return signalPassFailure();
       }
     }
@@ -129,11 +143,31 @@ class SPIRVVectorizePass : public SPIRVVectorizeBase<SPIRVVectorizePass> {
       llvm::dbgs() << "\n\n";
     });
 
+    // Speical peephole optimizations to clean up IR before unrolling.
     {
-      RewritePatternSet unrollPatterns(context);
-      populateVectorUnrollPatterns(unrollPatterns);
-      if (failed(applyPatternsAndFoldGreedily(funcOp,
-                                              std::move(unrollPatterns)))) {
+      RewritePatternSet patterns(context);
+      // Fold consumer add ops into the contraction op itself.
+      vector::ContractionOp::getCanonicalizationPatterns(patterns, context);
+      // Fold transpose ops if possible as we cannot unroll it later.
+      vector::TransposeOp::getCanonicalizationPatterns(patterns, context);
+
+      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+        return signalPassFailure();
+      }
+    }
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "--- After peephole optimization ---\n";
+      funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+      llvm::dbgs() << "\n\n";
+    });
+
+    // Then unroll vectors to native vector size. We try to use 128-bit
+    // vectors for memory access and 4/2/1 vector sizes for computation.
+    {
+      RewritePatternSet patterns(context);
+      populateVectorUnrollPatterns(patterns);
+      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
     }
@@ -144,6 +178,52 @@ class SPIRVVectorizePass : public SPIRVVectorizeBase<SPIRVVectorizePass> {
       llvm::dbgs() << "\n\n";
     });
 
+    // Next run canonicalization to cast away leading size-1 dimensions. They
+    // can be generated from vector unrolling and generally cause issues to
+    // cancel corresponding read/write or insert/extract op pairs. This also
+    // need to happen befor hositing, where we would make certain vectors loop
+    // carried. Once that's done, it's hard to handle the leading size-1
+    // dimensions across regions.
+    {
+      RewritePatternSet patterns(context);
+      // We need to pull in casting way leading one dims to allow cancelling
+      // some read/write ops.
+      vector::populateCastAwayVectorLeadingOneDimPatterns(patterns);
+      vector::TransferReadOp::getCanonicalizationPatterns(patterns, context);
+      vector::TransferWriteOp::getCanonicalizationPatterns(patterns, context);
+      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+        return signalPassFailure();
+      }
+    }
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "--- After casting away leading size-1 dims ---\n";
+      funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+      llvm::dbgs() << "\n\n";
+    });
+
+    // Now we may have vector.insert_strided_slice inserting 1-D native vectors
+    // into n-D larger vectors. Break that down too. This is a companion
+    // transformation of unrolling.
+    {
+      RewritePatternSet patterns(context);
+      vector::populateVectorInsertExtractStridedSliceDecompositionPatterns(
+          patterns);
+      vector::ExtractOp::getCanonicalizationPatterns(patterns, context);
+      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+        return signalPassFailure();
+      }
+    }
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "--- After breaking down n-D inserts/extracts ---\n";
+      funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+      llvm::dbgs() << "\n\n";
+    });
+
+    // Next perform hoisting. This would analyze transfer read/write ops into
+    // tensors and hoist them out of loop nests. So after it we have
+    // loop-carried vectors, not loop-carried tensors anymore.
     linalg::hoistRedundantVectorTransfersOnTensor(funcOp);
 
     LLVM_DEBUG({
@@ -152,7 +232,8 @@ class SPIRVVectorizePass : public SPIRVVectorizeBase<SPIRVVectorizePass> {
       llvm::dbgs() << "\n\n";
     });
 
-    {  // Canonicalization
+    // Lower vector transfer permutation map.
+    {
       RewritePatternSet patterns(context);
       vector::ExtractStridedSliceOp::getCanonicalizationPatterns(patterns,
                                                                  context);
@@ -163,31 +244,32 @@ class SPIRVVectorizePass : public SPIRVVectorizeBase<SPIRVVectorizePass> {
     }
 
     LLVM_DEBUG({
-      llvm::dbgs() << "--- After canonicalizing vectors ---\n";
+      llvm::dbgs() << "--- After lowering transfer ops ---\n";
       funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
       llvm::dbgs() << "\n\n";
     });
 
+    // Lower vector broadcast and contraction.
     {
-      RewritePatternSet contractLoweringPatterns(context);
-      vector::populateVectorBroadcastLoweringPatterns(contractLoweringPatterns);
+      RewritePatternSet patterns(context);
+      vector::populateVectorBroadcastLoweringPatterns(patterns);
       vector::populateVectorContractLoweringPatterns(
-          contractLoweringPatterns,
+          patterns,
           vector::VectorTransformsOptions().setVectorTransformsOptions(
               vector::VectorContractLowering::OuterProduct));
-      if (failed(applyPatternsAndFoldGreedily(
-              funcOp, std::move(contractLoweringPatterns)))) {
+      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
     }
 
     LLVM_DEBUG({
-      llvm::dbgs() << "--- After handling contraction ---\n";
+      llvm::dbgs() << "--- After lowering contract ops ---\n";
       funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
       llvm::dbgs() << "\n\n";
     });
 
-    {  // Canonicalization
+    // Cast away leading size-1 dimensions again.
+    {
       RewritePatternSet patterns(context);
       // We need to pull in casting way leading one dims to allow cancelling
       // some read/write ops.

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
@@ -76,11 +76,11 @@ hal.executable private @conv_static_shape_f32 {
 
 // Check tiling loop along filter height/width and input channel
 //      CHECK: scf.for %{{.*}} = %c0 to %c3 step %c1
-// CHECK-SAME:     -> (vector<1x4xf32>, vector<1x4xf32>, vector<1x4xf32>, vector<1x4xf32>)
+// CHECK-SAME:     -> (vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>)
 //      CHECK:   scf.for %{{.*}} = %c0 to %c3 step %c1
-// CHECK-SAME:       -> (vector<1x4xf32>, vector<1x4xf32>, vector<1x4xf32>, vector<1x4xf32>)
+// CHECK-SAME:       -> (vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>)
 //      CHECK:     scf.for %{{.*}} = %c0 to %c8 step %c4
-// CHECK-SAME:         -> (vector<1x4xf32>, vector<1x4xf32>, vector<1x4xf32>, vector<1x4xf32>)
+// CHECK-SAME:         -> (vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>)
 
 // CHECK-COUNT-16: vector.fma
 
@@ -167,9 +167,9 @@ hal.executable private @depthwise_conv_static_shape_f32 {
 
 // check tiling loop along filter height/width and input channel
 //      CHECK:    scf.for %{{.+}} = %c0 to %c3 step %c1
-// CHECK-SAME:        -> (vector<1x1x1x4xf32>)
+// CHECK-SAME:        -> (vector<4xf32>)
 //      CHECK:      scf.for %{{.+}} = %c0 to %c3 step %c1
-// CHECK-SAME:          -> (vector<1x1x1x4xf32>)
+// CHECK-SAME:          -> (vector<4xf32>)
 
 // CHECK: vector.fma
 

--- a/iree/compiler/Codegen/SPIRV/test/vectorize_elementwise_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/vectorize_elementwise_ops.mlir
@@ -52,13 +52,13 @@ func.func @transpose_add(%lhs: tensor<4x2xf32>, %rhs: tensor<2xf32>) -> tensor<2
 //   CHECK-DAG:   %[[RINIT:.+]] = arith.constant dense<0.000000e+00> : vector<4x2xf32>
 //       CHECK:   %[[OINIT:.+]] = linalg.init_tensor [2, 4] : tensor<2x4xf32>
 //       CHECK:   %[[LHS0:.+]] = vector.transfer_read %[[LHS]][%[[C0]], %[[C0]]]{{.*}} : tensor<4x2xf32>, vector<2xf32>
-//       CHECK:   %[[LHS0S:.+]] = vector.insert_strided_slice %[[LHS0:.+]]{{.+}} {offsets = [0, 0], strides = [1]} : vector<2xf32> into vector<4x2xf32>
+//       CHECK:   %[[LHS0S:.+]] = vector.insert %[[LHS0:.+]], %[[RINIT]] [0] : vector<2xf32> into vector<4x2xf32>
 //       CHECK:   %[[LHS1:.+]] = vector.transfer_read %[[LHS]][%[[C1]], %[[C0]]]{{.*}} : tensor<4x2xf32>, vector<2xf32>
-//       CHECK:   %[[LHS1S:.+]] = vector.insert_strided_slice %[[LHS1:.+]], %[[LHS0S:.+]] {offsets = [1, 0], strides = [1]} : vector<2xf32> into vector<4x2xf32>
+//       CHECK:   %[[LHS1S:.+]] = vector.insert %[[LHS1:.+]], %[[LHS0S:.+]] [1] : vector<2xf32> into vector<4x2xf32>
 //       CHECK:   %[[LHS2:.+]] = vector.transfer_read %[[LHS]][%[[C2]], %[[C0]]]{{.*}} : tensor<4x2xf32>, vector<2xf32>
-//       CHECK:   %[[LHS2S:.+]] = vector.insert_strided_slice %[[LHS2:.+]], %[[LHS1S:.+]] {offsets = [2, 0], strides = [1]} : vector<2xf32> into vector<4x2xf32>
+//       CHECK:   %[[LHS2S:.+]] = vector.insert %[[LHS2:.+]], %[[LHS1S:.+]] [2] : vector<2xf32> into vector<4x2xf32>
 //       CHECK:   %[[LHS3:.+]] = vector.transfer_read %[[LHS]][%[[C3]], %[[C0]]]{{.*}} : tensor<4x2xf32>, vector<2xf32>
-//       CHECK:   %[[LHS3S:.+]] = vector.insert_strided_slice %[[LHS3:.+]], %[[LHS2S:.+]] {offsets = [3, 0], strides = [1]} : vector<2xf32> into vector<4x2xf32>
+//       CHECK:   %[[LHS3S:.+]] = vector.insert %[[LHS3:.+]], %[[LHS2S:.+]] [3] : vector<2xf32> into vector<4x2xf32>
 //       CHECK:   %[[LT:.+]] = vector.transpose %[[LHS3S]], [1, 0] : vector<4x2xf32> to vector<2x4xf32>
 //       CHECK:   %[[READ:.+]] = vector.transfer_read %[[RHS]]{{.+}} : tensor<2xf32>, vector<2xf32>
 //       CHECK:   %[[INSERT0:.+]] = vector.insert %[[READ]], %[[RINIT]] [0] : vector<2xf32> into vector<4x2xf32>

--- a/iree/compiler/Codegen/SPIRV/test/vectorize_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/vectorize_matmul.mlir
@@ -45,7 +45,7 @@ func.func @matmul_2x128x4() {
 
 // CHECK-LABEL: func @matmul_2x128x4()
 
-//   CHECK-DAG:   %[[ZERO:.+]] = arith.constant dense<0.000000e+00> : vector<1x4xf32>
+//   CHECK-DAG:   %[[ZERO:.+]] = arith.constant dense<0.000000e+00> : vector<4xf32>
 //   CHECK-DAG:   %[[PAD:.+]] = arith.constant 0.000000e+00 : f32
 //   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
@@ -65,17 +65,16 @@ func.func @matmul_2x128x4() {
 //       CHECK:       %[[RHS_3_VECTOR:.+]] = vector.transfer_read %[[RHS_TILE]][%[[C3]], %[[C0]]], %[[PAD]]
 //       CHECK:       %[[LHS_0_SCALAR:.+]] = vector.extract %[[LHS_VECTOR]][0]
 //       CHECK:       %[[LHS_0_VECTOR:.+]] = vector.splat %[[LHS_0_SCALAR]] : vector<4xf32>
-//       CHECK:       %[[ACC_0_VECTOR:.+]] = vector.extract %[[ZERO]][0] : vector<1x4xf32>
-//       CHECK:       %[[FMA_0:.+]] = vector.fma %[[LHS_0_VECTOR]], %[[RHS_0_VECTOR]], %[[ACC_0_VECTOR]] : vector<4xf32>
+//       CHECK:       %[[FMA_0:.+]] = vector.fma %[[RHS_0_VECTOR]], %[[LHS_0_VECTOR]], %[[ZERO]] : vector<4xf32>
 //       CHECK:       %[[LHS_1_SCALAR:.+]] = vector.extract %[[LHS_VECTOR]][1]
 //       CHECK:       %[[LHS_1_VECTOR:.+]] = vector.splat %[[LHS_1_SCALAR]] : vector<4xf32>
-//       CHECK:       %[[FMA_1:.+]] = vector.fma %[[LHS_1_VECTOR]], %[[RHS_1_VECTOR]], %[[FMA_0]] : vector<4xf32>
+//       CHECK:       %[[FMA_1:.+]] = vector.fma %[[RHS_1_VECTOR]], %[[LHS_1_VECTOR]], %[[FMA_0]] : vector<4xf32>
 //       CHECK:       %[[LHS_2_SCALAR:.+]] = vector.extract %[[LHS_VECTOR]][2]
 //       CHECK:       %[[LHS_2_VECTOR:.+]] = vector.splat %[[LHS_2_SCALAR]] : vector<4xf32>
-//       CHECK:       %[[FMA_2:.+]] = vector.fma %[[LHS_2_VECTOR]], %[[RHS_2_VECTOR]], %[[FMA_1]] : vector<4xf32>
+//       CHECK:       %[[FMA_2:.+]] = vector.fma %[[RHS_2_VECTOR]], %[[LHS_2_VECTOR]], %[[FMA_1]] : vector<4xf32>
 //       CHECK:       %[[LHS_3_SCALAR:.+]] = vector.extract %[[LHS_VECTOR]][3]
 //       CHECK:       %[[LHS_3_VECTOR:.+]] = vector.splat %[[LHS_3_SCALAR]] : vector<4xf32>
-//       CHECK:       %[[FMA_3:.+]] = vector.fma %[[LHS_3_VECTOR]], %[[RHS_3_VECTOR]], %[[FMA_2]] : vector<4xf32>
+//       CHECK:       %[[FMA_3:.+]] = vector.fma %[[RHS_3_VECTOR]], %[[LHS_3_VECTOR]], %[[FMA_2]] : vector<4xf32>
 //       CHECK:       vector.transfer_write %[[FMA_3]], %[[ACC_TILE]][%[[IV_Y]], %[[IV_X]]]
 
 // -----
@@ -154,3 +153,66 @@ func.func @matmul_broadcast_add(%init: tensor<1x8xf32>, %a: tensor<1x8xf32>, %b:
 //          CHECK:   %[[WRITE0:.+]] = vector.transfer_write %[[ADD0]], %[[INIT]][%[[C0]], %[[C0]]]
 //          CHECK:   %[[WRITE1:.+]] = vector.transfer_write %[[ADD1]], %[[WRITE0]][%[[C0]], %[[C4]]]
 //          CHECK:   return %[[WRITE1]]
+
+// -----
+
+func.func @matmul_2x8x128_fp16(%a: tensor<2x128xf16>, %b: tensor<128x8xf16>, %x: tensor<2x8xf16>, %y: tensor<2x8xf16>) -> tensor<2x8xf16> {
+  %c0 = arith.constant 0 : index
+  %c8 = arith.constant 8 : index
+  %c128 = arith.constant 128 : index
+  %f0 = arith.constant 0.0 : f16
+
+  %init = linalg.init_tensor [2, 8] : tensor<2x8xf16>
+  %fill = linalg.fill ins(%f0 : f16) outs(%init : tensor<2x8xf16>) -> tensor<2x8xf16>
+  %matmul = scf.for %iv = %c0 to %c128 step %c8 iter_args(%arg = %fill) -> (tensor<2x8xf16>) {
+    %as = tensor.extract_slice %a[0, %iv] [2, 8] [1, 1] : tensor<2x128xf16> to tensor<2x8xf16>
+    %bs = tensor.extract_slice %b[%iv, 0] [8, 8] [1, 1] : tensor<128x8xf16> to tensor<8x8xf16>
+    %cs = linalg.matmul ins(%as, %bs : tensor<2x8xf16>, tensor<8x8xf16>) outs(%arg : tensor<2x8xf16>) -> tensor<2x8xf16>
+    scf.yield %cs : tensor<2x8xf16>
+  }
+  %0 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]
+  } ins(%matmul, %x : tensor<2x8xf16>, tensor<2x8xf16>) outs(%y : tensor<2x8xf16>) {
+  ^bb0(%arg0: f16, %arg1: f16, %arg2: f16):
+    %div = arith.divf %arg0, %arg1 : f16
+    linalg.yield %div : f16
+  } -> tensor<2x8xf16>
+
+  return %0: tensor<2x8xf16>
+}
+
+//    CHECK-LABEL: func @matmul_2x8x128_fp16
+//     CHECK-SAME: (%{{.+}}: tensor<2x128xf16>, %{{.+}}: tensor<128x8xf16>, %[[X:.+]]: tensor<2x8xf16>, %[[Y:.+]]: tensor<2x8xf16>)
+//          CHECK:   %[[ZERO:.+]] = arith.constant dense<0.000000e+00> : vector<8xf16>
+//          CHECK:   %[[FOR:.+]]:2 = scf.for %arg4 = %{{.+}} to %{{.+}} step %{{.+}} iter_args(%arg5 = %[[ZERO]], %arg6 = %[[ZERO]])
+//  CHECK-COUNT-2:     vector.transfer_read {{.+}} : tensor<2x8xf16>, vector<8xf16>
+//  CHECK-COUNT-8:     vector.transfer_read {{.+}} : tensor<8x8xf16>, vector<8xf16>
+// CHECK-COUNT-32:     vector.fma {{.+}} : vector<4xf16>
+//          CHECK:     %[[ISS0:.+]] = vector.insert_strided_slice %{{.+}}, %[[ZERO]] {offsets = [0], strides = [1]} : vector<4xf16> into vector<8xf16>
+//          CHECK:     %[[ISS1:.+]] = vector.insert_strided_slice %{{.+}}, %[[ISS0]] {offsets = [4], strides = [1]} : vector<4xf16> into vector<8xf16>
+//          CHECK:     %[[ISS2:.+]] = vector.insert_strided_slice %{{.+}}, %[[ZERO]] {offsets = [0], strides = [1]} : vector<4xf16> into vector<8xf16>
+//          CHECK:     %[[ISS3:.+]] = vector.insert_strided_slice %{{.+}}, %[[ISS2]] {offsets = [4], strides = [1]} : vector<4xf16> into vector<8xf16>
+//          CHECK:     scf.yield %[[ISS3]], %[[ISS1]] : vector<8xf16>, vector<8xf16>
+//          CHECK:   }
+// CHECK:   %[[X0:.+]] = vector.transfer_read %[[X]]{{.+}} : tensor<2x8xf16>, vector<8xf16>
+// CHECK:   %[[X1:.+]] = vector.transfer_read %[[X]]{{.+}} : tensor<2x8xf16>, vector<8xf16>
+// CHECK:   %[[LHS0:.+]] = vector.extract_strided_slice %[[FOR]]#1 {offsets = [0], sizes = [4], strides = [1]} : vector<8xf16> to vector<4xf16>
+// CHECK:   %[[RHS0:.+]] = vector.extract_strided_slice %[[X0]] {offsets = [0], sizes = [4], strides = [1]} : vector<8xf16> to vector<4xf16>
+// CHECK:   %[[DIV0:.+]] = arith.divf %[[LHS0]], %[[RHS0]]
+// CHECK:   %[[ISS0:.+]] = vector.insert_strided_slice %[[DIV0]], %[[ZERO]] {offsets = [0], strides = [1]} : vector<4xf16> into vector<8xf16>
+// CHECK:   %[[LHS1:.+]] = vector.extract_strided_slice %[[FOR]]#1 {offsets = [4], sizes = [4], strides = [1]} : vector<8xf16> to vector<4xf16>
+// CHECK:   %[[RHS1:.+]] = vector.extract_strided_slice %[[X0]] {offsets = [4], sizes = [4], strides = [1]} : vector<8xf16> to vector<4xf16>
+// CHECK:   %[[DIV1:.+]] = arith.divf %[[LHS1]], %[[RHS1]]
+// CHECK:   %[[ISS1:.+]] = vector.insert_strided_slice %[[DIV1]], %[[ISS0]] {offsets = [4], strides = [1]} : vector<4xf16> into vector<8xf16>
+// CHECK:   %[[LHS2:.+]] = vector.extract_strided_slice %[[FOR]]#0 {offsets = [0], sizes = [4], strides = [1]} : vector<8xf16> to vector<4xf16>
+// CHECK:   %[[RHS2:.+]] = vector.extract_strided_slice %[[X1]] {offsets = [0], sizes = [4], strides = [1]} : vector<8xf16> to vector<4xf16>
+// CHECK:   %[[DIV2:.+]] = arith.divf %[[LHS2]], %[[RHS2]]
+// CHECK:   %[[ISS2:.+]] = vector.insert_strided_slice %[[DIV2]], %[[ZERO]] {offsets = [0], strides = [1]} : vector<4xf16> into vector<8xf16>
+// CHECK:   %[[LHS3:.+]] = vector.extract_strided_slice %[[FOR]]#0 {offsets = [4], sizes = [4], strides = [1]} : vector<8xf16> to vector<4xf16>
+// CHECK:   %[[RHS3:.+]] = vector.extract_strided_slice %[[X1]] {offsets = [4], sizes = [4], strides = [1]} : vector<8xf16> to vector<4xf16>
+// CHECK:   %[[DIV3:.+]] = arith.divf %[[LHS3]], %[[RHS3]]
+// CHECK:   %[[ISS3:.+]] = vector.insert_strided_slice %[[DIV3]], %[[ISS2]] {offsets = [4], strides = [1]} : vector<4xf16> into vector<8xf16>
+// CHECK:   %[[W0:.+]] = vector.transfer_write %[[ISS1]], %[[Y]][%c0, %c0] {in_bounds = [true]} : vector<8xf16>, tensor<2x8xf16>
+// CHECK:   %[[W1:.+]] = vector.transfer_write %[[ISS3]], %[[W0]][%c1, %c0] {in_bounds = [true]} : vector<8xf16>, tensor<2x8xf16>
+// CHECK:   return %[[W1]]


### PR DESCRIPTION
* Use tile size 8 for matmul K to have better memory access.
* When unrolling, use different vector sizes between compute and
  memory transfer ops. For the former we use 4-element vectors
  at most, but for the latter we can try to use 8-element vectors
  for better memory load/store performance.
* Also perform leading size-1 dimension casting immediately after
  unrolling to avoid having leading size-1 dimensions in loop
  carried vectors.
* Re-wire bitbast bubbling patterns to help turning vector<8xf16>
  into vector<4xf32> across the function.