### PR TITLE
Print whenever reading from stdin.

### DIFF
--- a/iree/tools/iree-benchmark-module-main.cc
+++ b/iree/tools/iree-benchmark-module-main.cc
@@ -249,6 +249,7 @@ iree_status_t GetModuleContentsFromFlags(iree_file_contents_t** out_contents) {
   IREE_TRACE_SCOPE0("GetModuleContentsFromFlags");
   auto module_file = std::string(FLAG_module_file);
   if (module_file == "-") {
+    std::cout << "Reading module contents from stdin...\n";
     return iree_stdin_read_contents(iree_allocator_system(), out_contents);
   } else {
     return iree_file_read_contents(module_file.c_str(), iree_allocator_system(),

--- a/iree/tools/iree-check-module-main.cc
+++ b/iree/tools/iree-check-module-main.cc
@@ -97,6 +97,7 @@ iree_status_t Run(std::string module_file_path, int* out_exit_code) {
 
   iree_file_contents_t* flatbuffer_contents = NULL;
   if (module_file_path == "-") {
+    std::cout << "Reading module contents from stdin...\n";
     IREE_RETURN_IF_ERROR(iree_stdin_read_contents(iree_allocator_system(),
                                                   &flatbuffer_contents));
   } else {

--- a/iree/tools/iree-run-module-main.cc
+++ b/iree/tools/iree-run-module-main.cc
@@ -82,6 +82,7 @@ iree_status_t GetModuleContentsFromFlags(iree_file_contents_t** out_contents) {
   IREE_TRACE_SCOPE0("GetModuleContentsFromFlags");
   auto module_file = std::string(FLAG_module_file);
   if (module_file == "-") {
+    std::cout << "Reading module contents from stdin...\n";
     return iree_stdin_read_contents(iree_allocator_system(), out_contents);
   } else {
     return iree_file_read_contents(module_file.c_str(), iree_allocator_system(),

--- a/iree/tools/utils/trace_replay.c
+++ b/iree/tools/utils/trace_replay.c
@@ -129,6 +129,7 @@ static iree_status_t iree_trace_replay_load_bytecode_module(
   iree_file_contents_t* flatbuffer_contents = NULL;
   iree_status_t status = iree_ok_status();
   if (iree_yaml_string_equal(path_node, iree_make_cstring_view("<stdin>"))) {
+    fprintf(stdout, "Reading bytecode contents from stdin...\n");
     status =
         iree_stdin_read_contents(replay->host_allocator, &flatbuffer_contents);
   } else {

--- a/runtime/src/iree/testing/vulkan/iree-run-module-vulkan-gui-main.cc
+++ b/runtime/src/iree/testing/vulkan/iree-run-module-vulkan-gui-main.cc
@@ -98,6 +98,7 @@ iree_status_t GetModuleContentsFromFlags(iree_file_contents_t** out_contents) {
   IREE_TRACE_SCOPE0("GetModuleContentsFromFlags");
   auto module_file = std::string(FLAG_module_file);
   if (module_file == "-") {
+    IREE_LOG(INFO) << "Reading module contents from stdin...";
     return iree_stdin_read_contents(iree_allocator_system(), out_contents);
   } else {
     return iree_file_read_contents(module_file.c_str(), iree_allocator_system(),


### PR DESCRIPTION
We have a few tools that read from stdin by default. It's confusing when there is no difference in output between a correctly formatted tool invocation just taking a while (running benchmarks or compiling a program) compared to an invocation with a typo that is spinning waiting for input.

Some of these changes may be overly spammy, and https://github.com/google/iree/issues/5931 has other (complementary) suggestions on how to make these tools less error-prone.

---

I considered logging in the implementation of `iree_stdin_read_contents` itself (base/internal/file_io), but figured that each callsite can customize the message this way.