### PR TITLE
Fix dana uploading failure due to duplicated numbers

### DIFF
--- a/build_tools/benchmarks/upload_benchmarks_to_dashboard.py
+++ b/build_tools/benchmarks/upload_benchmarks_to_dashboard.py
@@ -303,8 +303,12 @@ def main(args):
   # Register a new build for the current commit.
   commit_hash = get_git_commit_hash(all_results.commit, verbose=args.verbose)
   commit_count = get_git_total_commit_count(commit_hash, verbose=args.verbose)
+
+  # Allow override to support uploading data for the same build in
+  # different batches.
   add_new_iree_build(commit_count,
                      commit_hash,
+                     override=True,
                      dry_run=args.dry_run,
                      verbose=args.verbose)
 


### PR DESCRIPTION
Right now we have two buildkite pipelines uploading benchmark
samples to Dana---one for Android targets and one for x86_64
CPUs. Each pipeline will try to create a new build for the
current landed commit. We need to allow overriding to make
sure both of them are accepted. (It should be the exact same
commit so no harm to override.)