### PR TITLE
Include LinalgStructuredOps headers from LLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,6 +512,7 @@ include(external_cc_library)
 include(flatbuffer_c_library)
 
 add_subdirectory(build_tools/third_party/libyaml EXCLUDE_FROM_ALL)
+add_subdirectory(build_tools/third_party/llvm-project EXCLUDE_FROM_ALL)
 add_subdirectory(build_tools/third_party/stblib EXCLUDE_FROM_ALL)
 add_subdirectory(build_tools/third_party/vulkan_memory_allocator EXCLUDE_FROM_ALL)
 

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -49,6 +49,9 @@ EXPLICIT_TARGET_MAPPING = {
     "@llvm-project//mlir:GPUDialect": ["MLIRGPUOps"],
     "@llvm-project//mlir:GPUTransforms": ["MLIRGPUTransforms"],
     "@llvm-project//mlir:LinalgInterfaces": ["MLIRLinalg"],
+    "@llvm-project//mlir:LinalgStructuredOpsIncGen": [
+        "LinalgStructuredOpsIncGen_Lib"
+    ],
     "@llvm-project//mlir:LinalgOps": ["MLIRLinalg"],
     "@llvm-project//mlir:LLVMDialect": ["MLIRLLVMIR"],
     "@llvm-project//mlir:LLVMTransforms": ["MLIRFuncToLLVM"],

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -50,7 +50,7 @@ EXPLICIT_TARGET_MAPPING = {
     "@llvm-project//mlir:GPUTransforms": ["MLIRGPUTransforms"],
     "@llvm-project//mlir:LinalgInterfaces": ["MLIRLinalg"],
     "@llvm-project//mlir:LinalgStructuredOpsIncGen": [
-        "LinalgStructuredOpsIncGen_Lib"
+        "MLIRLinalgStructuredOpsIncGenLib"
     ],
     "@llvm-project//mlir:LinalgOps": ["MLIRLinalg"],
     "@llvm-project//mlir:LLVMDialect": ["MLIRLLVMIR"],

--- a/build_tools/third_party/llvm-project/CMakeLists.txt
+++ b/build_tools/third_party/llvm-project/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+###############################################################################
+# Re-export LLVM header-only targets as header-only libraries.                #
+###############################################################################
+
+add_library(MLIRLinalgStructuredOpsIncGen_Lib INTERFACE)
+add_dependencies(MLIRLinalgStructuredOpsIncGen_Lib
+  MLIRLinalgStructuredOpsIncGen
+)

--- a/build_tools/third_party/llvm-project/CMakeLists.txt
+++ b/build_tools/third_party/llvm-project/CMakeLists.txt
@@ -8,7 +8,7 @@
 # Re-export LLVM header-only targets as header-only libraries.                #
 ###############################################################################
 
-add_library(MLIRLinalgStructuredOpsIncGen_Lib INTERFACE)
-add_dependencies(MLIRLinalgStructuredOpsIncGen_Lib
+add_library(MLIRLinalgStructuredOpsIncGenLib INTERFACE)
+add_dependencies(MLIRLinalgStructuredOpsIncGenLib
   MLIRLinalgStructuredOpsIncGen
 )

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/BUILD
@@ -200,6 +200,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgInterfaces",
         "@llvm-project//mlir:LinalgOps",
+        "@llvm-project//mlir:LinalgStructuredOpsIncGen",
         "@llvm-project//mlir:TensorDialect",
     ],
 )

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
@@ -123,6 +123,7 @@ iree_cc_library(
     ::PartitionableLoopsInterfaceGen
     IREELinalgExtDialect
     LLVMSupport
+    LinalgStructuredOpsIncGen_Lib
     MLIRIR
     MLIRLinalg
     MLIRTensor

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
@@ -123,9 +123,9 @@ iree_cc_library(
     ::PartitionableLoopsInterfaceGen
     IREELinalgExtDialect
     LLVMSupport
-    LinalgStructuredOpsIncGen_Lib
     MLIRIR
     MLIRLinalg
+    MLIRLinalgStructuredOpsIncGenLib
     MLIRTensor
   PUBLIC
 )

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/PartitionableLoopsInterface.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/PartitionableLoopsInterface.cpp
@@ -224,55 +224,10 @@ static void registerInterfaceForTiledOpInterfaceOps(MLIRContext *ctx) {
 void registerPartitionableLoopsInterfaceModels(DialectRegistry &registry) {
   registry.insert<linalg::LinalgDialect>();
 
+#define GET_OP_LIST
   registry.addExtension(+[](MLIRContext *ctx, linalg::LinalgDialect *dialect) {
     registerInterfaceForLinalgOps<
-        // clang-format off
-
-  // This is copy-pasted from LinalgStructuredOps.cpp.inc. In theory you could
-  // just include that generated file here, but that cause errors with bazel.
-  // The required generated header is not exposed correctly.
-  // Copy paste is fine for now.
-
-  ::mlir::linalg::BatchMatmulOp,
-  ::mlir::linalg::BatchMatvecOp,
-  ::mlir::linalg::Conv1DNwcWcfOp,
-  ::mlir::linalg::Conv1DOp,
-  ::mlir::linalg::Conv2DNchwFchwOp,
-  ::mlir::linalg::Conv2DNhwcHwcfOp,
-  ::mlir::linalg::Conv2DNhwcHwcfQOp,
-  ::mlir::linalg::Conv2DOp,
-  ::mlir::linalg::Conv3DNdhwcDhwcfOp,
-  ::mlir::linalg::Conv3DOp,
-  ::mlir::linalg::CopyOp,
-  ::mlir::linalg::DepthwiseConv1DNwcWcOp,
-  ::mlir::linalg::DepthwiseConv2DNhwcHwcOp,
-  ::mlir::linalg::DepthwiseConv2DNhwcHwcQOp,
-  ::mlir::linalg::DepthwiseConv2DNhwcHwcmOp,
-  ::mlir::linalg::DepthwiseConv2DNhwcHwcmQOp,
-  ::mlir::linalg::DotOp,
-  ::mlir::linalg::ElemwiseBinaryOp,
-  ::mlir::linalg::ElemwiseUnaryOp,
-  ::mlir::linalg::FillOp,
-  ::mlir::linalg::FillRng2DOp,
-  ::mlir::linalg::GenericOp,
-  ::mlir::linalg::MatmulOp,
-  ::mlir::linalg::MatmulUnsignedOp,
-  ::mlir::linalg::MatvecOp,
-  ::mlir::linalg::Mmt4DOp,
-  ::mlir::linalg::PoolingNchwMaxOp,
-  ::mlir::linalg::PoolingNchwSumOp,
-  ::mlir::linalg::PoolingNdhwcMaxOp,
-  ::mlir::linalg::PoolingNdhwcMinOp,
-  ::mlir::linalg::PoolingNdhwcSumOp,
-  ::mlir::linalg::PoolingNhwcMaxOp,
-  ::mlir::linalg::PoolingNhwcMaxUnsignedOp,
-  ::mlir::linalg::PoolingNhwcMinOp,
-  ::mlir::linalg::PoolingNhwcMinUnsignedOp,
-  ::mlir::linalg::PoolingNhwcSumOp,
-  ::mlir::linalg::QuantizedBatchMatmulOp,
-  ::mlir::linalg::QuantizedMatmulOp,
-  ::mlir::linalg::VecmatOp
-        // clang-format on
+#include "mlir/Dialect/Linalg/IR/LinalgStructuredOps.cpp.inc"
         >(ctx);
   });
 


### PR DESCRIPTION
This change tries to import the `LinalgStructuredOps.cpp.inc` from LLVM instead of keeping a copy in IREE. It will help us avoid #9036 in the future.

There is a compatibility issue between IREE and LLVM cmake system. The tablegen libraries in LLVM are only defined as custom targets and can not be used in `target_link_libraries`, so adding those targets to the `DEPS` of `iree_cc_library` breaks the build as the rule tries to link them.

I'm not sure about the best solution for this. In IREE, we can use `add_dependences` to add LLVM tablegen libraries but it will break the mapping between bazel and cmake, makes it harder to maintain. Another option is defining those targets as [Interface Libraries](https://cmake.org/cmake/help/latest/command/add_library.html#interface-libraries) in the LLVM upstream, but that might need to change LLVM a lot.

My current solution is to re-export those tablegen targets as interface libraries in IREE, so we can still map from bazel to cmake and link those targets as normal libraries in IREE.