### PR TITLE
Add peeling support to fusion.

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.td
@@ -142,7 +142,7 @@ def ScalarizeOp : Linalg_Transform_Operation<"scalarize",
 }
 
 def FuseOp : Linalg_Transform_Operation<"fuse",
-    [TransformOpInterface, TargetableSingleOperandTransformOpTrait]> {
+    [TransformOpInterface]> {
   let description = [{Tiles the operations pointed to by the target handle and
   fuses their producers greedily using the options provided as attributes.}];
 
@@ -150,14 +150,16 @@ def FuseOp : Linalg_Transform_Operation<"fuse",
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$tile_sizes,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$tile_interchange
                   );
-  let results = (outs PDL_Operation:$transformed);
+  let results = (outs PDL_Operation:$transformed,
+                      Variadic<PDL_Operation>:$loops);
 
-  let assemblyFormat = "$target attr-dict";
+  let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    ::mlir::FailureOr<::mlir::linalg::LinalgOp> applyToOne(
-        ::mlir::linalg::LinalgOp target);
+    ::mlir::LogicalResult apply(
+        ::mlir::linalg::transform::TransformResults &transformResults,
+        ::mlir::linalg::transform::TransformState &state);
   }];
 }
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.td
@@ -201,7 +201,7 @@ def PadOp : Linalg_Transform_Operation<"pad",
   using the options provides as operation attributes.}];
 
   let arguments = (ins PDL_Operation:$target,
-                   DefaultValuedAttr<StrArrayAttr, "{}">:$padding_values,
+                   DefaultValuedAttr<ArrayAttr, "{}">:$padding_values,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$padding_dimensions,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$pack_paddings,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$hoist_paddings,
@@ -281,7 +281,7 @@ def LowerToLLVMOp : Transform_Op<"lower_to_llvm"> {
 }
 
 def GetParentLoopOp : Linalg_Transform_Operation<"get_parent_loop", [
-    TransformOpInterface, 
+    TransformOpInterface,
     TargetableSingleOperandTransformOpTrait
   ]> {
   let description = [{Obtains a handle to a parent loop of the given
@@ -300,7 +300,7 @@ def GetParentLoopOp : Linalg_Transform_Operation<"get_parent_loop", [
 }
 
 def UnrollLoopOp : Linalg_Transform_Operation<"unroll_loop", [
-    TransformOpInterface, 
+    TransformOpInterface,
     TargetableSingleOperandTransformOpTrait
   ]> {
   let description = [{Unrolls the given loop with the given unroll factor.}];
@@ -354,7 +354,7 @@ def OutlineLoopOp : Linalg_Transform_Operation<"outline_loop", [
   let assemblyFormat = "$target attr-dict";
 }
 
-def PrintOp : Transform_Op<"print", [ 
+def PrintOp : Transform_Op<"print", [
     DeclareOpInterfaceMethods<TransformOpInterface, ["apply"]>
   ]> {
   let arguments = (ins Optional<PDL_Operation>:$target,
@@ -367,7 +367,7 @@ def PrintOp : Transform_Op<"print", [
 // LinalgExt specific transforms
 //===----------------------------------------------------------------------===//
 
-def TileToLinalgExtTileOp : 
+def TileToLinalgExtTileOp :
     Linalg_Transform_Operation<"tile_to_iree_linalg_ext_tile_op", [
       DeclareOpInterfaceMethods<TransformOpInterface, ["apply"]>
     ]> {

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/double-tiling.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/double-tiling.mlir
@@ -39,6 +39,6 @@ iree_linalg_transform.sequence {
   %0 = match @pdl_target
   %1, %loops1:3 = tile %0 {interchange = [0, 2, 1], sizes = [32, 32, 32]}
   %2, %loops2:3 = tile %1 {interchange = [0, 1, 2], sizes = [4, 4, 1]}
-  %3 = pad %2 {padding_values=["0.0", "0.0", "0.0"], pack_paddings = [1, 1, 1], hoist_paddings = [6, 6, 0], transpose_paddings = [[1, 0], [0, 1]]}
+  %3 = pad %2 {padding_values=[0.0 : f32, 0.0 : f32, 0.0 : f32], pack_paddings = [1, 1, 1], hoist_paddings = [6, 6, 0], transpose_paddings = [[1, 0], [0, 1]]}
   %4 = vectorize %3  {vectorize_padding = true}
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/fuse-and-peel.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/fuse-and-peel.mlir
@@ -1,9 +1,12 @@
 // RUN: iree-dialects-opt -linalg-interp-transforms %s | FileCheck %s
 
-
 // CHECK-LABEL: func @fuse_unary
 func @fuse_unary(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {
 
+  //     CHECK:   scf.for
+  //     CHECK:     scf.for
+  //     CHECK:       linalg.elemwise_unary
+  //     CHECK:       linalg.elemwise_binary
   //     CHECK:   scf.for
   //     CHECK:     scf.for
   //     CHECK:       linalg.elemwise_unary
@@ -29,4 +32,6 @@ pdl.pattern @pdl_target : benefit(1) {
 iree_linalg_transform.sequence {
   %0 = match @pdl_target
   %1, %loops:2 = fuse %0 {tile_sizes = [32, 32], tile_interchange = [0, 1]}
+
+  peel_loop %loops#0
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/invalid.mlir
@@ -30,6 +30,14 @@ iree_linalg_transform.sequence {
 
 iree_linalg_transform.sequence {
   %0 = match @match
+  // expected-error@below {{expected `tile_sizes` attribute}}
+  fuse %0
+}
+
+// -----
+
+iree_linalg_transform.sequence {
+  %0 = match @match
   // expected-error@below {{expects interchange to be a permutation, found [1, 1]}}
   fuse %0 {tile_sizes=[0, 1], tile_interchange = [1, 1]}
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/pad.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/pad.mlir
@@ -44,5 +44,5 @@ pdl.pattern @pdl_target : benefit(1) {
 
 iree_linalg_transform.sequence {
   %0 = match @pdl_target
-  %1 = pad %0 {padding_values=["0.0", "0.0"], padding_dimensions=[1], pack_paddings=[1, 1], hoist_paddings=[1, 0], transpose_paddings=[[1, 0], [0, 1]]}
+  %1 = pad %0 {padding_values=[0.0 : f32, 0.0 : f32], padding_dimensions=[1], pack_paddings=[1, 1], hoist_paddings=[1, 0], transpose_paddings=[[1, 0], [0, 1]]}
 }


### PR DESCRIPTION
The FuseOp now returns a handles to the generated tile loops, which then may be used to peel of loops from the fused loop nest.
    
Co-authored-by: Tobias Gysi <gysit@users.noreply.github.com>