### PR TITLE
Move validation of `IREE_BYTECODE_MODULE_*` options to `iree_bytecode_module`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,27 +133,6 @@ option(IREE_ENABLE_MSAN "Enable memory sanitizer" OFF)
 option(IREE_ENABLE_TSAN "Enable thread sanitizer" OFF)
 option(IREE_BYTECODE_MODULE_ENABLE_TSAN "Enable thread sanitizer in IREE modules in tests" OFF)
 
-# STREQUAL feels wrong here - we don't care about the exact true-value used,
-# ON or TRUE or something else. But we haven't been able to think of a less bad
-# alternative. https://github.com/google/iree/pull/8474#discussion_r840790062
-if(NOT IREE_ENABLE_TSAN STREQUAL IREE_BYTECODE_MODULE_ENABLE_TSAN)
-  message(SEND_ERROR
-      "IREE_ENABLE_TSAN and IREE_BYTECODE_MODULE_ENABLE_TSAN must be "
-      "simultaneously ON or OFF. "
-      "A discrepancy between the two would cause tests to crash as IREE "
-      "runtime code (controlled by IREE_ENABLE_TSAN) calls into test IREE "
-      "modules (controlled by IREE_BYTECODE_MODULE_ENABLE_TSAN)")
-endif()
-
-if(IREE_BYTECODE_MODULE_ENABLE_TSAN)
-  if(NOT IREE_BYTECODE_MODULE_FORCE_SYSTEM_DYLIB_LINKER)
-    message(SEND_ERROR
-        "When IREE_BYTECODE_MODULE_ENABLE_TSAN is ON, "
-        "IREE_BYTECODE_MODULE_FORCE_SYSTEM_DYLIB_LINKER must also be ON. "
-        "TSAN instrumentation is not currently supported in embedded modules.")
-  endif()
-endif()
-
 option(IREE_ENABLE_CCACHE "Use ccache if installed to speed up rebuilds." OFF)
 
 if(${IREE_ENABLE_CCACHE})

--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -114,11 +114,11 @@ function(iree_bytecode_module)
   # ON or TRUE or something else. But we haven't been able to think of a less bad
   # alternative. https://github.com/google/iree/pull/8474#discussion_r840790062
   if(NOT IREE_ENABLE_TSAN STREQUAL IREE_BYTECODE_MODULE_ENABLE_TSAN)
-    list(APPEND _CUSTOM_BUILD_TIME_CMAKE_ERRORS
-      ERROR_ON_INCONSISTENT_IREE_BYTECODE_MODULE_OPTIONS)
-    if(NOT TARGET ERROR_ON_INCONSISTENT_IREE_BYTECODE_MODULE_OPTIONS)
+    list(APPEND _CUSTOM_BUILD_TIME_CMAKE_ERROR_TARGETS
+      error_on_mismatched_tsan_options)
+    if(NOT TARGET error_on_mismatched_tsan_options)
       add_custom_target(
-        ERROR_ON_INCONSISTENT_IREE_BYTECODE_MODULE_OPTIONS
+        error_on_mismatched_tsan_options
         COMMAND
           cmake -E echo "ERROR: Inconsistent CMake options: IREE_ENABLE_TSAN and IREE_BYTECODE_MODULE_ENABLE_TSAN must be simultaneously ON or OFF."
         COMMAND
@@ -144,7 +144,7 @@ function(iree_bytecode_module)
       ${_LINKER_TOOL_EXECUTABLE}
       ${_RULE_SRC}
       ${_RULE_DEPENDS}
-      ${_CUSTOM_BUILD_TIME_CMAKE_ERRORS}
+      ${_CUSTOM_BUILD_TIME_CMAKE_ERROR_TARGETS}
     COMMENT
       "Generating VMFB for ${_FRIENDLY_NAME}"
     VERBATIM

--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -120,7 +120,7 @@ function(iree_bytecode_module)
       add_custom_target(
         error_on_mismatched_tsan_options
         COMMAND
-          cmake -E echo "ERROR: Inconsistent CMake options: IREE_ENABLE_TSAN and IREE_BYTECODE_MODULE_ENABLE_TSAN must be simultaneously ON or OFF."
+          cmake -E echo "ERROR: When building a bytecode-module target, if IREE_ENABLE_TSAN is ON then IREE_BYTECODE_MODULE_ENABLE_TSAN must also be ON."
         COMMAND
           cmake -E false
         VERBATIM


### PR DESCRIPTION
We were unconditionally enforcing that IREE_ENABLE_TSAN
itself implies the bytecode module options. That was unnecessary for
people who don't build targets that rely on iree_bytecode_module. This
enforcement is now deferred to build time, by means of a custom target.
This makes it possible again to just flip IREE_ENABLE_TSAN as long as
no iree_bytecode_module is built.