### PR TITLE
Remove obsolete Python 2 linter compatibility comments.

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2020 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2020 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/build_tools/scripts/utils.py
+++ b/build_tools/scripts/utils.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2020 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler/src/iree/compiler/API/python/test/tools/compiler_core_test.py
+++ b/compiler/src/iree/compiler/API/python/test/tools/compiler_core_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2020 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler/src/iree/compiler/API/python/test/tools/compiler_tflite_test.py
+++ b/compiler/src/iree/compiler/API/python/test/tools/compiler_tflite_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2020 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/compiler/src/iree/compiler/API/python/test/tools/compiler_xla_test.py
+++ b/compiler/src/iree/compiler/API/python/test/tools/compiler_xla_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2020 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/build_tools/testdata/generate_dynamic_samples.py
+++ b/integrations/tensorflow/build_tools/testdata/generate_dynamic_samples.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2021 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/build_tools/testdata/generate_errors_module.py
+++ b/integrations/tensorflow/build_tools/testdata/generate_errors_module.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2021 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/build_tools/testdata/generate_signature_samples.py
+++ b/integrations/tensorflow/build_tools/testdata/generate_signature_samples.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2021 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/module_utils.py
+++ b/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/module_utils.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2019 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/module_utils_test.py
+++ b/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/module_utils_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2020 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/tf_test_utils.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2019 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/tf_test_utils_test.py
+++ b/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/tf_test_utils_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2019 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/tf_utils.py
+++ b/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/tf_utils.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2019 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/tf_utils_test.py
+++ b/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/tf_utils_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2020 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/trace_utils.py
+++ b/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/trace_utils.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2019 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/trace_utils_test.py
+++ b/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/trace_utils_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2019 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/test/python/iree_tf_tests/layers/layers_test.py
+++ b/integrations/tensorflow/test/python/iree_tf_tests/layers/layers_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2020 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/batch_norm_test.py
+++ b/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/batch_norm_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2019 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/batch_to_space_nd_test.py
+++ b/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/batch_to_space_nd_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2020 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/broadcasting_test.py
+++ b/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/broadcasting_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2020 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/concat_test.py
+++ b/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/concat_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2020 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/conv_test.py
+++ b/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/conv_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2019 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/conv_transpose_test.py
+++ b/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/conv_transpose_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2019 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/depth_conv_test.py
+++ b/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/depth_conv_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2019 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/dynamic_mlp_relu_test.py
+++ b/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/dynamic_mlp_relu_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2020 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/dynamic_mlp_test.py
+++ b/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/dynamic_mlp_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2020 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/einsum_dynamic_test.py
+++ b/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/einsum_dynamic_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2020 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/einsum_static_test.py
+++ b/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/einsum_static_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2020 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/einsum_vector_test.py
+++ b/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/einsum_vector_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2020 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/matrix_ops_dynamic_test.py
+++ b/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/matrix_ops_dynamic_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2020 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/matrix_ops_static_test.py
+++ b/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/matrix_ops_static_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2020 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/mobile_bert_squad_test.py
+++ b/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/mobile_bert_squad_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2020 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/quantization_dyn_test.py
+++ b/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/quantization_dyn_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2020 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/quantization_test.py
+++ b/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/quantization_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2020 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/ring_buffer_test.py
+++ b/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/ring_buffer_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2019 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/simple_arithmetic_test.py
+++ b/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/simple_arithmetic_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2019 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/simple_stateful_test.py
+++ b/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/simple_stateful_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2019 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/space_to_batch_nd_test.py
+++ b/integrations/tensorflow/test/python/iree_tf_tests/uncategorized/space_to_batch_nd_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2020 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/integrations/tensorflow/test/python/iree_tfl_tests/test_util.py
+++ b/integrations/tensorflow/test/python/iree_tfl_tests/test_util.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2021 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/runtime/bindings/python/iree/runtime/function.py
+++ b/runtime/bindings/python/iree/runtime/function.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2021 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/runtime/bindings/python/iree/runtime/function_test.py
+++ b/runtime/bindings/python/iree/runtime/function_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2019 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/runtime/bindings/python/iree/runtime/system_api.py
+++ b/runtime/bindings/python/iree/runtime/system_api.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2019 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/runtime/bindings/python/iree/runtime/system_api_test.py
+++ b/runtime/bindings/python/iree/runtime/system_api_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2019 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/runtime/bindings/python/iree/runtime/vm_test.py
+++ b/runtime/bindings/python/iree/runtime/vm_test.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2019 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/samples/colab/test_notebooks.py
+++ b/samples/colab/test_notebooks.py
@@ -1,4 +1,3 @@
-# Lint as: python3
 # Copyright 2021 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.


### PR DESCRIPTION
These were required to tell the internal version of pylint to treat
code as Python 3 instead of Python 2. With Python 2 EOL and no longer
supported, they're no longer necessary.

Redo of / taking over https://github.com/google/iree/pull/8611