### PR TITLE
Remove retired RISC-V LLVM option

### DIFF
--- a/build_tools/kokoro/gcp_ubuntu/cmake/linux/riscv64/test.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/linux/riscv64/test.sh
@@ -49,7 +49,6 @@ function generate_dylib_vmfb {
       -iree-llvm-target-cpu-features="+m,+a,+f,+d,+c,+v"
       -riscv-v-fixed-length-vector-lmul-max=8
       -riscv-v-vector-bits-min=256
-      -riscv-v-fixed-length-vector-elen-max=64
       "${BUILD_RISCV_DIR?}/tosa.mlir"
     )
   fi


### PR DESCRIPTION
Remove `-riscv-v-fixed-length-vector-elen-max` since it is retired in
https://reviews.llvm.org/D123418. The function has been replaced with
Zve ISA extensions (v implies zve64f)