### PR TITLE
Enable matmul e2e tests for Vulkan

### DIFF
--- a/iree/test/e2e/matmul/BUILD
+++ b/iree/test/e2e/matmul/BUILD
@@ -193,3 +193,26 @@ py_binary(
 ) for lhs_rhs_type in [
     "f32",
 ]]
+
+[iree_generated_trace_runner_test(
+    name = "e2e_matmul_direct_f32_gpu_large_%s" % vulkan_target,
+    generator = ":generate_e2e_matmul_tests",
+    generator_args = [
+        "--lhs_rhs_type=f32",
+        "--shapes=gpu_large",
+        "--compilation_info=SPIRVVectorize",
+    ],
+    compiler_flags = [
+        "--iree-vulkan-target-triple=%s" % vulkan_target,
+    ],
+    tags = [
+        "requires-gpu-nvidia",
+    ],
+    target_backends_and_drivers = [
+        ("vulkan-spirv", "vulkan"),
+    ],
+    trace_runner = "//iree/tools:iree-e2e-matmul-test",
+) for vulkan_target in [
+    "valhall-unknown-android11",
+    "ampere-unknown-linux",
+]]

--- a/iree/test/e2e/matmul/BUILD
+++ b/iree/test/e2e/matmul/BUILD
@@ -196,14 +196,14 @@ py_binary(
 
 [iree_generated_trace_runner_test(
     name = "e2e_matmul_direct_f32_gpu_large_%s" % vulkan_target,
+    compiler_flags = [
+        "--iree-vulkan-target-triple=%s" % vulkan_target,
+    ],
     generator = ":generate_e2e_matmul_tests",
     generator_args = [
         "--lhs_rhs_type=f32",
         "--shapes=gpu_large",
         "--compilation_info=SPIRVVectorize",
-    ],
-    compiler_flags = [
-        "--iree-vulkan-target-triple=%s" % vulkan_target,
     ],
     tags = [
         "requires-gpu-nvidia",

--- a/iree/test/e2e/matmul/CMakeLists.txt
+++ b/iree/test/e2e/matmul/CMakeLists.txt
@@ -248,4 +248,46 @@ iree_generated_trace_runner_test(
     "requires-gpu-nvidia"
 )
 
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_direct_f32_gpu_large_valhall-unknown-android11
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--shapes=gpu_large"
+    "--compilation_info=SPIRVVectorize"
+  TRACE_RUNNER
+    iree_tools_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "vulkan-spirv"
+  DRIVERS
+    "vulkan"
+  COMPILER_FLAGS
+    "--iree-vulkan-target-triple=valhall-unknown-android11"
+  LABELS
+    "requires-gpu-nvidia"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_direct_f32_gpu_large_ampere-unknown-linux
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--shapes=gpu_large"
+    "--compilation_info=SPIRVVectorize"
+  TRACE_RUNNER
+    iree_tools_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "vulkan-spirv"
+  DRIVERS
+    "vulkan"
+  COMPILER_FLAGS
+    "--iree-vulkan-target-triple=ampere-unknown-linux"
+  LABELS
+    "requires-gpu-nvidia"
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/iree/test/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/iree/test/e2e/matmul/generate_e2e_matmul_tests.py
@@ -42,6 +42,7 @@ class CompilationInfoId(enum.Enum):
   NONE = ""
   LLVMGPUMatmulSimt = "LLVMGPUMatmulSimt"
   LLVMGPUMatmulTensorCore = "LLVMGPUMatmulTensorCore"
+  SPIRVVectorize = "SPIRVVectorize"
 
 
 # Enumerates ways to construct MLIR tensor types.
@@ -163,7 +164,8 @@ def get_test_compilation_infos(
 ) -> typing.List[typing.Optional[CompilationInfo]]:
   if compilation_info_id == CompilationInfoId.NONE:
     return [None]
-  if compilation_info_id == CompilationInfoId.LLVMGPUMatmulSimt:
+  if (compilation_info_id == CompilationInfoId.LLVMGPUMatmulSimt or
+      compilation_info_id == CompilationInfoId.SPIRVVectorize):
     tile_workgroup_size_pairs = [
         TileWorkgroupSizePair([32, 128, 32], [32, 8, 1]),
         TileWorkgroupSizePair([128, 64, 8], [16, 8, 1]),


### PR DESCRIPTION
Right now only check Mali Valhall and NVIDIA Ampere on NVIDIA
GPUs.