### PR TITLE
Specially handle width-sensitive arith cast ops.

### DIFF
--- a/iree/compiler/Dialect/Util/Transforms/BUILD
+++ b/iree/compiler/Dialect/Util/Transforms/BUILD
@@ -38,6 +38,7 @@ cc_library(
         "//iree/compiler/Dialect/Util/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:ArithmeticDialect",
         "@llvm-project//mlir:ControlFlowOps",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",

--- a/iree/compiler/Dialect/Util/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Util/Transforms/CMakeLists.txt
@@ -32,6 +32,7 @@ iree_cc_library(
   DEPS
     LLVMSupport
     MLIRAnalysis
+    MLIRArithmetic
     MLIRControlFlow
     MLIRFunc
     MLIRIR

--- a/iree/compiler/Dialect/Util/Transforms/test/demote_f64_to_f32.mlir
+++ b/iree/compiler/Dialect/Util/Transforms/test/demote_f64_to_f32.mlir
@@ -53,3 +53,23 @@ func.func @nested_region_f64() -> (tensor<4xf64>) {
   }) {dimensions = dense<1> : tensor<1xi64>} : (tensor<4x4xf64>, tensor<f64>) -> tensor<4xf64>
   return %3 : tensor<4xf64>
 }
+
+// -----
+
+// Check handling of width-sensitive arith casts.
+
+// CHECK-LABEL:   func @arith.truncf(
+// CHECK-SAME:            %[[ARG0:.*]]: f32) -> f32 {
+// CHECK:           return %[[ARG0]] : f32
+func @arith.truncf(%arg0: f64) -> f32 {
+  %0 = arith.truncf %arg0 : f64 to f32
+  return %0 : f32
+}
+
+// CHECK-LABEL:   func @arith.extf(
+// CHECK-SAME:            %[[ARG0:.*]]: f32) -> f32 {
+// CHECK:           return %[[ARG0]] : f32
+func @arith.extf(%arg0: f32) -> f64 {
+  %0 = arith.extf %arg0 : f32 to f64
+  return %0 : f64
+}

--- a/iree/compiler/Dialect/Util/Transforms/test/demote_i64_to_i32.mlir
+++ b/iree/compiler/Dialect/Util/Transforms/test/demote_i64_to_i32.mlir
@@ -204,3 +204,31 @@ func.func @nested_region_i64() -> (tensor<4xi64>) {
   // CHECK: return %{{.*}} : tensor<4xi32>
   return %3 : tensor<4xi64>
 }
+
+// -----
+
+// Check handling of width-sensitive arith casts.
+
+// CHECK-LABEL:   func @arith.trunci(
+// CHECK-SAME:            %[[ARG0:.*]]: i32) -> i32 {
+// CHECK:           return %[[ARG0]] : i32
+func @arith.trunci(%arg0: i64) -> i32 {
+  %0 = arith.trunci %arg0 : i64 to i32
+  return %0 : i32
+}
+
+// CHECK-LABEL:   func @arith.extui(
+// CHECK-SAME:            %[[ARG0:.*]]: i32) -> i32 {
+// CHECK:           return %[[ARG0]] : i32
+func @arith.extui(%arg0: i32) -> i64 {
+  %0 = arith.extui %arg0 : i32 to i64
+  return %0 : i64
+}
+
+// CHECK-LABEL:   func @arith.extsi(
+// CHECK-SAME:            %[[ARG0:.*]]: i32) -> i32 {
+// CHECK:           return %[[ARG0]] : i32
+func @arith.extsi(%arg0: i32) -> i64 {
+  %0 = arith.extsi %arg0 : i32 to i64
+  return %0 : i64
+}


### PR DESCRIPTION
Add special patterns to handle the arith cast ops that were causing
issues here when the operand and result types are the same.

Part of #8745 (it at least fixes the immediate issues we are seeing)