### PR TITLE
Order worker initialization vs other threads stealing work

### DIFF
--- a/iree/task/post_batch.c
+++ b/iree/task/post_batch.c
@@ -36,7 +36,7 @@ static iree_host_size_t iree_task_post_batch_select_random_worker(
     iree_task_post_batch_t* post_batch, iree_task_affinity_set_t affinity_set) {
   iree_task_affinity_set_t worker_live_mask =
       iree_atomic_task_affinity_set_load(
-          &post_batch->executor->worker_live_mask, iree_memory_order_relaxed);
+          &post_batch->executor->worker_live_mask, iree_memory_order_acquire);
   iree_task_affinity_set_t valid_worker_mask = affinity_set & worker_live_mask;
   if (!valid_worker_mask) {
     // No valid workers as desired; for now just bail to worker 0.


### PR DESCRIPTION
(Credits to @benvanik for guessing in [this comment](https://github.com/google/iree/pull/8710#issuecomment-1085095224))

When an executor creates a worker, it populates its data structures
such as `worker->task_queue`, creates the thread, then finally updates
the masks such as` executor->worker_live_mask` that control work-stealing
among workers.

When an executor looks for work to steal, it first looks up these masks,
such as executor->worker_live_mask, to identity the worker to steal
from. It then proceeds to stealing from that worker, which involve
accesses to its data structures such as `worker->task_queue`.

The above two do not seem to be currently ordered by anything, and TSan
reports that about once every 200 runs of `dylib_semaphore_test`:
https://gist.github.com/bjacob/f50543ec46de4e1142aeae0f20215b01

With this PR, the TSan error doesn't reproduce anymore, with 1000
repetitions:

```
ctest -R iree/hal/dylib/cts/dylib_semaphore_test --repeat-until-fail 1000 --output-on-failure
```

This could be resolved in any way providing the missing ordering; this
PR picks `executor->worker_live_mask` as the atomic to provide the
ordering because it seemed to be the variable most consistently accessed
by locations that need this synchronization, but that can be changed. In
the current implementation, stores are changed to release order, and
loads are changed to acquire order, and these loads and stores are
reordered so that `worker_live_mask` is always stored last and loaded
first, so that the release-acquire ordering on these accesses orders
everything else (that is, the release-store makes all prior writes
visible to all reads done after the acquire-load).