### PR TITLE
Improve the heuristic on picking distributed size.

### DIFF
--- a/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -189,13 +189,13 @@ static SmallVector<int64_t> getDefaultDistributedLoopTileSizes(
         // Pick the factor of dim which is closest to the target tile size and
         // is a multiplier of vector size.
         for (int64_t k = vectorSize; k <= targetSize; k += vectorSize) {
-          if (dimSize % k == 0) {
+          if (dimSize % k == 0 && k >= minTileSizes[i]) {
             candidateTileSize = k;
           }
         }
       }
       // Fallback to power of 2 if there's no hint or can't find the ideal size.
-      if (vectorSize == 1 || candidateTileSize < minTileSizes[i]) {
+      if (vectorSize <= 1 || candidateTileSize == 1) {
         candidateTileSize =
             std::max<int64_t>(llvm::PowerOf2Floor(targetSize), minTileSizes[i]);
       }

--- a/iree/compiler/Codegen/LLVMCPU/test/materialize_x86_64_launch_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/materialize_x86_64_launch_configuration.mlir
@@ -646,7 +646,7 @@ hal.executable private @conv_static {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 28, 56, 8, 0, 0, 0], [1, 1, 8, 8, 0, 0, 0], [0, 0, 0, 0, 1, 1, 3]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 28, 28, 16, 0, 0, 0], [1, 1, 4, 8, 0, 0, 0], [0, 0, 0, 0, 1, 1, 3]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUConvTileAndDecomposeExpert>
 //      CHECK: hal.executable.entry_point public @conv_static
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -665,7 +665,7 @@ hal.executable private @conv_static {
 hal.executable private @depthwise_conv_static {
   hal.executable.variant public @system_elf_x86_64, target = <"llvm", "system-elf-x86_64", {
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
-    native_vector_size = 16 : index,
+    native_vector_size = 64 : index,
     target_triple = "x86_64-unknown-linux-gnu"
   }> {
     hal.executable.entry_point public @depthwise_conv_static layout(#executable_layout)
@@ -673,27 +673,27 @@ hal.executable private @depthwise_conv_static {
       func.func @depthwise_conv_static() {
         %cst = arith.constant 0.0 : f32
         %input_binding = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
-            : !flow.dispatch.tensor<readonly:1x161x161x96xf32>
+            : !flow.dispatch.tensor<readonly:1x161x161x240xf32>
         %filter_binding = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
-            : !flow.dispatch.tensor<readonly:3x3x96xf32>
+            : !flow.dispatch.tensor<readonly:3x3x240xf32>
         %result_binding = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer)
-            : !flow.dispatch.tensor<writeonly:1x80x80x96xf32>
-        %input = flow.dispatch.tensor.load %input_binding, offsets = [0, 0, 0, 0], sizes = [1, 161, 161, 96], strides = [1, 1, 1, 1]
-            : !flow.dispatch.tensor<readonly:1x161x161x96xf32> -> tensor<1x161x161x96xf32>
-        %filter = flow.dispatch.tensor.load %filter_binding, offsets = [0, 0, 0], sizes = [3, 3, 96], strides = [1, 1, 1]
-            : !flow.dispatch.tensor<readonly:3x3x96xf32> -> tensor<3x3x96xf32>
-        %init = linalg.init_tensor [1, 80, 80, 96] : tensor<1x80x80x96xf32>
-        %fill = linalg.fill ins(%cst : f32) outs(%init : tensor<1x80x80x96xf32>) -> tensor<1x80x80x96xf32>
+            : !flow.dispatch.tensor<writeonly:1x80x80x240xf32>
+        %input = flow.dispatch.tensor.load %input_binding, offsets = [0, 0, 0, 0], sizes = [1, 161, 161, 240], strides = [1, 1, 1, 1]
+            : !flow.dispatch.tensor<readonly:1x161x161x240xf32> -> tensor<1x161x161x240xf32>
+        %filter = flow.dispatch.tensor.load %filter_binding, offsets = [0, 0, 0], sizes = [3, 3, 240], strides = [1, 1, 1]
+            : !flow.dispatch.tensor<readonly:3x3x240xf32> -> tensor<3x3x240xf32>
+        %init = linalg.init_tensor [1, 80, 80, 240] : tensor<1x80x80x240xf32>
+        %fill = linalg.fill ins(%cst : f32) outs(%init : tensor<1x80x80x240xf32>) -> tensor<1x80x80x240xf32>
         %conv = linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>}
-            ins(%input, %filter : tensor<1x161x161x96xf32>, tensor<3x3x96xf32>) outs(%fill : tensor<1x80x80x96xf32>) -> tensor<1x80x80x96xf32>
-        flow.dispatch.tensor.store %conv, %result_binding, offsets = [0, 0, 0, 0], sizes = [1, 80, 80, 96], strides = [1, 1, 1, 1]
-            : tensor<1x80x80x96xf32> -> !flow.dispatch.tensor<writeonly:1x80x80x96xf32>
+            ins(%input, %filter : tensor<1x161x161x240xf32>, tensor<3x3x240xf32>) outs(%fill : tensor<1x80x80x240xf32>) -> tensor<1x80x80x240xf32>
+        flow.dispatch.tensor.store %conv, %result_binding, offsets = [0, 0, 0, 0], sizes = [1, 80, 80, 240], strides = [1, 1, 1, 1]
+            : tensor<1x80x80x240xf32> -> !flow.dispatch.tensor<writeonly:1x80x80x240xf32>
         return
       }
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 20, 40, 48, 0, 0], [1, 1, 8, 8, 0, 0], [0, 0, 0, 0, 1, 3]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 40, 40, 48, 0, 0], [1, 1, 8, 16, 0, 0], [0, 0, 0, 0, 1, 3]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUConvTileAndDecomposeExpert>
 //      CHECK: hal.executable.entry_point public @depthwise_conv_static
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/iree/compiler/Codegen/LLVMCPU/test/materialize_x86_64_launch_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/materialize_x86_64_launch_configuration.mlir
@@ -646,7 +646,7 @@ hal.executable private @conv_static {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 28, 28, 16, 0, 0, 0], [1, 1, 4, 8, 0, 0, 0], [0, 0, 0, 0, 1, 1, 3]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 28, 56, 8, 0, 0, 0], [1, 1, 8, 8, 0, 0, 0], [0, 0, 0, 0, 1, 1, 3]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUConvTileAndDecomposeExpert>
 //      CHECK: hal.executable.entry_point public @conv_static
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]


