### PR TITLE
Printing the op when an allocation mapping fails.

### DIFF
--- a/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
+++ b/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
@@ -346,7 +346,9 @@ struct AllocationScope {
         AsmState asmState(rootOp->getParentOp());
         llvm::dbgs() << "!! storage not pre-allocated for resource ";
         resource.printAsOperand(llvm::dbgs(), asmState);
-        llvm::dbgs() << ":\n";
+        llvm::dbgs() << "\n";
+        resource.getDefiningOp()->print(llvm::dbgs(), asmState);
+        llvm::dbgs() << "\ncurrent mappings:\n";
         for (auto mapping : resourceRangeMap) {
           llvm::dbgs() << "  * mapping ";
           mapping.first.printAsOperand(llvm::dbgs(), asmState);


### PR DESCRIPTION
Since the IR is mutated during this step the SSA values don't line up
with the input IR and seeing the op makes it easier to correlate.