### PR TITLE
Replace usage of nested PassManager-s in BufferizeOp::apply

### DIFF
--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/bufferize-in-parallel.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/bufferize-in-parallel.mlir
@@ -1,6 +1,4 @@
 // RUN: iree-dialects-opt %s -linalg-interp-transforms -canonicalize | FileCheck %s
-// TODO(#8947): Fix the MLIRContext assertion and re-enable this
-// XFAIL: *
 
 // CHECK-LABEL: func @parallel_insert_slice_no_conflict(
 //  CHECK-SAME:     %[[idx:.*]]: index, %[[idx2:.*]]: index,

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/bufferize.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/bufferize.mlir
@@ -1,6 +1,4 @@
 // RUN: iree-dialects-opt -linalg-interp-transforms %s | FileCheck %s
-// TODO(#8947): Fix the MLIRContext assertion and re-enable this
-// XFAIL: *
 
 // CHECK-LABEL: func @matmul_tensors(
 // CHECK-SAME:    %[[TA:[0-9a-z]+]]: memref<128x128xf32

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/expert.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/expert.mlir
@@ -1,7 +1,5 @@
 // RUN: iree-dialects-opt -linalg-transform-expert-expansion -split-input-file %s | FileCheck %s --check-prefix=EXPAND
 // RUN: iree-dialects-opt -linalg-transform-expert-expansion -linalg-interp-transforms -split-input-file %s | FileCheck %s
-// TODO(#8947): Fix the MLIRContext assertion and re-enable this
-// XFAIL: *
 
 // CHECK-LABEL: func @matmul_tensors
 // CHECK-NOT: linalg

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/single-tiling-full-script.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/single-tiling-full-script.mlir
@@ -1,6 +1,4 @@
 // RUN: iree-dialects-opt -linalg-interp-transforms %s | FileCheck %s
-// TODO(#8947): Fix the MLIRContext assertion and re-enable this
-// XFAIL: *
 
 // CHECK-LABEL: func @matmul_tensors
 // CHECK-NOT: linalg


### PR DESCRIPTION
* Replace usage of nested PassManager-s in BufferizeOp::apply

* Use cast instead of dyn_cast

Co-authored-by: Denys Shabalin <shabalin@google.com>