### PR TITLE
[NFC] Add CPU microarchitecture to DeviceInfo

### DIFF
--- a/build_tools/benchmarks/common/android_device_utils.py
+++ b/build_tools/benchmarks/common/android_device_utils.py
@@ -60,7 +60,9 @@ def get_android_gpu_name(verbose: bool = False) -> str:
 
 def get_android_device_info(verbose: bool = False) -> DeviceInfo:
   """Returns device info for the Android device."""
-  return DeviceInfo(PlatformType.ANDROID, get_android_device_model(verbose),
-                    get_android_cpu_abi(verbose),
-                    get_android_cpu_features(verbose),
-                    get_android_gpu_name(verbose))
+  return DeviceInfo(platform_type=PlatformType.ANDROID,
+                    model=get_android_device_model(verbose),
+                    cpu_abi=get_android_cpu_abi(verbose),
+                    cpu_microarch=None,
+                    cpu_features=get_android_cpu_features(verbose),
+                    gpu_name=get_android_gpu_name(verbose))

--- a/build_tools/benchmarks/common/android_device_utils.py
+++ b/build_tools/benchmarks/common/android_device_utils.py
@@ -63,6 +63,6 @@ def get_android_device_info(verbose: bool = False) -> DeviceInfo:
   return DeviceInfo(platform_type=PlatformType.ANDROID,
                     model=get_android_device_model(verbose),
                     cpu_abi=get_android_cpu_abi(verbose),
-                    cpu_microarch=None,
+                    cpu_uarch=None,
                     cpu_features=get_android_cpu_features(verbose),
                     gpu_name=get_android_gpu_name(verbose))

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -36,6 +36,9 @@ GPU_NAME_TO_TARGET_ARCH_MAP = {
     "unknown": "gpu-unknown",
 }
 
+# A map of canonical microarchitecture names.
+CANONICAL_MICROARCHITECTURE_NAMES = {"CascadeLake", "Zen2"}
+
 
 @dataclass
 class DriverInfo:
@@ -167,7 +170,8 @@ class DeviceInfo:
   It includes the following characteristics:
   - platform_type: the OS platform, e.g., 'Android'
   - model: the product model, e.g., 'Pixel-4'
