### PR TITLE
Makes buffers retain the backing device allocator.

### DIFF
--- a/runtime/bindings/python/iree/runtime/hal.cc
+++ b/runtime/bindings/python/iree/runtime/hal.cc
@@ -407,14 +407,18 @@ void SetupHalBindings(pybind11::module m) {
       .def_static("map_to_dtype", &MapElementTypeToDType);
 
   py::class_<HalDevice>(m, "HalDevice")
-      .def_property_readonly("allocator", [](HalDevice& self) {
-        return HalAllocator::BorrowFromRawPtr(self.allocator());
-      });
+      .def_property_readonly(
+          "allocator",
+          [](HalDevice& self) {
+            return HalAllocator::BorrowFromRawPtr(self.allocator());
+          },
+          py::keep_alive<0, 1>());
 
   py::class_<HalDriver>(m, "HalDriver")
       .def_static("query", &HalDriver::Query)
       .def_static("create", &HalDriver::Create, py::arg("driver_name"))
-      .def("create_default_device", &HalDriver::CreateDefaultDevice);
+      .def("create_default_device", &HalDriver::CreateDefaultDevice,
+           py::keep_alive<0, 1>());
 
   py::class_<HalAllocator>(m, "HalAllocator")
       .def("trim",
@@ -456,12 +460,12 @@ void SetupHalBindings(pybind11::module m) {
             return HalBuffer::StealFromRawPtr(buffer);
           },
           py::arg("memory_type"), py::arg("allowed_usage"),
-          py::arg("allocation_size"),
+          py::arg("allocation_size"), py::keep_alive<0, 1>(),
           "Allocates a new buffer with requested characteristics (does not "
           "initialize with specific data).")
       .def("allocate_buffer_copy", &HalAllocator::AllocateBufferCopy,
            py::arg("memory_type"), py::arg("allowed_usage"), py::arg("buffer"),
-           py::arg("element_type") = py::none(),
+           py::arg("element_type") = py::none(), py::keep_alive<0, 1>(),
            "Allocates a new buffer and initializes it from a Python buffer "
            "object. If an element type is specified, wraps in a BufferView "
            "matching the characteristics of the Python buffer. The format is "
@@ -472,11 +476,11 @@ void SetupHalBindings(pybind11::module m) {
       .def("fill_zero", &HalBuffer::FillZero, py::arg("byte_offset"),
            py::arg("byte_length"))
       .def("create_view", &HalBuffer::CreateView, py::arg("shape"),
-           py::arg("element_size"))
+           py::arg("element_size"), py::keep_alive<0, 1>())
       .def("__repr__", &HalBuffer::Repr);
 
   py::class_<HalBufferView>(m, "HalBufferView")
-      .def("map", HalMappedMemory::Create)
+      .def("map", HalMappedMemory::Create, py::keep_alive<0, 1>())
       .def_property_readonly(
           "shape",
           [](HalBufferView& self) {

--- a/runtime/bindings/python/iree/runtime/hal.h
+++ b/runtime/bindings/python/iree/runtime/hal.h
@@ -18,6 +18,25 @@ namespace python {
 
 //------------------------------------------------------------------------------
 // Retain/release bindings
+// Note that all HAL types have keep alive relationships in addition to this
+// (using the py:keep_alive<>() facility). These relationships form a chain
+// such that any live Python leaf (like a buffer or buffer_view) must keep
+// alive the allocator, device and driver that created it.
+//
+// The hierarchy is:
+//   HalDriver
+//   HalDevice
+//   HalAllocator
+//   HalBuffer
+//   HalBufferView
+//
+// Any Python API which produces one of the above must be annotated with
+// py::keep_alive<0, 1>() in order to establish the relationship with the
+// parent.
+//
+// Any Python API which consumes one of these objects such that its lifetime
+// may extend outside of the current invocation must arrange to retain/release
+// all backing devices that may need to survive.
 //------------------------------------------------------------------------------
 
 template <>

--- a/runtime/src/iree/hal/buffer.c
+++ b/runtime/src/iree/hal/buffer.c
@@ -194,11 +194,6 @@ IREE_API_EXPORT void iree_hal_buffer_initialize(
   buffer->allowed_access = allowed_access;
   buffer->allowed_usage = allowed_usage;
 
-  // Retain the backing allocator.
-  if (IREE_LIKELY(device_allocator)) {
-    iree_hal_allocator_retain(device_allocator);
-  }
-
   // Retain the base allocated buffer if it's unique from the buffer we are
   // initializing.
   if (allocated_buffer != buffer) {
@@ -220,15 +215,8 @@ IREE_API_EXPORT void iree_hal_buffer_recycle(iree_hal_buffer_t* buffer) {
 
 IREE_API_EXPORT void iree_hal_buffer_destroy(iree_hal_buffer_t* buffer) {
   if (IREE_LIKELY(buffer)) {
-    iree_hal_allocator_t* device_allocator_to_release =
-        buffer->device_allocator;
     IREE_HAL_VTABLE_DISPATCH(buffer, iree_hal_buffer, destroy)
     (buffer);
-
-    // Release backing allocator, only after unused.
-    if (IREE_LIKELY(device_allocator_to_release)) {
-      iree_hal_allocator_release(device_allocator_to_release);
-    }
   }
 }
 

--- a/runtime/src/iree/hal/buffer.c
+++ b/runtime/src/iree/hal/buffer.c
@@ -194,6 +194,11 @@ IREE_API_EXPORT void iree_hal_buffer_initialize(
   buffer->allowed_access = allowed_access;
   buffer->allowed_usage = allowed_usage;
 
+  // Retain the backing allocator.
+  if (IREE_LIKELY(device_allocator)) {
+    iree_hal_allocator_retain(device_allocator);
+  }
+
   // Retain the base allocated buffer if it's unique from the buffer we are
   // initializing.
   if (allocated_buffer != buffer) {
@@ -215,8 +220,15 @@ IREE_API_EXPORT void iree_hal_buffer_recycle(iree_hal_buffer_t* buffer) {
 
 IREE_API_EXPORT void iree_hal_buffer_destroy(iree_hal_buffer_t* buffer) {
   if (IREE_LIKELY(buffer)) {
+    iree_hal_allocator_t* device_allocator_to_release =
+        buffer->device_allocator;
     IREE_HAL_VTABLE_DISPATCH(buffer, iree_hal_buffer, destroy)
     (buffer);
+
+    // Release backing allocator, only after unused.
+    if (IREE_LIKELY(device_allocator_to_release)) {
+      iree_hal_allocator_release(device_allocator_to_release);
+    }
   }
 }
 


### PR DESCRIPTION
Since the device/allocator often lives for the life of whatever is being done, this was not being caught. But some Python uses were hitting it. Added a Python test to catch regressions at that level (which should also catch various Python ref-counting issues). This uses the `pybind11::keep_alive<>` facility, which I don't love, but was built for just this case. We may need to revisit the ownership when transferring outside of the current thread of control. I've left notes in hal.h on the present and potential future state.

Fixes #9033