### PR TITLE
Fix path to samples/colab/test_notebooks.py.

### DIFF
--- a/build_tools/buildkite/samples.yml
+++ b/build_tools/buildkite/samples.yml
@@ -7,7 +7,7 @@
 steps:
   - label: "Test Colab notebooks"
     commands:
-      - "docker run --user=$(id -u):$(id -g) --volume=\\$PWD:\\$IREE_DOCKER_WORKDIR --workdir=\\$IREE_DOCKER_WORKDIR --rm gcr.io/iree-oss/samples@sha256:67c129c27ef1f3f3ed268e6a14cf36a58c965eb01058b9890524644f57fdf9a1 python3 ./colab/test_notebooks.py"
+      - "docker run --user=$(id -u):$(id -g) --volume=\\$PWD:\\$IREE_DOCKER_WORKDIR --workdir=\\$IREE_DOCKER_WORKDIR --rm gcr.io/iree-oss/samples@sha256:67c129c27ef1f3f3ed268e6a14cf36a58c965eb01058b9890524644f57fdf9a1 python3 ./samples/colab/test_notebooks.py"
     env:
       IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
     agents:


### PR DESCRIPTION
Missed this in https://github.com/google/iree/pull/8988 (and only tested the Buildkite pipeline on https://github.com/google/iree/pull/8987)

Should fix https://buildkite.com/iree/iree-samples/builds/321#645def5a-0354-4b8c-bfb4-a2a3985e9e54

```
[2022-04-27T00:05:04Z] python3: can't open file './colab/test_notebooks.py': [Errno 2] No such file or directory
```