### PR TITLE
[spirv] Fix SPIRVTileAndDistribute flow

### DIFF
--- a/iree/test/e2e/cpu_specific/BUILD
+++ b/iree/test/e2e/cpu_specific/BUILD
@@ -22,7 +22,6 @@ iree_check_single_backend_test_suite(
         # keep sorted
         [
             "dot_exp.mlir",
-            "tests.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/iree/test/e2e/cpu_specific/CMakeLists.txt
+++ b/iree/test/e2e/cpu_specific/CMakeLists.txt
@@ -15,7 +15,6 @@ iree_check_single_backend_test_suite(
     check_dylib-llvm-aot_dylib
   SRCS
     "dot_exp.mlir"
-    "tests.mlir"
   TARGET_BACKEND
     "dylib-llvm-aot"
   DRIVER

--- a/iree/test/e2e/cpu_specific/tests.mlir
+++ b/iree/test/e2e/cpu_specific/tests.mlir
@@ -1,8 +1,0 @@
-// TODO(#8782): Delete the test.
-func.func @matvec() {
-  %lhs = util.unfoldable_constant dense<1.0> : tensor<250x1024xf32>
-  %rhs = util.unfoldable_constant dense<0.5> : tensor<1024xf32>
-  %res = "mhlo.dot"(%lhs, %rhs) : (tensor<250x1024xf32>, tensor<1024xf32>) -> tensor<250xf32>
-  check.expect_almost_eq_const(%res, dense<512.0> : tensor<250xf32>) : tensor<250xf32>
-  return
-}

--- a/iree/test/e2e/xla_ops/dot.mlir
+++ b/iree/test/e2e/xla_ops/dot.mlir
@@ -51,14 +51,13 @@ func.func @large() {
   return
 }
 
-// TODO(#8782): Enable the test.
-// func.func @matvec() {
-//   %lhs = util.unfoldable_constant dense<1.0> : tensor<250x1024xf32>
-//   %rhs = util.unfoldable_constant dense<0.5> : tensor<1024xf32>
-//   %res = "mhlo.dot"(%lhs, %rhs) : (tensor<250x1024xf32>, tensor<1024xf32>) -> tensor<250xf32>
-//   check.expect_almost_eq_const(%res, dense<512.0> : tensor<250xf32>) : tensor<250xf32>
-//   return
-// }
+func.func @matvec() {
+  %lhs = util.unfoldable_constant dense<1.0> : tensor<250x1024xf32>
+  %rhs = util.unfoldable_constant dense<0.5> : tensor<1024xf32>
+  %res = "mhlo.dot"(%lhs, %rhs) : (tensor<250x1024xf32>, tensor<1024xf32>) -> tensor<250xf32>
+  check.expect_almost_eq_const(%res, dense<512.0> : tensor<250xf32>) : tensor<250xf32>
+  return
+}
 
 func.func @dot() {
   %lhs = util.unfoldable_constant dense<1.0> : tensor<1024xf32>


### PR DESCRIPTION
This commit cleans up SPIRVTileAndDistribute to avoid hard
coding specific ops in configurations for tiling and distributing
to threads. We now use op interfaces there. This allows proper
tiling of all Linalg ops, which we already deduced tiling
scheme during configuration. Hardcoding specific ops might
cause only specific ops gotten recognized and thus causing
discrepancy and error. The correctness error for matvec was
due to this. It is fixed by this patch.