### PR TITLE
One stop scripts to build Python wheels on MacOS.

### DIFF
--- a/build_tools/python_deploy/build_macos_packages.sh
+++ b/build_tools/python_deploy/build_macos_packages.sh
@@ -31,6 +31,9 @@ packages="${packages:-iree-runtime iree-runtime-instrumented iree-compiler}"
 export MACOSX_DEPLOYMENT_TARGET=11.0
 export CMAKE_OSX_ARCHITECTURES="arm64;x86_64"
 
+# cpuinfo is incompatible with universal builds.
+export IREE_ENABLE_CPUINFO=OFF
+
 function run() {
   echo "Using python versions: ${python_versions}"
 

--- a/build_tools/python_deploy/build_macos_packages.sh
+++ b/build_tools/python_deploy/build_macos_packages.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# build_macos_packages.sh
+# One stop build of IREE Python packages for MacOS. This presumes that
+# dependencies are installed from install_macos_deps.sh. This will build
+# for a list of Python versions synchronized with that script and corresponding
+# with directory names under:
+#   /Library/Frameworks/Python.framework/Versions
+#
+# MacOS convention is to refer to this as major.minor (i.e. "3.9", "3.10").
+# Valid packages:
+#   iree-runtime
+#   iree-runtime-instrumented
+#   iree-compiler
+
+set -eu -o errtrace
+
+this_dir="$(cd $(dirname $0) && pwd)"
+repo_root="$(cd $this_dir/../../ && pwd)"
+python_versions="${python_versions:3.9 3.10}"
+output_dir="${output_dir:-${this_dir}/wheelhouse}"
+packages="${packages:-iree-runtime iree-runtime-instrumented iree-compiler}"
+
+# Note that this typically is selected to match the version that the official
+# Python distributed is built at.
+export MACOSX_DEPLOYMENT_TARGET=11.0
+export CMAKE_OSX_ARCHITECTURES="arm64;x86_64"
+
+function run() {
+  echo "Using python versions: ${python_versions}"
+
+  local orig_path="$PATH"
+
+  # Build phase.
+  for package in $packages; do
+    echo "******************** BUILDING PACKAGE ${package} ********************"
+    for python_version in $python_versions; do
+      python_dir="/Library/Frameworks/Python.framework/Versions/$python_version"
+      if ! [ -x "$python_dir/bin/python3" ]; then
+        echo "ERROR: Could not find python3: $python_dir (skipping)"
+        continue
+      fi
+      export PATH=$python_dir/bin:$orig_path
+      echo ":::: Python version $(python3 --version)"
+      case "$package" in
+        iree-runtime)
+          clean_wheels iree_runtime $python_version
+          build_iree_runtime
+          run_audit_wheel iree_runtime $python_version
+          ;;
+        iree-runtime-instrumented)
+          clean_wheels iree_runtime_instrumented $python_version
+          build_iree_runtime_instrumented
+          run_audit_wheel iree_runtime_instrumented $python_version
+          ;;
+        iree-compiler)
+          clean_wheels iree_compiler $python_version
+          build_iree_compiler
+          run_audit_wheel iree_compiler $python_version
+          ;;
+        *)
+          echo "Unrecognized package '$package'"
+          exit 1
+          ;;
+      esac
+    done
+  done
+}
+
+function build_iree_runtime() {
+  IREE_HAL_DRIVER_VULKAN=ON \
+  python3 -m pip wheel -v -w $output_dir $repo_root/runtime/
+}
+
+function build_iree_runtime_instrumented() {
+  # TODO: Bundled tracy client on MacOS not yet supported.
+  # Add IREE_BUILD_TRACY=ON once it is.
+  IREE_HAL_DRIVER_VULKAN=ON IREE_ENABLE_RUNTIME_TRACING=ON \
+  IREE_RUNTIME_CUSTOM_PACKAGE_SUFFIX="-instrumented" \
+  python3 -m pip wheel -v -w $output_dir $repo_root/runtime/
+}
+
+function build_iree_compiler() {
+  python3 -m pip wheel -v -w $output_dir $repo_root/iree/compiler/
+}
+
+function run_audit_wheel() {
+  local wheel_basename="$1"
+  local python_version="$2"
+  return
+  generic_wheel="/wheelhouse/${wheel_basename}-*-${python_version}-linux_x86_64.whl"
+  echo ":::: Auditwheel $generic_wheel"
+  auditwheel repair -w $output_dir $generic_wheel
+  rm $generic_wheel
+}
+
+function clean_wheels() {
+  local wheel_basename="$1"
+  local python_version="$2"
+  echo ":::: Clean wheels $wheel_basename $python_version"
+  rm -f /wheelhouse/${wheel_basename}-*-${python_version}-*.whl
+}
+
+run

