### PR TITLE
drop `OPT_FLAGS` parameter, no longer used.

### DIFF
--- a/build_tools/bazel/iree_check_test.bzl
+++ b/build_tools/bazel/iree_check_test.bzl
@@ -22,8 +22,6 @@ def iree_check_test(
         driver = None,
         compiler_flags = [],
         runner_args = [],
-        opt_tool = "//iree/tools:iree-opt",
-        opt_flags = [],
         tags = [],
         target_cpu_features = None,
         timeout = None,
@@ -41,10 +39,6 @@ def iree_check_test(
           flags are passed automatically.
       runner_args: additional runner_args to pass to iree-check-module. The driver and input file
           are passed automatically.
-      opt_tool: Defaulting to iree-opt. Tool used to preprocess the source files
-          if opt_flags is specified.
-      opt_flags: If specified, source files are preprocessed with OPT_TOOL with
-          these flags.
       tags: additional tags to apply to the generated test. A tag "driver=DRIVER" is added
           automatically.
       target_cpu_features: currently unimplemented (must be empty), will eventually allow specifying target CPU features.
@@ -64,8 +58,6 @@ def iree_check_test(
             "-mlir-print-op-on-diagnostic=false",
             "-iree-hal-target-backends=%s" % target_backend,
         ] + compiler_flags,
-        opt_tool = opt_tool,
-        opt_flags = opt_flags,
         visibility = ["//visibility:private"],
     )
 
@@ -92,8 +84,6 @@ def iree_check_single_backend_test_suite(
         driver = None,
         compiler_flags = [],
         runner_args = [],
-        opt_tool = "//iree/tools:iree-opt",
-        opt_flags = [],
         tags = [],
         target_cpu_features = None,
         timeout = None,
@@ -114,10 +104,6 @@ def iree_check_single_backend_test_suite(
       runner_args: additional runner_args to pass to the underlying iree-check-module tests. The
           driver and input file are passed automatically. To use different runner_args per test,
           create a separate suite or iree_check_test.
-      opt_tool: Defaulting to iree-opt. Tool used to preprocess the source files
-          if opt_flags is specified.
-      opt_flags: If specified, source files are preprocessed with OPT_TOOL with
-          these flags.
       target_cpu_features: currently unimplemented (must be empty), will eventually allow specifying target CPU features.
       tags: tags to apply to the generated tests. Note that as in standard test suites, manual
           is treated specially and will also apply to the test suite itself.
@@ -145,8 +131,6 @@ def iree_check_single_backend_test_suite(
             driver = driver,
             compiler_flags = compiler_flags,
             runner_args = runner_args,
-            opt_tool = opt_tool,
-            opt_flags = opt_flags,
             tags = tags,
             timeout = timeout,
             **kwargs
@@ -174,8 +158,6 @@ def iree_check_test_suite(
         target_backends_and_drivers = ALL_TARGET_BACKENDS_AND_DRIVERS,
         compiler_flags = [],
         runner_args = [],
-        opt_tool = "//iree/tools:iree-opt",
-        opt_flags = [],
         tags = [],
         target_cpu_features_variants = [],
         **kwargs):
@@ -192,10 +174,6 @@ def iree_check_test_suite(
       runner_args: additional runner_args to pass to the underlying iree-check-module tests. The
           driver and input file are passed automatically. To use different runner_args per test,
           create a separate suite or iree_check_test.
-      opt_tool: Defaulting to iree-opt. Tool used to preprocess the source files
-          if opt_flags is specified.
-      opt_flags: If specified, source files are preprocessed with OPT_TOOL with
-          these flags.
       tags: tags to apply to the generated tests. Note that as in standard test suites, manual
           is treated specially and will also apply to the test suite itself.
       target_cpu_features_variants: list of target cpu features variants. Currently unimplemented, so each
@@ -223,8 +201,6 @@ def iree_check_test_suite(
             target_backend = backend,
             compiler_flags = compiler_flags,
             runner_args = runner_args,
-            opt_tool = opt_tool,
-            opt_flags = opt_flags,
             tags = tags,
             **kwargs
         )

--- a/build_tools/bazel/iree_trace_runner_test.bzl
+++ b/build_tools/bazel/iree_trace_runner_test.bzl
@@ -19,8 +19,6 @@ def iree_trace_runner_test(
         trace,
         compiler_flags = [],
         runner_args = [],
-        opt_tool = "//iree/tools:iree-opt",
-        opt_flags = [],
         tags = [],
         target_cpu_features = None,
         timeout = None,
@@ -38,10 +36,6 @@ def iree_trace_runner_test(
             and input file flags are passed automatically.
         tags: Additional labels to apply to the test. "driver=${DRIVER}" is added
             automatically.
-        opt_tool: Defaulting to iree-opt. Tool used to preprocess the source files
-            if opt_flags is specified.
-        opt_flags: If specified, source files are preprocessed with opt_tool with
-            these flags.
         trace_runner: trace-runner program to run.
         trace: trace file input to the trace-runner program.
         module: specifies the  path to use for the enerated IREE module (.vmfb). Mandatory,
@@ -64,8 +58,6 @@ def iree_trace_runner_test(
             "-mlir-print-op-on-diagnostic=false",
             "-iree-hal-target-backends=%s" % target_backend,
         ] + compiler_flags,
-        opt_tool = opt_tool,
-        opt_flags = opt_flags,
         visibility = ["//visibility:private"],
         **kwargs
     )
@@ -95,8 +87,6 @@ def iree_single_backend_generated_trace_runner_test(
         generator_args = [],
         compiler_flags = [],
         runner_args = [],
-        opt_tool = "//iree/tools:iree-opt",
-        opt_flags = [],
         tags = [],
         target_cpu_features = None,
         timeout = None,
@@ -122,10 +112,6 @@ def iree_single_backend_generated_trace_runner_test(
             and input file flags are passed automatically.
         tags: Additional labels to apply to the test. "driver=${DRIVER}" is added
             automatically.
-        opt_tool: Defaulting to iree-opt. Tool used to preprocess the source files
-            if opt_flags is specified.
-        opt_flags: If specified, source files are preprocessed with opt_tool with
-            these flags.
         trace_runner: trace-runner program to run.
         timeout: timeout for the generated tests.
         target_cpu_features: currently unimplemented (must be empty), will eventually allow specifying target CPU features.
@@ -166,8 +152,6 @@ def iree_single_backend_generated_trace_runner_test(
         trace = trace,
         compiler_flags = compiler_flags,
         runner_args = runner_args,
-        opt_tool = opt_tool,
-        opt_flags = opt_flags,
         tags = tags,
         timeout = timeout,
         **kwargs
@@ -181,8 +165,6 @@ def iree_generated_trace_runner_test(
         generator_args = [],
         compiler_flags = [],
         runner_args = [],
-        opt_tool = "//iree/tools:iree-opt",
-        opt_flags = [],
         tags = [],
         timeout = None,
         target_cpu_features_variants = [],
@@ -204,14 +186,6 @@ def iree_generated_trace_runner_test(
             and input file flags are passed automatically.
         tags: Additional labels to apply to the test. "driver=${DRIVER}" is added
             automatically.
-        opt_tool: Defaulting to iree-opt. Tool used to preprocess the source files
-            if opt_flags is specified.
-        opt_flags: If specified, source files are preprocessed with opt_tool with
-            these flags. The special string "#pass_options_variant#" is replaced
-            with the empty string. That may in the future be changed to some
-            automatically determined pass options for each entry in
-            target_cpu_features_variants, as is currently done in the CMake
-            build.
         trace_runner: trace-runner program to run.
         timeout: timeout for the generated tests.
         target_cpu_features_variants: list of target cpu features variants. Currently unimplemented, so each
@@ -225,7 +199,6 @@ def iree_generated_trace_runner_test(
             fail("Entry %s in target_cpu_features_variants: unimplemented" % target_cpu_features)
 
     tests = []
-    processed_opt_flags = [flag.replace("#pass_options_variant#", "") for flag in opt_flags]
     processsed_compiler_flags = [flag.replace("#pass_options_variant#", "") for flag in compiler_flags]
     for backend, driver in target_backends_and_drivers:
         # CUDA backend/driver not supported by Bazel build.
@@ -241,8 +214,6 @@ def iree_generated_trace_runner_test(
             generator_args = generator_args,
             compiler_flags = processsed_compiler_flags,
             runner_args = runner_args,
-            opt_tool = opt_tool,
-            opt_flags = processed_opt_flags,
             tags = tags,
             timeout = timeout,
             **kwargs

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
@@ -436,7 +436,6 @@ class BuildFileFunctions(object):
                            flags=None,
                            translate_tool=None,
                            c_identifier=None,
-                           opt_flags=None,
                            testonly=None):
     name_block = _convert_string_arg_block("NAME", name, quote=False)
     src_block = _convert_string_arg_block("SRC", src)
@@ -444,7 +443,6 @@ class BuildFileFunctions(object):
     translate_tool_block = _convert_target_block("TRANSLATE_TOOL",
                                                  translate_tool)
     flags_block = _convert_string_list_block("FLAGS", flags)
-    opt_flags_block = _convert_string_list_block("OPT_FLAGS", opt_flags)
     testonly_block = _convert_option_block("TESTONLY", testonly)
 
     self.converter.body += (f"iree_bytecode_module(\n"
@@ -453,7 +451,6 @@ class BuildFileFunctions(object):
                             f"{c_identifier_block}"
                             f"{translate_tool_block}"
                             f"{flags_block}"
-                            f"{opt_flags_block}"
                             f"{testonly_block}"
                             f"  PUBLIC\n)\n\n")
 
@@ -541,7 +538,6 @@ class BuildFileFunctions(object):
                                            target_backends_and_drivers=None,
                                            runner_args=None,
                                            tags=None,
-                                           opt_flags=None,
                                            target_cpu_features=None,
                                            **kwargs):
     name_block = _convert_string_arg_block("NAME", name, quote=False)
@@ -553,7 +549,6 @@ class BuildFileFunctions(object):
                                                       compiler_flags)
     runner_args_block = _convert_string_list_block("RUNNER_ARGS", runner_args)
     labels_block = _convert_string_list_block("LABELS", tags)
-    opt_flags_block = _convert_string_list_block("OPT_FLAGS", opt_flags)
     target_cpu_features_block = _convert_string_arg_block(
         "TARGET_CPU_FEATURES", target_cpu_features)
 
@@ -565,7 +560,6 @@ class BuildFileFunctions(object):
                             f"{compiler_flags_block}"
                             f"{runner_args_block}"
                             f"{labels_block}"
-                            f"{opt_flags_block}"
                             f"{target_cpu_features_block}"
                             f")\n\n")
 
@@ -576,7 +570,6 @@ class BuildFileFunctions(object):
                             compiler_flags=None,
                             runner_args=None,
                             tags=None,
-                            opt_flags=None,
                             target_cpu_features_variants=None,
                             **kwargs):
     target_backends = None
@@ -594,7 +587,6 @@ class BuildFileFunctions(object):
                                                       compiler_flags)
     runner_args_block = _convert_string_list_block("RUNNER_ARGS", runner_args)
     labels_block = _convert_string_list_block("LABELS", tags)
-    opt_flags_block = _convert_string_list_block("OPT_FLAGS", opt_flags)
     target_cpu_features_variants_block = _convert_string_list_block(
         "TARGET_CPU_FEATURES_VARIANTS", target_cpu_features_variants)
 
@@ -606,7 +598,6 @@ class BuildFileFunctions(object):
                             f"{compiler_flags_block}"
                             f"{runner_args_block}"
                             f"{labels_block}"
-                            f"{opt_flags_block}"
                             f"{target_cpu_features_variants_block}"
                             f")\n\n")
 
@@ -619,8 +610,6 @@ class BuildFileFunctions(object):
                                        compiler_flags=None,
                                        runner_args=None,
                                        tags=None,
-                                       opt_tool=None,
-                                       opt_flags=None,
                                        target_cpu_features_variants=None,
                                        **kwargs):
     target_backends = None
@@ -646,7 +635,6 @@ class BuildFileFunctions(object):
                                                       compiler_flags)
     runner_args_block = _convert_string_list_block("RUNNER_ARGS", runner_args)
     labels_block = _convert_string_list_block("LABELS", tags)
-    opt_flags_block = _convert_string_list_block("OPT_FLAGS", opt_flags)
     target_cpu_features_variants_block = _convert_string_list_block(
         "TARGET_CPU_FEATURES_VARIANTS", target_cpu_features_variants)
 
@@ -660,7 +648,6 @@ class BuildFileFunctions(object):
                             f"{compiler_flags_block}"
                             f"{runner_args_block}"
                             f"{labels_block}"
-                            f"{opt_flags_block}"
                             f"{target_cpu_features_variants_block}"
                             f")\n\n")
 

--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -18,8 +18,8 @@ function(iree_bytecode_module_for_iree_check_test_and_friends)
   cmake_parse_arguments(
     _RULE
     ""
-    "MODULE_NAME;SRC;TARGET_BACKEND;OPT_TOOL;MODULE_FILE_NAME"
-    "FLAGS;OPT_FLAGS;TARGET_CPU_FEATURES"
+    "MODULE_NAME;SRC;TARGET_BACKEND;MODULE_FILE_NAME"
+    "FLAGS;TARGET_CPU_FEATURES"
     ${ARGN}
   )
 
@@ -59,10 +59,6 @@ TARGET_BACKEND=${_RULE_TARGET_BACKEND}.")
       "-mlir-print-op-on-diagnostic=false"
       "--iree-hal-target-backends=${_RULE_TARGET_BACKEND}"
       ${_RULE_FLAGS}
-    OPT_TOOL
-      ${_RULE_OPT_TOOL}
-    OPT_FLAGS
-      ${_RULE_OPT_FLAGS}
     TESTONLY
   )
 endfunction()
@@ -86,10 +82,6 @@ endfunction()
 #       and input file are passed automatically.
 #   LABELS: Additional labels to apply to the test. The package path and
 #       "driver=${DRIVER}" are added automatically.
-#   OPT_TOOL: Defaulting to iree-opt. Tool used to preprocess the source files
-#       if OPT_FLAGS is specified.
-#   OPT_FLAGS: If specified, source files are preprocessed with OPT_TOOL with
-#       these flags.
 #   MODULE_FILE_NAME: Optional, specifies the absolute path to the filename
 #       to use for the generated IREE module (.vmfb).
 #   TARGET_CPU_FEATURES: If specified, a string passed as argument to
@@ -122,8 +114,8 @@ function(iree_check_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;SRC;TARGET_BACKEND;DRIVER;OPT_TOOL;MODULE_FILE_NAME"
-    "COMPILER_FLAGS;RUNNER_ARGS;LABELS;OPT_FLAGS;TARGET_CPU_FEATURES"
+    "NAME;SRC;TARGET_BACKEND;DRIVER;MODULE_FILE_NAME"
+    "COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES"
     ${ARGN}
   )
 
@@ -153,10 +145,6 @@ function(iree_check_test)
       "${_RULE_TARGET_BACKEND}"
     FLAGS
       ${_RULE_COMPILER_FLAGS}
-    OPT_TOOL
-      ${_RULE_OPT_TOOL}
-    OPT_FLAGS
-      ${_RULE_OPT_FLAGS}
     TARGET_CPU_FEATURES
       ${_RULE_TARGET_CPU_FEATURES}
   )
@@ -228,10 +216,6 @@ endfunction()
 #       different args per test, create a separate suite or iree_check_test.
 #   LABELS: Additional labels to apply to the generated tests. The package path is
 #       added automatically.
-#   OPT_TOOL: Defaulting to iree-opt. Tool used to preprocess the source files
-#       if OPT_FLAGS is specified.
-#   OPT_FLAGS: If specified, source files are preprocessed with OPT_TOOL with
-#       these flags.
 #   TARGET_CPU_FEATURES: If specified, a string passed as argument to
 #       --iree-llvm-target-cpu-features.
 function(iree_check_single_backend_test_suite)
@@ -246,8 +230,8 @@ function(iree_check_single_backend_test_suite)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;TARGET_BACKEND;DRIVER;OPT_TOOL"
-    "SRCS;COMPILER_FLAGS;RUNNER_ARGS;LABELS;OPT_FLAGS;TARGET_CPU_FEATURES"
+    "NAME;TARGET_BACKEND;DRIVER"
+    "SRCS;COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES"
     ${ARGN}
   )
 
