### PR TITLE
Fix data race: different mutexes were guarding the same data

### DIFF
--- a/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -75,8 +75,7 @@ class HALDispatchABI {
   // Returns a Type representing iree_hal_processor_v0_t.
   static LLVM::LLVMStructType getProcessorType(
       MLIRContext *context, LLVMTypeConverter *typeConverter) {
-    static llvm::sys::Mutex mutex;
-    llvm::sys::ScopedLock lock(mutex);
+    llvm::sys::ScopedLock lock(sMutex);
     auto structType =
         LLVM::LLVMStructType::getIdentified(context, "iree_hal_processor_v0_t");
     if (structType.isInitialized()) return structType;
@@ -108,8 +107,7 @@ class HALDispatchABI {
   static LLVM::LLVMStructType getEnvironmentType(
       MLIRContext *context, LLVMTypeConverter *typeConverter,
       LLVM::LLVMStructType processorType) {
-    static llvm::sys::Mutex mutex;
-    llvm::sys::ScopedLock lock(mutex);
+    llvm::sys::ScopedLock lock(sMutex);
     auto structType = LLVM::LLVMStructType::getIdentified(
         context, "iree_hal_executable_environment_v0_t");
     if (structType.isInitialized()) return structType;
@@ -164,8 +162,7 @@ class HALDispatchABI {
   // Returns a Type representing iree_hal_executable_dispatch_state_v0_t.
   static LLVM::LLVMStructType getDispatchStateType(
       MLIRContext *context, LLVMTypeConverter *typeConverter) {
-    static llvm::sys::Mutex mutex;
-    llvm::sys::ScopedLock lock(mutex);
+    llvm::sys::ScopedLock lock(sMutex);
     auto structType = LLVM::LLVMStructType::getIdentified(
         context, "iree_hal_executable_dispatch_state_v0_t");
     if (structType.isInitialized()) return structType;
@@ -229,8 +226,7 @@ class HALDispatchABI {
   // Returns a Type representing iree_hal_executable_workgroup_state_v0_t.
   static LLVM::LLVMStructType getWorkgroupStateType(
       MLIRContext *context, LLVMTypeConverter *typeConverter) {
-    static llvm::sys::Mutex mutex;
-    llvm::sys::ScopedLock lock(mutex);
+    llvm::sys::ScopedLock lock(sMutex);
     auto structType = LLVM::LLVMStructType::getIdentified(
         context, "iree_hal_executable_workgroup_state_v0_t");
     if (structType.isInitialized()) return structType;
@@ -602,7 +598,13 @@ class HALDispatchABI {
   LLVM::LLVMStructType environmentType;
   LLVM::LLVMStructType dispatchStateType;
   LLVM::LLVMStructType workgroupStateType;
+
+  // Used to lock around mutations of shared LLVM type information, e.g.
+  // mlir::LLVM::LLVMStructType::getIdentified.
+  static llvm::sys::Mutex sMutex;
 };
+
+llvm::sys::Mutex HALDispatchABI::sMutex;
 
 /// Converts Standard MLIR FuncOps to LLVMFuncOps matching the IREE HAL ABI.
 /// This is an IREE-specific conversion that assumes the input function is


### PR DESCRIPTION
[TSan report](https://gist.github.com/bjacob/7045d80702d1ebfebc1f5351d23cd50c)

The mutexes that I had recently added in each of these functions (#8688, #8590) fixed some data races occuring when two threads were concurrently calling the same one function among those. But I didn't understand then, that the data being raced on by these different functions is the same - so even with those mutexes on each of these functions, we still have a race when different threads call different functions concurrently. The fix is to let all these functions share a single mutex.