-  - cpu_abi: the CPU ABI, e.g., 'arm64-v8a'
+  - cpu_abi: the CPU ABI, e.g., 'arm64-v8a', 'x86_64'
+  - cpu_microarch: the CPU microarchitecture, e.g., 'CascadeLake'
   - cpu_features: the detailed CPU features, e.g., ['fphp', 'sve']
   - gpu_name: the GPU name, e.g., 'Mali-G77'
   """
@@ -175,6 +179,7 @@ class DeviceInfo:
   platform_type: PlatformType
   model: str
   cpu_abi: str
+  cpu_microarch: Optional[str]
   cpu_features: Sequence[str]
   gpu_name: str
 
@@ -183,6 +188,7 @@ class DeviceInfo:
     params = [
         f"model='{self.model}'",
         f"cpu_abi='{self.cpu_abi}'",
+        f"cpu_microarch='{self.cpu_microarch}'",
         f"gpu_name='{self.gpu_name}'",
         f"cpu_features=[{features}]",
     ]
@@ -194,6 +200,15 @@ class DeviceInfo:
     if not arch:
       raise ValueError(f"Unrecognized CPU ABI: '{self.cpu_abi}'; "
                        "need to update the map")
+
+    if self.cpu_microarch:
+      if self.cpu_microarch not in CANONICAL_MICROARCHITECTURE_NAMES:
+        raise ValueError(
+            f"Unrecognized CPU microarchitecture: '{self.cpu_microarch}'; "
+            "need to update the map")
+
+      arch = f'{arch}-{self.cpu_microarch.lower()}'
+
     return arch
 
   def get_iree_gpu_arch_name(self) -> str:
@@ -203,11 +218,13 @@ class DeviceInfo:
                        "need to update the map")
     return arch
 
-  def get_cpu_arch_revision(self) -> str:
+  def get_detailed_cpu_arch_name(self) -> str:
+    """Returns the detailed architecture name."""
+
     if self.cpu_abi == "arm64-v8a":
       return self.__get_arm_cpu_arch_revision()
     if self.cpu_abi == "x86_64":
-      return "x86_64"
+      return self.__get_x86_detailed_cpu_arch_name()
     raise ValueError("Unrecognized CPU ABI; need to update the list")
 
   def to_json_object(self) -> Dict[str, Any]:
@@ -215,15 +232,26 @@ class DeviceInfo:
         "platform_type": self.platform_type.value,
         "model": self.model,
         "cpu_abi": self.cpu_abi,
+        "cpu_microarch": self.cpu_microarch if self.cpu_microarch else "",
         "cpu_features": self.cpu_features,
         "gpu_name": self.gpu_name,
     }
 
   @staticmethod
   def from_json_object(json_object: Dict[str, Any]):
+    cpu_microarch = json_object.get("cpu_microarch")
     return DeviceInfo(PlatformType(json_object["platform_type"]),
                       json_object["model"], json_object["cpu_abi"],
+                      None if cpu_microarch == "" else cpu_microarch,
                       json_object["cpu_features"], json_object["gpu_name"])
+
+  def __get_x86_detailed_cpu_arch_name(self) -> str:
+    """Returns the x86 architecture with microarchitecture name."""
+
+    if not self.cpu_microarch:
+      return self.cpu_abi
+
+    return f"{self.cpu_abi}-{self.cpu_microarch}"
 
   def __get_arm_cpu_arch_revision(self) -> str:
     """Returns the ARM architecture revision."""
@@ -276,7 +304,7 @@ class BenchmarkInfo:
     if driver_info.device_type == 'GPU':
       target_arch = "GPU-" + self.device_info.gpu_name
     elif driver_info.device_type == 'CPU':
-      target_arch = "CPU-" + self.device_info.get_cpu_arch_revision()
+      target_arch = "CPU-" + self.device_info.get_detailed_cpu_arch_name()
     else:
       raise ValueError(
           f"Unrecognized device type '{driver_info.device_type}' of the runner '{self.runner}'"

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -171,7 +171,7 @@ class DeviceInfo:
   - platform_type: the OS platform, e.g., 'Android'
   - model: the product model, e.g., 'Pixel-4'
   - cpu_abi: the CPU ABI, e.g., 'arm64-v8a', 'x86_64'
-  - cpu_microarch: the CPU microarchitecture, e.g., 'CascadeLake'
+  - cpu_uarch: the CPU microarchitecture, e.g., 'CascadeLake'
   - cpu_features: the detailed CPU features, e.g., ['fphp', 'sve']
   - gpu_name: the GPU name, e.g., 'Mali-G77'
   """
@@ -179,7 +179,7 @@ class DeviceInfo:
   platform_type: PlatformType
   model: str
   cpu_abi: str
-  cpu_microarch: Optional[str]
+  cpu_uarch: Optional[str]
   cpu_features: Sequence[str]
   gpu_name: str
 
@@ -188,7 +188,7 @@ class DeviceInfo:
     params = [
         f"model='{self.model}'",
         f"cpu_abi='{self.cpu_abi}'",
-        f"cpu_microarch='{self.cpu_microarch}'",
+        f"cpu_uarch='{self.cpu_uarch}'",
         f"gpu_name='{self.gpu_name}'",
         f"cpu_features=[{features}]",
     ]
@@ -201,13 +201,13 @@ class DeviceInfo:
       raise ValueError(f"Unrecognized CPU ABI: '{self.cpu_abi}'; "
                        "need to update the map")
 
-    if self.cpu_microarch:
-      if self.cpu_microarch not in CANONICAL_MICROARCHITECTURE_NAMES:
+    if self.cpu_uarch:
+      if self.cpu_uarch not in CANONICAL_MICROARCHITECTURE_NAMES:
         raise ValueError(
-            f"Unrecognized CPU microarchitecture: '{self.cpu_microarch}'; "
+            f"Unrecognized CPU microarchitecture: '{self.cpu_uarch}'; "
             "need to update the map")
 