@@ -300,10 +284,6 @@ function(iree_check_single_backend_test_suite)
         ${_RULE_RUNNER_ARGS}
       LABELS
         ${_RULE_LABELS}
-      OPT_TOOL
-        ${_RULE_OPT_TOOL}
-      OPT_FLAGS
-        ${_RULE_OPT_FLAGS}
       TARGET_CPU_FEATURES
         ${_RULE_TARGET_CPU_FEATURES}
     )
@@ -411,10 +391,6 @@ endfunction()
 #       test, create a separate suite or iree_check_test.
 #   LABELS: Additional labels to apply to the generated tests. The package path is
 #       added automatically.
-#   OPT_TOOL: Defaulting to iree-opt. Tool used to preprocess the source files
-#       if OPT_FLAGS is specified.
-#   OPT_FLAGS: If specified, source files are preprocessed with OPT_TOOL with
-#       these flags.
 #   TARGET_CPU_FEATURES_VARIANTS: list of target cpu features variants. Only used
 #       for drivers that vary based on the target CPU features. For each list
 #       element, a separate test is created, with the list element passed as
@@ -458,7 +434,6 @@ function(iree_check_test_suite)
     endif()
     foreach(_TARGET_CPU_FEATURES_LIST_ELEM IN LISTS _TARGET_CPU_FEATURES_VARIANTS)
       process_target_cpu_features("${_TARGET_CPU_FEATURES_LIST_ELEM}" _ENABLED _TARGET_CPU_FEATURES _TARGET_CPU_FEATURES_SUFFIX _TARGET_PASS_OPTIONS)