### PR DESCRIPTION
As #8980 described, this PR changes the heuristic on the distributed size to take the vector size into account. When the vector size is provided, it tries to find `the largest multiplier of the vector size which can divide the dim size and <= dim size / 2`.

Since tiling with a multiplier of vector size doesn't always have benefits, the vector size is passed as an optional hint per dimension. This PR only enables the new heuristic for the Conv2d on output feature dimension.

On x86 with AVX512:
|                                   | Base(ms) | After(ms) | Speedup |
|-----------------------------------|----------|-----------|---------|
| MobileNetV3, dylib-sync, 1 thread | 6.13     | 5.12      | 1.19x   |
| MobileNetV3, dylib, 4 threads     | 4.27     | 3.94      | 1.08x   |

On the sample kernel `main_dispatch_33` from MobileNetV3:
```mlir
func @main_dispatch_33(%arg0: tensor<1x18x18x240xf32> {linalg.buffer_layout = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, linalg.inplaceable = false}, %arg1: tensor<5x5x240xf32> {linalg.buffer_layout = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, linalg.inplaceable = false}, %arg2: tensor<1x14x14x240xf32> {linalg.buffer_layout = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, linalg.inplaceable = true}) -> tensor<1x14x14x240xf32> {
  %0 = linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %arg1 : tensor<1x18x18x240xf32>, tensor<5x5x240xf32>) outs(%arg2 : tensor<1x14x14x240xf32>) -> tensor<1x14x14x240xf32>
  return %0 : tensor<1x14x14x240xf32>
}
```
|                                        | Base(ms) | After(ms) | Speedup |
|----------------------------------------|----------|-----------|---------|
| main_dispatch_33, dylib-sync, 1 thread | 27.2     | 2.43      | 11.19x  |
| main_dispatch_33, dylib, 4 threads     | 10.5     | 3.07      | 3.42x   |

(Compiled with `-iree-hal-benchmark-dispatch-repeat-count=100`)