### PR TITLE
Pin GitHub Action versions to specific commits, not tags.

### DIFF
--- a/.github/workflows/advance_upstream_forks.yml
+++ b/.github/workflows/advance_upstream_forks.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           repository: google/iree-llvm-fork
@@ -32,7 +32,7 @@ jobs:
           git remote add upstream https://github.com/llvm/llvm-project.git
           git pull --ff-only upstream main
       - name: Pushing changes
-        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6
+        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6  # v0.6.0
         with:
           github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           branch: main
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           repository: google/iree-mhlo-fork
@@ -56,7 +56,7 @@ jobs:
           git remote add upstream https://github.com/tensorflow/mlir-hlo.git
           git pull --ff-only upstream master
       - name: Pushing changes
-        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6
+        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6  # v0.6.0
         with:
           github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           branch: master
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           repository: google/iree-tf-fork
@@ -80,7 +80,7 @@ jobs:
           git remote add upstream https://github.com/tensorflow/tensorflow.git
           git pull --ff-only upstream master
       - name: Pushing changes
-        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6
+        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6  # v0.6.0
         with:
           github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           branch: master

--- a/.github/workflows/advance_upstream_forks.yml
+++ b/.github/workflows/advance_upstream_forks.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           repository: google/iree-llvm-fork
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           repository: google/iree-mhlo-fork
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           repository: google/iree-tf-fork

--- a/.github/workflows/advance_upstream_forks.yml
+++ b/.github/workflows/advance_upstream_forks.yml
@@ -32,7 +32,7 @@ jobs:
           git remote add upstream https://github.com/llvm/llvm-project.git
           git pull --ff-only upstream main
       - name: Pushing changes
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6
         with:
           github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           branch: main
@@ -56,7 +56,7 @@ jobs:
           git remote add upstream https://github.com/tensorflow/mlir-hlo.git
           git pull --ff-only upstream master
       - name: Pushing changes
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6
         with:
           github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           branch: master
@@ -80,7 +80,7 @@ jobs:
           git remote add upstream https://github.com/tensorflow/tensorflow.git
           git pull --ff-only upstream master
       - name: Pushing changes
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6
         with:
           github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           branch: master

--- a/.github/workflows/android_tflite_oneshot_build.yml
+++ b/.github/workflows/android_tflite_oneshot_build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_android_with_docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       ANDROID_CONTAINER: "gcr.io/iree-oss/gradle-android@sha256:61e55a46d58b881a22c6ce9b7e8186dbd362a0ebc9ebe1a0284f55cd6212bb18"
     steps:

--- a/.github/workflows/android_tflite_oneshot_build.yml
+++ b/.github/workflows/android_tflite_oneshot_build.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       ANDROID_CONTAINER: "gcr.io/iree-oss/gradle-android@sha256:61e55a46d58b881a22c6ce9b7e8186dbd362a0ebc9ebe1a0284f55cd6212bb18"
     steps:
-      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
         with:
           submodules: true
       - name: Execute Android Build
@@ -21,7 +21,7 @@ jobs:
           -v $PWD:/work \
           "${ANDROID_CONTAINER}" \
           bash -c build_tools/gradle/build_tflite_android_library.sh
