### PR TITLE
Stop stealing tasks from zombie workers.

### DIFF
--- a/iree/task/worker.c
+++ b/iree/task/worker.c
@@ -117,6 +117,11 @@ static bool iree_task_worker_is_zombie(iree_task_worker_t* worker) {
 void iree_task_worker_deinitialize(iree_task_worker_t* worker) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
+  // Withdraw this worker from the set of candidates for stealing from.
+  iree_atomic_task_affinity_set_fetch_and(&worker->executor->worker_live_mask,
+                                          ~worker->worker_bit,
+                                          iree_memory_order_acq_rel);
+
   // Wait for the thread to enter the zombie state indicating it has exited our
   // main function - it may still be live in the OS, but it'll not be touching
   // any of our data structures again so it's fine to blast away.


### PR DESCRIPTION
This seems to be fixing #8863.

This prevents new steals from starting while we wait for workers to reach zombie state.

What I don't understand at the moment is whether this always prevents ongoing steals from continuing past the point where the victim reaches zombie state. That's what I want to prevent, and this seems to be prevented in 1000 runs of tests with TSan, but I don't understand if that's guaranteed to be prevented.

I can make up half rationales of the form "a worker only reaches zombie state if it had nothing to work on anymore, so it has nothing to steal from at that point" but the fine details of how that's synchronized with `try_steal` are not clear to me. I understand that `try_steal` won't start a steal if the load-acquire of `worker_live_mask` returns 0 for this worker's bit, but I don't understand what happens if `try_steal` was already past that point by the time we clear that bit.

Fixes #8863.