### PR TITLE
Improve stack allocation check to infer upper bound sizes.

### DIFF
--- a/iree/compiler/Codegen/LLVMCPU/test/check_ir_before_llvm_conversion.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/check_ir_before_llvm_conversion.mlir
@@ -1,19 +1,31 @@
 // RUN: iree-opt -iree-llvmcpu-check-ir-before-llvm-conversion %s -verify-diagnostics -split-input-file
 
 module {
-func.func @no_dynamic_allocas(%arg0: index) {
-  // expected-error @+1 {{expected no stack allocations with dynamic shapes}}
-  %0 = memref.alloca(%arg0) : memref<?xf32>
-  return
-}
+  func.func @dynamic_allocas(%arg0: index) {
+    // expected-error @+1 {{expected no stack allocations without upper bound shapes}}
+    %0 = memref.alloca(%arg0) : memref<?xf32>
+    return
+  }
 }
 
 // -----
 
-// expected-error @+1 {{expected total size of stack allocation is smaller than 16 KB}}
+// expected-error @+1 {{expected total size of stack allocation is not greater than 32 KB, but got 65536 bytes}}
 module {
-func.func @big_allocas(%arg0: index) {
-  %0 = memref.alloca() : memref<65536xi32>
-  return
+  func.func @static_big_allocas(%arg0: index) {
+    %0 = memref.alloca() : memref<16384xi32>
+    return
+  }
 }
+
+// -----
+
+#map = affine_map<(d0) -> (-d0, 16384)>
+// expected-error @+1 {{expected total size of stack allocation is not greater than 32 KB, but got 65536 bytes}}
+module {
+  func @dynamic_big_allocas(%arg0: index) {
+    %0 = affine.min #map(%arg0)
+    %1 = memref.alloca(%0) : memref<?xf32>
+    return
+  }
 }


### PR DESCRIPTION
This also increases the limit to 32 KB. The default workgroup size is
64. There are cases that stack allocation sizes depend on workgroup
size, which produces 64x64xi64. Thus, 32 KB is a reasonable limit.

Fixes https://github.com/google/iree/issues/9020