### PR TITLE
Deprecate SingleTilingExpert pipeline.

### DIFF
--- a/iree/compiler/Codegen/Dialect/LoweringConfig.td
+++ b/iree/compiler/Codegen/Dialect/LoweringConfig.td
@@ -13,53 +13,52 @@ include "mlir/IR/EnumAttr.td"
 // List of pre-existing pipelines for translating executables.
 def CPU_Default
     : I32EnumAttrCase<"CPUDefault", 0>;
-def CPU_SingleTilingExpert
-    : I32EnumAttrCase<"CPUSingleTilingExpert", 1>;
 def CPU_DoubleTilingExpert
-    : I32EnumAttrCase<"CPUDoubleTilingExpert", 2>;
+    : I32EnumAttrCase<"CPUDoubleTilingExpert", 1>;
 def CPU_ConvTileAndDecomposeExpert
-    : I32EnumAttrCase<"CPUConvTileAndDecomposeExpert", 3>;
+    : I32EnumAttrCase<"CPUConvTileAndDecomposeExpert", 2>;
 def CPU_TileFuseAndVectorize
-    : I32EnumAttrCase<"CPUTileFuseAndVectorize", 4>;
+    : I32EnumAttrCase<"CPUTileFuseAndVectorize", 3>;
 def CPU_BufferOpsTileAndVectorize
-    : I32EnumAttrCase<"CPUBufferOpsTileAndVectorize", 5>;
+    : I32EnumAttrCase<"CPUBufferOpsTileAndVectorize", 4>;
 
 def Linalg_TransformInterpCodegen
-    : I32EnumAttrCase<"LinalgTransformInterpCodegen", 6>;
+    : I32EnumAttrCase<"LinalgTransformInterpCodegen", 5>;
 
 def LLVMGPU_SimpleDistribute
-    : I32EnumAttrCase<"LLVMGPUDistribute", 7>;
+    : I32EnumAttrCase<"LLVMGPUDistribute", 6>;
 def LLVMGPU_Vectorize
-    : I32EnumAttrCase<"LLVMGPUVectorize", 8>;
+    : I32EnumAttrCase<"LLVMGPUVectorize", 7>;
 def LLVMGPU_MatmulSimt
-    : I32EnumAttrCase<"LLVMGPUMatmulSimt", 9>;
+    : I32EnumAttrCase<"LLVMGPUMatmulSimt", 8>;
 def LLVMGPU_MatmulTensorCore
-    : I32EnumAttrCase<"LLVMGPUMatmulTensorCore", 10>;
+    : I32EnumAttrCase<"LLVMGPUMatmulTensorCore", 9>;
 
 def SPIRV_Distribute
-    : I32EnumAttrCase<"SPIRVDistribute", 11>;
+    : I32EnumAttrCase<"SPIRVDistribute", 10>;
 def SPIRV_Vectorize
-    : I32EnumAttrCase<"SPIRVVectorize", 12>;
+    : I32EnumAttrCase<"SPIRVVectorize", 11>;
 def SPIRV_VectorizeToCooperativeOps
-    : I32EnumAttrCase<"SPIRVVectorizeToCooperativeOps", 13>;
+    : I32EnumAttrCase<"SPIRVVectorizeToCooperativeOps", 12>;
 def SPIRV_VectorizeWithWorkgroupMemory
-    : I32EnumAttrCase<"SPIRVVectorizeWithWorkgroupMemory", 14>;
+    : I32EnumAttrCase<"SPIRVVectorizeWithWorkgroupMemory", 13>;
 
 def None
     : I32EnumAttrCase<"None", 0xff>;
 
 // EnumAttrCase for all known lowerings for ops within dispatch region
 // to scalar/native-vector code.
