### PR TITLE
Add iree-benchmark-module to iree-runtime python package.

### DIFF
--- a/runtime/bindings/python/iree/runtime/CMakeLists.txt
+++ b/runtime/bindings/python/iree/runtime/CMakeLists.txt
@@ -76,6 +76,12 @@ iree_py_library(
 
 iree_symlink_tool(
   TARGET runtime
+  FROM_TOOL_TARGET iree_tools_iree-benchmark-module
+  TO_EXE_NAME iree-benchmark-module
+)
+
+iree_symlink_tool(
+  TARGET runtime
   FROM_TOOL_TARGET iree_tools_iree-benchmark-trace
   TO_EXE_NAME iree-benchmark-trace
 )
@@ -158,6 +164,7 @@ iree_py_install_package(
     # TODO: Update CMake target/path mangling rules to make this syntactically
     # rooted on "iree" in some way.
     runtime_bindings_python_iree_runtime_PyExtRt
+    iree_tools_iree-benchmark-module
     iree_tools_iree-benchmark-trace
     iree_tools_iree-run-module
     iree_tools_iree-run-trace
@@ -176,6 +183,7 @@ install(
 
 install(
   TARGETS
+    iree_tools_iree-benchmark-module
     iree_tools_iree-benchmark-trace
     iree_tools_iree-run-module
     iree_tools_iree-run-trace

--- a/runtime/bindings/python/iree/runtime/scripts/iree_benchmark_module/__main__.py
+++ b/runtime/bindings/python/iree/runtime/scripts/iree_benchmark_module/__main__.py
@@ -1,0 +1,21 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import os
+import subprocess
+import sys
+
+
+def main(args=None):
+  if args is None:
+    args = sys.argv[1:]
+  exe = os.path.join(os.path.dirname(__file__), "..", "..",
+                     "iree-benchmark-module")
+  return subprocess.call(args=[exe] + args)
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/runtime/setup.py
+++ b/runtime/setup.py
@@ -402,6 +402,7 @@ setup(
             f"*{sysconfig.get_config_var('EXT_SUFFIX')}",
             "iree-run-module*",
             "iree-run-trace*",
+            "iree-benchmark-module*",
             "iree-benchmark-trace*",
             "iree-tracy-capture*",
         ],
@@ -410,6 +411,7 @@ setup(
         "console_scripts": [
             "iree-run-module = iree.runtime.scripts.iree_run_module.__main__:main",
             "iree-run-trace = iree.runtime.scripts.iree_run_trace.__main__:main",
+            "iree-benchmark-module = iree.runtime.scripts.iree_benchmark_module.__main__:main",
             "iree-benchmark-trace = iree.runtime.scripts.iree_benchmark_trace.__main__:main",
             "iree-tracy-capture = iree.runtime.scripts.iree_tracy_capture.__main__:main",
         ],


### PR DESCRIPTION
Fixes #8921