--- a/build_tools/python_deploy/build_macos_packages.sh
+++ b/build_tools/python_deploy/build_macos_packages.sh
@@ -51,17 +51,14 @@ function run() {
         iree-runtime)
           clean_wheels iree_runtime $python_version
           build_iree_runtime
-          run_audit_wheel iree_runtime $python_version
           ;;
         iree-runtime-instrumented)
           clean_wheels iree_runtime_instrumented $python_version
           build_iree_runtime_instrumented
-          run_audit_wheel iree_runtime_instrumented $python_version
           ;;
         iree-compiler)
           clean_wheels iree_compiler $python_version
           build_iree_compiler
-          run_audit_wheel iree_compiler $python_version
           ;;
         *)
           echo "Unrecognized package '$package'"
@@ -87,16 +84,6 @@ function build_iree_runtime_instrumented() {
 
 function build_iree_compiler() {
   python3 -m pip wheel -v -w $output_dir $repo_root/iree/compiler/
-}
-
-function run_audit_wheel() {
-  local wheel_basename="$1"
-  local python_version="$2"
-  return
-  generic_wheel="/wheelhouse/${wheel_basename}-*-${python_version}-linux_x86_64.whl"
-  echo ":::: Auditwheel $generic_wheel"
-  auditwheel repair -w $output_dir $generic_wheel
-  rm $generic_wheel
 }
 
 function clean_wheels() {

--- a/build_tools/python_deploy/install_macos_deps.sh
+++ b/build_tools/python_deploy/install_macos_deps.sh
@@ -1,0 +1,61 @@
+#!/bin/zsh
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Installs dependencies on MacOS necessary to build IREE.
+# Additional dependencies (i.e MoltenVK) may be needed to use all functionality.
+#
+# Usage:
+#   sudo install_macos_deps.sh
+
+set -e -o pipefail
+
+if [[ "$(whoami)" != "root" ]]; then
+  echo "ERROR: Must setup deps as root"
+  exit 1
+fi
+
+PYTHON_INSTALLER_URLS=(
+  "https://www.python.org/ftp/python/3.10.4/python-3.10.4-macos11.pkg"
+  "https://www.python.org/ftp/python/3.9.12/python-3.9.12-macos11.pkg"
+)
+
+PYTHON_SPECS=(
+  3.10@https://www.python.org/ftp/python/3.10.4/python-3.10.4-macos11.pkg
+  3.9@https://www.python.org/ftp/python/3.9.12/python-3.9.12-macos11.pkg
+)
+
+for python_spec in $PYTHON_SPECS; do
+  python_version="${python_spec%%@*}"
+  url="${python_spec##*@}"
+  echo "-- Installing Python $python_version from $url"
+  python_path="/Library/Frameworks/Python.framework/Versions/$python_version"
+  python_exe="$python_path/bin/python3"
+
+  # Install Python.
+  if ! [ -x "$python_exe" ]; then
+    package_basename="$(basename $url)"
+    download_path="/tmp/iree_python_install/$package_basename"
+    mkdir -p "$(dirname $download_path)"
+    echo "Downloading $url -> $download_path"
+    curl $url -o "$download_path"
+
+    echo "Installing $download_path"
+    installer -pkg "$download_path" -target /
+  else
+    echo ":: Python version already installed. Not reinstalling."
+  fi
+
+  echo ":: Python version $python_version installed:"
+  $python_exe --version
+  $python_exe -m pip --version
+
+  echo ":: Installing system pip packages"
+  $python_exe -m pip install --upgrade pip
+  $python_exe -m pip install --upgrade delocate
+done
+
+echo "*** All done ***"

--- a/iree/compiler/setup.py
+++ b/iree/compiler/setup.py
@@ -105,14 +105,42 @@ def load_version_info():
     return json.load(f)
 
 
+def find_git_versions():
+  revisions = {}
+  try:
+    revisions["IREE"] = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"],
+        cwd=IREE_SOURCE_DIR).decode("utf-8").strip()
+  except subprocess.SubprocessError as e:
+    print(f"ERROR: Could not get IREE revision: {e}", file=sys.stderr)
+  return revisions
+
+
+def find_git_submodule_revision(submodule_path):
+  try:
+    data = subprocess.check_output(["git", "ls-tree", "HEAD", submodule_path],
+                                   cwd=IREE_SOURCE_DIR).decode("utf-8").strip()
+    columns = re.split("\\s+", data)
+    return columns[2]
+  except Exception as e:
+    print(
+        f"ERROR: Could not get submodule revision for {submodule_path}"
+        f" ({e})",
+        file=sys.stderr)
+    return ""
+
+
 try:
   version_info = load_version_info()
 except FileNotFoundError:
   print("version_info.json not found. Using defaults", file=sys.stderr)
   version_info = {}
+git_versions = find_git_versions()
 
 PACKAGE_SUFFIX = version_info.get("package-suffix") or ""
-PACKAGE_VERSION = version_info.get("package-version") or "0.1dev1"
+PACKAGE_VERSION = version_info.get("package-version")
+if not PACKAGE_VERSION:
+  PACKAGE_VERSION = f"0.dev0+{git_versions.get('IREE') or '0'}"
 
 
 def maybe_nuke_cmake_cache():
@@ -164,6 +192,21 @@ def maybe_nuke_cmake_cache():
     f.write(expected_stamp_contents)
 
 
+def get_env_cmake_option(name: str, default_value: bool = False) -> str:
+  svalue = os.getenv(name)
+  if not svalue:
+    svalue = "ON" if default_value else "OFF"
+  return f"-D{name}={svalue}"
+
+
+def add_env_cmake_setting(args, env_name: str, cmake_name=None) -> str:
+  svalue = os.getenv(env_name)
+  if svalue is not None:
+    if not cmake_name:
+      cmake_name = env_name
+    args.append(f"-D{cmake_name}={svalue}")
+
+
 def prepare_installation():
   version_py_content = generate_version_py()
   print(f"Generating version.py:\n{version_py_content}", file=sys.stderr)
@@ -182,12 +225,15 @@ def prepare_installation():
         "-DIREE_BUILD_PYTHON_BINDINGS=ON",
         "-DPython3_EXECUTABLE={}".format(sys.executable),
         "-DCMAKE_BUILD_TYPE={}".format(cfg),
+        get_env_cmake_option("IREE_TARGET_BACKEND_CUDA"),
     ]
 
