### PR TITLE
Make MapElementTypeToDType consistent with the enum

### DIFF
--- a/bindings/python/iree/runtime/array_interop_test.py
+++ b/bindings/python/iree/runtime/array_interop_test.py
@@ -137,6 +137,13 @@ class DeviceHalTest(unittest.TestCase):
     self.assertEqual(f32_copy.dtype, np.float32)
     np.testing.assert_array_equal(orig_ary.astype(np.float32), f32_copy)
 
+  def testBool(self):
+    init_ary = np.zeros([3, 4], dtype=np.bool_)
+    init_ary[1] = True  # Set some non-zero value.
+    ary = iree.runtime.asdevicearray(self.device, init_ary)
+    self.assertEqual(repr(ary), "<IREE DeviceArray: shape=[3, 4], dtype=bool>")
+    np.testing.assert_array_equal(ary.to_host(), init_ary)
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/bindings/python/iree/runtime/hal.cc
+++ b/bindings/python/iree/runtime/hal.cc
@@ -402,7 +402,7 @@ void SetupHalBindings(pybind11::module m) {
       .value("BFLOAT_16", IREE_HAL_ELEMENT_TYPE_BFLOAT_16)
       .value("BOOL_8",
              static_cast<iree_hal_element_types_t>(IREE_HAL_ELEMENT_TYPE_VALUE(
-                 IREE_HAL_NUMERICAL_TYPE_INTEGER_SIGNED, 1)))
+                 IREE_HAL_NUMERICAL_TYPE_INTEGER, 1)))
       .export_values()
       .def_static("map_to_dtype", &MapElementTypeToDType);
 


### PR DESCRIPTION
I had to choose which one to be consistent with, and I chose to adjust
the "bool" type to be
`IREE_HAL_ELEMENT_TYPE_VALUE(IREE_HAL_NUMERICAL_TYPE_INTEGER, 1))`, as
this appears to be what IREE produces internally for tensor of i1 dtype.