### PR TITLE
Expose tm_tensor input type to Python

### DIFF
--- a/iree/compiler/InputConversion/TMTensor/Passes.td
+++ b/iree/compiler/InputConversion/TMTensor/Passes.td
@@ -10,8 +10,8 @@
 include "mlir/Pass/PassBase.td"
 
 def ConvertTMTensorToLinalgExt :
-    Pass<"iree-tmtensor-to-linalg-ext", "func::FuncOp"> {
-  let summary = "Convert from tm-tensor ops to Linalg ops on tensors";
+    Pass<"iree-tm-tensor-to-linalg-ext", "func::FuncOp"> {
+  let summary = "Convert from TMTensor ops to LinalgExt ops on tensors";
   let constructor = "mlir::iree_compiler::TMTensor::createConvertTMTensorToLinalgExtPass()";
 }
 

--- a/iree/compiler/InputConversion/TMTensor/test/BUILD
+++ b/iree/compiler/InputConversion/TMTensor/test/BUILD
@@ -19,7 +19,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
-            "convert_tmtensor_to_linalg_ext.mlir",
+            "convert_tm_tensor_to_linalg_ext.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/iree/compiler/InputConversion/TMTensor/test/CMakeLists.txt
+++ b/iree/compiler/InputConversion/TMTensor/test/CMakeLists.txt
@@ -14,7 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "convert_tmtensor_to_linalg_ext.mlir"
+    "convert_tm_tensor_to_linalg_ext.mlir"
   TOOLS
     FileCheck
     iree::tools::iree-opt

--- a/iree/compiler/InputConversion/TMTensor/test/convert_tm_tensor_to_linalg_ext.mlir
+++ b/iree/compiler/InputConversion/TMTensor/test/convert_tm_tensor_to_linalg_ext.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file --iree-tmtensor-to-linalg-ext %s | FileCheck %s
+// RUN: iree-opt -split-input-file --iree-tm-tensor-to-linalg-ext %s | FileCheck %s
 
 // -----
 func.func @scan(%in: tensor<128xi32>, %out: tensor<128xi32>, %acc: tensor<i32>) -> (tensor<128xi32>, tensor<i32>) {

--- a/iree/compiler/Pipelines/Options.cpp
+++ b/iree/compiler/Pipelines/Options.cpp
@@ -38,7 +38,7 @@ void InputDialectOptions::bindOptions(OptionsBinder &binder) {
                      "Legalize from TOSA ops."),
           clEnumValN(InputDialectOptions::Type::mhlo, "mhlo",
                      "Legalize from MHLO ops."),
-          clEnumValN(InputDialectOptions::Type::tmtensor, "tmtensor",
+          clEnumValN(InputDialectOptions::Type::tm_tensor, "tm_tensor",
                      "Legalize from TMTensor ops."),
           clEnumValN(
               InputDialectOptions::Type::xla, "xla",

--- a/iree/compiler/Pipelines/Options.h
+++ b/iree/compiler/Pipelines/Options.h
@@ -39,7 +39,7 @@ struct InputDialectOptions {
     // Legalizes input defined over MHLO ops.
     mhlo,
     // Legalizes input defined over TMTensor ops.
-    tmtensor,
+    tm_tensor,
     // Special case of 'mhlo' legalization which also performs some XLA
     // cleanup activities.
     xla,

--- a/iree/compiler/Pipelines/Pipelines.cpp
+++ b/iree/compiler/Pipelines/Pipelines.cpp
@@ -41,7 +41,7 @@ void buildIREEVMTransformPassPipeline(
     case InputDialectOptions::Type::mhlo:
       MHLO::buildMHLOInputConversionPassPipeline(passManager);
       break;
-    case InputDialectOptions::Type::tmtensor:
+    case InputDialectOptions::Type::tm_tensor:
       passManager.addNestedPass<func::FuncOp>(
           TMTensor::createConvertTMTensorToLinalgExtPass());
       break;

--- a/llvm-external-projects/iree-compiler-api/python/iree/compiler/tools/core.py
+++ b/llvm-external-projects/iree-compiler-api/python/iree/compiler/tools/core.py
@@ -42,6 +42,7 @@ class InputType(Enum):
   NONE = "none"
   MHLO = "mhlo"
   TOSA = "tosa"
+  TM_TENSOR = "tm_tensor"
   XLA = "xla"
 
   @staticmethod


### PR DESCRIPTION
This also tidies up the identifiers throughout the codebase to be
`tm-tensor` and `tm_tensor` for consistency.