### PR TITLE
Fixes for CompilationInfoAttr::get methods.

### DIFF
--- a/iree/compiler/Codegen/Dialect/LoweringConfig.cpp
+++ b/iree/compiler/Codegen/Dialect/LoweringConfig.cpp
@@ -192,6 +192,33 @@ LogicalResult LoweringConfigAttr::verify(
 // iree.compilation_info
 //===----------------------------------------------------------------------===//
 
+/// These builders are externally for auto-tuner to generate the attribute.
+CompilationInfoAttr CompilationInfoAttr::get(MLIRContext *context,
+                                             TileSizesListTypeRef tileSizes,
+                                             TileSizesListTypeRef interchange,
+                                             ArrayRef<int64_t> nativeVectorSize,
+                                             ArrayRef<int64_t> workgroupSize) {
+  LoweringConfigAttr configAttr = LoweringConfigAttr::get(
+      context, tileSizes, interchange, nativeVectorSize);
+  TranslationInfoAttr translationInfo =
+      TranslationInfoAttr::get(context, DispatchLoweringPassPipeline::None);
+  ArrayAttr workgroupSizeAttr = getI64IntegerArrayAttr(context, workgroupSize);
+  return get(context, configAttr, translationInfo, workgroupSizeAttr);
+}
+
+CompilationInfoAttr CompilationInfoAttr::get(
+    MLIRContext *context, TileSizesListTypeRef tileSizes,
+    TileSizesListTypeRef interchange, ArrayRef<int64_t> nativeVectorSize,
+    DispatchLoweringPassPipeline passPipeline,
+    ArrayRef<int64_t> workloadPerWorkgroup, ArrayRef<int64_t> workgroupSize) {
+  LoweringConfigAttr configAttr = LoweringConfigAttr::get(
+      context, tileSizes, interchange, nativeVectorSize);
+  TranslationInfoAttr translationInfoAttr =
+      TranslationInfoAttr::get(context, passPipeline, workloadPerWorkgroup);
+  ArrayAttr workgroupSizeAttr = getI64IntegerArrayAttr(context, workgroupSize);
+  return get(context, configAttr, translationInfoAttr, workgroupSizeAttr);
+}
+
 LogicalResult CompilationInfoAttr::verify(
     function_ref<InFlightDiagnostic()> emitError,
     LoweringConfigAttr loweringConfig, TranslationInfoAttr translationInfo,

--- a/iree/compiler/Codegen/Dialect/LoweringConfig.td
+++ b/iree/compiler/Codegen/Dialect/LoweringConfig.td
@@ -209,9 +209,10 @@ def IREECodegen_CompilationInfoAttr :
   let builders = [
     AttrBuilder<(ins "TileSizesListTypeRef":$tileSizes,
       "TileSizesListTypeRef":$tileInterchange,
-      CArg<"ArrayRef<int64_t>", "{{}}">:$nativeVectorSize,
+      CArg<"ArrayRef<int64_t>", "{}">:$nativeVectorSize,
       CArg<"ArrayRef<int64_t>", "{}">:$workgroupSize)>,
     AttrBuilder<(ins "TileSizesListTypeRef":$tileSizes,
+      "TileSizesListTypeRef":$tileInterchange,
       "ArrayRef<int64_t>":$nativeVectorSize,
       "DispatchLoweringPassPipeline":$passPipeline,
       "ArrayRef<int64_t>":$workloadPerWorkgroup,


### PR DESCRIPTION
These methods are used externally for auto-tuner, which were accidentally removed in https://github.com/google/iree/pull/8664