### PR TITLE
Adding iree_loop_t arg to executable cache creation.

### DIFF
--- a/experimental/rocm/rocm_device.c
+++ b/experimental/rocm/rocm_device.c
@@ -222,7 +222,7 @@ static iree_status_t iree_hal_rocm_device_create_event(
 
 static iree_status_t iree_hal_rocm_device_create_executable_cache(
     iree_hal_device_t* base_device, iree_string_view_t identifier,
-    iree_hal_executable_cache_t** out_executable_cache) {
+    iree_loop_t loop, iree_hal_executable_cache_t** out_executable_cache) {
   iree_hal_rocm_device_t* device = iree_hal_rocm_device_cast(base_device);
   return iree_hal_rocm_nop_executable_cache_create(
       &device->context_wrapper, identifier, out_executable_cache);

--- a/iree/hal/cts/command_buffer_dispatch_test.h
+++ b/iree/hal/cts/command_buffer_dispatch_test.h
@@ -22,7 +22,8 @@ class command_buffer_dispatch_test : public CtsTestBase {
  protected:
   void PrepareAbsExecutable() {
     IREE_ASSERT_OK(iree_hal_executable_cache_create(
-        device_, iree_make_cstring_view("default"), &executable_cache_));
+        device_, iree_make_cstring_view("default"),
+        iree_loop_inline(&loop_status_), &executable_cache_));
 
     iree_hal_descriptor_set_layout_binding_t descriptor_set_layout_bindings[] =
         {
@@ -57,8 +58,10 @@ class command_buffer_dispatch_test : public CtsTestBase {
     iree_hal_executable_layout_release(executable_layout_);
     iree_hal_descriptor_set_layout_release(descriptor_set_layout_);
     iree_hal_executable_cache_release(executable_cache_);
+    IREE_ASSERT_OK(loop_status_);
   }
 
+  iree_status_t loop_status_ = iree_ok_status();
   iree_hal_executable_cache_t* executable_cache_ = NULL;
   iree_hal_descriptor_set_layout_t* descriptor_set_layout_ = NULL;
   iree_hal_executable_layout_t* executable_layout_ = NULL;

--- a/iree/hal/cts/executable_cache_test.h
+++ b/iree/hal/cts/executable_cache_test.h
@@ -21,28 +21,36 @@ namespace cts {
 class executable_cache_test : public CtsTestBase {};
 
 TEST_P(executable_cache_test, Create) {
+  iree_status_t loop_status = iree_ok_status();
   iree_hal_executable_cache_t* executable_cache = NULL;
   IREE_ASSERT_OK(iree_hal_executable_cache_create(
-      device_, iree_make_cstring_view("default"), &executable_cache));
+      device_, iree_make_cstring_view("default"),
+      iree_loop_inline(&loop_status), &executable_cache));
 
   iree_hal_executable_cache_release(executable_cache);
+  IREE_ASSERT_OK(loop_status);
 }
 
 TEST_P(executable_cache_test, CantPrepareUnknownFormat) {
+  iree_status_t loop_status = iree_ok_status();
   iree_hal_executable_cache_t* executable_cache = NULL;
   IREE_ASSERT_OK(iree_hal_executable_cache_create(
-      device_, iree_make_cstring_view("default"), &executable_cache));
+      device_, iree_make_cstring_view("default"),
+      iree_loop_inline(&loop_status), &executable_cache));
 
   EXPECT_FALSE(iree_hal_executable_cache_can_prepare_format(
       executable_cache, /*caching_mode=*/0, iree_make_cstring_view("FOO?")));
 
   iree_hal_executable_cache_release(executable_cache);
+  IREE_ASSERT_OK(loop_status);
 }
 
 TEST_P(executable_cache_test, PrepareExecutable) {
+  iree_status_t loop_status = iree_ok_status();
   iree_hal_executable_cache_t* executable_cache = NULL;
   IREE_ASSERT_OK(iree_hal_executable_cache_create(
-      device_, iree_make_cstring_view("default"), &executable_cache));
+      device_, iree_make_cstring_view("default"),
+      iree_loop_inline(&loop_status), &executable_cache));
 
   // Note: this layout must match the testdata executable.
   iree_hal_descriptor_set_layout_t* descriptor_set_layout = NULL;
@@ -78,6 +86,7 @@ TEST_P(executable_cache_test, PrepareExecutable) {
   iree_hal_executable_layout_release(executable_layout);
   iree_hal_descriptor_set_layout_release(descriptor_set_layout);
   iree_hal_executable_cache_release(executable_cache);
+  IREE_ASSERT_OK(loop_status);
 }
 
 }  // namespace cts

