### PR TITLE
Improve compilation time and execution time for quantized matmul on ARM

### DIFF
--- a/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
@@ -1071,8 +1071,8 @@ hal.executable private @matmul_aarch_i8_i8_i32  {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0], [16, 4, 64], [4, 4, 4]]>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUTileFuseAndVectorize>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0], [4, 16, 0], [0, 0, 4]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable.entry_point public @matmul_aarch_i8_i8_i32
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.matmul


### PR DESCRIPTION
While more quantized models are added to benchmarks and the configurations are not well tuned, it takes long time to compile and execute. The PR takes the first stab at tuning configurations to have acceptable compilation time. The execution time is also improved as shown below.

The compilation time is cut from 5.5 mins to 1.3 mins.

Perf improvements (sampled from MobileBert Int8):

Before:

```
-----------------------------------------------------------------------------------------------
Benchmark                                                     Time             CPU   Iterations
-----------------------------------------------------------------------------------------------
BM_matmul_i8i8i32_384x128x128/process_time/real_time      0.954 ms        0.933 ms          738
BM_matmul_i8i8i32_384x512x128/process_time/real_time       3.73 ms         3.65 ms          187
BM_matmul_i8i8i32_384x384x32/process_time/real_time        1.12 ms         1.09 ms          628
BM_matmul_i8i8i32_384x128x512/process_time/real_time       3.68 ms         3.60 ms          190
BM_matmul_i8i8i32_384x32x384/process_time/real_time       0.758 ms        0.741 ms          922
BM_matmul_i8i8i32_384x512x384/process_time/real_time       11.7 ms         11.4 ms           60
BM_matmul_i8i8i32_384x2x512/process_time/real_time        0.137 ms        0.133 ms         5106
```

After:

```
-----------------------------------------------------------------------------------------------
Benchmark                                                     Time             CPU   Iterations
-----------------------------------------------------------------------------------------------
BM_matmul_i8i8i32_384x128x128/process_time/real_time      0.728 ms        0.711 ms          968
BM_matmul_i8i8i32_384x512x128/process_time/real_time       2.80 ms         2.74 ms          249
BM_matmul_i8i8i32_384x384x32/process_time/real_time       0.680 ms        0.663 ms         1029
BM_matmul_i8i8i32_384x128x512/process_time/real_time       2.63 ms         2.57 ms          266
BM_matmul_i8i8i32_384x32x384/process_time/real_time       0.521 ms        0.509 ms         1345
BM_matmul_i8i8i32_384x512x384/process_time/real_time       7.99 ms         7.82 ms           88
BM_matmul_i8i8i32_384x2x512/process_time/real_time        0.146 ms        0.142 ms         4789
```