### PR TITLE
Always build CUDA on CI.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,15 @@ set(IREE_CUDA_LIBDEVICE_PATH "" CACHE STRING "Absolute path to an appropriate li
 # back to this as needed for specific features.
 if(IREE_TARGET_BACKEND_CUDA OR IREE_HAL_DRIVER_CUDA)
   find_package(CUDAToolkit)
+
+  # We define the magic IREE_CUDA_DEPS_DIR env var in our CI docker images if we
+  # have a stripped down CUDA toolkit suitable for compiling available. We
+  # trigger on this below as a fallback for locating headers and libdevice
+  # files.
+  if(NOT CUDAToolkit_FOUND AND DEFINED ENV{IREE_CUDA_DEPS_DIR})
+    set(CUDAToolkit_ROOT "$ENV{IREE_CUDA_DEPS_DIR}")
+    message(STATUS "CUDA SDK not found by CMake but using IREE_CUDA_DEPS = ${CUDAToolkit_ROOT}")
+  endif()
 endif()
 
 # If an explicit libdevice file was not specified, and the compiler backend

--- a/build_tools/cmake/rebuild.sh
+++ b/build_tools/cmake/rebuild.sh
@@ -48,6 +48,12 @@ CMAKE_ARGS=(
   # get a reasonable mix of {builds with asserts, builds with other features
   # such as ASan but without asserts}.
   "-DIREE_ENABLE_ASSERTIONS=ON"
+
+  # Enable CUDA compiler and runtime builds unconditionally. Our CI images all
+  # have enough deps to at least build CUDA support and compile CUDA binaries
+  # (but not necessarily test on real hardware).
+  "-DIREE_HAL_DRIVER_CUDA=ON"
+  "-DIREE_TARGET_BACKEND_CUDA=ON"
 )
 
 "$CMAKE_BIN" "${CMAKE_ARGS[@]?}" "$@" ..


### PR DESCRIPTION
Adds a special case to detect when the stripped down CUDA deps on our CI
images are available and uses that (i.e. a full SDK will not detect in
this case).

Fixes #8847