### PR TITLE
TopK LinalgExt Op Lowering to Loops with convert_to_loops.mlir test

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -471,7 +471,9 @@ def IREELinalgExt_ReverseOp : IREELinalgExt_Op<"reverse", [
 }
 
 def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
-  DeclareOpInterfaceMethods<LinalgExtInterface>
+  DeclareOpInterfaceMethods<LinalgExtInterface>,
+  DeclareOpInterfaceMethods<TiledOpInterface,
+    ["generateScalarImplementation"]>
 ]> {
   let summary = "Top-K operator";
   let description = [{

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1273,16 +1273,16 @@ SmallVector<Range> TopkOp::getIterationDomain(OpBuilder &builder) {
   Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
   Value source = values();
 
-  ArrayRef<int64_t> inputShape = getInputType().getShape();
-  for (auto dim : llvm::seq<int64_t>(0, operandRank)) {
-    loopBounds[dim].offset = zero;
-    if (inputShape[dim] == ShapedType::kDynamicSize) {
-      loopBounds[dim].size = getDimValue(builder, loc, source, dim);
+  for (auto dim : llvm::enumerate(getInputType().getShape())) {
+    loopBounds[dim.index()].offset = zero;
+    if (dim.value() == ShapedType::kDynamicSize) {
+      loopBounds[dim.index()].size =
+          getDimValue(builder, loc, source, dim.value());
     } else {
-      loopBounds[dim].size =
-          builder.create<arith::ConstantIndexOp>(loc, inputShape[dim]);
+      loopBounds[dim.index()].size =
+          builder.create<arith::ConstantIndexOp>(loc, dim.value());
     }
-    loopBounds[dim].stride = one;
+    loopBounds[dim.index()].stride = one;
   }
   return loopBounds;
 }

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1272,16 +1272,10 @@ SmallVector<Range> TopkOp::getIterationDomain(OpBuilder &builder) {
   Value zero = builder.create<arith::ConstantIndexOp>(loc, 0);
   Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
   Value source = values();
-
   for (auto dim : llvm::enumerate(getInputType().getShape())) {
     loopBounds[dim.index()].offset = zero;
-    if (dim.value() == ShapedType::kDynamicSize) {
-      loopBounds[dim.index()].size =
-          getDimValue(builder, loc, source, dim.value());
-    } else {
-      loopBounds[dim.index()].size =
-          builder.create<arith::ConstantIndexOp>(loc, dim.value());
-    }
+    loopBounds[dim.index()].size =
+        getDimValue(builder, loc, source, dim.index());
     loopBounds[dim.index()].stride = one;
   }
   return loopBounds;
@@ -1303,14 +1297,8 @@ LogicalResult TopkOp::generateScalarImplementation(OpBuilder &b, Location loc,
   Value initialIndex = b.create<memref::LoadOp>(loc, indices(), ivs);
 
   // Compute K (ub) from the selected dim of the output
-  Value ub;
   ShapedType outputValuesType = outputValues().getType().cast<ShapedType>();
-  if (outputValuesType.isDynamicDim(dimension())) {
-    ub = b.create<memref::DimOp>(loc, outputValues(), dimension());
-  } else {
-    ub = b.create<arith::ConstantIndexOp>(
-        loc, outputValuesType.getDimSize(dimension()));
-  }
+  Value ub = b.create<memref::DimOp>(loc, outputValues(), dimension());
 
   // Inner K loop functions:
   //   Load current K val/ind
@@ -1332,50 +1320,56 @@ LogicalResult TopkOp::generateScalarImplementation(OpBuilder &b, Location loc,
   indices[kDim] = scfFor.getInductionVar();
   auto loopCarryValues = scfFor.getRegionIterArgs();
 
-  // Retrieve the comparison from the region and plug into our loop
+  // Retrieve region as black box comparision function f(x,y). Plug into op.
   auto &srcBlock = region().front();
-  Region &region = scfFor.getRegion();
-  BlockAndValueMapping bvm;
+  BlockAndValueMapping bvmF; // f(x,y)
+  BlockAndValueMapping bvmR; // f(y,x)
   {
+    // Save previous insertion point. Continue within loop body.
     OpBuilder::InsertionGuard guard(b);
-    auto &block = region.front();
-    b.setInsertionPointToEnd(&block);
-    for (auto it : llvm::zip(srcBlock.getArguments(),
-                             ValueRange{loopCarryValues[0], kValue})) {
-      bvm.map(std::get<0>(it), std::get<1>(it));
+    b.setInsertionPointToEnd(&scfFor.getRegion().front());
+    SmallVector<Value> forwardValues{loopCarryValues[0], kValue};
+    SmallVector<Value> reverseValues{kValue, loopCarryValues[0]};
+    for (auto it : llvm::zip(srcBlock.getArguments(), forwardValues)) {
+      bvmF.map(std::get<0>(it), std::get<1>(it));
+    }
+    for (auto it : llvm::zip(srcBlock.getArguments(), reverseValues)) {
+      bvmR.map(std::get<0>(it), std::get<1>(it));
     }
     for (auto &blockOp : srcBlock.without_terminator()) {
-      b.clone(blockOp, bvm);
+      b.clone(blockOp, bvmF);
+      b.clone(blockOp, bvmR);
     }
-  }
-  Value valueCmpRes =
-      bvm.lookupOrDefault(srcBlock.getTerminator()->getOperand(0));
-  OpBuilder::InsertionGuard g(b);
-  b.setInsertionPointToEnd(&region.front());
+    Value forwardCmpRes = bvmF.lookup(srcBlock.getTerminator()->getOperand(0));
+    Value reverseCmpRes = bvmR.lookup(srcBlock.getTerminator()->getOperand(0));
 
-  // Check if the two values are equal, which index came first.
-  Value cmpEqValRes = b.create<arith::CmpFOp>(loc, arith::CmpFPredicate::OEQ,
-                                              loopCarryValues[0], kValue);
-  Value cmpEqIndRes = b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::slt,
-                                              loopCarryValues[1], kIndex);
-  Value combinedCmpEqRes =
-      b.create<arith::AndIOp>(loc, cmpEqValRes, cmpEqIndRes);
-  // True if N > K or N came before K
-  Value indexCmpRes =
-      b.create<arith::OrIOp>(loc, valueCmpRes, combinedCmpEqRes);
-  // Select results for K based on comparisons
-  Value resultKValue =
-      b.create<arith::SelectOp>(loc, valueCmpRes, loopCarryValues[0], kValue);
-  Value resultKIndex =
-      b.create<arith::SelectOp>(loc, indexCmpRes, loopCarryValues[1], kIndex);
-  b.create<memref::StoreOp>(loc, resultKValue, outputValues(), indices);
-  b.create<memref::StoreOp>(loc, resultKIndex, outputIndices(), indices);
-  // Select loop carry, opposite of K results
-  Value resultCarryValue =
-      b.create<arith::SelectOp>(loc, valueCmpRes, kValue, loopCarryValues[0]);
-  Value resultCarryIndex =
-      b.create<arith::SelectOp>(loc, indexCmpRes, kIndex, loopCarryValues[1]);
-  b.create<scf::YieldOp>(loc, ValueRange{resultCarryValue, resultCarryIndex});
+    // Check value equality using strictly weak ordering from the region:
+    //   f(x,y) --> forwardCmpRes
+    //   f(y,x) --> reverseCmpRes
+    //   if forwardCmpRes == reverseCmpRes then select which came first
+    Value cmpEqValRes = b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
+                                                forwardCmpRes, reverseCmpRes);
+    Value cmpEqIndRes = b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::slt,
+                                                loopCarryValues[1], kIndex);
+    Value combinedCmpEqRes =
+        b.create<arith::AndIOp>(loc, cmpEqValRes, cmpEqIndRes);
+    // True if N > K or N came before K
+    Value indexCmpRes =
+        b.create<arith::OrIOp>(loc, forwardCmpRes, combinedCmpEqRes);
+    // Select results for K based on comparisons
+    Value resultKValue = b.create<arith::SelectOp>(loc, forwardCmpRes,
+                                                   loopCarryValues[0], kValue);
+    Value resultKIndex =
+        b.create<arith::SelectOp>(loc, indexCmpRes, loopCarryValues[1], kIndex);
+    b.create<memref::StoreOp>(loc, resultKValue, outputValues(), indices);
+    b.create<memref::StoreOp>(loc, resultKIndex, outputIndices(), indices);
+    // Select loop carry, opposite of K results
+    Value resultCarryValue = b.create<arith::SelectOp>(
+        loc, forwardCmpRes, kValue, loopCarryValues[0]);
+    Value resultCarryIndex =
+        b.create<arith::SelectOp>(loc, indexCmpRes, kIndex, loopCarryValues[1]);
+    b.create<scf::YieldOp>(loc, ValueRange{resultCarryValue, resultCarryIndex});
+  }
   return success();
 }
 

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
@@ -662,14 +662,15 @@ func @topk_memref(%input_values: memref<2x10xf32>, %input_indices: memref<2x10xi
 // CHECK:               %[[D3:.+]] = memref.load %[[ARG2]][%[[ARG4]], %[[ARG6]]]
 // CHECK:               %[[D4:.+]] = memref.load %[[ARG3]][%[[ARG4]], %[[ARG6]]]
 // CHECK:               %[[D5:.+]] = arith.cmpf ogt, %[[ARG7]], %[[D3]] : f32
-// CHECK:               %[[D6:.+]] = arith.cmpf oeq, %[[ARG7]], %[[D3]] : f32
-// CHECK:               %[[D7:.+]] = arith.cmpi slt, %[[ARG8]], %[[D4]] : i32
-// CHECK:               %[[D8:.+]] = arith.andi %[[D6]], %[[D7]] : i1
-// CHECK:               %[[D9:.+]] = arith.ori %[[D5]], %[[D8]] : i1
-// CHECK:               %[[D10:.+]] = arith.select %[[D5]], %[[ARG7]], %[[D3]] : f32
-// CHECK:               %[[D11:.+]] = arith.select %[[D9]], %[[ARG8]], %[[D4]] : i32
-// CHECK:               memref.store %[[D10]], %[[ARG2]][%[[ARG4]], %[[ARG6]]]
-// CHECK:               memref.store %[[D11]], %[[ARG3]][%[[ARG4]], %[[ARG6]]]
-// CHECK:               %[[D12:.+]] = arith.select %[[D5]], %[[D3]], %[[ARG7]] : f32
-// CHECK:               %[[D13:.+]] = arith.select %[[D9]], %[[D4]], %[[ARG8]] : i32
-// CHECK:               scf.yield %[[D12]], %[[D13]] : f32, i32
+// CHECK:               %[[D6:.+]] = arith.cmpf ogt, %[[D3]], %[[ARG7]] : f32
+// CHECK:               %[[D7:.+]] = arith.cmpi eq, %[[D5]], %[[D6]] : i1
+// CHECK:               %[[D8:.+]] = arith.cmpi slt, %[[ARG8]], %[[D4]] : i32
+// CHECK:               %[[D9:.+]] = arith.andi %[[D7]], %[[D8]] : i1
+// CHECK:               %[[D10:.+]] = arith.ori %[[D5]], %[[D9]] : i1
+// CHECK:               %[[D11:.+]] = arith.select %[[D5]], %[[ARG7]], %[[D3]] : f32
+// CHECK:               %[[D12:.+]] = arith.select %[[D10]], %[[ARG8]], %[[D4]] : i32
+// CHECK:               memref.store %[[D11]], %[[ARG2]][%[[ARG4]], %[[ARG6]]]
+// CHECK:               memref.store %[[D12]], %[[ARG3]][%[[ARG4]], %[[ARG6]]]
+// CHECK:               %[[D13:.+]] = arith.select %[[D5]], %[[D3]], %[[ARG7]] : f32
+// CHECK:               %[[D14:.+]] = arith.select %[[D10]], %[[D4]], %[[ARG8]] : i32
+// CHECK:               scf.yield %[[D13]], %[[D14]] : f32, i32

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
@@ -674,3 +674,48 @@ func @topk_memref(%input_values: memref<2x10xf32>, %input_indices: memref<2x10xi
 // CHECK:               %[[D13:.+]] = arith.select %[[D5]], %[[D3]], %[[ARG7]] : f32
 // CHECK:               %[[D14:.+]] = arith.select %[[D10]], %[[D4]], %[[ARG8]] : i32
 // CHECK:               scf.yield %[[D13]], %[[D14]] : f32, i32
+
+// -----
+
+func @topk_memref_dynamic(%input_values: memref<?x?xf32>, %input_indices: memref<?x?xi32>, %out_values: memref<?x3xf32>, %out_indices: memref<?x3xi32>) {
+  iree_linalg_ext.topk
+        dimension(1)
+        ins(%input_values, %input_indices : memref<?x?xf32> , memref<?x?xi32>)
+        outs(%out_values, %out_indices : memref<?x3xf32>, memref<?x3xi32>) {
+        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+          %0 = arith.cmpf ogt, %arg0, %arg1 : f32
+          iree_linalg_ext.yield %0 : i1
+        }
+  return
+}
+
+// CHECK-LABEL: func @topk_memref_dynamic
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG3:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:     %[[C3:.+]] = arith.constant 3 : index
+// CHECK:         %[[D0:.+]] = memref.dim %[[ARG0:.+]], %[[C0]]
+// CHECK:         %[[D1:.+]] = memref.dim %[[ARG0:.+]], %[[C1]]
+// CHECK:         scf.for %[[ARG4:.+]] = %[[C0]] to %[[D0]] step %[[C1]]
+// CHECK:           scf.for %[[ARG5:.+]] = %[[C0]] to %[[D1]] step %[[C1]]
+// CHECK:             %[[D2:.+]] = memref.load %[[ARG0]][%[[ARG4]], %[[ARG5]]]
+// CHECK:             %[[D3:.+]] = memref.load %[[ARG1]][%[[ARG4]], %[[ARG5]]]
+// CHECK:             %[[D4:.+]]:2 = scf.for %[[ARG6:.+]] = %[[C0]] to %[[C3]] step %[[C1]] iter_args(%[[ARG7:.+]] = %[[D2]], %[[ARG8:.+]] = %[[D3]])
+// CHECK:               %[[D5:.+]] = memref.load %[[ARG2]][%[[ARG4]], %[[ARG6]]]
+// CHECK:               %[[D6:.+]] = memref.load %[[ARG3]][%[[ARG4]], %[[ARG6]]]
+// CHECK:               %[[D7:.+]] = arith.cmpf ogt, %[[ARG7]], %[[D5]] : f32
+// CHECK:               %[[D8:.+]] = arith.cmpf ogt, %[[D5]], %[[ARG7]] : f32
+// CHECK:               %[[D9:.+]] = arith.cmpi eq, %[[D7]], %[[D8]] : i1
+// CHECK:               %[[D10:.+]] = arith.cmpi slt, %[[ARG8]], %[[D6]] : i32
+// CHECK:               %[[D11:.+]] = arith.andi %[[D9]], %[[D10]] : i1
+// CHECK:               %[[D12:.+]] = arith.ori %[[D7]], %[[D11]] : i1
+// CHECK:               %[[D13:.+]] = arith.select %[[D7]], %[[ARG7]], %[[D5]] : f32
+// CHECK:               %[[D14:.+]] = arith.select %[[D12]], %[[ARG8]], %[[D6]] : i32
+// CHECK:               memref.store %[[D13]], %[[ARG2]][%[[ARG4]], %[[ARG6]]]
+// CHECK:               memref.store %[[D14]], %[[ARG3]][%[[ARG4]], %[[ARG6]]]
+// CHECK:               %[[D15:.+]] = arith.select %[[D7]], %[[D5]], %[[ARG7]] : f32
+// CHECK:               %[[D16:.+]] = arith.select %[[D12]], %[[D6]], %[[ARG8]] : i32
+// CHECK:               scf.yield %[[D15]], %[[D16]] : f32, i32

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
@@ -629,3 +629,47 @@ func @scan_2d(%0: memref<16x32xi32>, %1: memref<16x32xi32>) {
 // CHECK:               memref.store %[[V4]], %[[BUFO]][%[[ARG1]], %[[ARG2]]]
 // CHECK:               memref.store %[[V4]], %[[ACC]][%[[ARG2]]]
 // CHECK:             }
+
+// -----
+
+func @topk_memref(%input_values: memref<2x10xf32>, %input_indices: memref<2x10xi32>, %out_values: memref<2x3xf32>, %out_indices: memref<2x3xi32>) {
+  iree_linalg_ext.topk
+        dimension(1)
+        ins(%input_values, %input_indices : memref<2x10xf32> , memref<2x10xi32>)
+        outs(%out_values, %out_indices : memref<2x3xf32>, memref<2x3xi32>) {
+        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+          %0 = arith.cmpf ogt, %arg0, %arg1 : f32
+          iree_linalg_ext.yield %0 : i1
+        }
+  return
+}
+
+// CHECK-LABEL: func @topk_memref
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG3:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:     %[[C2:.+]] = arith.constant 2 : index
+// CHECK-DAG:     %[[C10:.+]] = arith.constant 10 : index
+// CHECK-DAG:     %[[C3:.+]] = arith.constant 3 : index
+// CHECK:         scf.for %[[ARG4:.+]] = %[[C0]] to %[[C2]] step %[[C1]]
+// CHECK:           scf.for %[[ARG5:.+]] = %[[C0]] to %[[C10]] step %[[C1]]
+// CHECK:             %[[D0:.+]] = memref.load %[[ARG0]][%[[ARG4]], %[[ARG5]]]
+// CHECK:             %[[D1:.+]] = memref.load %[[ARG1]][%[[ARG4]], %[[ARG5]]]
+// CHECK:             %[[D2:.+]]:2 = scf.for %[[ARG6:.+]] = %[[C0]] to %[[C3]] step %[[C1]] iter_args(%[[ARG7:.+]] = %[[D0]], %[[ARG8:.+]] = %[[D1]])
+// CHECK:               %[[D3:.+]] = memref.load %[[ARG2]][%[[ARG4]], %[[ARG6]]]
+// CHECK:               %[[D4:.+]] = memref.load %[[ARG3]][%[[ARG4]], %[[ARG6]]]
+// CHECK:               %[[D5:.+]] = arith.cmpf ogt, %[[ARG7]], %[[D3]] : f32
+// CHECK:               %[[D6:.+]] = arith.cmpf oeq, %[[ARG7]], %[[D3]] : f32
+// CHECK:               %[[D7:.+]] = arith.cmpi slt, %[[ARG8]], %[[D4]] : i32
+// CHECK:               %[[D8:.+]] = arith.andi %[[D6]], %[[D7]] : i1
+// CHECK:               %[[D9:.+]] = arith.ori %[[D5]], %[[D8]] : i1
+// CHECK:               %[[D10:.+]] = arith.select %[[D5]], %[[ARG7]], %[[D3]] : f32
+// CHECK:               %[[D11:.+]] = arith.select %[[D9]], %[[ARG8]], %[[D4]] : i32
+// CHECK:               memref.store %[[D10]], %[[ARG2]][%[[ARG4]], %[[ARG6]]]
+// CHECK:               memref.store %[[D11]], %[[ARG3]][%[[ARG4]], %[[ARG6]]]
+// CHECK:               %[[D12:.+]] = arith.select %[[D5]], %[[D3]], %[[ARG7]] : f32
+// CHECK:               %[[D13:.+]] = arith.select %[[D9]], %[[D4]], %[[ARG8]] : i32
+// CHECK:               scf.yield %[[D12]], %[[D13]] : f32, i32


### PR DESCRIPTION
Implements part of the `TiledOpInterface` to lower Topk to loops through the `iree-linalg-ext-to-loops` pass.

Inner loop contents for Topk:

- Load current K values
- Apply provided block comparison for selecting TopK
- Check for equality between the N/K values and select the earliest index
- Choose and store the final K value
- Choose the loop carry values and yield. 