### PR TITLE
Use a consistent test name style for compile-mhlo-test.

### DIFF
--- a/compiler/src/iree/compiler/API/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API/test/CMakeLists.txt
@@ -4,19 +4,17 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-iree_cc_binary(
-  NAME
-    "compile-mhlo-test-binary"
-  SRCS
-    compile-mhlo-test-main.c
-  DEPS
+add_executable(
+  compile-mhlo-test-binary
+  compile-mhlo-test-main.c
+)
+target_link_libraries(compile-mhlo-test-binary
+  PRIVATE
     IREECompilerCAPILib
     MLIRCAPIIR
 )
 
-iree_native_test(
-  NAME
-    compile-mhlo-test
-  SRC
-    ::compile-mhlo-test-binary
+add_test(
+  NAME "iree/compiler/API/test/compile-mhlo-test"
+  COMMAND compile-mhlo-test-binary
 )

--- a/compiler/src/iree/compiler/API/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API/test/CMakeLists.txt
@@ -1,26 +1,22 @@
-################################################################################
-# iree-compiler-api-compile-mhlo-test
-# If there ever become more of these, please convert into a function instead
-# of open coding.
-################################################################################
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-set(_NAME "compile-mhlo-test")
-
-add_executable(
-  ${_NAME}
-  compile-mhlo-test-main.c
-)
-target_link_libraries(${_NAME}
-  PRIVATE
+iree_cc_binary(
+  NAME
+    "compile-mhlo-test-binary"
+  SRCS
+    compile-mhlo-test-main.c
+  DEPS
     IREECompilerCAPILib
     MLIRCAPIIR
 )
 
-iree_package_ns(_PACKAGE_NS)
-string(REPLACE "::" "/" _PACKAGE_PATH ${_PACKAGE_NS})
-set(_NAME_PATH "${_PACKAGE_PATH}/${_NAME}")
-
-add_test(
-  NAME ${_NAME_PATH}
-  COMMAND ${_NAME}
+iree_native_test(
+  NAME
+    compile-mhlo-test
+  SRC
+    ::compile-mhlo-test-binary
 )

--- a/compiler/src/iree/compiler/API/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API/test/CMakeLists.txt
@@ -4,17 +4,23 @@
 # of open coding.
 ################################################################################
 
+set(_NAME "compile-mhlo-test")
+
 add_executable(
-  iree-compiler-api-compile-mhlo-test
+  ${_NAME}
   compile-mhlo-test-main.c
 )
-target_link_libraries(iree-compiler-api-compile-mhlo-test
+target_link_libraries(${_NAME}
   PRIVATE
     IREECompilerCAPILib
     MLIRCAPIIR
 )
 
+iree_package_ns(_PACKAGE_NS)
+string(REPLACE "::" "/" _PACKAGE_PATH ${_PACKAGE_NS})
+set(_NAME_PATH "${_PACKAGE_PATH}/${_NAME}")
+
 add_test(
-  NAME iree-compiler-api-compile-mhlo-test
-  COMMAND iree-compiler-api-compile-mhlo-test
+  NAME ${_NAME_PATH}
+  COMMAND ${_NAME}
 )


### PR DESCRIPTION
This makes IDE integration cleaner (e.g. VSCode with `"cmakeExplorer.suiteDelimiter": "/",`).

Before (test uses `-` instead of `/` as a delimiter):
![image](https://user-images.githubusercontent.com/4010439/167212246-3a8b9d6b-1fc8-43d1-a637-45705c451efd.png)

After:
![image](https://user-images.githubusercontent.com/4010439/167212574-14adb811-db51-4571-9eb4-0fbd80852a5f.png)

---

I went back and forth on the specific CMake functions used here (see the commit history), but decided to omit Bazel support and keep using base CMake functions (no IREE helpers) based on this comment: https://github.com/google/iree/blob/18b9df4ac41f7cbf86ec0e036771b39f9f3420f4/compiler/src/iree/compiler/API/CMakeLists.txt#L7-L15