### PR TITLE
Force push latest-snapshot

### DIFF
--- a/.github/workflows/validate_and_publish_release.yml
+++ b/.github/workflows/validate_and_publish_release.yml
@@ -96,3 +96,4 @@ jobs:
         with:
           github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           branch: latest-snapshot
+          force: true


### PR DESCRIPTION
This is to handle the case when downstream forks may diverge
temporarily and not be able to push from another tree.

Tested with github actions downstream
