### PR TITLE
Fix absolute paths to compiler/ directories in CODEOWNERS.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -60,17 +60,18 @@
 /iree/ @benvanik
 
 # Compiler
-/compiler/Codegen/ @MaheshRavishankar
-/compiler/Codegen/LLVMCPU/ @hanhanW @MaheshRavishankar
-/compiler/Codegen/LLVMGPU/ @MaheshRavishankar @ThomasRaoux
-/compiler/Codegen/Sandbox/ @hanhanW @MaheshRavishankar
-/compiler/Codegen/SPIRV/ @antiagainst @MaheshRavishankar
-/compiler/ConstEval/ @stellaraccident
-/compiler/Dialect/Flow/ @MaheshRavishankar
-/compiler/Dialect/Vulkan/ @antiagainst
-/compiler/InputConversion/ @MaheshRavishankar @stellaraccident
-/compiler/InputConversion/MHLO @hanhanW @MaheshRavishankar @rsuderman
-/compiler/InputConversion/TOSA @MaheshRavishankar @rsuderman
+/compiler/src/iree/compiler/ @benvanik
+/compiler/src/iree/compiler/Codegen/ @MaheshRavishankar
+/compiler/src/iree/compiler/Codegen/LLVMCPU/ @hanhanW @MaheshRavishankar
+/compiler/src/iree/compiler/Codegen/LLVMGPU/ @MaheshRavishankar @ThomasRaoux
+/compiler/src/iree/compiler/Codegen/Sandbox/ @hanhanW @MaheshRavishankar
+/compiler/src/iree/compiler/Codegen/SPIRV/ @antiagainst @MaheshRavishankar
+/compiler/src/iree/compiler/ConstEval/ @stellaraccident
+/compiler/src/iree/compiler/Dialect/Flow/ @MaheshRavishankar
+/compiler/src/iree/compiler/Dialect/Vulkan/ @antiagainst
+/compiler/src/iree/compiler/InputConversion/ @MaheshRavishankar @stellaraccident
+/compiler/src/iree/compiler/InputConversion/MHLO @hanhanW @MaheshRavishankar @rsuderman
+/compiler/src/iree/compiler/InputConversion/TOSA @MaheshRavishankar @rsuderman
 
 
 # Runtime


### PR DESCRIPTION
Missed this when reviewing https://github.com/google/iree/pull/9022, but these paths are absolute from the root of the repo, so just `/compiler/` won't trigger as expected.

Also add Ben back as the top level default (from back when `/iree/` covered `/iree/compiler/`)