### PR TITLE
Drop the elision of dead results from dispatch regions.

### DIFF
--- a/iree/compiler/Dialect/Util/IR/ClosureOpUtils.cpp
+++ b/iree/compiler/Dialect/Util/IR/ClosureOpUtils.cpp
@@ -250,13 +250,9 @@ LogicalResult optimizeClosureLikeOp(ClosureOpInterface closureOp,
   SmallVector<Value, 4> preservedResults;
   SmallVector<unsigned, 4> elidedResults;
   for (auto result : llvm::enumerate(closureOp.getClosureResults())) {
-    // You can drop a result if the use is empty and not read via a tie.
-    auto access = closureOp.getResultAccess(result.index());
-    if (result.value().use_empty() && !access.isRead) {
-      elidedResults.push_back(result.index());
-    } else {
-      preservedResults.push_back(result.value());
-    }
+    // TODO(#8899): It should be possible to add results that are not used
+    // to `elidedResults`. For now `elidedResults` is just left empty.
+    preservedResults.push_back(result.value());
   }
 
   if (elidedOperands.empty() && elidedResults.empty()) {


### PR DESCRIPTION
The elision of dead results from dispatch regions causes stack
allocation in certain cases. The reason is down to how some ops are
represented in Linalg. See #8899.

Fixes #8411
Fixes #8592