### PR TITLE
Adding IREE_ENABLE_CPUINFO to allow disabling cpuinfo usage.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,9 @@ option(IREE_ENABLE_RUNTIME_TRACING "Enables instrumented runtime tracing." OFF)
 option(IREE_ENABLE_COMPILER_TRACING "Enables instrumented compiler tracing." OFF)
 option(IREE_ENABLE_THREADING "Builds IREE in with thread library support." ON)
 
+# TODO(#8469): remove the dependency on cpuinfo entirely.
+option(IREE_ENABLE_CPUINFO "Enables runtime use of cpuinfo for processor topology detection." ON)
+
 option(IREE_BUILD_COMPILER "Builds the IREE compiler." ON)
 option(IREE_BUILD_TESTS "Builds IREE unit tests." ON)
 option(IREE_BUILD_BENCHMARKS "Builds IREE benchmark suites." OFF)
@@ -520,8 +523,10 @@ add_subdirectory(third_party/googletest EXCLUDE_FROM_ALL)
 if(IREE_ENABLE_THREADING)
   iree_set_benchmark_cmake_options()
   add_subdirectory(third_party/benchmark EXCLUDE_FROM_ALL)
-  iree_set_cpuinfo_cmake_options()
-  add_subdirectory(third_party/cpuinfo EXCLUDE_FROM_ALL)
+  if(IREE_ENABLE_CPUINFO)
+    iree_set_cpuinfo_cmake_options()
+    add_subdirectory(third_party/cpuinfo EXCLUDE_FROM_ALL)
+  endif()
 endif()
 
 add_subdirectory(build_tools/third_party/flatcc EXCLUDE_FROM_ALL)

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -166,7 +166,7 @@ EXPLICIT_TARGET_MAPPING = {
     "@com_github_yaml_libyaml//:yaml": ["yaml"],
     "@com_google_googletest//:gtest": ["gmock", "gtest"],
     "@spirv_cross//:spirv_cross_lib": ["spirv-cross-msl"],
-    "@cpuinfo": ["cpuinfo"],
+    "@cpuinfo": ["${IREE_CPUINFO_TARGET}"],
     "@vulkan_memory_allocator//:impl_header_only": ["vulkan_memory_allocator"],
 }
 

--- a/iree/task/BUILD
+++ b/iree/task/BUILD
@@ -18,6 +18,13 @@ iree_cmake_extra_content(
 if(NOT ${IREE_ENABLE_THREADING})
   return()
 endif()
+
+# cpuinfo can be conditionally disabled when it is not supported.
+# If disabled then by default the task system will use 1 thread.
+set(IREE_CPUINFO_TARGET)
+if(IREE_ENABLE_CPUINFO)
+  set(IREE_CPUINFO_TARGET cpuinfo)
+endif()
 """,
     inline = True,
 )

--- a/iree/task/CMakeLists.txt
+++ b/iree/task/CMakeLists.txt
@@ -15,6 +15,13 @@ if(NOT ${IREE_ENABLE_THREADING})
   return()
 endif()
 
+# cpuinfo can be conditionally disabled when it is not supported.
+# If disabled then by default the task system will use 1 thread.
+set(IREE_CPUINFO_TARGET)
+if(IREE_ENABLE_CPUINFO)
+  set(IREE_CPUINFO_TARGET cpuinfo)
+endif()
+
 iree_cc_library(
   NAME
     api
@@ -62,7 +69,7 @@ iree_cc_library(
     "worker.c"
     "worker.h"
   DEPS
-    cpuinfo
+    ${IREE_CPUINFO_TARGET}
     iree::base
     iree::base::core_headers
     iree::base::internal
@@ -190,3 +197,10 @@ iree_cc_test(
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###
+
+if(NOT IREE_ENABLE_CPUINFO)
+  target_compile_definitions(iree_task_task
+    PUBLIC
+      "IREE_TASK_CPUINFO_DISABLED=1"
+  )
+endif()


### PR DESCRIPTION
When set to OFF the --task_topology_max_group_count= value will be used.
If you don't want the random default it has then make sure to specify
--task_topology_group_count=.

Progress on #8469.