### PR TITLE
Adding optional import support to the VM.

### DIFF
--- a/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -510,8 +510,8 @@ class HALDispatchABI {
     return builder.createOrFold<LLVM::LoadOp>(loc, elementPtrValue);
   }
 
-  // Returns an i1 indicating whether the weak import with |ordinal| is defined.
-  // Equivalent to:
+  // Returns an i1 indicating whether the optional import with |ordinal| is
+  // defined. Equivalent to:
   //   state->imports[ordinal] != NULL
   Value isImportFuncAvailable(Location loc, int64_t ordinal,
                               OpBuilder &builder) {

--- a/iree/compiler/Dialect/Modules/Check/Conversion/ConversionPatterns.cpp
+++ b/iree/compiler/Dialect/Modules/Check/Conversion/ConversionPatterns.cpp
@@ -17,18 +17,45 @@ namespace iree_compiler {
 namespace IREE {
 namespace Check {
 
+// Converts check ops to vm.call ops with handling for when the check module is
+// not compiled in (we just ignore them). This allows us to run benchmarks on
+// modules using the check ops.
+template <typename T, typename Adaptor = typename T::Adaptor>
+struct OptionalCheckImportConversion : public VMImportOpConversion<T, Adaptor> {
+  using VMImportOpConversion<T, Adaptor>::VMImportOpConversion;
+  LogicalResult matchAndRewrite(
+      T op, typename T::Adaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    auto hasImport = rewriter.create<IREE::VM::ImportResolvedOp>(
+        op.getLoc(), rewriter.getI32Type(), this->importOp.getName());
+    auto *followingBlock = rewriter.splitBlock(rewriter.getInsertionBlock(),
+                                               rewriter.getInsertionPoint());
+    auto *callBlock = rewriter.createBlock(followingBlock);
+    rewriter.setInsertionPointAfter(hasImport);
+    rewriter.create<IREE::VM::CondBranchOp>(op.getLoc(), hasImport, callBlock,
+                                            followingBlock);
+    rewriter.setInsertionPointToStart(callBlock);
+    auto results = rewriteToCall(op, adaptor, this->importOp,
+                                 *this->getTypeConverter(), rewriter);
+    if (!results.hasValue()) return failure();
+    rewriter.replaceOp(op, results.getValue());
+    rewriter.create<IREE::VM::BranchOp>(op.getLoc(), followingBlock);
+    return success();
+  }
+};
+
 void populateCheckToVMPatterns(MLIRContext *context, SymbolTable &importSymbols,
                                RewritePatternSet &patterns,
                                TypeConverter &typeConverter) {
-  patterns.insert<VMImportOpConversion<IREE::Check::ExpectTrueOp>>(
+  patterns.insert<OptionalCheckImportConversion<IREE::Check::ExpectTrueOp>>(
       context, importSymbols, typeConverter, "check.expect_true");
-  patterns.insert<VMImportOpConversion<IREE::Check::ExpectFalseOp>>(
+  patterns.insert<OptionalCheckImportConversion<IREE::Check::ExpectFalseOp>>(
       context, importSymbols, typeConverter, "check.expect_false");
-  patterns.insert<VMImportOpConversion<IREE::Check::ExpectAllTrueOp>>(
+  patterns.insert<OptionalCheckImportConversion<IREE::Check::ExpectAllTrueOp>>(
       context, importSymbols, typeConverter, "check.expect_all_true");
-  patterns.insert<VMImportOpConversion<IREE::Check::ExpectEqOp>>(
+  patterns.insert<OptionalCheckImportConversion<IREE::Check::ExpectEqOp>>(
       context, importSymbols, typeConverter, "check.expect_eq");
-  patterns.insert<VMImportOpConversion<IREE::Check::ExpectAlmostEqOp>>(
+  patterns.insert<OptionalCheckImportConversion<IREE::Check::ExpectAlmostEqOp>>(
       context, importSymbols, typeConverter, "check.expect_almost_eq");
 }
 

--- a/iree/compiler/Dialect/Modules/Check/check.imports.mlir
+++ b/iree/compiler/Dialect/Modules/Check/check.imports.mlir
@@ -6,24 +6,24 @@
 
 vm.module @check {
 
-vm.import @expect_true(
+vm.import optional @expect_true(
   %operand : i32
 )
 
-vm.import @expect_false(
+vm.import optional @expect_false(
   %operand : i32
 )
 
-vm.import @expect_all_true(
+vm.import optional @expect_all_true(
   %operand : !vm.ref<!hal.buffer_view>,
 )
 
-vm.import @expect_eq(
+vm.import optional @expect_eq(
   %lhs : !vm.ref<!hal.buffer_view>,
   %rhs : !vm.ref<!hal.buffer_view>
 )
 
-vm.import @expect_almost_eq(
+vm.import optional @expect_almost_eq(
   %lhs : !vm.ref<!hal.buffer_view>,
   %rhs : !vm.ref<!hal.buffer_view>
 )

--- a/iree/compiler/Dialect/VM/IR/VMOpcodesCore.td
+++ b/iree/compiler/Dialect/VM/IR/VMOpcodesCore.td
@@ -133,6 +133,7 @@ def VM_OPC_Call                  : VM_OPC<0x52, "Call">;
 def VM_OPC_CallVariadic          : VM_OPC<0x53, "CallVariadic">;
 def VM_OPC_Return                : VM_OPC<0x54, "Return">;
 def VM_OPC_Fail                  : VM_OPC<0x55, "Fail">;
+def VM_OPC_ImportResolved        : VM_OPC<0x56, "ImportResolved">;
 
 // Async/fiber ops:
 def VM_OPC_Yield                 : VM_OPC<0x60, "Yield">;
@@ -253,6 +254,7 @@ def VM_CoreOpcodeAttr :
     VM_OPC_CallVariadic,
     VM_OPC_Return,
     VM_OPC_Fail,
+    VM_OPC_ImportResolved,
     VM_OPC_Yield,
     VM_OPC_Trace,
     VM_OPC_Print,

--- a/iree/compiler/Dialect/VM/IR/VMOps.cpp
+++ b/iree/compiler/Dialect/VM/IR/VMOps.cpp
@@ -203,6 +203,9 @@ void ExportOp::build(OpBuilder &builder, OperationState &result,
 
 ParseResult ImportOp::parse(OpAsmParser &parser, OperationState &result) {
   auto builder = parser.getBuilder();
+  if (succeeded(parser.parseOptionalKeyword("optional"))) {
+    result.addAttribute("is_optional", builder.getUnitAttr());
+  }
   StringAttr nameAttr;
   if (failed(parser.parseSymbolName(nameAttr,
                                     mlir::SymbolTable::getSymbolAttrName(),
@@ -261,6 +264,9 @@ ParseResult ImportOp::parse(OpAsmParser &parser, OperationState &result) {
 void ImportOp::print(OpAsmPrinter &p) {
   Operation *op = getOperation();
   p << ' ';
+  if (is_optional()) {
+    p << "optional ";
+  }
   p.printSymbolName(getName());
   p << "(";
   for (int i = 0; i < getArgumentTypes().size(); ++i) {
@@ -287,6 +293,7 @@ void ImportOp::print(OpAsmPrinter &p) {
       /*elided=*/
       {
           "is_variadic",
+          "is_optional",
       });
 }
 
@@ -1315,6 +1322,12 @@ void CondFailOp::print(OpAsmPrinter &p) {
   }
   p.printOptionalAttrDict(getOperation()->getAttrs(),
                           /*elidedAttrs=*/{"message"});
+}
+
+void ImportResolvedOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  std::string name = ("has_" + import()).str();
+  std::replace(name.begin(), name.end(), '.', '_');
+  setResultName(setNameFn, getResult(), name);
 }
 
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -181,7 +181,8 @@ def VM_ImportOp : VM_Op<"import", [
   }];
 
   let arguments = (ins
-    OptionalAttr<VM_Ordinal>:$ordinal
+    OptionalAttr<VM_Ordinal>:$ordinal,
+    OptionalAttr<UnitAttr>:$is_optional
   );
 
   let regions = (region AnyRegion:$body);
@@ -3829,6 +3830,37 @@ def VM_CheckNEOp : VM_BinaryCheckOp<"check.ne", [Commutative]> {
 }
 
 def VM_CheckNZOp : VM_UnaryCheckOp<"check.nz"> {
+  let hasCanonicalizer = 1;
+}
+
+def VM_ImportResolvedOp : VM_PureOp<"import.resolved", [
+  DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
+]> {
+  let summary = [{returns true if an optional import was resolved at runtime}];
+  let description = [{
+    Allows for checking whether a optional import was resolved at runtime. If
+    this returns false then attempting to call the imported function will result
+    in a failure at runtime.
+  }];
+
+  let arguments = (ins
+    VM_FuncRefAttr:$import
+  );
+  let results = (outs
+    VM_CondValue:$result
+  );
+
+  let assemblyFormat = [{
+    $import attr-dict `:` type($result)
+  }];
+
+  let encoding = [
+    VM_EncOpcode<VM_OPC_ImportResolved>,
+    VM_EncFuncAttr<"import">,
+    VM_EncResult<"result">,
+  ];
+
   let hasCanonicalizer = 1;
 }
 

--- a/iree/compiler/Dialect/VM/IR/test/control_flow_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/control_flow_folding.mlir
@@ -140,3 +140,19 @@ vm.module @check_folds {
     // CHECK-NEXT: vm.fail %[[STATUS]], "expected nz"
   }
 }
+
+// -----
+
+// CHECK-LABEL: @check_imports
+vm.module @check_imports {
+  vm.import @required_import_fn(%arg0 : i32) -> i32
+  vm.import optional @optional_import_fn(%arg0 : i32) -> i32
+  vm.func @call_fn() -> (i32, i32) {
+    // CHECK-NOT: vm.import.resolved @required_import_fn
+    // CHECK-DAG: %[[HAS_STRONG:.+]] = vm.const.i32 1
+    %has_required_import_fn = vm.import.resolved @required_import_fn : i32
+    // CHECK-DAG: %[[HAS_WEAK:.+]] = vm.import.resolved @optional_import_fn : i32
+    %has_optional_import_fn = vm.import.resolved @optional_import_fn : i32
+    vm.return %has_required_import_fn, %has_optional_import_fn : i32, i32
+  }
+}

--- a/iree/compiler/Dialect/VM/IR/test/control_flow_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/control_flow_ops.mlir
@@ -223,3 +223,15 @@ vm.module @my_module {
     vm.return
   }
 }
+
+// -----
+
+vm.module @my_module {
+  // CHECK: vm.import optional @optional_import_fn(%arg0 : i32) -> i32
+  vm.import optional @optional_import_fn(%arg0 : i32) -> i32
+  vm.func @call_fn() -> i32 {
+    // CHECK: %has_optional_import_fn = vm.import.resolved @optional_import_fn : i32
+    %has_optional_import_fn = vm.import.resolved @optional_import_fn : i32
+    vm.return %has_optional_import_fn : i32
+  }
+}

--- a/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
@@ -704,9 +704,13 @@ static LogicalResult buildFlatBufferModule(BytecodeTargetOptions targetOptions,
         auto fullNameRef = fbb.createString(importOp.getName());
         auto signatureRef =
             makeImportFunctionSignatureDef(importOp, typeOrdinalMap, fbb);
+        iree_vm_ImportFlagBits_enum_t flags =
+            importOp.is_optional() ? iree_vm_ImportFlagBits_OPTIONAL
+                                   : iree_vm_ImportFlagBits_REQUIRED;
         iree_vm_ImportFunctionDef_start(fbb);
         iree_vm_ImportFunctionDef_full_name_add(fbb, fullNameRef);
         iree_vm_ImportFunctionDef_signature_add(fbb, signatureRef);
+        iree_vm_ImportFunctionDef_flags_add(fbb, flags);
         return iree_vm_ImportFunctionDef_end(fbb);
       }));
   auto exportFuncRefs =

--- a/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
+++ b/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
@@ -202,7 +202,10 @@ static LogicalResult buildModuleDescriptors(IREE::VM::ModuleOp &moduleOp,
              rhs.ordinal().getValue().getZExtValue();
     });
     for (auto importOp : importOps) {
-      output << "{" << printStringView(importOp.getName()) << "},\n";
+      output << "{"
+             << (importOp.is_optional() ? "IREE_VM_NATIVE_IMPORT_OPTIONAL"
+                                        : "IREE_VM_NATIVE_IMPORT_REQUIRED")
+             << ", " << printStringView(importOp.getName()) << "},\n";
     }
   }
   output << "};\n";

--- a/iree/modules/check/check_test.cc
+++ b/iree/modules/check/check_test.cc
@@ -162,11 +162,10 @@ class CheckTest : public ::testing::Test {
 
   iree_status_t Invoke(const char* function_name) {
     iree_vm_function_t function;
-    IREE_RETURN_IF_ERROR(
-        check_module_->lookup_function(
-            check_module_->self, IREE_VM_FUNCTION_LINKAGE_EXPORT,
-            iree_make_cstring_view(function_name), &function),
-        "exported function '%s' not found", function_name);
+    IREE_RETURN_IF_ERROR(iree_vm_module_lookup_function_by_name(
+                             check_module_, IREE_VM_FUNCTION_LINKAGE_EXPORT,
+                             iree_make_cstring_view(function_name), &function),
+                         "exported function '%s' not found", function_name);
     // TODO(#2075): don't directly invoke native functions like this.
     return iree_vm_invoke(context_, function, IREE_VM_INVOCATION_FLAG_NONE,
                           /*policy=*/nullptr, inputs_.get(),

--- a/iree/modules/check/test/BUILD
+++ b/iree/modules/check/test/BUILD
@@ -20,6 +20,7 @@ iree_lit_test_suite(
         [
             "failure.mlir",
             "success.mlir",
+            "unavailable.mlir",
         ],
         include = ["*.mlir"],
     ),
@@ -27,6 +28,7 @@ iree_lit_test_suite(
     tools = [
         "//iree/tools:iree-check-module",
         "//iree/tools:iree-compile",
+        "//iree/tools:iree-run-module",
         "@llvm-project//llvm:FileCheck",
     ],
 )

--- a/iree/modules/check/test/CMakeLists.txt
+++ b/iree/modules/check/test/CMakeLists.txt
@@ -16,10 +16,12 @@ iree_lit_test_suite(
   SRCS
     "failure.mlir"
     "success.mlir"
+    "unavailable.mlir"
   TOOLS
     FileCheck
     iree::tools::iree-check-module
     iree::tools::iree-compile
+    iree::tools::iree-run-module
   LABELS
     "hostonly"
 )

--- a/iree/modules/check/test/unavailable.mlir
+++ b/iree/modules/check/test/unavailable.mlir
@@ -1,0 +1,15 @@
+// RUN: iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vmvx -iree-mlir-to-vm-bytecode-module %s | iree-run-module --module_file=- --entry_function=expect_true_of_false | FileCheck %s
+
+// Tests that even if the check module is not available (in this case because
+// we are running with iree-run-module instead of iree-check-module) the
+// execution still completes.
+
+// CHECK-LABEL: EXEC @expect_true_of_false
+// CHECK: result[0]: i32=0
+module @expect_failure {
+  func.func @expect_true_of_false() -> i32 {
+    %false = util.unfoldable_constant 0 : i32
+    check.expect_true(%false) : i32
+    return %false : i32
+  }
+}

--- a/iree/schemas/bytecode_module_def.fbs
+++ b/iree/schemas/bytecode_module_def.fbs
@@ -46,6 +46,11 @@ table FunctionSignatureDef {
   reflection_attrs:[ReflectionAttrDef];
 }
 
+enum ImportFlagBits:uint32 (bit_flags) {
+  REQUIRED = 0,  // 1u << 0
+  OPTIONAL = 1,  // 1u << 1
+}
+
 // Defines a runtime-resolved import function.
 table ImportFunctionDef {
   // Fully-qualified name of the function (including the module namespace).
@@ -53,6 +58,9 @@ table ImportFunctionDef {
 
   // Signature of the function expected used for verifying that imports match.
   signature:FunctionSignatureDef;
+
+  // Version flags controlling the behavior of import resolution.
+  flags:ImportFlagBits = REQUIRED;
 }
 
 // Defines a runtime-resolved export function.

--- a/iree/tools/android/run_module_app/src/main.cc
+++ b/iree/tools/android/run_module_app/src/main.cc
@@ -118,8 +118,8 @@ Status RunModule(const IreeModuleInvocation& invocation) {
   const std::string& function_name = invocation.entry_function;
   iree_vm_function_t function;
   IREE_RETURN_IF_ERROR(
-      input_module->lookup_function(
-          input_module->self, IREE_VM_FUNCTION_LINKAGE_EXPORT,
+      iree_vm_module_lookup_function_by_name(
+          input_module, IREE_VM_FUNCTION_LINKAGE_EXPORT,
           iree_string_view_t{function_name.data(), function_name.size()},
           &function),
       "looking up function '%s'", function_name.c_str());

--- a/iree/tools/iree-run-module-main.cc
+++ b/iree/tools/iree-run-module-main.cc
@@ -131,8 +131,8 @@ iree_status_t Run() {
                             "no --entry_function= specified");
   } else {
     IREE_RETURN_IF_ERROR(
-        input_module->lookup_function(
-            input_module->self, IREE_VM_FUNCTION_LINKAGE_EXPORT,
+        iree_vm_module_lookup_function_by_name(
+            input_module, IREE_VM_FUNCTION_LINKAGE_EXPORT,
             iree_string_view_t{function_name.data(), function_name.size()},
             &function),
         "looking up function '%s'", function_name.c_str());

--- a/iree/vm/bytecode_dispatch_test.cc
+++ b/iree/vm/bytecode_dispatch_test.cc
@@ -94,8 +94,8 @@ class VMBytecodeDispatchTest
 
   iree_status_t RunFunction(const char* function_name) {
     iree_vm_function_t function;
-    IREE_CHECK_OK(bytecode_module_->lookup_function(
-        bytecode_module_->self, IREE_VM_FUNCTION_LINKAGE_EXPORT,
+    IREE_CHECK_OK(iree_vm_module_lookup_function_by_name(
+        bytecode_module_, IREE_VM_FUNCTION_LINKAGE_EXPORT,
         iree_make_cstring_view(function_name), &function));
 
     return iree_vm_invoke(context_, function, IREE_VM_INVOCATION_FLAG_NONE,

--- a/iree/vm/generated/bytecode_op_table.h
+++ b/iree/vm/generated/bytecode_op_table.h
@@ -93,7 +93,7 @@ typedef enum {
   IREE_VM_OP_CORE_CallVariadic = 0x53,
   IREE_VM_OP_CORE_Return = 0x54,
   IREE_VM_OP_CORE_Fail = 0x55,
-  IREE_VM_OP_CORE_RSV_0x56,
+  IREE_VM_OP_CORE_ImportResolved = 0x56,
   IREE_VM_OP_CORE_RSV_0x57,
   IREE_VM_OP_CORE_RSV_0x58,
   IREE_VM_OP_CORE_RSV_0x59,
@@ -352,7 +352,7 @@ typedef enum {
     OPC(0x53, CallVariadic) \
     OPC(0x54, Return) \
     OPC(0x55, Fail) \
-    RSV(0x56) \
+    OPC(0x56, ImportResolved) \
     RSV(0x57) \
     RSV(0x58) \
     RSV(0x59) \

--- a/iree/vm/module.h
+++ b/iree/vm/module.h
@@ -42,6 +42,8 @@ typedef enum iree_vm_function_linkage_e {
   IREE_VM_FUNCTION_LINKAGE_IMPORT = 1,
   // Function is an export from the module.
   IREE_VM_FUNCTION_LINKAGE_EXPORT = 2,
+  // Function is an import from another module that may be unavailable.
+  IREE_VM_FUNCTION_LINKAGE_IMPORT_OPTIONAL = 3,
   // TODO(#1979): add linkage types for well-known functions like __init.
 } iree_vm_function_linkage_t;
 

--- a/iree/vm/native_module.c
+++ b/iree/vm/native_module.c
@@ -116,7 +116,10 @@ static iree_status_t IREE_API_PTR iree_vm_native_module_get_import_function(
       &module->descriptor->imports[ordinal];
   if (out_function) {
     out_function->module = &module->base_interface;
-    out_function->linkage = IREE_VM_FUNCTION_LINKAGE_IMPORT;
+    out_function->linkage = iree_all_bits_set(import_descriptor->flags,
+                                              IREE_VM_NATIVE_IMPORT_OPTIONAL)
+                                ? IREE_VM_FUNCTION_LINKAGE_IMPORT_OPTIONAL
+                                : IREE_VM_FUNCTION_LINKAGE_IMPORT;
     out_function->ordinal = (uint16_t)ordinal;
   }
   if (out_name) {
@@ -165,6 +168,7 @@ static iree_status_t IREE_API_PTR iree_vm_native_module_get_function(
   }
   switch (linkage) {
     case IREE_VM_FUNCTION_LINKAGE_IMPORT:
+    case IREE_VM_FUNCTION_LINKAGE_IMPORT_OPTIONAL:
       return iree_vm_native_module_get_import_function(
           module, ordinal, out_function, out_name, out_signature);
     case IREE_VM_FUNCTION_LINKAGE_EXPORT:

--- a/iree/vm/native_module.h
+++ b/iree/vm/native_module.h
@@ -19,10 +19,18 @@
 extern "C" {
 #endif  // __cplusplus
 
+enum iree_vm_native_import_flag_bits_e {
+  IREE_VM_NATIVE_IMPORT_REQUIRED = 1u << 0,
+  IREE_VM_NATIVE_IMPORT_OPTIONAL = 1u << 1,
+};
+typedef uint32_t iree_vm_native_import_flags_t;
+
 // Describes an imported native function in a native module.
 // All of this information is assumed read-only and will be referenced for the
 // lifetime of any module created with the descriptor.
 typedef struct iree_vm_native_import_descriptor_t {
+  // Flags controlling import resolution.
+  iree_vm_native_import_flags_t flags;
   // Fully-qualified function name (for example, 'other_module.foo').
   iree_string_view_t full_name;
 } iree_vm_native_import_descriptor_t;

--- a/iree/vm/native_module_test.h
+++ b/iree/vm/native_module_test.h
@@ -242,8 +242,8 @@ static const iree_vm_native_function_ptr_t module_b_funcs_[] = {
 };
 
 static const iree_vm_native_import_descriptor_t module_b_imports_[] = {
-    {iree_make_cstring_view("module_a.add_1")},
-    {iree_make_cstring_view("module_a.sub_1")},
+    {IREE_VM_NATIVE_IMPORT_REQUIRED, iree_make_cstring_view("module_a.add_1")},
+    {IREE_VM_NATIVE_IMPORT_REQUIRED, iree_make_cstring_view("module_a.sub_1")},
 };
 static_assert(IREE_ARRAYSIZE(module_b_state_t::imports) ==
                   IREE_ARRAYSIZE(module_b_imports_),

--- a/iree/vm/test/control_flow_ops.mlir
+++ b/iree/vm/test/control_flow_ops.mlir
@@ -42,6 +42,30 @@ vm.module @control_flow_ops {
   }
 
   //===--------------------------------------------------------------------===//
+  // vm.import.resolved
+  //===--------------------------------------------------------------------===//
+
+  vm.import optional @reserved.optional(%arg0: i32) -> i32
+
+  // The optional import should not be found.
+  vm.export @test_optional_import_resolved
+  vm.func @test_optional_import_resolved() {
+    %c1 = vm.const.i32 1
+    %has_reserved_optional = vm.import.resolved @reserved.optional : i32
+    vm.check.ne %has_reserved_optional, %c1, "missing optional import found" : i32
+    vm.return
+  }
+
+  // The call should fail at runtime because the optional import is not resolved.
+  vm.export @fail_optional_import_call
+  vm.func @fail_optional_import_call() {
+    %c1 = vm.const.i32 1
+    %0 = vm.call @reserved.optional(%c1) : (i32) -> i32
+    %code = vm.const.i32 4
+    vm.fail %code, "unreachable!"
+  }
+
+  //===--------------------------------------------------------------------===//
   // vm.cond_br
   //===--------------------------------------------------------------------===//
 

--- a/runtime/bindings/python/iree/runtime/vm.cc
+++ b/runtime/bindings/python/iree/runtime/vm.cc
@@ -490,6 +490,7 @@ void SetupVmBindings(pybind11::module m) {
   py::enum_<enum iree_vm_function_linkage_e>(m, "Linkage")
       .value("INTERNAL", IREE_VM_FUNCTION_LINKAGE_INTERNAL)
       .value("IMPORT", IREE_VM_FUNCTION_LINKAGE_IMPORT)
+      .value("IMPORT_OPTIONAL", IREE_VM_FUNCTION_LINKAGE_IMPORT_OPTIONAL)
       .value("EXPORT", IREE_VM_FUNCTION_LINKAGE_EXPORT)
       .export_values();
 


### PR DESCRIPTION
This allows us to add functions that may not exist at runtime based on older versions, compile-time optional features, or different tooling.

This finally lets us run programs using the `check` module outside of `iree-check-module`, so tests can be easily passed to `iree-run-module`/`iree-benchmark-module`/etc.

Fixes #5731.