-      string(REPLACE "#pass_options_variant#" "${_TARGET_PASS_OPTIONS}" _PROCESSED_OPT_FLAGS "${_RULE_OPT_FLAGS}")
       string(REPLACE "#pass_options_variant#" "${_TARGET_PASS_OPTIONS}" _PROCESSED_COMPILER_FLAGS "${_RULE_COMPILER_FLAGS}")
       if (NOT _ENABLED)
         # The current entry is disabled on the target CPU architecture.
@@ -479,10 +454,6 @@ function(iree_check_test_suite)
           ${_RULE_RUNNER_ARGS}
         LABELS
           ${_RULE_LABELS}
-        OPT_TOOL
-          ${_RULE_OPT_TOOL}
-        OPT_FLAGS
-          ${_PROCESSED_OPT_FLAGS}
         TARGET_CPU_FEATURES
           ${_TARGET_CPU_FEATURES}
       )

--- a/build_tools/cmake/iree_trace_runner_test.cmake
+++ b/build_tools/cmake/iree_trace_runner_test.cmake
@@ -22,10 +22,6 @@ include(CMakeParseArguments)
 #       and input file flags are passed automatically.
 #   LABELS: Additional labels to apply to the test. The package path and
 #       "driver=${DRIVER}" are added automatically.
