### PR TITLE
Fix several paths following samples/ and runtime/ code moves.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,6 +21,7 @@
 
 # Bindings
 /bindings/python/ @stellaraccident
+/runtime/bindings/python/ @stellaraccident
 /bindings/tflite/ @benvanik
 
 # Integrations
@@ -41,9 +42,9 @@
 /build_tools/ @GMNGeoffrey @ScottTodd
 /build_tools/benchmarks/ @GMNGeoffrey @antiagainst
 /build_tools/python_deploy/ @stellaraccident
+/build_tools/scripts/ @GMNGeoffrey @ScottTodd
 /build_tools/third_party/ @GMNGeoffrey @ScottTodd @stellaraccident
 /.github/ @GMNGeoffrey @ScottTodd
-/scripts/ @GMNGeoffrey @ScottTodd
 
 # llvm-external-projects
 /llvm-external-projects/ @stellaraccident
@@ -74,11 +75,12 @@
 
 
 # Runtime
-/iree/hal/cuda/ @ThomasRaoux
-/iree/hal/cts/ @ScottTodd
-/iree/hal/vulkan/ @antiagainst @ScottTodd
+/runtime/src/iree/ @benvanik
+/runtime/src/iree/hal/cuda/ @ThomasRaoux
+/runtime/src/iree/hal/cts/ @ScottTodd
+/runtime/src/iree/hal/vulkan/ @antiagainst @ScottTodd
 
 # Other IREE directories
-/iree/samples/ @ScottTodd
+/samples/ @ScottTodd
 /iree/test/ @ghost
 /iree/tools/ @benvanik @GMNGeoffrey

--- a/build_tools/cmake/build_runtime_emscripten.sh
+++ b/build_tools/cmake/build_runtime_emscripten.sh
@@ -48,4 +48,4 @@ emcmake "${CMAKE_BIN?}" -G Ninja .. \
   -DIREE_BUILD_SAMPLES=ON
 
 # TODO(scotttodd): expand this list of targets
-"${CMAKE_BIN?}" --build . --target iree_samples_simple_embedding_simple_embedding_vmvx_sync -- -k 0
+"${CMAKE_BIN?}" --build . --target iree_samples_iree_simple_embedding_simple_embedding_vmvx_sync -- -k 0

--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -109,7 +109,7 @@ function(iree_bytecode_module)
       ${_RULE_SRC}
       ${_RULE_DEPENDS}
     COMMENT
-      "Generating VMFB for ${_FRIENDLY_NAME}"
+      "Generating ${_MODULE_FILE_NAME} from ${_FRIENDLY_NAME}"
     VERBATIM
   )
 

--- a/build_tools/testing/test_samples.sh
+++ b/build_tools/testing/test_samples.sh
@@ -14,5 +14,5 @@ cd ${ROOT_DIR?}
 git submodule sync
 git submodule update --init
 
-./iree/samples/dynamic_shapes/test.sh
-./iree/samples/variables_and_state/test.sh
+./samples/dynamic_shapes/test.sh
+./samples/variables_and_state/test.sh

--- a/docs/developers/developing_iree/developer_overview.md
+++ b/docs/developers/developing_iree/developer_overview.md
@@ -3,6 +3,9 @@
 This guide provides an overview of IREE's project structure and main tools for
 developers.
 
