### PR TITLE
Support bufferization of linalg_ext.fft and reverse

### DIFF
--- a/iree/compiler/Codegen/Interfaces/BUILD
+++ b/iree/compiler/Codegen/Interfaces/BUILD
@@ -58,6 +58,7 @@ cc_library(
     deps = [
         "//iree/compiler/Dialect/Flow/IR",
         "//iree/compiler/Dialect/HAL/IR",
+        "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
         "@llvm-project//mlir:ArithmeticTransforms",
         "@llvm-project//mlir:BufferizationDialect",
         "@llvm-project//mlir:BufferizationTransforms",

--- a/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -235,8 +235,7 @@ struct LinalgExtOpInterface
                                                     OpTy> {
   bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand,
                               const AnalysisState &state) const {
-    // All operands are read.
-    // TODO: Is this correct?
+    // All operands (including outputs) may be read.
     return true;
   }
 

--- a/iree/compiler/Codegen/Interfaces/CMakeLists.txt
+++ b/iree/compiler/Codegen/Interfaces/CMakeLists.txt
@@ -32,6 +32,7 @@ iree_cc_library(
   SRCS
     "BufferizationInterfaces.cpp"
   DEPS
+    IREELinalgExtDialect
     MLIRArithmeticTransforms
     MLIRBufferization
     MLIRBufferizationTransforms

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtInterfaces.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtInterfaces.td
@@ -259,6 +259,22 @@ def LinalgExtInterface : OpInterface<"LinalgExtOp"> {
         return result;
       }]
     >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Return the result tied to `opOperand`.
+      }],
+      /*retTy=*/"OpResult",
+      /*methodName=*/"getTiedOpResult",
+      /*args=*/(ins "OpOperand*":$opOperand),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        assert(opOperand->getOwner() == this->getOperation());
+        int64_t resultIndex = opOperand->getOperandNumber() - getNumInputs();
+        assert(resultIndex >= 0 &&
+               resultIndex < this->getOperation()->getNumResults() );
+        return this->getOperation()->getResult(resultIndex);
+      }]
+    >,
     //===------------------------------------------------------------------===//
     // Input and Output arguments handling.
     //===------------------------------------------------------------------===//
@@ -423,6 +439,26 @@ def LinalgExtInterface : OpInterface<"LinalgExtOp"> {
           r.cloneInto(state.addRegion(), bvm);
         return b.create(state);
       }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Clone the current operation with the given location and operands but
+        leave the regions empty. This is used to abstract away the optional
+        underlying region creation. This does not change the balance between
+        input, output_buffer and init_tensors operands.
+      }],
+      /*retTy=*/"Operation *",
+      /*methodName=*/"cloneWithoutRegions",
+      (ins "OpBuilder &":$b, "Location":$loc, "TypeRange":$resultTypes,
+           "ValueRange":$operands),
+      [{
+        OperationState state(
+          loc, ConcreteOp::getOperationName(), operands, resultTypes,
+          $_op->getAttrs());
+        for (size_t cnt = 0, e = $_op->getNumRegions(); cnt < e; ++cnt)
+          state.addRegion();
+        return b.create(state);
+      }]
     >
   ];
 
@@ -431,7 +467,7 @@ def LinalgExtInterface : OpInterface<"LinalgExtOp"> {
     /// shape of the input operands where possible.
     LogicalResult reifyResultShapes(OpBuilder &b,
         mlir::ReifiedRankedShapedTypeDims &reifiedReturnShapes);
-    
+
     //========================================================================//
     // Helper functions to mutate the `operand_segment_sizes` attribute.
     // These are useful when cloning and changing operand types.


### PR DESCRIPTION
This commit provides the missing bufferizations for #9004.

Note: This implementation is largely copied from `mlir/lib/Dialect/Linalg/Transforms/BufferizableOpInterfaceImpl.cpp`.