-      arch = f'{arch}-{self.cpu_microarch.lower()}'
+      arch = f'{arch}-{self.cpu_uarch.lower()}'
 
     return arch
 
@@ -232,26 +232,26 @@ class DeviceInfo:
         "platform_type": self.platform_type.value,
         "model": self.model,
         "cpu_abi": self.cpu_abi,
-        "cpu_microarch": self.cpu_microarch if self.cpu_microarch else "",
+        "cpu_uarch": self.cpu_uarch if self.cpu_uarch else "",
         "cpu_features": self.cpu_features,
         "gpu_name": self.gpu_name,
     }
 
   @staticmethod
   def from_json_object(json_object: Dict[str, Any]):
-    cpu_microarch = json_object.get("cpu_microarch")
+    cpu_uarch = json_object.get("cpu_uarch")
     return DeviceInfo(PlatformType(json_object["platform_type"]),
                       json_object["model"], json_object["cpu_abi"],
-                      None if cpu_microarch == "" else cpu_microarch,
+                      None if cpu_uarch == "" else cpu_uarch,
                       json_object["cpu_features"], json_object["gpu_name"])
 
   def __get_x86_detailed_cpu_arch_name(self) -> str:
     """Returns the x86 architecture with microarchitecture name."""
 
-    if not self.cpu_microarch:
+    if not self.cpu_uarch:
       return self.cpu_abi
 
-    return f"{self.cpu_abi}-{self.cpu_microarch}"
+    return f"{self.cpu_abi}-{self.cpu_uarch}"
 
   def __get_arm_cpu_arch_revision(self) -> str:
     """Returns the ARM architecture revision."""

--- a/build_tools/benchmarks/common/benchmark_driver.py
+++ b/build_tools/benchmarks/common/benchmark_driver.py
@@ -106,8 +106,8 @@ class BenchmarkDriver(object):
       benchmark_cases = self.benchmark_suite.filter_benchmarks_for_category(
           category=category,
           available_drivers=drivers,
-          cpu_target_arch_filter=cpu_target_arch,
-          gpu_target_arch_filter=gpu_target_arch,
+          cpu_target_arch_filter=f"^{cpu_target_arch}$",
+          gpu_target_arch_filter=f"^{gpu_target_arch}$",
           driver_filter=self.config.driver_filter,
           mode_filter=self.config.mode_filter,
           model_name_filter=self.config.model_name_filter)

--- a/build_tools/benchmarks/common/benchmark_driver_test.py
+++ b/build_tools/benchmarks/common/benchmark_driver_test.py
@@ -65,8 +65,12 @@ class BenchmarkDriverTest(unittest.TestCase):
             capture_tarball="captures.tar",
             capture_tmp_dir=os.path.join(self.tmp_dir.name, CAPTURES_REL_PATH)))
 
