### PR TITLE
hide output of adb push when the output is not a TTY

### DIFF
--- a/build_tools/benchmarks/run_benchmarks_on_android.py
+++ b/build_tools/benchmarks/run_benchmarks_on_android.py
@@ -108,9 +108,13 @@ def adb_push_to_tmp_dir(content: str,
   """
   filename = os.path.basename(content)
   android_path = os.path.join(ANDROID_TMP_DIR, relative_dir, filename)
-  execute_cmd(["adb", "push", "-p",
-               os.path.abspath(content), android_path],
-              verbose=verbose)
+  # When the output is a TTY, keep the default progress info output.
+  # In other cases, redirect progress info to null to avoid bloating log files.
+  stdout_redirect = None if sys.stdout.isatty() else subprocess.DEVNULL
+  execute_cmd(
+      ["adb", "push", os.path.abspath(content), android_path],
+      verbose=verbose,
+      stdout=stdout_redirect)
   return android_path
 
 


### PR DESCRIPTION
Currently, that logging (progress % information) amounts for the bulk of the size of our log files, which are over the 1M limit for viewing in buildkite.

[Example](https://buildkite-cloud.s3.amazonaws.com/logs-by-pipeline/16761a6a-9657-40e7-9bc0-04b04571c704/4349691f-b612-4a0a-9cb4-702f8c87e692/4d02f837-2910-4475-830d-ddc835522bae.log?response-content-disposition=inline&response-content-type=text%2Fplain&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQPCP3C7L6WZRU7I2%2F20220407%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220407T174239Z&X-Amz-Expires=600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjECcaCXVzLWVhc3QtMSJIMEYCIQC6OW6SxplX4kRoi0FwPjrzl2bLM5tuzxfSG%2F5AcIoQHwIhAITynKZukg6CzIOdZCvUKtBFvmBjm%2FBvU3GaXcU3iqPqKoMECMD%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEQABoMMDMyMzc5NzA1MzAzIgyfCwHsiTboU8HRdeMq1wPKWMab4HZym7rW6TsTcuEAkOSFce1MhJQGxUI73YeoIwsQMoUaIjrjXBIigLe2SfqqhNextvGZSIkt4a7J6tD2AkeGbe8DhJWdfcFNRSixa7PSkakft4Ek%2BMwQngqQnivza5qbxmhAUAFg4KCvrYNFUtT1HYxgvBxgFbT6RikYGhlu9dVaj49l%2FUEMIN4ftrasNR4rFXST7Dw%2BH58ArxneMD8vsU6uLTKcxzK3ZxF%2FULMcqmseqA7gVlsjUCqxUIfzJMUIgqZcbKxpyN1B34ACJcnu5RxPXXe6anKyd%2Bg6NOO4CCPhdf29F1Gkrqt%2B9XS8P%2BfqGZJSxR%2BwLoczHZH5gSPJYQoQWnu9%2FA8v8%2FQ4Rgu6uVgXQKkI8DCgMz2vw0qkO1F0U5oeDwngFYzq8eSzca1a0X9u%2BRbbMuvSt1RvSW%2FBMr6lbQ4hbCpitIJIDL29iAlSnuBAwcXhE3O1H64SVJdzhrYu6GrU%2BpC5MeQr30b5s%2BGDkUIqW7v0ZeMRJmrwyh9uAFnVQ0EDraue35Te1FfYLnuLllIOgKmcao9tox2HJ8ls3DfgbWg85eMRRa5FyTk6wFUBrkXvNBN0gTeAibArGGP6n84Li1vogIEfNMzMVJphGVowkvG7kgY6pAFHBNz0WKHhOUaf1iR6qWCSx4GrjdnjbFGIw34wMgBJDiLu5Jp1reu5654cO8P4bW9T3hkhhphOF4Ci8sOV3rC5s0xo8x4BYtGU11S9KKMELqfApS0antMlGsIvy49cJTCdwaxC1d%2Bxv0G6Qf%2FqbftCvfcvFh1Clm%2FYouJD%2FV56G9o3LKdpxazpGdOXYU0qecQl1CivlrCHDvaH11bJTux%2B5umwnA%3D%3D&X-Amz-SignedHeaders=host&X-Amz-Signature=fcb376ab84df10c584d433fd5e7c5645293f02a35769cf2a4da0f913da39095d)

Note: this drops the `-p` flag to `adb push`, that flag doesn't exist anymore, is just supported for compatibility but that behavior, of outputting progress info, is now default and it's not even possible to opt out of it, AFAICS.

Another similar problem is the progress info from the `tracy-capture` transfer.  But that is mixed on the same stdout file with quite useful logging (in case for some reason we wouldn't be getting the tracy file correctly transferred, or in case it would stall). So I'm going to instead fix that upstream in Tracy.