### PR TITLE
Change lit output dir to specified dir if set.

### DIFF
--- a/integrations/tensorflow/test/lit.cfg.py
+++ b/integrations/tensorflow/test/lit.cfg.py
@@ -59,14 +59,13 @@ config.substitutions.extend([
 python_projects_dir = os.path.join(os.path.dirname(__file__), "..",
                                    "python_projects")
 test_src_dir = os.path.join(os.path.dirname(__file__), "python")
-llvm_config.with_environment(
-    'PYTHONPATH', [
-        test_src_dir,
-        os.path.join(python_projects_dir, 'iree_tf'),
-        os.path.join(python_projects_dir, 'iree_tflite'),
-        os.path.join(python_projects_dir, 'iree_xla'),
-    ],
-    append_path=True)
+llvm_config.with_environment('PYTHONPATH', [
+    test_src_dir,
+    os.path.join(python_projects_dir, 'iree_tf'),
+    os.path.join(python_projects_dir, 'iree_tflite'),
+    os.path.join(python_projects_dir, 'iree_xla'),
+],
+                             append_path=True)
 
 # Enable features based on -D FEATURES=hugetest,vulkan
 # syntax.

--- a/integrations/tensorflow/test/lit.cfg.py
+++ b/integrations/tensorflow/test/lit.cfg.py
@@ -26,56 +26,59 @@ config.test_exec_root = (os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR") or
                          os.path.join(tempfile.gettempdir(), "lit"))
 
 # name: The name of this test suite.
-config.name = 'TENSORFLOW_TESTS'
+config.name = "TENSORFLOW_TESTS"
 
 config.test_format = lit.formats.ShTest()
 
 # suffixes: A list of file extensions to treat as test files.
-config.suffixes = ['.run']
+config.suffixes = [".run"]
 
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)
 
 #config.use_default_substitutions()
 config.excludes = [
-    'lit.cfg.py',
-    'lit.site.cfg.py',
-    'test_util.py',
-    'manual_test.py',
-    'squad_test_data.py',
-    'imagenet_test_data.py',
+    "lit.cfg.py",
+    "lit.site.cfg.py",
+    "test_util.py",
+    "manual_test.py",
+    "squad_test_data.py",
+    "imagenet_test_data.py",
 ]
 
 PYTHON_EXEC = sys.executable
 
+# Some environments use a version of Python built against an embedded
+# interpreter and lack a sys.executable. In this case, we allow an explicit
+# override from the environment.
 if PYTHON_EXEC is None:
   PYTHON_EXEC = os.getenv("PYTHON")
 
 config.substitutions.extend([
-    ('%PYTHON', PYTHON_EXEC),
+    ("%PYTHON", PYTHON_EXEC),
 ])
 
 # Add our local projects to the PYTHONPATH
 python_projects_dir = os.path.join(os.path.dirname(__file__), "..",
                                    "python_projects")
 test_src_dir = os.path.join(os.path.dirname(__file__), "python")
-llvm_config.with_environment('PYTHONPATH', [
+llvm_config.with_environment("PYTHONPATH", [
     test_src_dir,
-    os.path.join(python_projects_dir, 'iree_tf'),
-    os.path.join(python_projects_dir, 'iree_tflite'),
-    os.path.join(python_projects_dir, 'iree_xla'),
+    os.path.join(python_projects_dir, "iree_tf"),
+    os.path.join(python_projects_dir, "iree_tflite"),
+    os.path.join(python_projects_dir, "iree_xla"),
 ],
                              append_path=True)
 
 # Enable features based on -D FEATURES=hugetest,vulkan
 # syntax.
-# We always allow 'llvmaot'. It can be disabled with -D DISABLE_FEATURES=llvmaot
-disable_features_param = lit_config.params.get('DISABLE_FEATURES')
+# We always allow "llvmaot". It can be disabled with -D DISABLE_FEATURES=llvmaot
+disable_features_param = lit_config.params.get("DISABLE_FEATURES")
 disable_features = []
 if disable_features_param:
-  disable_features = disable_features_param.split(',')
-if 'llvmaot' not in disable_features:
-  config.available_features.add('llvmaot')
-features_param = lit_config.params.get('FEATURES')
+  disable_features = disable_features_param.split(",")
+if "llvmaot" not in disable_features:
+  config.available_features.add("llvmaot")
+features_param = lit_config.params.get("FEATURES")
 if features_param:
-  config.available_features.update(features_param.split(','))
+  config.available_features.update(features_param.split(","))

--- a/integrations/tensorflow/test/lit.cfg.py
+++ b/integrations/tensorflow/test/lit.cfg.py
@@ -21,7 +21,9 @@ llvm_config.with_system_environment("PYTHONPATH")
 llvm_config.with_system_environment("VK_ICD_FILENAMES")
 
 # Put execution artifacts in the temp dir.
-config.test_exec_root = os.path.join(tempfile.gettempdir(), "lit")
+config.test_exec_root = (os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR") or
+                         os.environ.get("TEST_TMPDIR") or
+                         os.path.join(tempfile.gettempdir(), "lit"))
 
 # name: The name of this test suite.
 config.name = 'TENSORFLOW_TESTS'
@@ -44,21 +46,27 @@ config.excludes = [
     'imagenet_test_data.py',
 ]
 
+PYTHON_EXEC = sys.executable
+
+if PYTHON_EXEC is None:
+  PYTHON_EXEC = os.getenv("PYTHON")
+
 config.substitutions.extend([
-    ('%PYTHON', sys.executable),
+    ('%PYTHON', PYTHON_EXEC),
 ])
 
 # Add our local projects to the PYTHONPATH
 python_projects_dir = os.path.join(os.path.dirname(__file__), "..",
                                    "python_projects")
 test_src_dir = os.path.join(os.path.dirname(__file__), "python")
-llvm_config.with_environment("PYTHONPATH", [
-    test_src_dir,
-    os.path.join(python_projects_dir, "iree_tf"),
-    os.path.join(python_projects_dir, "iree_tflite"),
-    os.path.join(python_projects_dir, "iree_xla"),
-],
-                                      append_path=True)
+llvm_config.with_environment(
+    'PYTHONPATH', [
+        test_src_dir,
+        os.path.join(python_projects_dir, 'iree_tf'),
+        os.path.join(python_projects_dir, 'iree_tflite'),
+        os.path.join(python_projects_dir, 'iree_xla'),
+    ],
+    append_path=True)
 
 # Enable features based on -D FEATURES=hugetest,vulkan
 # syntax.


### PR DESCRIPTION
If TEST_UNDECLARED_OUTPUTS_DIR or TEST_TMPDIR is set, use those
directories instead to write output instead of creating new temporary
directory. These directories are used by bazel and tooling around bazel
often expect output there in failing cases.
