### PR TITLE
Clean up references to deleted CMake options.

### DIFF
--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build.sh
@@ -56,7 +56,6 @@ CMAKE_BUILD_DIR="$HOME/iree/build/tf"
 # we can still run the other tests.
 echo "Configuring CMake"
 "${CMAKE_BIN}" -B "${CMAKE_BUILD_DIR?}" -G Ninja \
-   -DIREE_TF_TOOLS_ROOT="${BAZEL_BINDIR?}/iree_tf_compiler/" \
    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
    -DIREE_BUILD_COMPILER=ON \
    -DIREE_BUILD_TESTS=ON \

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
@@ -59,7 +59,6 @@ CMAKE_BUILD_DIR="$HOME/iree/build/tf"
 # we can still run the other tests.
 echo "Configuring CMake"
 "${CMAKE_BIN}" -B "${CMAKE_BUILD_DIR?}" -G Ninja \
-   -DIREE_TF_TOOLS_ROOT="${BAZEL_BINDIR?}/iree_tf_compiler/" \
    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
    -DIREE_BUILD_COMPILER=ON \
    -DIREE_BUILD_TESTS=ON \

--- a/docs/developers/developing_iree/e2e_benchmarking.md
+++ b/docs/developers/developing_iree/e2e_benchmarking.md
@@ -29,8 +29,7 @@ $ cd iree-build/  # Make and cd into some build directory
 $ cmake ../iree -G Ninja \
     -DCMAKE_C_COMPILER=clang \
     -DCMAKE_CXX_COMPILER=clang++ \
-    -DIREE_BUILD_PYTHON_BINDINGS=ON  \
-    -DIREE_BUILD_TENSORFLOW_COMPILER=ON
+    -DIREE_BUILD_PYTHON_BINDINGS=ON
 $ cmake --build .
 # Also from the Python get-started doc, set this environment variable:
 $ export PYTHONPATH=$(pwd)/bindings/python

--- a/docs/developers/get_started/cmake_options_and_variables.md
+++ b/docs/developers/get_started/cmake_options_and_variables.md
@@ -105,35 +105,6 @@ the current build type is Debug and the compiler supports it.
 Enable [thread sanitizer](https://clang.llvm.org/docs/ThreadSanitizer.html) if
 the current build type is Debug and the compiler supports it.
 
-#### `IREE_BUILD_TENSORFLOW_COMPILER`:BOOL
-
-Enables building of the TensorFlow to IREE compiler under
-`integrations/tensorflow`, including some native binaries and Python packages.
-Note that TensorFlow's build system is bazel and this will require having
-previously built (or installed) the iree-import-tf at the path specified by
-`IREE_TF_TOOLS_ROOT`.
-
-#### `IREE_BUILD_TFLITE_COMPILER`:BOOL
-
-Enables building of the TFLite to IREE compiler under `integrations/tensorflow`,
-including some native binaries and Python packages. Note that TensorFlow's build
-system is bazel and this will require having previously built (or installed) the
-iree-import-tf at the path specified by `IREE_TF_TOOLS_ROOT`.
-
-#### `IREE_BUILD_XLA_COMPILER`:BOOL
-
-Enables building of the XLA to IREE compiler under `integrations/tensorflow`,
-including some native binaries and Python packages. Note that TensorFlow's build
-system is bazel and this will require having previously built (or installed) the
-iree-import-tf at the path specified by `IREE_TF_TOOLS_ROOT`.
-
-#### `IREE_TF_TOOLS_ROOT`:STRING
-
-Path to prebuilt TensorFlow integration binaries to be used by the Python
-bindings. Defaults to
-"${CMAKE_SOURCE_DIR}/integrations/tensorflow/bazel-bin/iree_tf_compiler", which
-is where they would be placed by a `bazel build` invocation.
-
 #### `IREE_BUILD_TORCH_MLIR_SUPPORT`:BOOL
 
 Enables building of the torch-mlir-dialects to IREE compiler. Defaults to `ON`.

--- a/docs/developers/get_started/cmake_options_and_variables.md
+++ b/docs/developers/get_started/cmake_options_and_variables.md
@@ -105,13 +105,6 @@ the current build type is Debug and the compiler supports it.
 Enable [thread sanitizer](https://clang.llvm.org/docs/ThreadSanitizer.html) if
 the current build type is Debug and the compiler supports it.
 
-#### `IREE_MLIR_DEP_MODE`:STRING
-
-Defines the MLIR dependency mode. Case-sensitive. Can be `BUNDLED`, `DISABLED`
-or `INSTALLED`. Defaults to `BUNDLED`. If set to `INSTALLED`, the variable
-`MLIR_DIR` needs to be passed and that LLVM needs to be compiled with
-`LLVM_ENABLE_RTTI` set to `ON`.
-
 #### `IREE_BUILD_TENSORFLOW_COMPILER`:BOOL
 
 Enables building of the TensorFlow to IREE compiler under
@@ -144,13 +137,6 @@ is where they would be placed by a `bazel build` invocation.
 #### `IREE_BUILD_TORCH_MLIR_SUPPORT`:BOOL
 
 Enables building of the torch-mlir-dialects to IREE compiler. Defaults to `ON`.
-
-## MLIR-specific CMake Options and Variables
-
-#### `MLIR_DIR`:STRING
-
-Specifies the path where to look for the installed MLIR/LLVM packages. Required
-if `IREE_MLIR_DEP_MODE` is set to `INSTALLED`.
 
 ## Cross-compilation
 


### PR DESCRIPTION
I noticed `MLIR_DEP_MODE` was mentioned on https://github.com/google/iree/issues/3843. That option no longer exists, but we still had references to it in our docs. Similar story for the TF/TFLITE/XLA options.

(Normally I'd go through history to find where those were removed / made obsolete, but I haven't done that in this case [yet])