### PR TITLE
TopK LinalgExt Op Implementation with roundtrip.mlir test

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -51,7 +51,7 @@ class IREELinalgExt_Op<string mnemonic, list<Trait> traits = []> :
 
 //===----------------------------------------------------------------------===//
 // Temporary stripped-down copies of IREE HAL ops needed for composition.
-// These can be removed once dialects can register transformations with the 
+// These can be removed once dialects can register transformations with the
 // transform dialect.
 //===----------------------------------------------------------------------===//
 def IREELinalgExt_Dim : TypeAlias<Index>;
@@ -117,8 +117,8 @@ def IREELinalgExt_HALInterfaceWorkgroupCountOp : Op<IREELinalgExt_Dialect, "hal.
   }];
 }
 
-// Stripped-down version of the HAL::ExecutableEntryPoint op. 
-// Using a custom op in generic form is not deemed acceptable but we should not 
+// Stripped-down version of the HAL::ExecutableEntryPoint op.
+// Using a custom op in generic form is not deemed acceptable but we should not
 // either blindly take the complexity.
 def IREELinalgExt_HALExecutableEntryPointOp : Op<IREELinalgExt_Dialect, "hal.executable.entry_point", [
     IsolatedFromAbove,
@@ -129,15 +129,15 @@ def IREELinalgExt_HALExecutableEntryPointOp : Op<IREELinalgExt_Dialect, "hal.exe
     information describing the IO interface it uses and other dispatch metadata.
 
     The `workgroup_count_region` region represents the
-    computation that returns the number of workgroups to use. 
+    computation that returns the number of workgroups to use.
     It returns the number of workgroups along x, y, and z.
 
     Note: this is a stripped-down of the HAL::ExecutableEntryPoint to only keep
     the essential information needed to perform the transformation.
-    This is only used within the parent func of an IREELinalgExt_InParallelOp 
+    This is only used within the parent func of an IREELinalgExt_InParallelOp
     that is in the process of translating to the HAL abstraction.
     This goes away once transform dialect ops can be registered from different
-    dialects. 
+    dialects.
   }];
 
   // This op only propagates information to HAL, it inherits none of the design.
@@ -466,6 +466,61 @@ def IREELinalgExt_ReverseOp : IREELinalgExt_Op<"reverse", [
         ret.push_back(elem.getLimitedValue());
       }
       return ret;