-#   OPT_TOOL: Defaulting to iree-opt. Tool used to preprocess the source files
-#       if OPT_FLAGS is specified.
-#   OPT_FLAGS: If specified, source files are preprocessed with OPT_TOOL with
-#       these flags.
 #   TRACE_RUNNER: trace-runner program to run.
 #   TRACE: trace file input to the trace-runner program.
 #   MODULE_FILE_NAME: specifies the absolute path to the filename to use for the
@@ -46,8 +42,8 @@ function(iree_trace_runner_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;SRC;TRACE;TARGET_BACKEND;DRIVER;OPT_TOOL;TRACE_RUNNER;MODULE_FILE_NAME"
-    "COMPILER_FLAGS;RUNNER_ARGS;LABELS;OPT_FLAGS;TARGET_CPU_FEATURES"
+    "NAME;SRC;TRACE;TARGET_BACKEND;DRIVER;TRACE_RUNNER;MODULE_FILE_NAME"
+    "COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES"
     ${ARGN}
   )
 
@@ -67,10 +63,6 @@ function(iree_trace_runner_test)
       "${_RULE_TARGET_BACKEND}"
     FLAGS
       ${_RULE_COMPILER_FLAGS}
-    OPT_TOOL
-      ${_RULE_OPT_TOOL}
-    OPT_FLAGS
-      ${_RULE_OPT_FLAGS}
     TARGET_CPU_FEATURES
       ${_RULE_TARGET_CPU_FEATURES}
   )
