### PR TITLE
Fix pytype attribute-error in system_api.py.

### DIFF
--- a/runtime/bindings/python/iree/runtime/system_api.py
+++ b/runtime/bindings/python/iree/runtime/system_api.py
@@ -289,7 +289,7 @@ class SystemContext:
 
   @property
   def instance(self) -> _binding.VmInstance:
-    return self._instance
+    return self._config.vm_instance
 
   @property
   def modules(self) -> BoundModules:


### PR DESCRIPTION
`File "/home/runner/work/iree/iree/runtime/bindings/python/iree/runtime/system_api.py", line 291, in instance: No attribute '_instance' on SystemContext [attribute-error]`