-    # Enable CUDA if specified.
-    cuda_target_option = os.getenv("IREE_TARGET_BACKEND_CUDA")
-    if cuda_target_option:
-      cmake_args.append(f"-DIREE_TARGET_BACKEND_CUDA={cuda_target_option}")
+    # These usually flow through the environment, but we add them explicitly
+    # so that they show clearly in logs (getting them wrong can have bad
+    # outcomes).
+    add_env_cmake_setting(cmake_args, "CMAKE_OSX_ARCHITECTURES")
+    add_env_cmake_setting(cmake_args, "MACOSX_DEPLOYMENT_TARGET",
+                          "CMAKE_OSX_DEPLOYMENT_TARGET")
 
     # Only do a from-scratch configure if not already configured.
     cmake_cache_file = os.path.join(IREE_BINARY_DIR, "CMakeCache.txt")
@@ -275,7 +321,7 @@ def generate_version_py():
   return f"""# Auto-generated version info.
 PACKAGE_SUFFIX = "{PACKAGE_SUFFIX}"
 VERSION = "{PACKAGE_VERSION}"
-REVISIONS = {json.dumps(find_git_versions())}
+REVISIONS = {json.dumps(git_versions)}
 """
 
 

--- a/iree/compiler/setup.py
+++ b/iree/compiler/setup.py
@@ -18,6 +18,11 @@
 #
 # On CIs, it is often advantageous to re-use/control the CMake build directory.
 # This can be set with the IREE_COMPILER_API_CMAKE_BUILD_DIR env var.
+#
+# Select CMake options are available from environment variables:
+#   IREE_TARGET_BACKEND_CUDA
+#   IREE_ENABLE_CPUINFO
+
 from gettext import install
 import json
 from multiprocessing.spawn import prepare
@@ -226,6 +231,7 @@ def prepare_installation():
         "-DPython3_EXECUTABLE={}".format(sys.executable),
         "-DCMAKE_BUILD_TYPE={}".format(cfg),
         get_env_cmake_option("IREE_TARGET_BACKEND_CUDA"),
+        get_env_cmake_option("IREE_ENABLE_CPUINFO", "ON"),
     ]
 
     # These usually flow through the environment, but we add them explicitly

--- a/runtime/setup.py
+++ b/runtime/setup.py
@@ -113,14 +113,42 @@ def load_version_info():
     return json.load(f)
 
 
+def find_git_versions():
+  revisions = {}
+  try:
+    revisions["IREE"] = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"],
+        cwd=IREE_SOURCE_DIR).decode("utf-8").strip()
+  except subprocess.SubprocessError as e:
+    print(f"ERROR: Could not get IREE revision: {e}", file=sys.stderr)
+  return revisions
+
+
+def find_git_submodule_revision(submodule_path):
+  try:
+    data = subprocess.check_output(["git", "ls-tree", "HEAD", submodule_path],
+                                   cwd=IREE_SOURCE_DIR).decode("utf-8").strip()
+    columns = re.split("\\s+", data)
+    return columns[2]
+  except Exception as e:
+    print(
+        f"ERROR: Could not get submodule revision for {submodule_path}"
+        f" ({e})",
+        file=sys.stderr)
+    return ""
+
+
 try:
   version_info = load_version_info()
 except FileNotFoundError:
   print("version_info.json not found. Using defaults", file=sys.stderr)
   version_info = {}
