### PR TITLE
Move `ConvertToDestinationPassingStyle` after rewrite of destructive updates

### DIFF
--- a/iree/compiler/Codegen/Common/RewriteLinalgDestructiveUpdatesPass.cpp
+++ b/iree/compiler/Codegen/Common/RewriteLinalgDestructiveUpdatesPass.cpp
@@ -52,6 +52,7 @@ void RewriteLinalgDestructiveUpdatesPass::runOnOperation() {
   // After rewriting destructive updates, there might be uses of compute
   // operations only in `tensor.dim` ops. Resolve these.
   RewritePatternSet resolveDimOps(context);
+  linalg::InitTensorOp::getCanonicalizationPatterns(resolveDimOps, context);
   memref::populateResolveRankedShapeTypeResultDimsPatterns(resolveDimOps);
   if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(resolveDimOps)))) {
     return signalPassFailure();

--- a/iree/compiler/Codegen/Sandbox/LinalgTensorCodegenDriver.cpp
+++ b/iree/compiler/Codegen/Sandbox/LinalgTensorCodegenDriver.cpp
@@ -256,7 +256,7 @@ void LinalgFusePass::runOnOperation() {
 
   // Created a nested OpPassManager and run.
   OpPassManager dynamicPM(func::FuncOp::getOperationName());
-  strategy.configurePassPipeline(dynamicPM, funcOp.getContext());
+  strategy.configurePassPipeline(dynamicPM, funcOp.getContext(), false);
 
   if (failed(runPipeline(dynamicPM, funcOp))) {
     return signalPassFailure();


### PR DESCRIPTION
The conversion to destination passing style needs to run after rewrite
of destructive updates to use the IREE workgroup-level parallelism
constructs (`flow.dispatch.tensor.load/flow.dispatch.tensor.store`
ops). This ordering is important for things to connect to upstream
bufferization correctly. Additionally need to ensure that there is no
CSE passes run before conversion to destination passing style can kick
in.