### PR TITLE
Activate pdl Python bindings

### DIFF
--- a/iree/compiler/API/python/CMakeLists.txt
+++ b/iree/compiler/API/python/CMakeLists.txt
@@ -94,6 +94,7 @@ set(_source_components
   MLIRPythonSources.Dialects.linalg
   MLIRPythonSources.Dialects.math
   MLIRPythonSources.Dialects.memref
+  MLIRPythonSources.Dialects.pdl
   MLIRPythonSources.Dialects.shape
   MLIRPythonSources.Dialects.tensor
   MLIRPythonSources.Dialects.tosa

--- a/iree/compiler/API/python/test/transforms/ireec/compile_sample_module.py
+++ b/iree/compiler/API/python/test/transforms/ireec/compile_sample_module.py
@@ -21,6 +21,7 @@ from iree.compiler.dialects import builtin
 from iree.compiler.dialects import linalg
 from iree.compiler.dialects import math
 from iree.compiler.dialects import memref
+from iree.compiler.dialects import pdl
 from iree.compiler.dialects import shape
 from iree.compiler.dialects import tensor
 from iree.compiler.dialects import tosa


### PR DESCRIPTION
This is needed for experiments with the transform dialect.