### PR TITLE
Expose and enable LinalgTransform pass registration.

### DIFF
--- a/llvm-external-projects/iree-dialects/BUILD
+++ b/llvm-external-projects/iree-dialects/BUILD
@@ -737,6 +737,7 @@ cc_library(
         ":IREEInputDialect",
         ":IREELinalgExtDialect",
         ":IREELinalgTransformDialect",
+        ":IREELinalgTransformDialectTransforms",
         ":IREEPyDMDialect",
         ":IREEPyDMTransforms",
         "@llvm-project//mlir:CAPIIR",

--- a/llvm-external-projects/iree-dialects/include/iree-dialects-c/Dialects.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects-c/Dialects.h
@@ -33,6 +33,9 @@ MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(IREELinalgExt, iree_linalg_ext);
 
 MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(LinalgTransform, iree_linalg_transform);
 
+/// Register all passes for LinalgTransform.
+MLIR_CAPI_EXPORTED void mlirIREELinalgTransformRegisterPasses();
+
 //===----------------------------------------------------------------------===//
 // IREEPyDMDialect
 //===----------------------------------------------------------------------===//

--- a/llvm-external-projects/iree-dialects/lib/CAPI/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/CAPI/CMakeLists.txt
@@ -6,6 +6,7 @@ add_mlir_public_c_api_library(IREEDialectsCAPI
   IREEInputDialect
   IREELinalgExtDialect
   IREELinalgTransformDialect
+  IREELinalgTransformDialectTransforms
   IREEPyDMDialect
   IREEPyDMPasses
 )

--- a/llvm-external-projects/iree-dialects/lib/CAPI/Dialects.cpp
+++ b/llvm-external-projects/iree-dialects/lib/CAPI/Dialects.cpp
@@ -9,6 +9,7 @@
 #include "iree-dialects/Dialect/Input/InputDialect.h"
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.h"
+#include "iree-dialects/Dialect/LinalgTransform/Passes.h"
 #include "iree-dialects/Dialect/PyDM/IR/PyDMDialect.h"
 #include "iree-dialects/Dialect/PyDM/Transforms/Passes.h"
 #include "mlir/CAPI/IR.h"
@@ -44,6 +45,12 @@ MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(
     IREELinalgTransform, iree_linalg_transform,
     mlir::linalg::transform::LinalgTransformDialect)
+
+void mlirIREELinalgTransformRegisterPasses() {
+  mlir::linalg::transform::registerLinalgTransformInterpreterPass();
+  mlir::linalg::transform::registerLinalgTransformExpertExpansionPass();
+  mlir::linalg::transform::registerDropSchedulePass();
+}
 
 //===----------------------------------------------------------------------===//
 // IREEPyDMDialect

--- a/llvm-external-projects/iree-dialects/python/IREEDialectsModule.cpp
+++ b/llvm-external-projects/iree-dialects/python/IREEDialectsModule.cpp
@@ -110,6 +110,7 @@ PYBIND11_MODULE(_ireeDialects, m) {
   // LinalgTransform
   //===--------------------------------------------------------------------===//
   auto iree_linalg_transform_m = m.def_submodule("iree_linalg_transform");
+  mlirIREELinalgTransformRegisterPasses();
   iree_linalg_transform_m.def(
       "register_dialect",
       [](MlirContext context, bool load) {


### PR DESCRIPTION
This simplifies the use of the transform dialect in downstream python code.