### PR TITLE
Add test rule for generic python tests.

### DIFF
--- a/build_tools/benchmarks/CMakeLists.txt
+++ b/build_tools/benchmarks/CMakeLists.txt
@@ -6,4 +6,37 @@
 
 set(BENCHMARKS_TOOL_PYTHON_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 
+# benchmark_tool_py_test()
+#
+# CMake function to test benchmark python tools.
+#
+# Parameters:
+# NAME: name of test
+# SRC: Test source file
+# ARGS: Command line arguments to the Python source file.
+# LABELS: Additional labels to apply to the test. The package path is added
+#     automatically.
+function(benchmark_tool_py_test)
+  cmake_parse_arguments(
+    _RULE
+    ""
+    "NAME;SRC"
+    "ARGS;LABELS"
+    ${ARGN}
+  )
+
+  iree_local_py_test(
+    NAME
+      "${_RULE_NAME}"
+    SRC
+      "${_RULE_SRC}"
+    ARGS
+      ${_RULE_ARGS}
+    LABELS
+      ${_RULE_LABELS}
+    PACKAGE_DIRS
+      ${BENCHMARKS_TOOL_PYTHON_DIR}
+  )
+endfunction()
+
 add_subdirectory(common)

--- a/build_tools/benchmarks/common/CMakeLists.txt
+++ b/build_tools/benchmarks/common/CMakeLists.txt
@@ -8,53 +8,37 @@
 # Tests
 ################################################################################
 
-if(IREE_BUILD_TESTS AND NOT ANDROID)
-
-iree_py_test(
+benchmark_tool_py_test(
   NAME
     linux_device_utils_test
-  SRCS
+  SRC
     "linux_device_utils_test.py"
 )
 
-iree_py_test(
+benchmark_tool_py_test(
   NAME
     common_arguments_test
-  SRCS
+  SRC
     "common_arguments_test.py"
 )
 
-iree_py_test(
+benchmark_tool_py_test(
   NAME
     benchmark_config_test
-  SRCS
+  SRC
     "benchmark_config_test.py"
 )
 
-iree_py_test(
+benchmark_tool_py_test(
   NAME
     benchmark_suite_test
-  SRCS
+  SRC
     "benchmark_suite_test.py"
 )
 
-iree_py_test(
+benchmark_tool_py_test(
   NAME
     benchmark_driver_test
-  SRCS
+  SRC
     "benchmark_driver_test.py"
 )
-
-# TODO(#8708): Temporary solution to fix python path for tests.
-set_property(TEST "build_tools/benchmarks/common/linux_device_utils_test"
-    APPEND PROPERTY ENVIRONMENT "PYTHONPATH=${BENCHMARKS_TOOL_PYTHON_DIR}:$ENV{PYTHONPATH}")
-set_property(TEST "build_tools/benchmarks/common/common_arguments_test"
-    APPEND PROPERTY ENVIRONMENT "PYTHONPATH=${BENCHMARKS_TOOL_PYTHON_DIR}:$ENV{PYTHONPATH}")
-set_property(TEST "build_tools/benchmarks/common/benchmark_config_test"
-    APPEND PROPERTY ENVIRONMENT "PYTHONPATH=${BENCHMARKS_TOOL_PYTHON_DIR}:$ENV{PYTHONPATH}")
-set_property(TEST "build_tools/benchmarks/common/benchmark_suite_test"
-    APPEND PROPERTY ENVIRONMENT "PYTHONPATH=${BENCHMARKS_TOOL_PYTHON_DIR}:$ENV{PYTHONPATH}")
-set_property(TEST "build_tools/benchmarks/common/benchmark_driver_test"
-    APPEND PROPERTY ENVIRONMENT "PYTHONPATH=${BENCHMARKS_TOOL_PYTHON_DIR}:$ENV{PYTHONPATH}")
-
-endif()


### PR DESCRIPTION
This solves #8708 by adding a test rule to support custom python paths.