### PR TITLE
Audit and fix inconsistencies in Kokoro build/test scripts.

### DIFF
--- a/build_tools/cmake/rebuild.sh
+++ b/build_tools/cmake/rebuild.sh
@@ -38,8 +38,7 @@ CMAKE_ARGS=(
   # give us early warnings for some types of website publication errors.
   "-DIREE_BUILD_DOCS=ON"
 
-  # Enable building the python bindings on CI. Most heavy targets are gated on
-  # IREE_ENABLE_TENSORFLOW, so what's left here should be fast.
+  # Enable building the python bindings on CI.
   "-DIREE_BUILD_PYTHON_BINDINGS=ON"
 
   # Enable assertions. We wouldn't want to be testing *only* with assertions

--- a/build_tools/cmake/test.sh
+++ b/build_tools/cmake/test.sh
@@ -18,17 +18,16 @@ fi
 # Respect the user setting, but default to as many jobs as we have cores.
 export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-$(nproc)}
 
-# Respect the user setting, but default to turning on vulkan.
+# Respect the user setting, but default to turning on Vulkan.
 export IREE_VULKAN_DISABLE=${IREE_VULKAN_DISABLE:-0}
-# CUDA is off by default.
+# Respect the user setting, but default to turning off CUDA.
 export IREE_CUDA_DISABLE=${IREE_CUDA_DISABLE:-1}
 # The VK_KHR_shader_float16_int8 extension is optional prior to Vulkan 1.2.
-# We test on SwiftShader, which does not support this extension.
+# We test on SwiftShader as a baseline, which does not support this extension.
 export IREE_VULKAN_F16_DISABLE=${IREE_VULKAN_F16_DISABLE:-1}
 
 # Tests to exclude by label. In addition to any custom labels (which are carried
