### PR TITLE
[CUDA] Allow async copy for fp16

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
@@ -31,8 +31,10 @@ static void createAsyncGroups(func::FuncOp funcOp) {
     if (!read || read.getVectorType() != writeOp.getVectorType() ||
         !read.isDimInBounds(0) || !read.getPermutationMap().isMinorIdentity())
       return WalkResult::advance();
-    if (read.getVectorType().getNumElements() > 4 ||
-        !read.getVectorType().getElementType().isF32())
+    if (!((read.getVectorType().getElementType().isF32() &&
+           read.getVectorType().getNumElements() <= 4) ||
+          (read.getVectorType().getElementType().isF16() &&
+           read.getVectorType().getNumElements() <= 8)))
       return WalkResult::advance();
     copyToSharedMem.insert(writeOp);
     return WalkResult::advance();


### PR DESCRIPTION
Async copy can be used to form better software pipeline and reduce the pressure on register use in fp16 too.