+** Note: project layout is evolving at the moment, see
+   https://github.com/google/iree/issues/8955 **
+
 ## Project Code Layout
 
 [iree/](https://github.com/google/iree/blob/main/iree/)
@@ -13,31 +16,38 @@ developers.
 
 *   Integrations between IREE and other frameworks, such as TensorFlow
 
+[runtime/](https://github.com/google/iree/tree/main/runtime/)
+
+*   IREE runtime code, with no dependencies on the compiler
+
 [bindings/](https://github.com/google/iree/blob/main/bindings/)
 
 *   Language and platform bindings, such as Python
+*   Also see [runtime/bindings/](https://github.com/google/iree/tree/main/runtime/bindings)
 
-[colab/](https://github.com/google/iree/blob/main/colab/)
+[samples/](https://github.com/google/iree/blob/main/samples/)
 
-*   Colab notebooks for interactively using IREE's Python bindings
+*   Samples built using IREE's runtime and compiler
+*   Also see the separate https://github.com/google/iree-samples repository
 
-## IREE Code Layout
-
-[iree/base/](https://github.com/google/iree/blob/main/iree/base/)
-
-*   Common types and utilities used throughout IREE
+## IREE Compiler Code Layout
 
 [iree/compiler/](https://github.com/google/iree/blob/main/iree/compiler/)
 
 *   IREE's MLIR dialects, LLVM compiler passes, module translation code, etc.
-    Code here should not depend on anything in the runtime
 
-[iree/hal/](https://github.com/google/iree/blob/main/iree/hal/)
+## IREE Runtime Code Layout
+
+[iree/base/](https://github.com/google/iree/blob/main/runtime/src/iree/base/)
+
+*   Common types and utilities used throughout the runtime
+
+[iree/hal/](https://github.com/google/iree/blob/main/runtime/src/iree/hal/)
 
 *   **H**ardware **A**bstraction **L**ayer for IREE's runtime, with
     implementations for hardware and software backends
 
-[iree/schemas/](https://github.com/google/iree/blob/main/iree/schemas/)
+[iree/schemas/](https://github.com/google/iree/blob/main/runtime/src/iree/schemas/)
 
 *   Shared data storage format definitions, primarily using
     [FlatBuffers](https://google.github.io/flatbuffers/)
@@ -46,7 +56,7 @@ developers.
 
 *   Assorted tools used to optimize, translate, and evaluate IREE
 
-[iree/vm/](https://github.com/google/iree/blob/main/iree/vm/)
+[iree/vm/](https://github.com/google/iree/blob/main/runtime/src/iree/vm/)
 
 *   Bytecode **V**irtual **M**achine used to work with IREE modules and invoke
     IREE functions

--- a/docs/developers/get_started/building_with_emscripten.md
+++ b/docs/developers/get_started/building_with_emscripten.md
@@ -55,7 +55,7 @@ Build:
 
 ```
 cmake --build ../iree-build-emscripten/ \
-  --target iree_samples_simple_embedding_simple_embedding_vmvx_sync
+  --target iree_samples_iree_simple_embedding_simple_embedding_vmvx_sync
 ```
 
 ### Load into a WebAssembly Environment

--- a/docs/website/docs/bindings/c-api.md
+++ b/docs/website/docs/bindings/c-api.md
@@ -7,11 +7,11 @@ API header files are organized by runtime component:
 
 | Component header file                                                       | Overview                                                                  |
 |-----------------------------------------------------------------------------|---------------------------------------------------------------------------|
-| [iree/base/api.h](https://github.com/google/iree/blob/main/iree/base/api.h) | Core API, type definitions, ownership policies, utilities                 |
-| [iree/vm/api.h](https://github.com/google/iree/blob/main/iree/vm/api.h)     | VM APIs: loading modules, I/O, calling functions                          |
-| [iree/hal/api.h](https://github.com/google/iree/blob/main/iree/hal/api.h)   | HAL APIs: device management, synchronization, accessing hardware features |
+| [iree/base/api.h](https://github.com/google/iree/blob/main/runtime/src/iree/base/api.h) | Core API, type definitions, ownership policies, utilities                 |
+| [iree/vm/api.h](https://github.com/google/iree/blob/main/runtime/src/iree/vm/api.h)     | VM APIs: loading modules, I/O, calling functions                          |
+| [iree/hal/api.h](https://github.com/google/iree/blob/main/runtime/src/iree/hal/api.h)   | HAL APIs: device management, synchronization, accessing hardware features |
 
-The [samples/](https://github.com/google/iree/tree/main/iree/samples)
+The [samples/](https://github.com/google/iree/tree/main/samples)
 directory demonstrates several ways to use IREE's C API.
 
 ## Prerequisites

--- a/docs/website/docs/building-from-source/python-bindings-and-importers.md
+++ b/docs/website/docs/building-from-source/python-bindings-and-importers.md
@@ -34,8 +34,8 @@ Also see [instructions for installing pre-built binaries](../bindings/python.md)
 
 * **`IREE_BUILD_PYTHON_BINDINGS`** : `BOOL`
 
-    Enables building of Python bindings under `bindings/python` in the repository.
-    Defaults to `OFF`.
+    Enables building of Python bindings under `runtime/bindings/python` in the
+    repository. Defaults to `OFF`.
 
 * **`Python3_EXECUTABLE`** : `PATH`
 

--- a/experimental/web/sample_dynamic/README.md
+++ b/experimental/web/sample_dynamic/README.md
@@ -23,7 +23,7 @@ etc.), just `control + C` to stop the local webserver and rerun the script.
 to compile the runtime into WebAssembly and JavaScript files.
 
 Any supported IREE program, such as
-[simple_abs.mlir](../../../iree/samples/models/simple_abs.mlir), is compiled using
+[simple_abs.mlir](../../../samples/models/simple_abs.mlir), is compiled using
 the "system library" linking mode. This creates a shared object (typically
 .so/.dll, .wasm in this case). When the runtime attempts to load this file
 using `dlopen()` and `dlsym()`, Emscripten makes use of its

--- a/experimental/web/sample_dynamic/build_sample.sh
+++ b/experimental/web/sample_dynamic/build_sample.sh
@@ -57,7 +57,7 @@ compile_sample() {
 }
 
 echo "=== Compiling sample MLIR files to VM flatbuffer outputs (.vmfb) ==="
-compile_sample "simple_abs"     "${ROOT_DIR?}/iree/samples/models/simple_abs.mlir"
+compile_sample "simple_abs"     "${ROOT_DIR?}/samples/models/simple_abs.mlir"
 compile_sample "fullyconnected" "${ROOT_DIR?}/iree/test/e2e/models/fullyconnected.mlir"
 compile_sample "collatz"        "${ROOT_DIR?}/iree/test/e2e/models/collatz.mlir"
 

--- a/experimental/web/sample_dynamic/serve_sample.sh
+++ b/experimental/web/sample_dynamic/serve_sample.sh
@@ -11,4 +11,4 @@ BINARY_DIR=${BUILD_DIR}/experimental/web/sample_dynamic
 
 echo "=== Running local webserver, open at http://localhost:8000/ ==="
 
-python3 ${ROOT_DIR?}/scripts/local_web_server.py --directory ${BINARY_DIR}
+python3 ${ROOT_DIR?}/build_tools/scripts/local_web_server.py --directory ${BINARY_DIR}

--- a/experimental/web/sample_static/CMakeLists.txt
+++ b/experimental/web/sample_static/CMakeLists.txt
@@ -51,7 +51,7 @@ target_link_libraries(${_NAME}
 
 target_link_options(${_NAME} PRIVATE
   # https://emscripten.org/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.html#interacting-with-code-ccall-cwrap
-  "-sEXPORTED_FUNCTIONS=['_setup_sample', '_cleanup_sample', '_run_sample']"
+  "-sEXPORTED_FUNCTIONS=['_setup_sample', '_cleanup_sample', '_run_sample', '_malloc']"
   "-sEXPORTED_RUNTIME_METHODS=['ccall','cwrap']"
   #
   "-sASSERTIONS=1"
@@ -96,7 +96,7 @@ target_link_libraries(${_NAME}
 
 target_link_options(${_NAME} PRIVATE
   # https://emscripten.org/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.html#interacting-with-code-ccall-cwrap
-  "-sEXPORTED_FUNCTIONS=['_setup_sample', '_cleanup_sample', '_run_sample']"
+  "-sEXPORTED_FUNCTIONS=['_setup_sample', '_cleanup_sample', '_run_sample', '_malloc']"
   "-sEXPORTED_RUNTIME_METHODS=['ccall','cwrap']"
   #
   "-sASSERTIONS=1"
@@ -132,5 +132,7 @@ target_link_options(${_NAME} PRIVATE
   # IREE is pretty good about not allocating outside of startup, so concerns
   # about this causing slow access to memory *may* not affect IREE too much.
   # "-sALLOW_MEMORY_GROWTH=1"
+  # TODO(scotttodd): tune this (figure out where memory is going and trim)
+  # "-sINITIAL_MEMORY=33554432"
   # ------------------------------------------------------------------------- #
 )

--- a/experimental/web/sample_static/README.md
+++ b/experimental/web/sample_static/README.md
@@ -22,10 +22,10 @@ etc.), just `control + C` to stop the local webserver and rerun the script.
 
 ## How it works
 
-This [MNIST model](../../../iree/samples/models/mnist.mlir), also used in the
-[Vision sample](../../../iree/samples/vision/), is compiled using the "static
+This [MNIST model](../../../samples/models/mnist.mlir), also used in the
+[Vision sample](../../../samples/iree_vision_inference/), is compiled using the "static
 library" output setting of IREE's compiler (see the
-[Static library sample](../../../iree/samples/static_library)). The resulting
+[Static library sample](../../../samples/iree_static_library)). The resulting
 `.h` and `.o` files are compiled together with `main.c`, while the `.vmfb` is
 embedded into a C file that is similarly linked in.
 

--- a/experimental/web/sample_static/build_sample.sh
+++ b/experimental/web/sample_static/build_sample.sh
@@ -46,7 +46,7 @@ INSTALL_ROOT="${1:-${ROOT_DIR}/build-host/install}"
 COMPILE_TOOL="${INSTALL_ROOT?}/bin/iree-compile"
 EMBED_DATA_TOOL="${INSTALL_ROOT?}/bin/generate_embed_data"
 INPUT_NAME="mnist"
-INPUT_PATH="${ROOT_DIR?}/iree/samples/models/mnist.mlir"
+INPUT_PATH="${ROOT_DIR?}/samples/models/mnist.mlir"
 
 echo "=== Compiling MLIR to static library output (.vmfb, .h, .o) ==="
 ${COMPILE_TOOL?} ${INPUT_PATH} \

--- a/experimental/web/sample_static/iree_worker.js
+++ b/experimental/web/sample_static/iree_worker.js
@@ -17,8 +17,10 @@ function ireeError(...args) {
 }
 
 // TODO(scotttodd): configure this through the build system / scripts?
-const MAIN_SCRIPT_URL = 'web-sample-static-multithreaded.js';
-// const MAIN_SCRIPT_URL = 'web-sample-static-sync.js';
+// TODO(scotttodd): fix multithreading (startup silently fails on some emsdk
+//                  versions, memory growth or high initial memory also req.)
+// const MAIN_SCRIPT_URL = 'web-sample-static-multithreaded.js';
+const MAIN_SCRIPT_URL = 'web-sample-static-sync.js';
 
 let wasmSetupSampleFn;
 let wasmCleanupSampleFn;

--- a/experimental/web/sample_static/serve_sample.sh
+++ b/experimental/web/sample_static/serve_sample.sh
@@ -11,4 +11,4 @@ BINARY_DIR=${BUILD_DIR}/experimental/web/sample_static
 
 echo "=== Running local webserver, open at http://localhost:8000/ ==="
 
-python3 ${ROOT_DIR?}/scripts/local_web_server.py --directory ${BINARY_DIR}
+python3 ${ROOT_DIR?}/build_tools/scripts/local_web_server.py --directory ${BINARY_DIR}

--- a/samples/dynamic_shapes/README.md
+++ b/samples/dynamic_shapes/README.md
@@ -13,7 +13,7 @@ Steps 1-2 are performed in Python via the
 [`dynamic_shapes.ipynb`](./dynamic_shapes.ipynb)
 [Colab](https://research.google.com/colaboratory/) notebook:
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/iree/blob/main/iree/samples/dynamic_shapes/dynamic_shapes.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/iree/blob/main/samples/dynamic_shapes/dynamic_shapes.ipynb)
 
 Step 3 should be performed on your development host machine
 
@@ -97,6 +97,6 @@ them.
 5. Run the sample binary:
 
    ```
-   ../iree-build/iree/samples/dynamic_shapes/dynamic-shapes \
+   ../iree-build/samples/dynamic_shapes/dynamic-shapes \
        /path/to/dynamic_shapes_dylib.vmfb dylib
    ```

--- a/samples/dynamic_shapes/test.sh
+++ b/samples/dynamic_shapes/test.sh
@@ -18,7 +18,7 @@ ARTIFACTS_DIR=/tmp/iree/colab_artifacts
 
 # 1. Run the notebook to generate `counter.mlir` and `counter_vmvx.vmfb`
 ${ROOT_DIR}/build_tools/testing/run_python_notebook.sh \
-  ${ROOT_DIR}/iree/samples/dynamic_shapes/dynamic_shapes.ipynb
+  ${ROOT_DIR}/samples/dynamic_shapes/dynamic_shapes.ipynb
 test -f ${ARTIFACTS_DIR}/dynamic_shapes.mlir && echo "dynamic_shapes.mlir exists"
 
 # 2. Build the `iree-compile` tool.
@@ -36,5 +36,5 @@ ${BUILD_DIR}/iree/tools/iree-compile \
 cmake --build ${BUILD_DIR} --target iree_samples_dynamic_shapes -- -k 0
 
 # 5. Run the sample binary.
-${BUILD_DIR}/iree/samples/dynamic_shapes/dynamic-shapes \
+${BUILD_DIR}/samples/dynamic_shapes/dynamic-shapes \
   ${ARTIFACTS_DIR}/dynamic_shapes_dylib.vmfb dylib

--- a/samples/variables_and_state/README.md
+++ b/samples/variables_and_state/README.md
@@ -13,7 +13,7 @@ Steps 1-3 are performed in Python via the
 [`variables_and_state.ipynb`](./variables_and_state.ipynb)
 [Colab](https://research.google.com/colaboratory/) notebook:
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/iree/blob/main/iree/samples/variables_and_state/variables_and_state.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/iree/blob/main/samples/variables_and_state/variables_and_state.ipynb)
 
 Steps 4-5 are in [`main.c`](./main.c)
 
@@ -73,7 +73,7 @@ functions in the compiled programs.
 3. Run the sample binary:
 
    ```
-   ../iree-build/iree/samples/variables_and_state/variables-and-state \
+   ../iree-build/samples/variables_and_state/variables-and-state \
        /path/to/counter_vmvx.vmfb vmvx
    ```
 
@@ -101,6 +101,6 @@ and compile the imported `counter.mlir` file using `iree-compile`:
 then run the program with that new VM bytecode module:
 
 ```
-../iree-build/iree/samples/variables_and_state/variables-and-state \
+../iree-build/samples/variables_and_state/variables-and-state \
     /path/to/counter_dylib.vmfb dylib
 ```

--- a/samples/variables_and_state/test.sh
+++ b/samples/variables_and_state/test.sh
@@ -18,7 +18,7 @@ ARTIFACTS_DIR=/tmp/iree/colab_artifacts
 
 # 1. Run the notebook to generate `counter.mlir` and `counter_vmvx.vmfb`
 ${ROOT_DIR}/build_tools/testing/run_python_notebook.sh \
-  ${ROOT_DIR}/iree/samples/variables_and_state/variables_and_state.ipynb
+  ${ROOT_DIR}/samples/variables_and_state/variables_and_state.ipynb
 test -f ${ARTIFACTS_DIR}/counter.mlir && echo "counter.mlir exists"
 test -f ${ARTIFACTS_DIR}/counter_vmvx.vmfb && echo "counter_vmvx.vmfb exists"
 
@@ -27,5 +27,5 @@ cmake -B ${BUILD_DIR} -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo ${ROOT_DIR}
 cmake --build ${BUILD_DIR} --target iree_samples_variables_and_state -- -k 0
 
 # 3. Run the sample binary.
-${BUILD_DIR}/iree/samples/variables_and_state/variables-and-state \
+${BUILD_DIR}/samples/variables_and_state/variables-and-state \
   ${ARTIFACTS_DIR}/counter_vmvx.vmfb vmvx

--- a/samples/vulkan/vulkan_inference_gui.cc
+++ b/samples/vulkan/vulkan_inference_gui.cc
@@ -26,7 +26,7 @@
 #include "iree/base/logging.h"
 
 // Compiled module embedded here to avoid file IO:
-#include "iree/samples/vulkan/simple_mul_bytecode_module_c.h"
+#include "samples/vulkan/simple_mul_bytecode_module_c.h"
 
 static VkAllocationCallbacks* g_Allocator = NULL;
 static VkInstance g_Instance = VK_NULL_HANDLE;


### PR DESCRIPTION
Following https://github.com/google/iree/pull/8950 and https://github.com/google/iree/pull/8958. Probably more to follow with https://github.com/google/iree/issues/8955.

This should fix the failing builds on https://buildkite.com/iree/iree-build-configurations and https://buildkite.com/iree/iree-samples.