### PR TITLE
Fix LLVMAOTTarget file extensions for debug artifacts.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp
@@ -575,19 +575,19 @@ class LLVMAOTTargetBackend final : public TargetBackend {
       switch (targetTriple.getObjectFormat()) {
         case llvm::Triple::ObjectFormatType::COFF:
           mimeType = "application/x-msdownload";
-          extension = "dll";
+          extension = ".dll";
           break;
         case llvm::Triple::ObjectFormatType::ELF:
           mimeType = "application/x-elf";
-          extension = "so";
+          extension = ".so";
           break;
         case llvm::Triple::ObjectFormatType::MachO:
           mimeType = "application/x-dylib";
-          extension = "dylib";
+          extension = ".dylib";
           break;
         case llvm::Triple::ObjectFormatType::Wasm:
           mimeType = "application/wasm";
-          extension = "wasm";
+          extension = ".wasm";
           break;
         default:
           mimeType = "application/octet-stream";


### PR DESCRIPTION
The helper function does not add a period on its own, so file names were looking like `module_mobilebert_squad_tosa_linked_llvm_system_wasm_wasm_32wasm` instead of `module_mobilebert_squad_tosa_linked_llvm_system_wasm_wasm_32.wasm`: https://github.com/google/iree/blob/e2f6c0f1deb47bee7c60e7ab37f771e935252f66/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp#L253-L255
All other uses of this helper function already include the period, for example: https://github.com/google/iree/blob/e2f6c0f1deb47bee7c60e7ab37f771e935252f66/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp#L288-L289 https://github.com/google/iree/blob/e2f6c0f1deb47bee7c60e7ab37f771e935252f66/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/VMVXTarget.cpp#L138-L139