### PR TITLE
Adding plumbing for querying runtime CPU concurrency information in the compiler.

### DIFF
--- a/iree/compiler/Codegen/Common/InsertDistributionInfoPass.cpp
+++ b/iree/compiler/Codegen/Common/InsertDistributionInfoPass.cpp
@@ -70,7 +70,7 @@ static LogicalResult defineWorkgroupCountRegion(
   }
   WorkgroupCountRegionBuilder regionBuilder =
       [&workloadPerWorkgroup, &interchange](
-          OpBuilder &b, Location loc,
+          OpBuilder &b, Location loc, Value device,
           std::array<Value, 3> workload) -> std::array<Value, 3> {
     Value one = b.create<arith::ConstantIndexOp>(loc, 1);
     std::array<Value, 3> numWorkgroups = {one, one, one};

--- a/iree/compiler/Codegen/Common/SetNumWorkgroupsPass.cpp
+++ b/iree/compiler/Codegen/Common/SetNumWorkgroupsPass.cpp
@@ -114,7 +114,7 @@ LogicalResult setNumWorkgroupsImpl(IREE::HAL::ExecutableVariantOp variantOp,
     if (currWorkloadPerWorkgroup.empty()) {
       // If no workgroup size is specified, leave the workgroup size as is, just
       // set the number of workgroups to be 1, 1, 1 to have a single invocation.
-      regionBuilder = [](OpBuilder &b, Location loc,
+      regionBuilder = [](OpBuilder &b, Location loc, Value device,
                          std::array<Value, 3> workload) {
         Value one = b.create<arith::ConstantIndexOp>(loc, 1);
         return std::array<Value, 3>{one, one, one};
@@ -123,7 +123,7 @@ LogicalResult setNumWorkgroupsImpl(IREE::HAL::ExecutableVariantOp variantOp,
       assert(currWorkloadPerWorkgroup.size() <= kNumMaxParallelDims &&
              "workloadPerWorkgroup size greater than max num parallel dims");
       regionBuilder = [&currWorkloadPerWorkgroup](
-                          OpBuilder &b, Location loc,
+                          OpBuilder &b, Location loc, Value device,
                           std::array<Value, 3> workload) {
         Value one = b.create<arith::ConstantIndexOp>(loc, 1);
         std::array<Value, 3> returnValues = {one, one, one};

--- a/iree/compiler/Codegen/Common/test/insert_distribution_info.mlir
+++ b/iree/compiler/Codegen/Common/test/insert_distribution_info.mlir
@@ -50,12 +50,13 @@ hal.executable private @matmul_tensors {
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUTileFuseAndVectorize, workload_per_wg = [64, 64]>
 //      CHECK: hal.executable.entry_point public @matmul_tensors
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
-// CHECK-NEXT:   (%[[ARG0:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9_]+]]: index)
+// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Y:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Z:[a-zA-Z0-9_]+]]: index)
 //  CHECK-DAG:    %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:    %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
-//  CHECK-DAG:    %[[D1:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]]]
+//  CHECK-DAG:    %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[WORKLOAD_X]]]
+//  CHECK-DAG:    %[[D1:.+]] = affine.apply #[[MAP0]]()[%[[WORKLOAD_Y]]]
 //      CHECK:    hal.return %[[D0]], %[[D1]], %[[C1]] : index, index, index
 //      CHECK: func @matmul_tensors()
 
@@ -115,12 +116,13 @@ hal.executable private @add {
 //      CHECK: hal.executable private @add
 //      CHECK: hal.executable.entry_point public @add
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
-// CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
+// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Y:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Z:[a-zA-Z0-9_]+]]: index)
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP]]()[%[[ARG0]]]
-//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP]]()[%[[ARG1]]]
+//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP]]()[%[[WORKLOAD_X]]]
+//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP]]()[%[[WORKLOAD_Y]]]
 //      CHECK:   hal.return %[[D0]], %[[D1]], %[[C1]] : index, index, index
 //      CHECK: func @add()
 
@@ -179,12 +181,13 @@ hal.executable private @add4D {
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert, workload_per_wg = [64, 64, 64]>
 //      CHECK: hal.executable.entry_point public @add4D
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
-// CHECK-NEXT:   (%[[ARG0:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9_]+]]: index)
-//  CHECK-DAG:    %[[D0:.+]] = affine.apply #[[MAP]]()[%[[ARG0]]]
-//  CHECK-DAG:    %[[D1:.+]] = affine.apply #[[MAP]]()[%[[ARG1]]]
-//  CHECK-DAG:    %[[D2:.+]] = affine.apply #[[MAP]]()[%[[ARG2]]]
+// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Y:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Z:[a-zA-Z0-9_]+]]: index)
+//  CHECK-DAG:    %[[D0:.+]] = affine.apply #[[MAP]]()[%[[WORKLOAD_X]]]
+//  CHECK-DAG:    %[[D1:.+]] = affine.apply #[[MAP]]()[%[[WORKLOAD_Y]]]
+//  CHECK-DAG:    %[[D2:.+]] = affine.apply #[[MAP]]()[%[[WORKLOAD_Z]]]
 //      CHECK:    hal.return %[[D0]], %[[D1]], %[[D2]] : index, index, index
 //      CHECK: func @add4D()
 
@@ -237,12 +240,13 @@ hal.executable private @batch_matmul_tensors {
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUTileFuseAndVectorize, workload_per_wg = [64, 64, 1]>
 //      CHECK: hal.executable.entry_point public @batch_matmul_tensors
-// CHECK-NEXT:   (%[[ARG0:[a-zA-Z0-9]+]]: index
-// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: index
-// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]: index)
-//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
-//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]]]
-//      CHECK:   hal.return %[[D0]], %[[D1]], %[[ARG2]]
+// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Y:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Z:[a-zA-Z0-9_]+]]: index)
+//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[WORKLOAD_X]]]
+//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP0]]()[%[[WORKLOAD_Y]]]
+//      CHECK:   hal.return %[[D0]], %[[D1]], %[[WORKLOAD_Z]]
 //      CHECK: func @batch_matmul_tensors()
 
 // -----
@@ -288,12 +292,13 @@ hal.executable private @preset_config_matmul_tensors {
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 32)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert, workload_per_wg = [16, 32]>
 //      CHECK: hal.executable.entry_point public @preset_config
-// CHECK-NEXT:   (%[[ARG0:[a-zA-Z0-9]+]]: index
-// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: index
-// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]: index)
+// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Y:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Z:[a-zA-Z0-9_]+]]: index)
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
-//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP1]]()[%[[ARG1]]]
+//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[WORKLOAD_X]]]
+//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP1]]()[%[[WORKLOAD_Y]]]
 //      CHECK:   hal.return %[[D0]], %[[D1]], %[[C1]]
 //      CHECK: func @preset_config()
 
@@ -345,12 +350,13 @@ hal.executable public @copy_op {
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUBufferOpsTileAndVectorize, workload_per_wg = [64, 64]>
 //      CHECK: hal.executable.entry_point public @copy_op
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
-// CHECK-NEXT:   (%[[ARG0:[a-zA-Z0-9]+]]: index
-// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: index
-// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]: index)
+// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Y:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Z:[a-zA-Z0-9_]+]]: index)
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
-//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]]]
+//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[WORKLOAD_X]]]
+//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP0]]()[%[[WORKLOAD_Y]]]
 //      CHECK:   hal.return %[[D0]], %[[D1]], %[[C1]]
 
 // -----
@@ -396,11 +402,12 @@ hal.executable private @static_1d_fft_stage2 {
 //      CHECK: hal.executable private @static_1d_fft_stage2
 //      CHECK: hal.executable.entry_point public @static_1d_fft_stage2
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
-// CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
+// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Y:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Z:[a-zA-Z0-9_]+]]: index)
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP]]()[%[[ARG0]]]
+//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP]]()[%[[WORKLOAD_X]]]
 //      CHECK:   hal.return %[[D0]], %[[C1]], %[[C1]] : index, index, index
 //      CHECK: func @static_1d_fft_stage2()
 
@@ -439,12 +446,13 @@ hal.executable private @static_3d_fft_stage3 {
 //      CHECK: hal.executable private @static_3d_fft_stage3
 //      CHECK: hal.executable.entry_point public @static_3d_fft_stage3
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
-// CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
-//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP]]()[%[[ARG0]]]
-//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP]]()[%[[ARG1]]]
-//  CHECK-DAG:   %[[D2:.+]] = affine.apply #[[MAP]]()[%[[ARG2]]]
+// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Y:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Z:[a-zA-Z0-9_]+]]: index)
+//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP]]()[%[[WORKLOAD_X]]]
+//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP]]()[%[[WORKLOAD_Y]]]
+//  CHECK-DAG:   %[[D2:.+]] = affine.apply #[[MAP]]()[%[[WORKLOAD_Z]]]
 //      CHECK:   hal.return %[[D0]], %[[D1]], %[[D2]] : index, index, index
 //      CHECK: func @static_3d_fft_stage3()
 
@@ -508,12 +516,13 @@ hal.executable private @outs_fusion {
 //      CHECK: hal.executable private @outs_fusion
 //      CHECK: hal.executable.entry_point public @outs_fusion_fn
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
-// CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
+// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Y:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Z:[a-zA-Z0-9_]+]]: index)
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP]]()[%[[ARG0]]]
-//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP]]()[%[[ARG1]]]
+//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP]]()[%[[WORKLOAD_X]]]
+//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP]]()[%[[WORKLOAD_Y]]]
 //      CHECK:   hal.return %[[D0]], %[[D1]], %[[C1]] : index, index, index
 //      CHECK: func @outs_fusion_fn()
 
@@ -572,12 +581,13 @@ hal.executable private @conv {
 //      CHECK: hal.executable private @conv
 //      CHECK: hal.executable.entry_point public @conv
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
-// CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
-//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP]]()[%[[ARG0]]]
-//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP]]()[%[[ARG1]]]
-//  CHECK-DAG:   %[[D2:.+]] = affine.apply #[[MAP]]()[%[[ARG2]]]
+// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Y:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Z:[a-zA-Z0-9_]+]]: index)
+//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP]]()[%[[WORKLOAD_X]]]
+//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP]]()[%[[WORKLOAD_Y]]]
+//  CHECK-DAG:   %[[D2:.+]] = affine.apply #[[MAP]]()[%[[WORKLOAD_Z]]]
 //      CHECK:   hal.return %[[D0]], %[[D1]], %[[D2]] : index, index, index
 //      CHECK: func @conv()
 
@@ -630,12 +640,13 @@ hal.executable private @conv_static {
 //      CHECK: hal.executable private @conv_static
 //      CHECK: hal.executable.entry_point public @conv_static
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
-// CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
-//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
-//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP1]]()[%[[ARG1]]]
-//  CHECK-DAG:   %[[D2:.+]] = affine.apply #[[MAP2]]()[%[[ARG2]]]
+// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Y:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Z:[a-zA-Z0-9_]+]]: index)
+//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[WORKLOAD_X]]]
+//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP1]]()[%[[WORKLOAD_Y]]]
+//  CHECK-DAG:   %[[D2:.+]] = affine.apply #[[MAP2]]()[%[[WORKLOAD_Z]]]
 //      CHECK:   hal.return %[[D0]], %[[D1]], %[[D2]] : index, index, index
 //      CHECK: func @conv_static()
 
@@ -686,12 +697,13 @@ hal.executable private @generic_static {
 //      CHECK: hal.executable private @generic_static
 //      CHECK: hal.executable.entry_point public @generic_static
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
-// CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
+// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Y:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Z:[a-zA-Z0-9_]+]]: index)
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
-//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP1]]()[%[[ARG1]]]
+//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[WORKLOAD_X]]]
+//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP1]]()[%[[WORKLOAD_Y]]]
 //      CHECK:   hal.return %[[D0]], %[[D1]], %[[C1]] : index, index, index
 //      CHECK: func @generic_static()
 
@@ -743,12 +755,13 @@ hal.executable private @matmul_static {
 //      CHECK: hal.executable private @matmul_static
 //      CHECK: hal.executable.entry_point public @matmul_static
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
-// CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
+// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Y:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Z:[a-zA-Z0-9_]+]]: index)
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
-//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP1]]()[%[[ARG1]]]
+//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[WORKLOAD_X]]]
+//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP1]]()[%[[WORKLOAD_Y]]]
 //      CHECK:   hal.return %[[D0]], %[[D1]], %[[C1]] : index, index, index
 
 // -----
@@ -799,12 +812,13 @@ hal.executable private @restrict_num_workgroups {
 //      CHECK: hal.executable private @restrict_num_workgroups
 //      CHECK: hal.executable.entry_point public @restrict_num_workgroups
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
-// CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
-//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
-//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP1]]()[%[[ARG1]]]
-//      CHECK:   hal.return %[[D0]], %[[D1]], %[[ARG2]] : index, index, index
+// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Y:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Z:[a-zA-Z0-9_]+]]: index)
+//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[WORKLOAD_X]]]
+//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP1]]()[%[[WORKLOAD_Y]]]
+//      CHECK:   hal.return %[[D0]], %[[D1]], %[[WORKLOAD_Z]] : index, index, index
 
 // -----
 
@@ -862,11 +876,12 @@ hal.executable private @reduction {
 //      CHECK: hal.executable private @reduction
 //      CHECK: hal.executable.entry_point public @reduction
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
-// CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
+// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Y:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Z:[a-zA-Z0-9_]+]]: index)
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
+//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[WORKLOAD_X]]]
 //      CHECK:   hal.return %[[D0]], %[[C1]], %[[C1]] : index, index, index
 //      CHECK: func @reduction
 
@@ -919,11 +934,12 @@ hal.executable private @gemm_unit_N {
 //      CHECK: hal.executable private @gemm_unit_N
 //      CHECK: hal.executable.entry_point public @gemm_unit_N
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
-// CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
+// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Y:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Z:[a-zA-Z0-9_]+]]: index)
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
+//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[WORKLOAD_X]]]
 //      CHECK:   hal.return %[[D0]], %[[C1]], %[[C1]] : index, index, index
 //      CHECK: func @gemm_unit_N()
 
@@ -974,9 +990,10 @@ hal.executable private @gemm_unit_M_unit_N {
 //      CHECK: hal.executable private @gemm_unit_M_unit_N
 //      CHECK: hal.executable.entry_point public @gemm_unit_M_unit_N
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
-// CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
+// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Y:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Z:[a-zA-Z0-9_]+]]: index)
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //      CHECK:   hal.return %[[C1]], %[[C1]], %[[C1]] : index, index, index
 //      CHECK: func @gemm_unit_M_unit_N()
@@ -1032,12 +1049,13 @@ hal.executable private @generic_unit_dims {
 //      CHECK: hal.executable private @generic_unit_dims
 //      CHECK: hal.executable.entry_point public @generic_unit_dims
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
-// CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
-//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
-//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]]]
-//  CHECK-DAG:   %[[D2:.+]] = affine.apply #[[MAP0]]()[%[[ARG2]]]
+// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Y:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Z:[a-zA-Z0-9_]+]]: index)
+//  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[WORKLOAD_X]]]
+//  CHECK-DAG:   %[[D1:.+]] = affine.apply #[[MAP0]]()[%[[WORKLOAD_Y]]]
+//  CHECK-DAG:   %[[D2:.+]] = affine.apply #[[MAP0]]()[%[[WORKLOAD_Z]]]
 //      CHECK:   hal.return %[[D0]], %[[D1]], %[[D2]] : index, index, index
 //      CHECK: func @generic_unit_dims()
 
@@ -1090,9 +1108,10 @@ hal.executable private @reduce_to_scalar {
 //      CHECK: hal.executable private @reduce_to_scalar
 //      CHECK: hal.executable.entry_point public @reduce_to_scalar
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
-// CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
+// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Y:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Z:[a-zA-Z0-9_]+]]: index)
 //      CHECK:   %[[C1:.+]] = arith.constant 1 : index
 //      CHECK:   hal.return %[[C1]], %[[C1]], %[[C1]] : index, index, index
 //      CHECK: func @reduce_to_scalar()
@@ -1143,9 +1162,10 @@ hal.executable private @scalar {
 //      CHECK: hal.executable private @scalar
 //      CHECK: hal.executable.entry_point public @scalar
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
-// CHECK-NEXT:  (%[[ARG0:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index)
+// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Y:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Z:[a-zA-Z0-9_]+]]: index)
 //      CHECK:   %[[C1:.+]] = arith.constant 1 : index
 //      CHECK:   hal.return %[[C1]], %[[C1]], %[[C1]] : index, index, index
 //      CHECK: func @scalar()
@@ -1202,11 +1222,12 @@ hal.executable private @matmul_interchange {
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert, workload_per_wg = [64, 32]>
 //      CHECK: hal.executable.entry_point public @matmul_interchange
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
-// CHECK-NEXT:   (%[[ARG0:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9_]+]]: index)
+// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Y:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_Z:[a-zA-Z0-9_]+]]: index)
 //  CHECK-DAG:    %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:    %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
-//  CHECK-DAG:    %[[D1:.+]] = affine.apply #[[MAP1]]()[%[[ARG1]]]
+//  CHECK-DAG:    %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[WORKLOAD_X]]]
+//  CHECK-DAG:    %[[D1:.+]] = affine.apply #[[MAP1]]()[%[[WORKLOAD_Y]]]
 //      CHECK:    hal.return %[[D1]], %[[D0]], %[[C1]] : index, index, index
 //      CHECK: func @matmul_interchange()

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_to_cooperative_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_to_cooperative_ops.mlir
@@ -34,7 +34,7 @@ hal.executable public @matmul_256x1024x128_div_sub {
       translation_info = #translation,
       workgroup_size = [32 : index, 1 : index, 1 : index]
     } {
-    ^bb0(%arg0: index, %arg1: index, %arg2: index):  // no predecessors
+    ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):  // no predecessors
       %c1 = arith.constant 1 : index
       %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 16)>()[%arg0]
       %1 = affine.apply affine_map<()[s0] -> (s0 ceildiv 16)>()[%arg1]

--- a/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -60,10 +60,13 @@ LogicalResult defineWorkgroupCountRegion(
   auto indexType = builder.getIndexType();
   assert(IREE::HAL::ExecutableEntryPointOp::getNumWorkgroupDims() == 3 &&
          "expected 3 dims");
+  auto device =
+      entryBlock->addArgument(builder.getType<IREE::HAL::DeviceType>(), loc);
   std::array<Value, 3> workload = {entryBlock->addArgument(indexType, loc),
                                    entryBlock->addArgument(indexType, loc),
                                    entryBlock->addArgument(indexType, loc)};
-  std::array<Value, 3> workgroupCount = regionBuilder(builder, loc, workload);
+  std::array<Value, 3> workgroupCount =
+      regionBuilder(builder, loc, device, workload);
   builder.create<IREE::HAL::ReturnOp>(loc, workgroupCount);
   entryPointOp.erase();
   return success();

--- a/iree/compiler/Codegen/Transforms/Transforms.h
+++ b/iree/compiler/Codegen/Transforms/Transforms.h
@@ -28,7 +28,7 @@ namespace iree_compiler {
 /// callback function, which computes the workgroup count (x,y,z) given the
 /// workload along (x,y,z).
 using WorkgroupCountRegionBuilder = std::function<std::array<Value, 3>(
-    OpBuilder &b, Location loc, std::array<Value, 3> workload)>;
+    OpBuilder &b, Location loc, Value device, std::array<Value, 3> workload)>;
 LogicalResult defineWorkgroupCountRegion(
     OpBuilder &builder, func::FuncOp funcOp,
     WorkgroupCountRegionBuilder regionBuilder);

--- a/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/ConvertStreamToHAL.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/ConvertStreamToHAL.cpp
@@ -699,7 +699,7 @@ struct CmdDispatchOpPattern
                              {SymbolRefAttr::get(entryPointOp->getParentOp()),
                               SymbolRefAttr::get(entryPointOp)});
       auto caseWorkgroupCount = entryPointOp.calculateWorkgroupCount(
-          loc, adaptor.workgroup_count(), caseBuilder);
+          loc, device, adaptor.workgroup_count(), caseBuilder);
       caseBuilder.create<IREE::HAL::CommandBufferDispatchSymbolOp>(
           loc, commandBuffer, entryPointSymRef, caseWorkgroupCount[0],
           caseWorkgroupCount[1], caseWorkgroupCount[2]);

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -1587,11 +1587,11 @@ def HAL_ExecutableEntryPointOp : HAL_Op<"executable.entry_point", [
 
     // Calculates an XYZ workgroup count based on the given |workload|.
     std::array<Value, 3> calculateWorkgroupCount(
-        Location loc, ValueRange workload, OpBuilder &builder);
+        Location loc, Value device, ValueRange workload, OpBuilder &builder);
 
     // Calculates an XYZ workgroup size based on the given |workload|.
     std::array<Value, 3> calculateWorkgroupSize(
-        Location loc, ValueRange workload, OpBuilder &builder);
+        Location loc, Value device, ValueRange workload, OpBuilder &builder);
   }];
 }
 

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -1386,6 +1386,21 @@ def HAL_DeviceQueryOp :
     much care as a binary file format change. Keys should be prefixed with `ex.`
     when experimental indicating that they are not expected to be present
     forever; all non-experimental keys should be vetted.
+
+    Well-known keys:
+
+    * hal.executable.format :: {some format}
+      Returns 1 if the given format is supported by the device loader.
+
+    * hal.device :: concurrency
+      The maximum concurrently executable submissions, mapping roughly to the
+      queue count. The actual concurrency available may be less than this based
+      on dynamic runtime parameters such as power/thermal modes, quota limits,
+      or user choice.
+
+    * hal.dispatch :: concurrency
+      The maximum concurrently executable workgroups for a particular dispatch.
+      The actual concurrency available may be less depending on device state.
   }];
 
   let arguments = (ins

--- a/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
@@ -44,7 +44,7 @@ hal.executable @ex_with_workgroup_count_region {
     ]>) {
       workgroup_size = [4 : index, 1 : index, 1 : index]
     } {
-    ^bb0(%arg0: index, %arg1: index, %arg2: index):
+    ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):
       hal.return %arg0, %arg1, %arg2 : index, index, index
     }
   }

--- a/iree/compiler/Dialect/HAL/Transforms/DumpExecutableBenchmarks.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/DumpExecutableBenchmarks.cpp
@@ -265,7 +265,7 @@ static void appendDispatchBenchmark(
 
   // Compute the workgroup parameters.
   auto workgroupCount = entryPointOp.calculateWorkgroupCount(
-      loc,
+      loc, device,
       {
           indexSet.get(std::get<0>(dispatchParams.workload)),
           indexSet.get(std::get<1>(dispatchParams.workload)),

--- a/iree/compiler/Dialect/HAL/Transforms/test/convert_to_hal.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/convert_to_hal.mlir
@@ -23,7 +23,7 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
       hal.executable.entry_point public @dispatch ordinal(0) layout(#executable_layout) {
         translation_info = #iree_codegen.translation_info<CPUDefault, workload_per_wg = [4]>
       } {
-      ^bb0(%arg0: index, %arg1: index, %arg2: index):  // no predecessors
+      ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):  // no predecessors
         %c1 = arith.constant 1 : index
         %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 4)>()[%arg0]
         hal.return %0, %c1, %c1 : index, index, index

--- a/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_benchmarks.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_benchmarks.mlir
@@ -30,7 +30,7 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
       hal.executable.entry_point public @dispatch0 ordinal(0) layout(#executable_layout_0) {
         translation_info = #iree_codegen.translation_info<CPUDefault, workload_per_wg = [4]>
       } {
-      ^bb0(%arg0: index, %arg1: index, %arg2: index):
+      ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):
         %c1 = arith.constant 1 : index
         %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 4)>()[%arg0]
         hal.return %0, %c1, %c1 : index, index, index
@@ -44,7 +44,7 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
       hal.executable.entry_point public @dispatch1 ordinal(1) layout(#executable_layout_1) {
         translation_info = #iree_codegen.translation_info<CPUDefault, workload_per_wg = [4]>
       } {
-      ^bb0(%arg0: index, %arg1: index, %arg2: index):
+      ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):
         %c1 = arith.constant 1 : index
         %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 4)>()[%arg0]
         hal.return %0, %c1, %c1 : index, index, index

--- a/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_sources.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_sources.mlir
@@ -25,7 +25,7 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
       hal.executable.entry_point public @dispatch0 ordinal(0) layout(#executable_layout) {
         translation_info = #iree_codegen.translation_info<CPUDefault, workload_per_wg = [4]>
       } {
-      ^bb0(%arg0: index, %arg1: index, %arg2: index):  // no predecessors
+      ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):  // no predecessors
         %c1 = arith.constant 1 : index
         %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 4)>()[%arg0]
         hal.return %0, %c1, %c1 : index, index, index
@@ -44,7 +44,7 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
       hal.executable.entry_point public @dispatch1 ordinal(0) layout(#executable_layout) {
         translation_info = #iree_codegen.translation_info<CPUDefault, workload_per_wg = [4]>
       } {
-      ^bb0(%arg0: index, %arg1: index, %arg2: index):  // no predecessors
+      ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):  // no predecessors
         %c1 = arith.constant 1 : index
         %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 4)>()[%arg0]
         hal.return %0, %c1, %c1 : index, index, index

--- a/iree/hal/local/sync_device.c
+++ b/iree/hal/local/sync_device.c
@@ -153,6 +153,18 @@ static iree_status_t iree_hal_sync_device_query_i32(
             ? 1
             : 0;
     return iree_ok_status();
+  } else if (iree_string_view_equal(category,
+                                    iree_make_cstring_view("hal.device"))) {
+    if (iree_string_view_equal(key, iree_make_cstring_view("concurrency"))) {
+      *out_value = 1;
+      return iree_ok_status();
+    }
+  } else if (iree_string_view_equal(category,
+                                    iree_make_cstring_view("hal.dispatch"))) {
+    if (iree_string_view_equal(key, iree_make_cstring_view("concurrency"))) {
+      *out_value = 1;
+      return iree_ok_status();
+    }
   }
 
   return iree_make_status(

--- a/iree/hal/local/task_device.c
+++ b/iree/hal/local/task_device.c
@@ -201,6 +201,18 @@ static iree_status_t iree_hal_task_device_query_i32(
             ? 1
             : 0;
     return iree_ok_status();
+  } else if (iree_string_view_equal(category,
+                                    iree_make_cstring_view("hal.device"))) {
+    if (iree_string_view_equal(key, iree_make_cstring_view("concurrency"))) {
+      *out_value = (int32_t)device->queue_count;
+      return iree_ok_status();
+    }
+  } else if (iree_string_view_equal(category,
+                                    iree_make_cstring_view("hal.dispatch"))) {
+    if (iree_string_view_equal(key, iree_make_cstring_view("concurrency"))) {
+      *out_value = (int32_t)iree_task_executor_worker_count(device->executor);
+      return iree_ok_status();
+    }
   }
 
   return iree_make_status(

--- a/iree/task/executor.c
+++ b/iree/task/executor.c
@@ -234,6 +234,11 @@ void iree_task_executor_trim(iree_task_executor_t* executor) {
   // iree_task_pool_trim(&executor->transient_task_pool);
 }
 
+iree_host_size_t iree_task_executor_worker_count(
+    iree_task_executor_t* executor) {
+  return executor->worker_count;
+}
+
 iree_event_pool_t* iree_task_executor_event_pool(
     iree_task_executor_t* executor) {
   return executor->event_pool;

--- a/iree/task/executor.h
+++ b/iree/task/executor.h
@@ -313,6 +313,11 @@ void iree_task_executor_release(iree_task_executor_t* executor);
 // Trims pools and caches used by the executor and its workers.
 void iree_task_executor_trim(iree_task_executor_t* executor);
 
+// Returns the number of live workers usable by the executor.
+// The actual number used for any particular operation is dynamic.
+iree_host_size_t iree_task_executor_worker_count(
+    iree_task_executor_t* executor);
+
 // Returns an iree_event_t pool managed by the executor.
 // Users of the task system should acquire their transient events from this.
 // Long-lived events should be allocated on their own in order to avoid


### PR DESCRIPTION
hal.device.concurrency exposes the number of concurrently executable
submissions (mapping to queue count) and hal.dispatch.concurrency
exposes the number of concurrently executable workgroups. These are
maxes.

These are exposed on the CPU devices now and ideally something we can
expose on others in order to have a more normalized API surface. If
we can use these instead of specific hardware information we'll have
more portable programs with less duplication.

To enable the compiler to use this information a !hal.device is passed to
the HAL entry point workgroup count region so that backends can add
the `hal.device.query` ops it needs.