### PR TITLE
Fix the format of driver and target_arch

### DIFF
--- a/build_tools/benchmarks/common/benchmark_suite.py
+++ b/build_tools/benchmarks/common/benchmark_suite.py
@@ -115,13 +115,13 @@ class BenchmarkSuite(object):
 
     chosen_cases = []
     for benchmark_case in self.suite_map[category_dir]:
-      matched_driver = (benchmark_case.driver in available_drivers) and (
-          driver_filter is None or
-          re.match(driver_filter, benchmark_case.driver) is not None)
+      driver = benchmark_case.driver[len("iree-"):].lower()
+      matched_driver = (driver in available_drivers) and (
+          driver_filter is None or re.match(driver_filter, driver) is not None)
+      target_arch = benchmark_case.target_arch.lower()
       matched_arch = (re.match(cpu_target_arch_filter,
-                               benchmark_case.target_arch) is not None or
-                      re.match(gpu_target_arch_filter,
-                               benchmark_case.target_arch) is not None)
+                               target_arch) is not None or
+                      re.match(gpu_target_arch_filter, target_arch) is not None)
       matched_mode = (mode_filter is None or re.match(
           mode_filter, benchmark_case.bench_mode) is not None)
 
@@ -152,8 +152,6 @@ class BenchmarkSuite(object):
         continue
 
       iree_driver, target_arch, bench_mode = segments
-      iree_driver = iree_driver[len("iree-"):].lower()
-      target_arch = target_arch.lower()
 
       # The path of model_dir is expected to be:
       #   <benchmark_suite_dir>/<category>/<model_name>-<model_tags>

--- a/build_tools/benchmarks/common/benchmark_suite_test.py
+++ b/build_tools/benchmarks/common/benchmark_suite_test.py
@@ -26,14 +26,14 @@ class BenchmarkSuiteTest(unittest.TestCase):
   def test_filter_benchmarks_for_category(self):
     case1 = BenchmarkCase(model_name_with_tags="deepnet",
                           bench_mode="1-thread,full-inference",
-                          target_arch="ARMv8",
-                          driver="dylib",
+                          target_arch="CPU-ARMv8",
+                          driver="iree-dylib",
                           benchmark_case_dir="case1",
                           benchmark_tool_name="tool")
     case2 = BenchmarkCase(model_name_with_tags="deepnetv2-f32",
                           bench_mode="full-inference",
-                          target_arch="Mali",
-                          driver="vulkan",
+                          target_arch="GPU-Mali",
+                          driver="iree-vulkan",
                           benchmark_case_dir="case2",
                           benchmark_tool_name="tool")
     suite = BenchmarkSuite({
@@ -43,16 +43,16 @@ class BenchmarkSuiteTest(unittest.TestCase):
     both_benchmarks = suite.filter_benchmarks_for_category(
         category="TFLite",
         available_drivers=["dylib", "vulkan"],
-        cpu_target_arch_filter="ARMv8",
-        gpu_target_arch_filter="Mali",
+        cpu_target_arch_filter="cpu-armv8",
+        gpu_target_arch_filter="gpu-mali",
         driver_filter=None,
         mode_filter=".*full-inference.*",
         model_name_filter="deepnet.*")
     gpu_benchmarks = suite.filter_benchmarks_for_category(
         category="TFLite",
         available_drivers=["dylib", "vulkan"],
-        cpu_target_arch_filter="Unknown",
-        gpu_target_arch_filter="Mali",
+        cpu_target_arch_filter="cpu-unknown",
+        gpu_target_arch_filter="gpu-mali",
         driver_filter="vulkan",
         mode_filter=".*full-inference.*",
         model_name_filter="deepnet.*/case2")
@@ -77,17 +77,17 @@ class BenchmarkSuiteTest(unittest.TestCase):
     with tempfile.TemporaryDirectory() as tmp_dir:
       tflite_dir = os.path.join(tmp_dir, "TFLite")
       pytorch_dir = os.path.join(tmp_dir, "PyTorch")
-      case1 = BenchmarkSuiteTest.__create_bench(tflite_dir,
-                                                model="deepnet",
-                                                bench_mode="4-thread,full",
-                                                target_arch="cpu-armv8",
-                                                driver="dylib",
-                                                tool="run-cpu-bench")
+      BenchmarkSuiteTest.__create_bench(tflite_dir,
+                                        model="DeepNet",
+                                        bench_mode="4-thread,full",
+                                        target_arch="CPU-ARMv8",
+                                        driver="iree-dylib",
+                                        tool="run-cpu-bench")
       case2 = BenchmarkSuiteTest.__create_bench(pytorch_dir,
-                                                model="deepnetv2",
+                                                model="DeepNetv2",
                                                 bench_mode="full-inference",
-                                                target_arch="gpu-mali",
-                                                driver="vulkan",
+                                                target_arch="GPU-Mali",
+                                                driver="iree-vulkan",
                                                 tool="run-gpu-bench")
 
       suite = BenchmarkSuite.load_from_benchmark_suite_dir(tmp_dir)
@@ -104,7 +104,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
   @staticmethod
   def __create_bench(dir_path: str, model: str, bench_mode: str,
                      target_arch: str, driver: str, tool: str):
-    case_name = f"iree-{driver}__{target_arch}__{bench_mode}"
+    case_name = f"{driver}__{target_arch}__{bench_mode}"
     bench_path = os.path.join(dir_path, model, case_name)
     os.makedirs(bench_path)
     with open(os.path.join(bench_path, "tool"), "w") as f:


### PR DESCRIPTION
The internal format of driver name should be `iree-*`, and it is better to keep the original form of the `target_arch` from benchmark suite directory name. Only normalize them when we need to do match.