### PR TITLE
Remove absl test and logging deps from Python unit tests.

### DIFF
--- a/runtime/bindings/python/iree/runtime/function_test.py
+++ b/runtime/bindings/python/iree/runtime/function_test.py
@@ -6,8 +6,7 @@
 
 import json
 import numpy as np
-
-from absl.testing import absltest
+import unittest
 
 from iree import runtime as rt
 from iree.runtime.function import (
@@ -40,7 +39,7 @@ class MockVmFunction:
     self.reflection = reflection
 
 
-class FunctionTest(absltest.TestCase):
+class FunctionTest(unittest.TestCase):
 
   @classmethod
   def setUpClass(cls):
@@ -592,4 +591,4 @@ class FunctionTest(absltest.TestCase):
 
 
 if __name__ == "__main__":
-  absltest.main()
+  unittest.main()

--- a/runtime/bindings/python/iree/runtime/system_api_test.py
+++ b/runtime/bindings/python/iree/runtime/system_api_test.py
@@ -6,12 +6,12 @@
 
 # pylint: disable=unused-variable
 
+import logging
 import os
 import re
 import tempfile
+import unittest
 
-from absl import logging
-from absl.testing import absltest
 import iree.compiler
 import iree.runtime
 import numpy as np
@@ -34,7 +34,7 @@ def create_simple_mul_module():
   return m
 
 
-class SystemApiTest(absltest.TestCase):
+class SystemApiTest(unittest.TestCase):
 
   def test_non_existing_driver(self):
     with self.assertRaisesRegex(RuntimeError,
@@ -137,4 +137,5 @@ class SystemApiTest(absltest.TestCase):
 
 
 if __name__ == "__main__":
-  absltest.main()
+  logging.basicConfig(level=logging.DEBUG)
+  unittest.main()

--- a/runtime/bindings/python/iree/runtime/vm_test.py
+++ b/runtime/bindings/python/iree/runtime/vm_test.py
@@ -6,11 +6,12 @@
 
 # pylint: disable=unused-variable
 
-from absl import logging
-from absl.testing import absltest
+import logging
+import numpy as np
+import unittest
+
 import iree.compiler
 import iree.runtime
-import numpy as np
 
 
 def create_add_scalar_module():
@@ -60,7 +61,7 @@ def create_simple_dynamic_abs_module():
   return m
 
 
-class VmTest(absltest.TestCase):
+class VmTest(unittest.TestCase):
 
   @classmethod
   def setUpClass(cls):
@@ -189,4 +190,5 @@ class VmTest(absltest.TestCase):
 
 
 if __name__ == "__main__":
-  absltest.main()
+  logging.basicConfig(level=logging.DEBUG)
+  unittest.main()

--- a/samples/colab/test_notebooks.py
+++ b/samples/colab/test_notebooks.py
@@ -5,11 +5,10 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import glob
+import logging
 import os
 import subprocess
 import unittest
-
-from absl.testing import absltest
 
 NOTEBOOKS_TO_SKIP = []
 
@@ -18,7 +17,7 @@ NOTEBOOKS_EXPECTED_TO_FAIL = [
 ]
 
 
-class ColabNotebookTests(absltest.TestCase):
+class ColabNotebookTests(unittest.TestCase):
   """Tests running all Colab notebooks in this directory."""
 
   @classmethod
@@ -50,4 +49,5 @@ class ColabNotebookTests(absltest.TestCase):
 
 if __name__ == "__main__":
   ColabNotebookTests.generateTests()
-  absltest.main()
+  logging.basicConfig(level=logging.DEBUG)
+  unittest.main()


### PR DESCRIPTION
This has been bugging me for a while because it adds no value and requires more deps to be installed.

Does not touch integrations/tensorflow since installing TF pulls absl-py along for the ride.