### PR TITLE
Adding -iree-hal-dump-executable-intermediates/binaries-to= flags.

### DIFF
--- a/docs/website/docs/deployment-configurations/gpu-cuda-rocm.md
+++ b/docs/website/docs/deployment-configurations/gpu-cuda-rocm.md
@@ -103,14 +103,17 @@ IREE's TensorFlow importer. We can now compile them for each GPU by running the 
     iree-compile \
         -iree-mlir-to-vm-bytecode-module \
         -iree-hal-target-backends=cuda \
-        -iree-cuda-llvm-target-arch=<...> \
+        -iree-hal-cuda-llvm-target-arch=<...> \
         -iree-hal-cuda-disable-loop-nounroll-wa \
         iree_input.mlir -o mobilenet-cuda.vmfb
     ```
 
-    Note that a cuda target architecture(`iree-cuda-llvm-target-arch`) of the form `sm_<arch_number>` is needed
-    to compile towards each GPU architecture. If no architecture is specified then we will default to `sm_35`
-    Here are a table of commonly used architecture
+    Note that a cuda target architecture(`iree-hal-cuda-llvm-target-arch`) of
+    the form `sm_<arch_number>` is needed to compile towards each GPU
+    architecture. If no architecture is specified then we will default to
+    `sm_35`.
+
+    Here are a table of commonly used architectures:
 
     CUDA GPU  | Target Architecture
     :--------: | :-----------:

--- a/iree/compiler/Dialect/HAL/Target/CUDA/test/smoketest.mlir
+++ b/iree/compiler/Dialect/HAL/Target/CUDA/test/smoketest.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-opt -split-input-file -iree-hal-transformation-pipeline %s | FileCheck %s
-// RUN: iree-opt -split-input-file -iree-hal-transformation-pipeline -iree-cuda-dump-ptx %s 2>&1 | FileCheck %s -check-prefix=PTX
+// RUN: iree-opt -split-input-file -iree-hal-transformation-pipeline -iree-hal-cuda-dump-ptx %s 2>&1 | FileCheck %s -check-prefix=PTX
 
 #map = affine_map<(d0) -> (d0)>
 

--- a/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.h
+++ b/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.h
@@ -21,9 +21,6 @@ struct VulkanSPIRVTargetOptions {
   std::string vulkanTargetEnv;
   // Vulkan target triple.
   std::string vulkanTargetTriple;
-
-  // True to keep shader modules for debugging.
-  bool keepShaderModules;
 };
 
 // Returns a VulkanSPIRVTargetOptions struct initialized with Vulkan/SPIR-V

--- a/iree/compiler/Dialect/HAL/Target/WebGPU/WebGPUTarget.h
+++ b/iree/compiler/Dialect/HAL/Target/WebGPU/WebGPUTarget.h
@@ -19,9 +19,6 @@ namespace HAL {
 struct WebGPUTargetOptions {
   // Include debug information like variable names in outputs.
   bool debugSymbols = true;
-
-  // True to keep shader modules for debugging.
-  bool keepShaderModules = false;
 };
 
 // Returns a WebGPUTargetOptions struct initialized with WebGPU/WGSL related

--- a/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -223,7 +223,9 @@ void buildHALTransformPassPipeline(OpPassManager &passManager,
   // contents not turned into a big base64 string.
   if (transformOptions.serializeExecutables) {
     passManager.addNestedPass<IREE::HAL::ExecutableOp>(
-        createSerializeExecutablesPass());
+        createSerializeExecutablesPass(
+            targetOptions.executableIntermediatesPath,
+            targetOptions.executableBinariesPath));
 
     // NOTE: symbol DCE will destroy executable target contents, so only run it
     // if we serialized things.

--- a/iree/compiler/Dialect/HAL/Transforms/Passes.h
+++ b/iree/compiler/Dialect/HAL/Transforms/Passes.h
@@ -112,11 +112,14 @@ createResolveEntryPointOrdinalsPass();
 
 // Converts hal.executable.variants to one or more hal.executable.binary ops.
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableOp>>
-createSerializeExecutablesPass();
+createSerializeExecutablesPass(std::string dumpIntermediatesPath = "",
+                               std::string dumpBinariesPath = "");
 
 // Serializes executables for the specified |target| backend.
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableOp>>
-createSerializeTargetExecutablesPass(StringRef target);
+createSerializeTargetExecutablesPass(StringRef target,
+                                     std::string dumpIntermediatesPath = "",
+                                     std::string dumpBinariesPath = "");
 
 //===----------------------------------------------------------------------===//
 // Resource initialization, caching, and optimization

--- a/iree/test/e2e/matmul/BUILD
+++ b/iree/test/e2e/matmul/BUILD
@@ -143,7 +143,7 @@ py_binary(
 [iree_generated_trace_runner_test(
     name = "e2e_matmul_direct_f32_gpu_large_%s" % compilation_info,
     compiler_flags = [
-        "--iree-cuda-llvm-target-arch=sm_80",
+        "--iree-hal-cuda-llvm-target-arch=sm_80",
     ],
     generator = ":generate_e2e_matmul_tests",
     generator_args = [

--- a/iree/test/e2e/matmul/CMakeLists.txt
+++ b/iree/test/e2e/matmul/CMakeLists.txt
@@ -213,7 +213,7 @@ iree_generated_trace_runner_test(
   DRIVERS
     "cuda"
   COMPILER_FLAGS
-    "--iree-cuda-llvm-target-arch=sm_80"
+    "--iree-hal-cuda-llvm-target-arch=sm_80"
   LABELS
     "noasan"
     "nomsan"

--- a/iree/test/microbenchmarks/linalg_transpose.mlir
+++ b/iree/test/microbenchmarks/linalg_transpose.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-run-mlir --iree-hal-target-backends=dylib-llvm-aot --iree-llvm-link-embedded=true -mlir-disable-threading --iree-llvm-target-cpu-features='host' --iree-codegen-llvm-generic-ops-workgroup-size=2048 %s
+// RUN: iree-run-mlir -iree-hal-target-backends=dylib-llvm-aot -iree-llvm-link-embedded=true -iree-llvm-target-cpu-features='host' -iree-codegen-llvm-generic-ops-workgroup-size=2048 %s
 
 //===----------------------------------------------------------------------===//
 // Transpose ops.


### PR DESCRIPTION
These allow target backends to route intermediate files and final
serialized binaries to a specific path for easier user inspection.
These do not change the behavior of serialization or any other output
flags (such as where to write static library files or how binaries
are embedded in VMFBs) and are strictly for debugging.

Targets that previously had their own flags for dumping outputs now use
the new common -iree-hal-dump-executable-binaries-to= flag. Both flags
are target-dependent and may have differing behavior (for example
LLVM CPU static library output doesn't produce a binary, and the CUDA
target isn't dumping anything yet).

The LLVM CPU target needs some cleanup to allow it to use the
intermediates path and today keeps it's own flag, but that is something
we can remove in future changes for consistency.

We now have a full set of flags for getting the interesting files in
either scripts or for human inspection:
```
iree-compile ... \
        -iree-hal-dump-executable-sources-to=${workspaceFolder}/../iree-tmp/exe/src/ \
        -iree-hal-dump-executable-benchmarks-to=${workspaceFolder}/../iree-tmp/exe/bench/ \
        -iree-hal-dump-executable-intermediates-to=${workspaceFolder}/../iree-tmp/exe/int/ \
        -iree-hal-dump-executable-binaries-to=${workspaceFolder}/../iree-tmp/exe/bin/
```

Fixes #8948.