-      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2  # v2
         with:
           path: ./bindings/tflite/java/build/outputs/aar/*.aar
           retention-days: 1

--- a/.github/workflows/android_tflite_oneshot_build.yml
+++ b/.github/workflows/android_tflite_oneshot_build.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       ANDROID_CONTAINER: "gcr.io/iree-oss/gradle-android@sha256:61e55a46d58b881a22c6ce9b7e8186dbd362a0ebc9ebe1a0284f55cd6212bb18"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
         with:
           submodules: true
       - name: Execute Android Build

--- a/.github/workflows/android_tflite_oneshot_build.yml
+++ b/.github/workflows/android_tflite_oneshot_build.yml
@@ -21,7 +21,7 @@ jobs:
           -v $PWD:/work \
           "${ANDROID_CONTAINER}" \
           bash -c build_tools/gradle/build_tflite_android_library.sh
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2
         with:
           path: ./bindings/tflite/java/build/outputs/aar/*.aar
           retention-days: 1

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -173,7 +173,7 @@ jobs:
             "${MANYLINUX_X86_64_IMAGE}" \
             bash -c 'export PATH=/opt/python/cp39-cp39/bin:$PATH; python ./main_checkout/build_tools/github_actions/build_dist.py py-tf-compiler-tools-pkg'
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2
         with:
           # We upload all wheels (which includes deps so that subsequent
           # steps can run without further fetching).

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -62,7 +62,7 @@ jobs:
       MANYLINUX_X86_64_IMAGE: gcr.io/iree-oss/manylinux2014_x86_64-release@sha256:3e7ac081b69bdc54650a98725b793f072f3c3beb229f8886dbcd6f23bc1eb9ca
 
     steps:
-      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
         with:
           path: 'main_checkout'
           submodules: true
@@ -173,7 +173,7 @@ jobs:
             "${MANYLINUX_X86_64_IMAGE}" \
             bash -c 'export PATH=/opt/python/cp39-cp39/bin:$PATH; python ./main_checkout/build_tools/github_actions/build_dist.py py-tf-compiler-tools-pkg'
 
-      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2  # v2
         with:
           # We upload all wheels (which includes deps so that subsequent
           # steps can run without further fetching).
@@ -184,7 +184,7 @@ jobs:
       - name: Upload Release Assets
         if: github.event.inputs.release_id != ''
         id: upload-release-assets
-        uses: dwenegar/upload-release-assets@5bc3024cf83521df8ebfadf00ad0c4614fd59148
+        uses: dwenegar/upload-release-assets@5bc3024cf83521df8ebfadf00ad0c4614fd59148  # v1
         env:
           GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_TOKEN }}
         with:
@@ -198,7 +198,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: "Invoke workflow :: Validate and Publish Release"
-        uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7
+        uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7  # v1
         with:
           workflow: Validate and Publish Release
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -62,7 +62,7 @@ jobs:
       MANYLINUX_X86_64_IMAGE: gcr.io/iree-oss/manylinux2014_x86_64-release@sha256:3e7ac081b69bdc54650a98725b793f072f3c3beb229f8886dbcd6f23bc1eb9ca
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
         with:
           path: 'main_checkout'
           submodules: true

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -184,7 +184,7 @@ jobs:
       - name: Upload Release Assets
         if: github.event.inputs.release_id != ''
         id: upload-release-assets
-        uses: dwenegar/upload-release-assets@v1
+        uses: dwenegar/upload-release-assets@5bc3024cf83521df8ebfadf00ad0c4614fd59148
         env:
           GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_TOKEN }}
         with:

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -198,7 +198,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: "Invoke workflow :: Validate and Publish Release"
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7
         with:
           workflow: Validate and Publish Release
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}

--- a/.github/workflows/copybara_fixup.yml
+++ b/.github/workflows/copybara_fixup.yml
@@ -28,7 +28,7 @@ jobs:
     if: github.repository == 'google/iree'
     steps:
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           # Get all history. We're force-pushing here and will otherwise drop
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
       - name: Checking for Copybara tag
         run: |
           if git log --format=%B -n 1 HEAD | grep -q "${COPYBARA_TAG}"; then

--- a/.github/workflows/copybara_fixup.yml
+++ b/.github/workflows/copybara_fixup.yml
@@ -28,7 +28,7 @@ jobs:
     if: github.repository == 'google/iree'
     steps:
       - name: Checking out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           # Get all history. We're force-pushing here and will otherwise drop
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
       - name: Checking for Copybara tag
         run: |
           if git log --format=%B -n 1 HEAD | grep -q "${COPYBARA_TAG}"; then

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
       - name: Running bazel_to_cmake for IREE core
         run: ./build_tools/bazel_to_cmake/bazel_to_cmake.py --verbosity=2
       - name: Running bazel_to_cmake for IREE TF Integration Tests
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
       - name: Fetching Base Branch
         # We have to explicitly fetch the base branch as well
         run: git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"
@@ -53,9 +53,9 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
       - name: Setting up python
-        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a
+        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a  # v2
       - name: Fetching Base Branch
         # We have to explicitly fetch the base branch as well
         run: git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"
@@ -76,9 +76,9 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
       - name: Setting up python
-        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a
+        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a  # v2
         with:
           # Pytype does not support python3.9, which this action defaults to.
           python-version: '3.8'
@@ -100,7 +100,7 @@ jobs:
           wget https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/git-clang-format -O /tmp/git-clang-format
           chmod +x /tmp/git-clang-format
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
       - name: Fetching Base Branch
         # We have to explicitly fetch the base branch as well
         run: git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
       - name: Fetching Base Branch
         # We have to explicitly fetch the base branch as well
         run: git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"
@@ -124,7 +124,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
       - name: Fetching Base Branch
         # We have to explicitly fetch the base branch as well
         run: git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Checking out repository
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
       - name: Setting up python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a
       - name: Fetching Base Branch
         # We have to explicitly fetch the base branch as well
         run: git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"
@@ -78,7 +78,7 @@ jobs:
       - name: Checking out repository
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
       - name: Setting up python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a
         with:
           # Pytype does not support python3.9, which this action defaults to.
           python-version: '3.8'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
       - name: Running bazel_to_cmake for IREE core
         run: ./build_tools/bazel_to_cmake/bazel_to_cmake.py --verbosity=2
       - name: Running bazel_to_cmake for IREE TF Integration Tests
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
       - name: Fetching Base Branch
         # We have to explicitly fetch the base branch as well
         run: git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
       - name: Setting up python
         uses: actions/setup-python@v2
       - name: Fetching Base Branch
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
       - name: Setting up python
         uses: actions/setup-python@v2
         with:
@@ -100,7 +100,7 @@ jobs:
           wget https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/git-clang-format -O /tmp/git-clang-format
           chmod +x /tmp/git-clang-format
       - name: Checking out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
       - name: Fetching Base Branch
         # We have to explicitly fetch the base branch as well
         run: git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
       - name: Fetching Base Branch
         # We have to explicitly fetch the base branch as well
         run: git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"
@@ -124,7 +124,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
       - name: Fetching Base Branch
         # We have to explicitly fetch the base branch as well
         run: git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"

--- a/.github/workflows/oneshot_candidate_release.yml
+++ b/.github/workflows/oneshot_candidate_release.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e
         env:
           GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_TOKEN }}
         with:

--- a/.github/workflows/oneshot_candidate_release.yml
+++ b/.github/workflows/oneshot_candidate_release.yml
@@ -46,7 +46,7 @@ jobs:
           prerelease: true
 
       - name: "Invoke workflow :: Build Native Release Packages"
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7
         with:
           workflow: Build Native Release Packages
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}

--- a/.github/workflows/oneshot_candidate_release.yml
+++ b/.github/workflows/oneshot_candidate_release.yml
@@ -26,7 +26,7 @@ jobs:
           git tag "${tag_name}"
 
       - name: Pushing changes
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6
         with:
           github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           branch: ${{ github.ref_name }}

--- a/.github/workflows/oneshot_candidate_release.yml
+++ b/.github/workflows/oneshot_candidate_release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
 

--- a/.github/workflows/oneshot_candidate_release.yml
+++ b/.github/workflows/oneshot_candidate_release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
 
@@ -26,7 +26,7 @@ jobs:
           git tag "${tag_name}"
 
       - name: Pushing changes
-        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6
+        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6  # v0.6.0
         with:
           github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           branch: ${{ github.ref_name }}
@@ -34,7 +34,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e  # v1
         env:
           GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_TOKEN }}
         with:
@@ -46,7 +46,7 @@ jobs:
           prerelease: true
 
       - name: "Invoke workflow :: Build Native Release Packages"
-        uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7
+        uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7  # v1
         with:
           workflow: Build Native Release Packages
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -31,7 +31,7 @@ jobs:
         # We have to explicitly fetch the gh-pages branch as well to preserve history
         run: git fetch --no-tags --prune --depth=1 origin "gh-pages:gh-pages"
       - name: Setting up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a
         with:
           python-version: 3.x
       - name: Installing Material for MkDocs

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
       - name: Fetching base gh-pages branch

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -24,14 +24,14 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
       - name: Fetching base gh-pages branch
         # We have to explicitly fetch the gh-pages branch as well to preserve history
         run: git fetch --no-tags --prune --depth=1 origin "gh-pages:gh-pages"
       - name: Setting up Python
-        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a
+        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a  # v2
         with:
           python-version: 3.x
       - name: Installing Material for MkDocs

--- a/.github/workflows/schedule_candidate_release.yml
+++ b/.github/workflows/schedule_candidate_release.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository == 'google/iree'
     steps:
       - name: Checking out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
 

--- a/.github/workflows/schedule_candidate_release.yml
+++ b/.github/workflows/schedule_candidate_release.yml
@@ -31,7 +31,7 @@ jobs:
           git tag "${tag_name}"
 
       - name: Pushing changes
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6
         with:
           github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           branch: ${{ github.ref_name }}

--- a/.github/workflows/schedule_candidate_release.yml
+++ b/.github/workflows/schedule_candidate_release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e
         env:
           GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_TOKEN }}
         with:

--- a/.github/workflows/schedule_candidate_release.yml
+++ b/.github/workflows/schedule_candidate_release.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository == 'google/iree'
     steps:
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
 
@@ -31,7 +31,7 @@ jobs:
           git tag "${tag_name}"
 
       - name: Pushing changes
-        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6
+        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6  # v0.6.0
         with:
           github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           branch: ${{ github.ref_name }}
@@ -39,7 +39,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e  # v1
         env:
           GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_TOKEN }}
         with:
@@ -51,7 +51,7 @@ jobs:
           prerelease: true
 
       - name: "Invoke workflow :: Build Native Release Packages"
-        uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7
+        uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7  # v1
         with:
           workflow: Build Native Release Packages
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}

--- a/.github/workflows/schedule_candidate_release.yml
+++ b/.github/workflows/schedule_candidate_release.yml
@@ -51,7 +51,7 @@ jobs:
           prerelease: true
 
       - name: "Invoke workflow :: Build Native Release Packages"
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7
         with:
           workflow: Build Native Release Packages
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}

--- a/.github/workflows/validate_and_publish_release.yml
+++ b/.github/workflows/validate_and_publish_release.yml
@@ -77,7 +77,7 @@ jobs:
     steps:
       - name: Publish Release
         id: publish_release
-        uses: eregon/publish-release@v1
+        uses: eregon/publish-release@d6aee8c288e653387d895ee64d559fc0dd63339d
         env:
           GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_TOKEN }}
         with:

--- a/.github/workflows/validate_and_publish_release.yml
+++ b/.github/workflows/validate_and_publish_release.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Download packages
         id: download_packages
-        uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39
+        uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2
         with:
           github_token: ${{secrets.WRITE_ACCESS_TOKEN}}
           workflow: build_package.yml
@@ -35,7 +35,7 @@ jobs:
           ls -R
       - name: Set up python
         id: set_up_python
-        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a
+        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a  # v2
         with:
           python-version: '3.8'
       - name: Install python packages
@@ -77,14 +77,14 @@ jobs:
     steps:
       - name: Publish Release
         id: publish_release
-        uses: eregon/publish-release@d6aee8c288e653387d895ee64d559fc0dd63339d
+        uses: eregon/publish-release@d6aee8c288e653387d895ee64d559fc0dd63339d  # v1.0.3
         env:
           GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_TOKEN }}
         with:
           release_id: ${{ github.event.inputs.release_id }}
 
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           # Get all history. Otherwise the latest-snapshot branch can't be
@@ -92,7 +92,7 @@ jobs:
           fetch-depth: 0
 
       - name: Updating latest-snapshot branch
-        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6
+        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6  # v0.6.0
         with:
           github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           branch: latest-snapshot

--- a/.github/workflows/validate_and_publish_release.yml
+++ b/.github/workflows/validate_and_publish_release.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Download packages
         id: download_packages
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39
         with:
           github_token: ${{secrets.WRITE_ACCESS_TOKEN}}
           workflow: build_package.yml

--- a/.github/workflows/validate_and_publish_release.yml
+++ b/.github/workflows/validate_and_publish_release.yml
@@ -92,7 +92,7 @@ jobs:
           fetch-depth: 0
 
       - name: Updating latest-snapshot branch
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6
         with:
           github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           branch: latest-snapshot

--- a/.github/workflows/validate_and_publish_release.yml
+++ b/.github/workflows/validate_and_publish_release.yml
@@ -35,7 +35,7 @@ jobs:
           ls -R
       - name: Set up python
         id: set_up_python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a
         with:
           python-version: '3.8'
       - name: Install python packages

--- a/.github/workflows/validate_and_publish_release.yml
+++ b/.github/workflows/validate_and_publish_release.yml
@@ -84,7 +84,7 @@ jobs:
           release_id: ${{ github.event.inputs.release_id }}
 
       - name: Checking out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           # Get all history. Otherwise the latest-snapshot branch can't be

--- a/docs/developers/debugging/releases.md
+++ b/docs/developers/debugging/releases.md
@@ -105,7 +105,7 @@ And change the branch from 'main' to the branch you are developing on
 [here](https://github.com/google/iree/blob/392449e986493bf710e3da637ebf807715da9ffe/.github/workflows/schedule_snapshot_release.yml#L37):
 ```yaml
 - name: Pushing changes
-  uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6
+  uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6  # v0.6.0
   with:
     github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
     branch: main

--- a/docs/developers/debugging/releases.md
+++ b/docs/developers/debugging/releases.md
@@ -105,7 +105,7 @@ And change the branch from 'main' to the branch you are developing on
 [here](https://github.com/google/iree/blob/392449e986493bf710e3da637ebf807715da9ffe/.github/workflows/schedule_snapshot_release.yml#L37):
 ```yaml
 - name: Pushing changes
-  uses: ad-m/github-push-action@v0.6.0
+  uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6
   with:
     github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
     branch: main


### PR DESCRIPTION
The policy we followed changed for this at some point, from allowing tagged releases to requiring specific commits: https://opensource.google/documentation/reference/github/services#actions

> When using a third-party action (one not hosted in a Google-managed org), a fixed version of the action MUST be used by [specifying a specific commit](https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsuses), rather than a branch like "master", or a tagged release, which can be overwritten by any maintainer of the action. Docker images should always be run at a fixed version rather than "latest".

I searched each action for the commits we were using anyways (so not upgrading from v2 to v3, for example), but some drift may have occurred. If this breaks any of our workflows after merging, we can take a closer look.