-# over from Bazel tags), every test should be labeled with the directory it is
-# in.
+# over from Bazel tags), every test should be labeled with its directory.
 declare -a label_exclude_args=(
   # Exclude specific labels.
   # Put the whole label with anchors for exact matches.

--- a/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader/build.sh
@@ -6,7 +6,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Build the project with cmake using Kokoro.
+# Build and test the project with CMake using Kokoro, using SwiftShader's
+# software Vulkan driver.
 
 set -e
 set -x

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/fuse-operands.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/fuse-operands.mlir
@@ -30,7 +30,7 @@ module {
       // CHECK:    %[[T3:.*]] = linalg.fill {{.*}} outs(%[[T2]]
       %7 = tensor.extract_slice %1[%4] [%5] [1] : tensor<64xf32> to tensor<?xf32>
 
-      // CHECK:    %[[T4:.*]] = linalg.elemwise_unary {{.*}} ins(%[[T1]] {{.*}} outs(%[[T3]]
+      // CHECK:    %[[T4:.*]] = linalg.elemwise_unary{{.*}}ins(%[[T1]] {{.*}} outs(%[[T3]]
       %8 = linalg.elemwise_unary ins(%6 : tensor<?xf32>) outs(%7 : tensor<?xf32>) -> tensor<?xf32>
       iree_linalg_ext.perform_concurrently {
         iree_linalg_ext.parallel_insert_slice %8 into %arg2[%4] [%5] [1] : tensor<?xf32> into tensor<64xf32>
@@ -88,7 +88,7 @@ module {
       // CHECK:    %[[T1:.*]] = linalg.fill {{.*}} outs(%[[T0]]
       %6 = tensor.extract_slice %0[%3] [%4] [1] : tensor<?xf32> to tensor<?xf32>
 
-      // CHECK:    %[[T2:.*]] = linalg.elemwise_unary {{.*}} ins(%[[T1]]
+      // CHECK:    %[[T2:.*]] = linalg.elemwise_unary{{.*}}ins(%[[T1]]
       %7 = linalg.elemwise_unary ins(%6 : tensor<?xf32>) outs(%5 : tensor<?xf32>) -> tensor<?xf32>
       iree_linalg_ext.perform_concurrently {
         iree_linalg_ext.parallel_insert_slice %7 into %arg2[%3] [%4] [1] : tensor<?xf32> into tensor<?xf32>

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/tile-and-peel.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/tile-and-peel.mlir
@@ -11,11 +11,11 @@ func @matmul_tensors(
   // CHECK: scf.for {{.*}} to %[[c124]]
   // CHECK:   scf.for {{.*}} to %[[c128]]
   // CHECK:     scf.for {{.*}} to %[[c124]]
-  // CHECK:       linalg.matmul {{.*}} ins({{.*}} : tensor<4x4xf32>, tensor<4x4xf32>) outs({{.*}} : tensor<4x4xf32>) -> tensor<4x4xf32>
-  // CHECK:     linalg.matmul {{.*}} ins({{.*}} : tensor<4x3xf32>, tensor<3x4xf32>) outs({{.*}} : tensor<4x4xf32>) -> tensor<4x4xf32>
+  // CHECK:       linalg.matmul{{.*}}ins({{.*}} : tensor<4x4xf32>, tensor<4x4xf32>) outs({{.*}} : tensor<4x4xf32>) -> tensor<4x4xf32>
+  // CHECK:     linalg.matmul{{.*}}ins({{.*}} : tensor<4x3xf32>, tensor<3x4xf32>) outs({{.*}} : tensor<4x4xf32>) -> tensor<4x4xf32>
   // CHECK: scf.for {{.*}} to %[[c128]]
   // CHECK:   scf.for {{.*}} to %[[c127]]
-  // CHECK:     linalg.matmul {{.*}} ins({{.*}} : tensor<2x?xf32>, tensor<?x4xf32>) outs({{.*}} : tensor<2x4xf32>) -> tensor<2x4xf32>
+  // CHECK:     linalg.matmul{{.*}}ins({{.*}} : tensor<2x?xf32>, tensor<?x4xf32>) outs({{.*}} : tensor<2x4xf32>) -> tensor<2x4xf32>
   %0 = linalg.matmul  ins(%arg0, %arg1: tensor<126x127xf32>, tensor<127x128xf32>)
                      outs(%arg2: tensor<126x128xf32>)
     -> tensor<126x128xf32>

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/tile.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/tile.mlir
@@ -14,7 +14,7 @@ func @matmul_tensors(
 //      CHECK:       %[[sTA:.*]] = tensor.extract_slice %[[TA]][{{.*}}] : tensor<128x128xf32> to tensor<4x4xf32>
 //      CHECK:       %[[sTB:.*]] = tensor.extract_slice %[[TB]][{{.*}}] : tensor<128x128xf32> to tensor<4x4xf32>
 //      CHECK:       %[[sTC:.*]] = tensor.extract_slice %[[TC2]][{{.*}}] : tensor<128x128xf32> to tensor<4x4xf32>
-//      CHECK:       %[[sTD:.*]] = linalg.matmul {{.*}} ins(%[[sTA]], %[[sTB]] : tensor<4x4xf32>, tensor<4x4xf32>)
+//      CHECK:       %[[sTD:.*]] = linalg.matmul{{.*}}ins(%[[sTA]], %[[sTB]] : tensor<4x4xf32>, tensor<4x4xf32>)
 // CHECK-SAME:                                  outs(%[[sTC]] : tensor<4x4xf32>)  -> tensor<4x4xf32>
 //      CHECK:       %[[TD:.*]] = tensor.insert_slice %[[sTD]] into %[[TC2]][{{.*}}]  : tensor<4x4xf32> into tensor<128x128xf32>
 //      CHECK:       scf.yield %[[TD]] : tensor<128x128xf32>
@@ -42,5 +42,5 @@ pdl.pattern @pdl_target : benefit(1) {
 iree_linalg_transform.sequence {
   %0 = match @pdl_target
   %1, %loops:3 = tile %0 {sizes = [4, 4, 4]}
-  print %1 {name = "Tiled"} 
+  print %1 {name = "Tiled"}
 }

--- a/llvm-external-projects/iree-dialects/test/iree_pydm/rtl/lit.local.cfg
+++ b/llvm-external-projects/iree-dialects/test/iree_pydm/rtl/lit.local.cfg
@@ -1,0 +1,2 @@
+if not config.enable_bindings_python:
+  config.unsupported = True


### PR DESCRIPTION
* The ASan pipeline now includes llvm-external-projects builds+tests (`check-iree-dialects`)
  * The ASan pipeline builds with asserts and the python bindings set to `OFF`, so I made some tweaks to tests that were passing only in debug builds or were depending on the python bindings
* The Turing build now reuses an existing script instead of duplicating that script's logic

Progress on https://github.com/google/iree/issues/8996