--- a/iree/hal/cuda/cuda_device.c
+++ b/iree/hal/cuda/cuda_device.c
@@ -291,7 +291,7 @@ static iree_status_t iree_hal_cuda_device_create_event(
 
 static iree_status_t iree_hal_cuda_device_create_executable_cache(
     iree_hal_device_t* base_device, iree_string_view_t identifier,
-    iree_hal_executable_cache_t** out_executable_cache) {
+    iree_loop_t loop, iree_hal_executable_cache_t** out_executable_cache) {
   iree_hal_cuda_device_t* device = iree_hal_cuda_device_cast(base_device);
   return iree_hal_cuda_nop_executable_cache_create(
       &device->context_wrapper, identifier, out_executable_cache);

--- a/iree/hal/device.h
+++ b/iree/hal/device.h
@@ -393,7 +393,7 @@ typedef struct iree_hal_device_vtable_t {
 
   iree_status_t(IREE_API_PTR* create_executable_cache)(
       iree_hal_device_t* device, iree_string_view_t identifier,
-      iree_hal_executable_cache_t** out_executable_cache);
+      iree_loop_t loop, iree_hal_executable_cache_t** out_executable_cache);
 
   iree_status_t(IREE_API_PTR* create_executable_layout)(
       iree_hal_device_t* device, iree_host_size_t push_constants,

--- a/iree/hal/executable_cache.c
+++ b/iree/hal/executable_cache.c
@@ -29,15 +29,15 @@ void iree_hal_executable_params_initialize(
 IREE_HAL_API_RETAIN_RELEASE(executable_cache);
 
 IREE_API_EXPORT iree_status_t iree_hal_executable_cache_create(
-    iree_hal_device_t* device, iree_string_view_t identifier,
+    iree_hal_device_t* device, iree_string_view_t identifier, iree_loop_t loop,
     iree_hal_executable_cache_t** out_executable_cache) {
   IREE_ASSERT_ARGUMENT(device);
   IREE_ASSERT_ARGUMENT(out_executable_cache);
   *out_executable_cache = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
-  iree_status_t status = IREE_HAL_VTABLE_DISPATCH(
-      device, iree_hal_device, create_executable_cache)(device, identifier,
-                                                        out_executable_cache);
+  iree_status_t status = IREE_HAL_VTABLE_DISPATCH(device, iree_hal_device,
+                                                  create_executable_cache)(
+      device, identifier, loop, out_executable_cache);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/iree/hal/executable_cache.h
+++ b/iree/hal/executable_cache.h
@@ -145,8 +145,13 @@ typedef struct iree_hal_executable_cache_t iree_hal_executable_cache_t;
 // Creates an executable cache using the given identifier.
 // The identifier is provided to the backing cache API as way to partition
 // caches between different groups of executables (from different modules, etc).
+//
+// Any host-side work that needs to be performed will be scheduled on |loop|.
+// This enables JITs, device-specific translation, and verification to be
+// parallelized using a shared scheduler. The loop must remain valid for the
+// lifetime of the executable cache.
 IREE_API_EXPORT iree_status_t iree_hal_executable_cache_create(
-    iree_hal_device_t* device, iree_string_view_t identifier,
+    iree_hal_device_t* device, iree_string_view_t identifier, iree_loop_t loop,
     iree_hal_executable_cache_t** out_executable_cache);
 
 // Retains the given |executable_cache| for the caller.

--- a/iree/hal/local/sync_device.c
+++ b/iree/hal/local/sync_device.c
@@ -202,7 +202,7 @@ static iree_status_t iree_hal_sync_device_create_event(
 
 static iree_status_t iree_hal_sync_device_create_executable_cache(
     iree_hal_device_t* base_device, iree_string_view_t identifier,
-    iree_hal_executable_cache_t** out_executable_cache) {
+    iree_loop_t loop, iree_hal_executable_cache_t** out_executable_cache) {
   iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
   return iree_hal_local_executable_cache_create(
       identifier, device->loader_count, device->loaders,

--- a/iree/hal/local/task_device.c
+++ b/iree/hal/local/task_device.c
@@ -266,7 +266,7 @@ static iree_status_t iree_hal_task_device_create_event(
 
 static iree_status_t iree_hal_task_device_create_executable_cache(
     iree_hal_device_t* base_device, iree_string_view_t identifier,
-    iree_hal_executable_cache_t** out_executable_cache) {
+    iree_loop_t loop, iree_hal_executable_cache_t** out_executable_cache) {
   iree_hal_task_device_t* device = iree_hal_task_device_cast(base_device);
   return iree_hal_local_executable_cache_create(
       identifier, device->loader_count, device->loaders,

--- a/iree/hal/vulkan/vulkan_device.cc
+++ b/iree/hal/vulkan/vulkan_device.cc
@@ -1060,7 +1060,7 @@ static iree_status_t iree_hal_vulkan_device_create_event(
 
 static iree_status_t iree_hal_vulkan_device_create_executable_cache(
     iree_hal_device_t* base_device, iree_string_view_t identifier,
-    iree_hal_executable_cache_t** out_executable_cache) {
+    iree_loop_t loop, iree_hal_executable_cache_t** out_executable_cache) {
   iree_hal_vulkan_device_t* device = iree_hal_vulkan_device_cast(base_device);
   return iree_hal_vulkan_nop_executable_cache_create(
       device->logical_device, identifier, out_executable_cache);


### PR DESCRIPTION
Executable caches are allowed to use this to schedule async/parallel
operations that will run on an external scheduler. Future changes will
need to make the Vulkan implementation parallelize pipeline creation.

Fixes #8001.