-    self.device_info = DeviceInfo(PlatformType.LINUX, "Unknown", "arm64-v8a",
-                                  ["sha2"], "Mali-G78")
+    self.device_info = DeviceInfo(platform_type=PlatformType.LINUX,
+                                  model="Unknown",
+                                  cpu_abi="arm64-v8a",
+                                  cpu_microarch=None,
+                                  cpu_features=["sha2"],
+                                  gpu_name="Mali-G78")
 
     case1 = BenchmarkCase(model_name_with_tags="DeepNet",
                           bench_mode=["1-thread", "full-inference"],

--- a/build_tools/benchmarks/common/benchmark_driver_test.py
+++ b/build_tools/benchmarks/common/benchmark_driver_test.py
@@ -68,7 +68,7 @@ class BenchmarkDriverTest(unittest.TestCase):
     self.device_info = DeviceInfo(platform_type=PlatformType.LINUX,
                                   model="Unknown",
                                   cpu_abi="arm64-v8a",
-                                  cpu_microarch=None,
+                                  cpu_uarch=None,
                                   cpu_features=["sha2"],
                                   gpu_name="Mali-G78")
 

--- a/build_tools/benchmarks/common/linux_device_utils.py
+++ b/build_tools/benchmarks/common/linux_device_utils.py
@@ -7,7 +7,7 @@
 """Utils for accessing Linux device information."""
 
 import re
-from typing import Sequence
+from typing import Optional, Sequence
 
 from .benchmark_definition import (execute_cmd_and_get_output, DeviceInfo,
                                    PlatformType)
@@ -35,11 +35,13 @@ def get_linux_cpu_model(verbose: bool = False) -> str:
 
 
 def get_linux_device_info(device_model: str = "Unknown",
+                          cpu_microarch: Optional[str] = None,
                           verbose: bool = False) -> DeviceInfo:
   """Returns device info for the Linux device.
 
     Args:
     - device_model: the device model name, e.g., 'ThinkStation P520' 
+    - cpu_microarch: the CPU microarchitecture, e.g., 'CascadeLake'
   """
   return DeviceInfo(
       PlatformType.LINUX,
@@ -47,6 +49,7 @@ def get_linux_device_info(device_model: str = "Unknown",
       model=f"{device_model}({get_linux_cpu_model(verbose)})",
       # Currently we only have x86, so CPU ABI = CPU arch.
       cpu_abi=get_linux_cpu_arch(verbose),
+      cpu_microarch=cpu_microarch,
       cpu_features=get_linux_cpu_features(verbose),
       # We don't yet support GPU benchmark on Linux devices.
       gpu_name="Unknown")

--- a/build_tools/benchmarks/common/linux_device_utils.py
+++ b/build_tools/benchmarks/common/linux_device_utils.py
@@ -35,13 +35,13 @@ def get_linux_cpu_model(verbose: bool = False) -> str:
 
 
 def get_linux_device_info(device_model: str = "Unknown",
-                          cpu_microarch: Optional[str] = None,
+                          cpu_uarch: Optional[str] = None,
                           verbose: bool = False) -> DeviceInfo:
   """Returns device info for the Linux device.
 
     Args:
-    - device_model: the device model name, e.g., 'ThinkStation P520' 
-    - cpu_microarch: the CPU microarchitecture, e.g., 'CascadeLake'
+    - device_model: the device model name, e.g., 'ThinkStation P520'
+    - cpu_uarch: the CPU microarchitecture, e.g., 'CascadeLake'
   """
   return DeviceInfo(
       PlatformType.LINUX,
@@ -49,7 +49,7 @@ def get_linux_device_info(device_model: str = "Unknown",
       model=f"{device_model}({get_linux_cpu_model(verbose)})",
       # Currently we only have x86, so CPU ABI = CPU arch.
       cpu_abi=get_linux_cpu_arch(verbose),
-      cpu_microarch=cpu_microarch,
+      cpu_uarch=cpu_uarch,
       cpu_features=get_linux_cpu_features(verbose),
       # We don't yet support GPU benchmark on Linux devices.
       gpu_name="Unknown")

--- a/build_tools/benchmarks/common/linux_device_utils_test.py
+++ b/build_tools/benchmarks/common/linux_device_utils_test.py
@@ -40,10 +40,11 @@ class LinuxDeviceUtilsTest(unittest.TestCase):
 
   def test_get_linux_device_info(self):
     self.assertEqual(
-        get_linux_device_info("Dummy"),
+        get_linux_device_info("Dummy", "Zen2"),
         DeviceInfo(platform_type=PlatformType.LINUX,
                    model="Dummy(AMD EPYC 7B12)",
                    cpu_abi="x86_64",
+                   cpu_microarch="Zen2",
                    cpu_features=["fpu", "vme", "de", "pse", "tsc"],
                    gpu_name="Unknown"))
 

--- a/build_tools/benchmarks/common/linux_device_utils_test.py
+++ b/build_tools/benchmarks/common/linux_device_utils_test.py
@@ -44,7 +44,7 @@ class LinuxDeviceUtilsTest(unittest.TestCase):
         DeviceInfo(platform_type=PlatformType.LINUX,
                    model="Dummy(AMD EPYC 7B12)",
                    cpu_abi="x86_64",
-                   cpu_microarch="Zen2",
+                   cpu_uarch="Zen2",
                    cpu_features=["fpu", "vme", "de", "pse", "tsc"],
                    gpu_name="Unknown"))
 

--- a/build_tools/benchmarks/run_benchmarks_on_linux.py
+++ b/build_tools/benchmarks/run_benchmarks_on_linux.py
@@ -91,7 +91,7 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
 
 
 def main(args):
-  device_info = get_linux_device_info(args.device_model, args.cpu_microarch,
+  device_info = get_linux_device_info(args.device_model, args.cpu_uarch,
                                       args.verbose)
   if args.verbose:
     print(device_info)
@@ -142,7 +142,7 @@ def parse_argument():
   arg_parser.add_argument("--device_model",
                           default="Unknown",
                           help="Device model")
-  arg_parser.add_argument("--cpu_microarch",
+  arg_parser.add_argument("--cpu_uarch",
                           default=None,
                           help="CPU microarchitecture, e.g., CascadeLake")
 

--- a/build_tools/benchmarks/run_benchmarks_on_linux.py
+++ b/build_tools/benchmarks/run_benchmarks_on_linux.py
@@ -91,7 +91,8 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
 
 
 def main(args):
-  device_info = get_linux_device_info(args.device_model, args.verbose)
+  device_info = get_linux_device_info(args.device_model, args.cpu_microarch,
+                                      args.verbose)
   if args.verbose:
     print(device_info)
 
@@ -141,6 +142,9 @@ def parse_argument():
   arg_parser.add_argument("--device_model",
                           default="Unknown",
                           help="Device model")
+  arg_parser.add_argument("--cpu_microarch",
+                          default=None,
+                          help="CPU microarchitecture, e.g., CascadeLake")
 
   return arg_parser.parse_args()
 


### PR DESCRIPTION
Currently we don't have CPU microarchitecture in DeviceInfo, which is important when benchmarking on different CPUs.

On x86, we want to build benchmarks with specified `-mtune` for the target machine in order to utilize full features of the CPU (e.g. AVX512, instruction scheduling). Without CPU microarchitecture in DeviceInfo, the benchmark tool can't select the benchmark cases which are built for the target CPU.

To add CPU microarchitecture in IREE benchmark, we need to consider the items below:

1. The definition of `cpu_abi` and `cpu_microarch`.
2. How does the microarchitecture present in the benchmark suite?
3. How to present the microarchitecture in benchmark tool internally?
4. How to present the microarchitecture in the key of benchmark result? (the primary key of results in dashboard)

In this change, I take the following approach:

1. Following this [article](https://community.arm.com/arm-community-blogs/b/tools-software-ides-blog/posts/compiler-flags-across-architectures-march-mtune-and-mcpu), use the definition of `-march` for `cpu_abi` and `-mtune` for `cpu_microarch`. Therefore, for ARM, `cpu_abi` is `ARM-v8.2-A` and `cpu_microarch` is `Cortex-A75`. For x86, `cpu_abi` is `x86_64` and `cpu_microarch` is `CascadeLake`
2. In benchmark suite and the key of benchmark result, the microarchitecture is part of the CPU architecture name . For example: x86_64-CascadeLake, x86_64-Zen2. This is for backward compatibility.
3. Inside the benchmark tool, the `DeviceInfo` has `cpu_abi` and `cpu_microarch` to store "x86_64" and "Cascadelake" separately. So we can preserve the clear detailed information in the result JSON file. Also in the future we can refactor the benchmark suite and dashboard to treat microarchitecture separately. This might make it easier to compare between microarchitectures.

On Linux, we can also use `host` as microarchitecture to represent the benchmarks which are built with `--iree-llvm-target-cpu=host`.