-def DispatchLoweringPassPipelineEnum : I32EnumAttr<
-    "DispatchLoweringPassPipeline",
-    "identifier for pass pipeline use to lower dispatch region",
-    [CPU_Default, CPU_SingleTilingExpert, CPU_DoubleTilingExpert,
-     CPU_ConvTileAndDecomposeExpert, CPU_TileFuseAndVectorize,
-     CPU_BufferOpsTileAndVectorize, Linalg_TransformInterpCodegen,
-     LLVMGPU_SimpleDistribute, LLVMGPU_Vectorize, LLVMGPU_MatmulSimt,
-     LLVMGPU_MatmulTensorCore, SPIRV_Distribute, SPIRV_Vectorize,
-     SPIRV_VectorizeToCooperativeOps, SPIRV_VectorizeWithWorkgroupMemory,
-     None]> {
+def DispatchLoweringPassPipelineEnum
+    : I32EnumAttr<
+          "DispatchLoweringPassPipeline",
+          "identifier for pass pipeline use to lower dispatch region", [
+            CPU_Default, CPU_DoubleTilingExpert, CPU_ConvTileAndDecomposeExpert,
+            CPU_TileFuseAndVectorize, CPU_BufferOpsTileAndVectorize,
+            Linalg_TransformInterpCodegen, LLVMGPU_SimpleDistribute,
+            LLVMGPU_Vectorize, LLVMGPU_MatmulSimt, LLVMGPU_MatmulTensorCore,
+            SPIRV_Distribute, SPIRV_Vectorize, SPIRV_VectorizeToCooperativeOps,
+            SPIRV_VectorizeWithWorkgroupMemory, None
+          ]> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Codegen";
   // Don't generate a C++ class! We want to use the AttrDef
   let genSpecializedAttr = 0;

--- a/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -201,10 +201,6 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
             addCPUBufferOpsTileAndVectorizePipeline(nestedModulePM);
             break;
           case IREE::Codegen::DispatchLoweringPassPipeline::
-              CPUSingleTilingExpert:
-            addSingleTilingExpertPassPipeline(nestedModulePM);
-            break;
-          case IREE::Codegen::DispatchLoweringPassPipeline::
               CPUDoubleTilingExpert:
             addDoubleTilingExpertPassPipeline(nestedModulePM, lowerToAVX2);
             break;

--- a/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -189,46 +189,6 @@ LogicalResult verifyDoubleTilingExpertPassPipelineConfig(
 // Codegen pipelines.
 //===---------------------------------------------------------------------===//
 
-void addSingleTilingExpertPassPipeline(OpPassManager &passManager) {
-  // Do first level of tiling and distribution.
-  passManager.addNestedPass<func::FuncOp>(createInsertDistributionInfoPass());
-  passManager.addNestedPass<func::FuncOp>(
-      createTileAndDistributeToWorkgroupsPass());
-  passManager.addNestedPass<func::FuncOp>(
-      createFoldAffineMinInDistributedLoopsPass());
-  passManager.addPass(createCanonicalizerPass());
-  passManager.addPass(createCSEPass());
-
-  passManager.addNestedPass<func::FuncOp>(
-      createConvertToDestinationPassingStylePass());
-  passManager.addPass(createCanonicalizerPass());
-  // Add the sandbox single tiling expert to tile and vectorize.
-  {
-    LinalgSingleTilingExpertPassOptions options;
-    options.vectorize = true;
-    options.tilingLevel = static_cast<int64_t>(TilingLevel::L1Tiles);
-    passManager.addNestedPass<func::FuncOp>(
-        createLinalgSingleTilingExpertPass(options));
-  }
-
-  // TODO(ravishankarm): This is commented cause this is WIP, to be enabled
-  // soon.
-  // auto callbacks =
-  //     std::make_unique<linalg::comprehensive_bufferize::AllocationCallbacks>(
-  //         cpuComprehensiveBufferizeAllocationFn,
-  //         cpuComprehensiveBufferizeDeallocationFn,
-  //         cpuComprehensiveBufferizeCopyFn);
-  // addIREEComprehensiveBufferizePasses(passManager, std::move(callbacks));
-  addLinalgBufferizePasses(passManager, cpuAllocationFunction);
-
-  // Add the vector lowering expert.
-  {
-    OpPassManager &nestedFuncPassManager = passManager.nest<func::FuncOp>();
-    LinalgVectorLoweringPassOptions options;
-    addLowerToVectorTransforms(nestedFuncPassManager, options);
-  }
-}
-
 void addCPUBufferOpsTileAndVectorizePipeline(OpPassManager &passManager) {
   // Do first level of tiling and distribution.
   passManager.addNestedPass<func::FuncOp>(createInsertDistributionInfoPass());

--- a/iree/compiler/Codegen/Passes.h
+++ b/iree/compiler/Codegen/Passes.h
@@ -269,10 +269,6 @@ LogicalResult verifyTensorToVectorsPassPipelineConfig(
 void addTensorToVectorsPassPipeline(OpPassManager &passManager,
                                     bool lowerToVectors = true);
 
-/// Populates the passes needed to do one-level tile + vectorize of linalg ops
-/// using the Codegen drivers from sandbox.
-void addSingleTilingExpertPassPipeline(OpPassManager &passManager);
-
 /// Populates the passes needed to do two-level tile + vectorize of linalg ops
 /// using the Codegen drivers from sandbox.
 LogicalResult verifyDoubleTilingExpertPassPipelineConfig(


### PR DESCRIPTION
This pipeline is not used, and won't be used. We intend to vectorizes as
many ops as possible. In this context, we will apply second level of
tiling to avoid big vectors. The distribution level of tiling only tiles
three loops. This means that some dims are not tiled, which might result
in big tensors.