@@ -142,10 +134,6 @@ endfunction()
 #       and input file flags are passed automatically.
 #   LABELS: Additional labels to apply to the test. The package path and
 #       "driver=${DRIVER}" are added automatically.
-#   OPT_TOOL: Defaulting to iree-opt. Tool used to preprocess the source files
-#       if OPT_FLAGS is specified.
-#   OPT_FLAGS: If specified, source files are preprocessed with OPT_TOOL with
-#       these flags.
 #   TRACE_RUNNER: trace-runner program to run.
 #   TARGET_CPU_FEATURES: If specified, a string passed as argument to
 #       --iree-llvm-target-cpu-features.
@@ -169,8 +157,8 @@ function(iree_single_backend_generated_trace_runner_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;GENERATOR;TARGET_BACKEND;DRIVER;OPT_TOOL;TRACE_RUNNER"
-    "GENERATOR_ARGS;COMPILER_FLAGS;RUNNER_ARGS;LABELS;OPT_FLAGS;TARGET_CPU_FEATURES"
+    "NAME;GENERATOR;TARGET_BACKEND;DRIVER;TRACE_RUNNER"
+    "GENERATOR_ARGS;COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES"
     ${ARGN}
   )
 
@@ -256,10 +244,6 @@ function(iree_single_backend_generated_trace_runner_test)
       ${_RULE_RUNNER_ARGS}
     LABELS
       ${_RULE_LABELS}