+git_versions = find_git_versions()
 
 PACKAGE_SUFFIX = version_info.get("package-suffix") or ""
-PACKAGE_VERSION = version_info.get("package-version") or "0.1dev1"
+PACKAGE_VERSION = version_info.get("package-version")
+if not PACKAGE_VERSION:
+  PACKAGE_VERSION = f"0.dev0+{git_versions.get('IREE') or '0'}"
 
 
 def maybe_nuke_cmake_cache():
@@ -170,11 +198,19 @@ def maybe_nuke_cmake_cache():
     f.write(expected_stamp_contents)
 
 
-def get_env_cmake_option(name: str, default_value: bool = False) -> bool:
+def get_env_cmake_option(name: str, default_value: bool = False) -> str:
   svalue = os.getenv(name)
   if not svalue:
     svalue = "ON" if default_value else "OFF"
   return f"-D{name}={svalue}"
+
+
+def add_env_cmake_setting(args, env_name: str, cmake_name=None) -> str:
+  svalue = os.getenv(env_name)
+  if svalue is not None:
+    if not cmake_name:
+      cmake_name = env_name
+    args.append(f"-D{cmake_name}={svalue}")
 
 
 def prepare_installation():
@@ -204,6 +240,13 @@ def prepare_installation():
         get_env_cmake_option("IREE_ENABLE_RUNTIME_TRACING"),
         get_env_cmake_option("IREE_BUILD_TRACY"),
     ]
+
+    # These usually flow through the environment, but we add them explicitly
+    # so that they show clearly in logs (getting them wrong can have bad
+    # outcomes).
+    add_env_cmake_setting(cmake_args, "CMAKE_OSX_ARCHITECTURES")
+    add_env_cmake_setting(cmake_args, "MACOSX_DEPLOYMENT_TARGET",
+                          "CMAKE_OSX_DEPLOYMENT_TARGET")
 
     # Only do a from-scratch configure if not already configured.
     cmake_cache_file = os.path.join(IREE_BINARY_DIR, "CMakeCache.txt")
@@ -293,33 +336,8 @@ def generate_version_py():
   return f"""# Auto-generated version info.
 PACKAGE_SUFFIX = "{PACKAGE_SUFFIX}"
 VERSION = "{PACKAGE_VERSION}"
-REVISIONS = {json.dumps(find_git_versions())}
+REVISIONS = {json.dumps(git_versions)}
 """
-
-
-def find_git_versions():
-  revisions = {}
-  try:
-    revisions["IREE"] = subprocess.check_output(
-        ["git", "rev-parse", "HEAD"],
-        cwd=IREE_SOURCE_DIR).decode("utf-8").strip()
-  except subprocess.SubprocessError as e:
-    print(f"ERROR: Could not get IREE revision: {e}", file=sys.stderr)
-  return revisions
-
-
-def find_git_submodule_revision(submodule_path):
-  try:
-    data = subprocess.check_output(["git", "ls-tree", "HEAD", submodule_path],
-                                   cwd=IREE_SOURCE_DIR).decode("utf-8").strip()
-    columns = re.split("\\s+", data)
-    return columns[2]
-  except Exception as e:
-    print(
-        f"ERROR: Could not get submodule revision for {submodule_path}"
-        f" ({e})",
-        file=sys.stderr)
-    return ""
 
 
 prepare_installation()

--- a/runtime/setup.py
+++ b/runtime/setup.py
@@ -25,6 +25,7 @@
 #   IREE_HAL_DRIVER_VULKAN
 #   IREE_ENABLE_RUNTIME_TRACING
 #   IREE_BUILD_TRACY
+#   IREE_ENABLE_CPUINFO
 
 from gettext import install
 import json
@@ -239,6 +240,7 @@ def prepare_installation():
                              "OFF" if platform.system() == "Darwin" else "ON"),
         get_env_cmake_option("IREE_ENABLE_RUNTIME_TRACING"),
         get_env_cmake_option("IREE_BUILD_TRACY"),
+        get_env_cmake_option("IREE_ENABLE_CPUINFO", "ON"),
     ]
 
     # These usually flow through the environment, but we add them explicitly


### PR DESCRIPTION
* Also adds a script to install known needed Python versions.
* Fixes setup.py files to plumb through vars needed to control MacOS arch and target versions.
* CMake hack to let cpuinfo build for universal (just guts it for all Apple targets pending more specific work).
* Build script will build universal2 wheels targeting MacOS 11.0 (matches the official Python binaries).
* Needs a couple of other local fixes for cpuinfo to actually work (will update once Ben's changes land).