+    }
+  }];
+}
+
+def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
+  DeclareOpInterfaceMethods<LinalgExtInterface>
+]> {
+  let summary = "Top-K operator";
+  let description = [{
+   A Top-K operation for N-D tensors.
+
+   Accepts two N-D tensor inputs consisting of values (f32) and indices of those
+   values (i32 type). Both input values/indices tensors and output
+   values/indicies tensors must have the same shape. Top-K is computed along the
+   specified dimension. Returns two output tensors of values and the indicies of
+   Top-K results. The output dimensions must match the input save for the
+   dimension that is reduced to K results.
+
+   Setting "min_k" to true computes min K elements instead.
+  }];
+
+  let arguments = (ins Variadic<AnyShaped>:$inputs,
+                       Variadic<AnyShaped>:$outputs,
+                       I64Attr:$dimension,
+                       BoolAttr:$min_k
+  );
+
+  let results = (outs Variadic<AnyRankedTensor>:$results);
+  let assemblyFormat = [{
+    attr-dict
+    `dimension` `(` $dimension `)`
+    `min_k` `(` $min_k `)`
+    `ins` `(` $inputs `:` type($inputs) `)`
+    `outs` `(` $outputs `:` type($outputs) `)`
+    (`:` type($results)^)?
+  }];
+
+  let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
+    Value inputValues() {
+      return getInputOperand(0)->get();
+    }
+    Value inputIndices() {
+      return getInputOperand(1)->get();
+    }
+    Value outputValues() {
+      return getOutputOperand(0)->get();
+    }
+    Value outputIndices() {
+      return getOutputOperand(1)->get();
+    }
+    ShapedType getOperandType() {
+      return inputValues().getType().cast<ShapedType>();
+    }
+    int64_t getOperandRank() {
+      return getOperandType().getRank();
     }
   }];
 }

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -475,39 +475,43 @@ def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
 ]> {
   let summary = "Top-K operator";
   let description = [{
-   A Top-K operation for N-D tensors.
+   A Top-K operation for N-D tensors. Reduces the taret dimension from the input
+   size N down to K elements based on the supplied binary region.
 
-   Accepts two N-D tensor inputs consisting of values (f32) and indices of those
+   Accepts two N-D tensor inputs consisting of values and indices of those
    values (i32 type). Both input values/indices tensors and output
    values/indicies tensors must have the same shape. Top-K is computed along the
-   specified dimension. Returns two output tensors of values and the indicies of
-   Top-K results. The output dimensions must match the input save for the
-   dimension that is reduced to K results.
+   target dimension (from dimension()). Returns two output tensors of values and
+   the indicies of Top-K results. The output dimensions must match the input
+   save for the dimension that is reduced to K results.
 
-   Setting "min_k" to true computes min K elements instead.
+   Region accepts lhs=[next N input] and rhs=[exiting K output] and yeilds an
+   i1. If true, the two values are swapped:
+     - For Top-K compoarision: >
+     - For Min-K comparision: <
+   Note: when the two values are equal, the first occurence is always selected.
   }];
 
   let arguments = (ins Variadic<AnyShaped>:$inputs,
                        Variadic<AnyShaped>:$outputs,
-                       I64Attr:$dimension,
-                       BoolAttr:$min_k
+                       I64Attr:$dimension
   );
 
   let results = (outs Variadic<AnyRankedTensor>:$results);
+  let regions = (region AnyRegion:$region);
   let assemblyFormat = [{
     attr-dict
     `dimension` `(` $dimension `)`
-    `min_k` `(` $min_k `)`
     `ins` `(` $inputs `:` type($inputs) `)`
     `outs` `(` $outputs `:` type($outputs) `)`
-    (`:` type($results)^)?
+    $region (`->` type($results)^)?
   }];
 
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
-    Value inputValues() {
+    Value values() {
       return getInputOperand(0)->get();
     }
-    Value inputIndices() {
+    Value indices() {
       return getInputOperand(1)->get();
     }
     Value outputValues() {
@@ -516,11 +520,11 @@ def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
     Value outputIndices() {
       return getOutputOperand(1)->get();
     }
-    ShapedType getOperandType() {
-      return inputValues().getType().cast<ShapedType>();
+    ShapedType getInputType() {
+      return values().getType().cast<ShapedType>();
     }
-    int64_t getOperandRank() {
-      return getOperandType().getRank();
+    int64_t getInputRank() {
+      return getInputType().getRank();
     }
   }];
 }

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -475,7 +475,7 @@ def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
 ]> {
   let summary = "Top-K operator";
   let description = [{
-   A Top-K operation for N-D tensors. Reduces the taret dimension from the input
+   A Top-K operation for N-D tensors. Reduces the target dimension from the input
    size N down to K elements based on the supplied binary region.
 
    Accepts two N-D tensor inputs consisting of values and indices of those

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -80,7 +80,7 @@ static Value getSlice(OpBuilder &b, Location loc, Value source,
       .Default([&](Type t) { return nullptr; });
 }
 
-/// Returns true the dimensions of ShapedType are dynamic or equal.
+/// Returns true if the dimensions of ShapedType are dynamic or equal.
 static bool isShapedTypeDimEqual(int64_t lhs, int64_t rhs) {
   return lhs != ShapedType::kDynamicSize && rhs != ShapedType::kDynamicSize &&
          lhs != rhs;
@@ -1255,9 +1255,12 @@ LogicalResult TopkOp::verify() {
     return op->emitOpError("region block should have 2 arguments");
   }
   if (block.getArgument(0).getType() != inputValuesType.getElementType() ||
-
       block.getArgument(1).getType() != inputValuesType.getElementType()) {
     return op->emitOpError("region block types must match input");
+  }
+  auto terminatorOp = llvm::cast<YieldOp>(block.getTerminator());
+  if (!terminatorOp || !terminatorOp.getOperand(0).getType().isInteger(1)) {
+    return op->emitOpError("region block must end with a Yield i1!");
   }
   return success();
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
@@ -446,3 +446,122 @@ func @type_mismatch(%1 : tensor<1xf32>, %out : tensor<200xf32>) -> () {
       }
   }
 }
+
+// -----
+
+func @topk_invalid(%input_values: tensor<2x10xf32>, %input_indices: tensor<2x10xi32>, %out_values : tensor<2x3xf32>, %out_indices: tensor<2x3xi32>) -> (tensor<2x3xf32>, tensor<2x3xi32>) {
+  // expected-error@+1 {{expected two input operands}}
+  %0:2 = iree_linalg_ext.topk
+        dimension(1)
+        ins(%input_indices : tensor<2x10xi32>)
+        outs(%out_values, %out_indices : tensor<2x3xf32>, tensor<2x3xi32>) {
+        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+          %0 = arith.cmpf ogt, %arg0, %arg1 : f32
+          iree_linalg_ext.yield %0 : i1
+        } -> tensor<2x3xf32>, tensor<2x3xi32>
+  return %0#0, %0#1 : tensor<2x3xf32>, tensor<2x3xi32>
+}
+
+// -----
+
+func @topk_invalid(%input_values: tensor<2x10xi32>, %input_indices: tensor<2x10xi32>, %out_values : tensor<2x3xf32>, %out_indices: tensor<2x3xi32>) -> (tensor<2x3xf32>, tensor<2x3xi32>) {
+   // expected-error@+1 {{expected input/output value types to be identical}}
+  %0:2 = iree_linalg_ext.topk
+        dimension(1)
+        ins(%input_values, %input_indices : tensor<2x10xi32> , tensor<2x10xi32>)
+        outs(%out_values, %out_indices : tensor<2x3xf32>, tensor<2x3xi32>) {
+        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+          %0 = arith.cmpf ogt, %arg0, %arg1 : f32
+          iree_linalg_ext.yield %0 : i1
+        } -> tensor<2x3xf32>, tensor<2x3xi32>
+  return %0#0, %0#1 : tensor<2x3xf32>, tensor<2x3xi32>
+}
+
+// -----
+
+func @topk_invalid(%input_values: tensor<2x10xf32>, %input_indices: tensor<2x10xf32>, %out_values : tensor<2x3xf32>, %out_indices: tensor<2x3xi32>) -> (tensor<2x3xf32>, tensor<2x3xi32>) {
+   // expected-error@+1 {{expected input/output indices types to be int}}
+  %0:2 = iree_linalg_ext.topk
+        dimension(1)
+        ins(%input_values, %input_indices : tensor<2x10xf32> , tensor<2x10xf32>)
+        outs(%out_values, %out_indices : tensor<2x3xf32>, tensor<2x3xi32>) {
+        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+          %0 = arith.cmpf ogt, %arg0, %arg1 : f32
+          iree_linalg_ext.yield %0 : i1
+        } -> tensor<2x3xf32>, tensor<2x3xi32>
+  return %0#0, %0#1 : tensor<2x3xf32>, tensor<2x3xi32>
+}
+
+// -----
+
+func @topk_invalid(%input_values: tensor<10x2x10xf32>, %input_indices: tensor<10x2x10xi32>, %out_values : tensor<2x3xf32>, %out_indices: tensor<2x3xi32>) -> (tensor<2x3xf32>, tensor<2x3xi32>) {
+   // expected-error@+1 {{expected input/output to have the same rank}}
+  %0:2 = iree_linalg_ext.topk
+        dimension(1)
+        ins(%input_values, %input_indices : tensor<10x2x10xf32> , tensor<10x2x10xi32>)
+        outs(%out_values, %out_indices : tensor<2x3xf32>, tensor<2x3xi32>) {
+        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+          %0 = arith.cmpf ogt, %arg0, %arg1 : f32
+          iree_linalg_ext.yield %0 : i1
+        } -> tensor<2x3xf32>, tensor<2x3xi32>
+  return %0#0, %0#1 : tensor<2x3xf32>, tensor<2x3xi32>
+}
+
+// -----
+
+func @topk_invalid(%input_values: tensor<3x10xf32>, %input_indices: tensor<2x10xi32>, %out_values : tensor<2x3xf32>, %out_indices: tensor<2x3xi32>) -> (tensor<2x3xf32>, tensor<2x3xi32>) {
+   // expected-error@+1 {{input indices/values shape must match}}
+  %0:2 = iree_linalg_ext.topk
+        dimension(1)
+        ins(%input_values, %input_indices : tensor<3x10xf32> , tensor<2x10xi32>)
+        outs(%out_values, %out_indices : tensor<2x3xf32>, tensor<2x3xi32>) {
+        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+          %0 = arith.cmpf ogt, %arg0, %arg1 : f32
+          iree_linalg_ext.yield %0 : i1
+        } -> tensor<2x3xf32>, tensor<2x3xi32>
+  return %0#0, %0#1 : tensor<2x3xf32>, tensor<2x3xi32>
+}
+
+// -----
+
+func @topk_invalid(%input_values: tensor<2x10xf32>, %input_indices: tensor<2x10xi32>, %out_values : tensor<3x3xf32>, %out_indices: tensor<2x3xi32>) -> (tensor<3x3xf32>, tensor<2x3xi32>) {
+   // expected-error@+1 {{output indices/values shape must match}}
+  %0:2 = iree_linalg_ext.topk
+        dimension(1)
+        ins(%input_values, %input_indices : tensor<2x10xf32> , tensor<2x10xi32>)
+        outs(%out_values, %out_indices : tensor<3x3xf32>, tensor<2x3xi32>) {
+        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+          %0 = arith.cmpf ogt, %arg0, %arg1 : f32
+          iree_linalg_ext.yield %0 : i1
+        } -> tensor<3x3xf32>, tensor<2x3xi32>
+  return %0#0, %0#1 : tensor<3x3xf32>, tensor<2x3xi32>
+}
+
+// -----
+
+func @topk_invalid(%input_values: tensor<3x10xf32>, %input_indices: tensor<3x10xi32>, %out_values : tensor<2x3xf32>, %out_indices: tensor<2x3xi32>) -> (tensor<2x3xf32>, tensor<2x3xi32>) {
+   // expected-error@+1 {{incompatible input/output shapes}}
+  %0:2 = iree_linalg_ext.topk
+        dimension(1)
+        ins(%input_values, %input_indices  : tensor<3x10xf32> , tensor<3x10xi32>)
+        outs(%out_values, %out_indices : tensor<2x3xf32>, tensor<2x3xi32>) {
+        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+          %0 = arith.cmpf ogt, %arg0, %arg1 : f32
+          iree_linalg_ext.yield %0 : i1
+        } -> tensor<2x3xf32>, tensor<2x3xi32>
+  return %0#0, %0#1 : tensor<2x3xf32>, tensor<2x3xi32>
+}
+
+// -----
+
+func @topk_invalid(%input_values: tensor<2x10xf32>, %input_indices: tensor<2x10xi32>, %out_values : tensor<2x3xf32>, %out_indices: tensor<2x3xi32>) -> (tensor<2x3xf32>, tensor<2x3xi32>) {
+  %0:2 = iree_linalg_ext.topk
+        dimension(1)
+        ins(%input_values, %input_indices : tensor<2x10xf32> , tensor<2x10xi32>)
+        outs(%out_values, %out_indices : tensor<2x3xf32>, tensor<2x3xi32>) {
+        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+          %0 = arith.cmpf ogt, %arg0, %arg1 : f32
+          iree_linalg_ext.yield %0 : i1
+        } -> tensor<2x3xf32>, tensor<2x3xi32>
+  return %0#0, %0#1 : tensor<2x3xf32>, tensor<2x3xi32>
+}

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
@@ -551,17 +551,3 @@ func @topk_invalid(%input_values: tensor<3x10xf32>, %input_indices: tensor<3x10x
         } -> tensor<2x3xf32>, tensor<2x3xi32>
   return %0#0, %0#1 : tensor<2x3xf32>, tensor<2x3xi32>
 }
-
-// -----
-
-func @topk_invalid(%input_values: tensor<2x10xf32>, %input_indices: tensor<2x10xi32>, %out_values : tensor<2x3xf32>, %out_indices: tensor<2x3xi32>) -> (tensor<2x3xf32>, tensor<2x3xi32>) {
-  %0:2 = iree_linalg_ext.topk
-        dimension(1)
-        ins(%input_values, %input_indices : tensor<2x10xf32> , tensor<2x10xi32>)
-        outs(%out_values, %out_indices : tensor<2x3xf32>, tensor<2x3xi32>) {
-        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
-          %0 = arith.cmpf ogt, %arg0, %arg1 : f32
-          iree_linalg_ext.yield %0 : i1
-        } -> tensor<2x3xf32>, tensor<2x3xi32>
-  return %0#0, %0#1 : tensor<2x3xf32>, tensor<2x3xi32>
-}

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
@@ -546,10 +546,13 @@ func @topk_tensor(%input_values: tensor<20x10x8x4xf32>, %input_indices: tensor<2
   %out_values = linalg.init_tensor [20, 10, 3, 4] : tensor<20x10x3x4xf32>
   %out_indices = linalg.init_tensor [20, 10, 3, 4] : tensor<20x10x3x4xi32>
   %0:2 = iree_linalg_ext.topk
-         dimension(2)
-         min_k(false)
-         ins(%input_values, %input_indices : tensor<20x10x8x4xf32> , tensor<20x10x8x4xi32>)
-         outs(%out_values, %out_indices : tensor<20x10x3x4xf32>, tensor<20x10x3x4xi32>) : tensor<20x10x3x4xf32>, tensor<20x10x3x4xi32>
+        dimension(2)
+        ins(%input_values, %input_indices : tensor<20x10x8x4xf32> , tensor<20x10x8x4xi32>)
+        outs(%out_values, %out_indices : tensor<20x10x3x4xf32>, tensor<20x10x3x4xi32>) {
+        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+          %0 = arith.cmpf ogt, %arg0, %arg1 : f32
+          iree_linalg_ext.yield %0 : i1
+        } -> tensor<20x10x3x4xf32>, tensor<20x10x3x4xi32>
   return %0#0, %0#1 : tensor<20x10x3x4xf32>, tensor<20x10x3x4xi32>
 }
 
@@ -558,20 +561,24 @@ func @topk_tensor(%input_values: tensor<20x10x8x4xf32>, %input_indices: tensor<2
 //  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9]+]]: tensor<20x10x8x4xi32>
 //       CHECK:   %[[OUT_VALUES:.+]] = linalg.init_tensor [20, 10, 3, 4]
 //       CHECK:   %[[OUT_INDICES:.+]] = linalg.init_tensor [20, 10, 3, 4]
-//       CHECK:   %[[RESULT:.+]] = iree_linalg_ext.topk
+//       CHECK:   %[[RESULT:.+]]:2 = iree_linalg_ext.topk
 //  CHECK-SAME:      dimension(2)
-//  CHECK-SAME:      min_k(false)
 //  CHECK-SAME:      ins(%[[ARG0]], %[[ARG1]]
 //  CHECK-SAME:      outs(%[[OUT_VALUES]], %[[OUT_INDICES]]
+//       CHECK:      iree_linalg_ext.yield
+//       CHECK:   return %[[RESULT]]#0, %[[RESULT]]#1
 
 // -----
 
-func @topk_memref(%arg0: memref<4x10xf32>, %arg1: memref<4x10xi32>, %arg2: memref<4x3xf32>, %arg3: memref<4x3xi32>) {
+func @topk_memref(%input_values: memref<4x10xf32>, %input_indices: memref<4x10xi32>, %out_values: memref<4x3xf32>, %out_indices: memref<4x3xi32>) {
   iree_linalg_ext.topk
-         dimension(1)
-         min_k(false)
-         ins(%arg0, %arg1 : memref<4x10xf32> , memref<4x10xi32>)
-         outs(%arg2, %arg3 : memref<4x3xf32>, memref<4x3xi32>)
+        dimension(1)
+        ins(%input_values, %input_indices : memref<4x10xf32> , memref<4x10xi32>)
+        outs(%out_values, %out_indices : memref<4x3xf32>, memref<4x3xi32>) {
+        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+          %0 = arith.cmpf ogt, %arg0, %arg1 : f32
+          iree_linalg_ext.yield %0 : i1
+        }
   return
 }
 // CHECK-LABEL: func @topk_memref
@@ -581,24 +588,21 @@ func @topk_memref(%arg0: memref<4x10xf32>, %arg1: memref<4x10xi32>, %arg2: memre
 //  CHECK-SAME:   %[[ARG3:[a-zA-Z0-9]+]]: memref<4x3xi32>
 //       CHECK:   iree_linalg_ext.topk
 //  CHECK-SAME:      dimension(1)
-//  CHECK-SAME:      min_k(false)
 //  CHECK-SAME:      ins(%[[ARG0]], %[[ARG1]]
 //  CHECK-SAME:      outs(%[[ARG2]], %[[ARG3]]
+//       CHECK:      iree_linalg_ext.yield
 
 // -----
 
-func @topk_dynamic_tensor(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xi32>, %arg2: tensor<?x?xf32>, %arg3: tensor<?x?xi32>) -> (tensor<?x?xf32>, tensor<?x?xi32>)  {
-//   %c0 = arith.constant 0 : index
-//   %c1 = arith.constant 1 : index
-//   %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
-//   %d1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
-//   %out_values = linalg.init_tensor [%c1, 3] : tensor<?x?xf32>
-//   %out_indices = linalg.init_tensor [4, 3] : tensor<?x?xi32>
+func @topk_dynamic_tensor(%input_values: tensor<?x?xf32>, %input_indices: tensor<?x?xi32>, %out_values: tensor<?x?xf32>, %out_indices: tensor<?x?xi32>) -> (tensor<?x?xf32>, tensor<?x?xi32>)  {
   %0:2 = iree_linalg_ext.topk
-         dimension(1)
-         min_k(false)
-         ins(%arg0, %arg1 : tensor<?x?xf32> , tensor<?x?xi32>)
-         outs(%arg2, %arg3 : tensor<?x?xf32>, tensor<?x?xi32>) : tensor<?x?xf32>, tensor<?x?xi32>
+        dimension(1)
+        ins(%input_values, %input_indices : tensor<?x?xf32> , tensor<?x?xi32>)
+        outs(%out_values, %out_indices : tensor<?x?xf32>, tensor<?x?xi32>) {
+        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+          %0 = arith.cmpf ogt, %arg0, %arg1 : f32
+          iree_linalg_ext.yield %0 : i1
+        } -> tensor<?x?xf32>, tensor<?x?xi32>
   return %0#0, %0#1 : tensor<?x?xf32>, tensor<?x?xi32>
 }
 // CHECK-LABEL: func @topk_dynamic_tensor
@@ -606,11 +610,12 @@ func @topk_dynamic_tensor(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xi32>, %arg2:
 //  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xi32>
 //  CHECK-SAME:   %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?xf32>
 //  CHECK-SAME:   %[[ARG3:[a-zA-Z0-9]+]]: tensor<?x?xi32>
-//       CHECK:   %[[RESULT:.+]] = iree_linalg_ext.topk
+//       CHECK:   %[[RESULT:.+]]:2 = iree_linalg_ext.topk
 //  CHECK-SAME:      dimension(1)
-//  CHECK-SAME:      min_k(false)
 //  CHECK-SAME:      ins(%[[ARG0]], %[[ARG1]]
 //  CHECK-SAME:      outs(%[[ARG2]], %[[ARG3]]
+//       CHECK:      iree_linalg_ext.yield
+//       CHECK:   return %[[RESULT]]#0, %[[RESULT]]#1
 
 // -----
 


### PR DESCRIPTION
Introduces an operation for computing the top K elements along a specified dimension of an N-D tensor. Can also calculate the min K elements instead. 

Defines a verifier and tests through `roundtrip.mlir`. 