-    OPT_TOOL
-      ${_RULE_OPT_TOOL}
-    OPT_FLAGS
-      ${_RULE_OPT_FLAGS}
     TARGET_CPU_FEATURES
       ${_RULE_TARGET_CPU_FEATURES}
   )
@@ -302,10 +286,6 @@ endfunction()
 #       and input file flags are passed automatically.
 #   LABELS: Additional labels to apply to the test. The package path and
 #       "driver=${DRIVER}" are added automatically.
-#   OPT_TOOL: Defaulting to iree-opt. Tool used to preprocess the source files
-#       if OPT_FLAGS is specified.
-#   OPT_FLAGS: If specified, source files are preprocessed with OPT_TOOL with
-#       these flags.
 #   TRACE_RUNNER: trace-runner program to run.
 #   TARGET_CPU_FEATURES_VARIANTS: list of target cpu features variants. Only used
 #       for drivers that vary based on the target CPU features. For each list
@@ -321,8 +301,8 @@ function(iree_generated_trace_runner_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;GENERATOR;OPT_TOOL;TRACE_RUNNER"
-    "TARGET_BACKENDS;DRIVERS;GENERATOR_ARGS;COMPILER_FLAGS;RUNNER_ARGS;LABELS;OPT_FLAGS;TARGET_CPU_FEATURES_VARIANTS"
+    "NAME;GENERATOR;TRACE_RUNNER"
+    "TARGET_BACKENDS;DRIVERS;GENERATOR_ARGS;COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES_VARIANTS"
     ${ARGN}
   )
 
@@ -350,7 +330,6 @@ function(iree_generated_trace_runner_test)
     endif()
     foreach(_TARGET_CPU_FEATURES_LIST_ELEM IN LISTS _TARGET_CPU_FEATURES_VARIANTS)
       process_target_cpu_features("${_TARGET_CPU_FEATURES_LIST_ELEM}" _ENABLED _TARGET_CPU_FEATURES _TARGET_CPU_FEATURES_SUFFIX _TARGET_PASS_OPTIONS)
-      string(REPLACE "#pass_options_variant#" "${_TARGET_PASS_OPTIONS}" _PROCESSED_OPT_FLAGS "${_RULE_OPT_FLAGS}")
       string(REPLACE "#pass_options_variant#" "${_TARGET_PASS_OPTIONS}" _PROCESSED_COMPILER_FLAGS "${_RULE_COMPILER_FLAGS}")
       if (NOT _ENABLED)
         # The current entry is disabled on the target CPU architecture.
@@ -375,10 +354,6 @@ function(iree_generated_trace_runner_test)
           ${_RULE_RUNNER_ARGS}
         LABELS
           ${_RULE_LABELS}
-        OPT_TOOL
-          ${_RULE_OPT_TOOL}
-        OPT_FLAGS
-          ${_PROCESSED_OPT_FLAGS}
         TARGET_CPU_FEATURES
           ${_TARGET_CPU_FEATURES}
       )


### PR DESCRIPTION
That was added back when enabling mmt4d required preprocessing the input MLIR file with `iree-opt` with a custom pass. That has been unused since #8402 exposed that in `iree-translate`.