### PR TITLE
Switch to use upstream comphrensive bufferization for all CPU kernels

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
@@ -11,37 +11,42 @@ include "iree/compiler/Codegen/Dialect/IREECodegenDialect.td"
 include "mlir/IR/EnumAttr.td"
 
 // List of pre-existing pipelines for translating executables.
+// TODO(#9047): Merge CPUDefault and CPUBuffersDefault pipelines. The latter one
+// is needed because of early bufferized ops. We're able to remove it if
+// upstream bufferization is used in this case.
 def CPU_Default
     : I32EnumAttrCase<"CPUDefault", 0>;
+def CPU_BufferOpsDefault
+    : I32EnumAttrCase<"CPUBufferOpsDefault", 1>;
 def CPU_DoubleTilingExpert
-    : I32EnumAttrCase<"CPUDoubleTilingExpert", 1>;
+    : I32EnumAttrCase<"CPUDoubleTilingExpert", 2>;
 def CPU_ConvTileAndDecomposeExpert
-    : I32EnumAttrCase<"CPUConvTileAndDecomposeExpert", 2>;
+    : I32EnumAttrCase<"CPUConvTileAndDecomposeExpert", 3>;
 def CPU_TileFuseAndVectorize
-    : I32EnumAttrCase<"CPUTileFuseAndVectorize", 3>;
+    : I32EnumAttrCase<"CPUTileFuseAndVectorize", 4>;
 def CPU_BufferOpsTileAndVectorize
-    : I32EnumAttrCase<"CPUBufferOpsTileAndVectorize", 4>;
+    : I32EnumAttrCase<"CPUBufferOpsTileAndVectorize", 5>;
 
 def Linalg_TransformInterpCodegen
-    : I32EnumAttrCase<"LinalgTransformInterpCodegen", 5>;
+    : I32EnumAttrCase<"LinalgTransformInterpCodegen", 6>;
 
 def LLVMGPU_SimpleDistribute
-    : I32EnumAttrCase<"LLVMGPUDistribute", 6>;
+    : I32EnumAttrCase<"LLVMGPUDistribute", 7>;
 def LLVMGPU_Vectorize
-    : I32EnumAttrCase<"LLVMGPUVectorize", 7>;
+    : I32EnumAttrCase<"LLVMGPUVectorize", 8>;
 def LLVMGPU_MatmulSimt
-    : I32EnumAttrCase<"LLVMGPUMatmulSimt", 8>;
+    : I32EnumAttrCase<"LLVMGPUMatmulSimt", 9>;
 def LLVMGPU_MatmulTensorCore
-    : I32EnumAttrCase<"LLVMGPUMatmulTensorCore", 9>;
+    : I32EnumAttrCase<"LLVMGPUMatmulTensorCore", 10>;
 
 def SPIRV_Distribute
-    : I32EnumAttrCase<"SPIRVDistribute", 10>;
+    : I32EnumAttrCase<"SPIRVDistribute", 11>;
 def SPIRV_Vectorize
-    : I32EnumAttrCase<"SPIRVVectorize", 11>;
+    : I32EnumAttrCase<"SPIRVVectorize", 12>;
 def SPIRV_VectorizeToCooperativeOps
-    : I32EnumAttrCase<"SPIRVVectorizeToCooperativeOps", 12>;
+    : I32EnumAttrCase<"SPIRVVectorizeToCooperativeOps", 13>;
 def SPIRV_VectorizeWithWorkgroupMemory
-    : I32EnumAttrCase<"SPIRVVectorizeWithWorkgroupMemory", 13>;
+    : I32EnumAttrCase<"SPIRVVectorizeWithWorkgroupMemory", 14>;
 
 def None
     : I32EnumAttrCase<"None", 0xff>;
@@ -49,16 +54,17 @@ def None
 // EnumAttrCase for all known lowerings for ops within dispatch region
 // to scalar/native-vector code.
 def DispatchLoweringPassPipelineEnum
-    : I32EnumAttr<
-          "DispatchLoweringPassPipeline",
-          "identifier for pass pipeline use to lower dispatch region", [
-            CPU_Default, CPU_DoubleTilingExpert, CPU_ConvTileAndDecomposeExpert,
-            CPU_TileFuseAndVectorize, CPU_BufferOpsTileAndVectorize,
-            Linalg_TransformInterpCodegen, LLVMGPU_SimpleDistribute,
-            LLVMGPU_Vectorize, LLVMGPU_MatmulSimt, LLVMGPU_MatmulTensorCore,
-            SPIRV_Distribute, SPIRV_Vectorize, SPIRV_VectorizeToCooperativeOps,
-            SPIRV_VectorizeWithWorkgroupMemory, None
-          ]> {
+    : I32EnumAttr<"DispatchLoweringPassPipeline",
+                  "identifier for pass pipeline use to lower dispatch region", [
+                    CPU_Default, CPU_BufferOpsDefault, CPU_DoubleTilingExpert,
+                    CPU_ConvTileAndDecomposeExpert, CPU_TileFuseAndVectorize,
+                    CPU_BufferOpsTileAndVectorize,
+                    Linalg_TransformInterpCodegen, LLVMGPU_SimpleDistribute,
+                    LLVMGPU_Vectorize, LLVMGPU_MatmulSimt,
+                    LLVMGPU_MatmulTensorCore, SPIRV_Distribute, SPIRV_Vectorize,
+                    SPIRV_VectorizeToCooperativeOps,
+                    SPIRV_VectorizeWithWorkgroupMemory, None
+                  ]> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Codegen";
   // Don't generate a C++ class! We want to use the AttrDef
   let genSpecializedAttr = 0;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -198,6 +198,9 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
           case IREE::Codegen::DispatchLoweringPassPipeline::None:
             addCPUDefaultPassPipeline(nestedModulePM);
             break;
+          case IREE::Codegen::DispatchLoweringPassPipeline::CPUBufferOpsDefault:
+            addCPUBufferOpsDefaultPipeline(nestedModulePM);
+            break;
           case IREE::Codegen::DispatchLoweringPassPipeline::
               CPUBufferOpsTileAndVectorize:
             addCPUBufferOpsTileAndVectorizePipeline(nestedModulePM);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -371,6 +371,16 @@ void addTileFuseAndVectorizePassPipeline(OpPassManager &passManager,
   passManager.addNestedPass<func::FuncOp>(createOptimizeVectorTransferPass());
 }
 
+void addCPUBufferOpsDefaultPipeline(OpPassManager &passManager) {
+  passManager.addNestedPass<func::FuncOp>(createInsertDistributionInfoPass());
+  passManager.addNestedPass<func::FuncOp>(
+      createTileAndDistributeToWorkgroupsPass());
+  passManager.addNestedPass<func::FuncOp>(
+      createFoldAffineMinInDistributedLoopsPass());
+  passManager.addPass(createCanonicalizerPass());
+  passManager.addPass(createCSEPass());
+}
+
 void addCPUDefaultPassPipeline(OpPassManager &passManager) {
   // Do first level of tile and distribute to workgroups.
   passManager.addNestedPass<func::FuncOp>(createInsertDistributionInfoPass());
@@ -381,13 +391,10 @@ void addCPUDefaultPassPipeline(OpPassManager &passManager) {
   passManager.addPass(createCanonicalizerPass());
   passManager.addPass(createCSEPass());
 
-  // TODO(#9004): Use upstream bufferization once the bufferization of LinalgExt
-  // ops are implemented.
-  // passManager.addNestedPass<func::FuncOp>(
-  // createConvertToDestinationPassingStylePass());
-  // passManager.addPass(createCanonicalizerPass());
-  // addCPUIREEComprehensiveBufferizePasses(passManager);
-  addLinalgBufferizePasses(passManager, cpuAllocationFunction);
+  passManager.addNestedPass<func::FuncOp>(
+      createConvertToDestinationPassingStylePass());
+  passManager.addPass(createCanonicalizerPass());
+  addCPUIREEComprehensiveBufferizePasses(passManager);
 }
 
 void addLinalgTransformInterpPasses(OpPassManager &passManager) {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD
@@ -28,6 +28,7 @@ iree_lit_test_suite(
             "linalg_transform.mlir",
             "materialize_aarch64_launch_configuration.mlir",
             "materialize_riscv_launch_configuration.mlir",
+            "materialize_vmvx_launch_configuration.mlir",
             "materialize_x86_64_launch_configuration.mlir",
             "pipeline_tests.mlir",
             "synchronize_symbol_visibility.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_lit_test_suite(
     "linalg_transform.mlir"
     "materialize_aarch64_launch_configuration.mlir"
     "materialize_riscv_launch_configuration.mlir"
+    "materialize_vmvx_launch_configuration.mlir"
     "materialize_x86_64_launch_configuration.mlir"
     "pipeline_tests.mlir"
     "synchronize_symbol_visibility.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_vmvx_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_vmvx_launch_configuration.mlir
@@ -1,0 +1,119 @@
+// RUN: iree-opt -pass-pipeline='hal.executable(hal.executable.variant(iree-llvmcpu-lower-executable-target{test-lowering-configuration=true}))' -split-input-file %s | FileCheck %s
+
+#executable_layout = #hal.executable.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable private @matmul_static  {
+  hal.executable.variant @vmvx_bytecode_fb, target = <"vmvx", "vmvx-bytecode-fb"> {
+    hal.executable.entry_point public @matmul_static layout(#executable_layout)
+    builtin.module {
+      func.func @matmul_static() {
+        %cst = arith.constant 0.0 : f32
+        %lhs_binding = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:384x512xf32>
+        %rhs_binding = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<readonly:512x128xf32>
+        %result_binding = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : !flow.dispatch.tensor<writeonly:384x128xf32>
+        %lhs = flow.dispatch.tensor.load %lhs_binding, offsets = [0, 0], sizes = [384, 512], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:384x512xf32> -> tensor<384x512xf32>
+        %rhs = flow.dispatch.tensor.load %rhs_binding, offsets = [0, 0], sizes = [512, 128], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:512x128xf32> -> tensor<512x128xf32>
+        %init = linalg.init_tensor [384, 128] : tensor<384x128xf32>
+        %fill = linalg.fill ins(%cst : f32) outs(%init : tensor<384x128xf32>) -> tensor<384x128xf32>
+        %gemm = linalg.matmul ins(%lhs, %rhs : tensor<384x512xf32>, tensor<512x128xf32>)
+            outs(%fill : tensor<384x128xf32>) -> tensor<384x128xf32>
+        flow.dispatch.tensor.store %gemm, %result_binding, offsets = [0, 0], sizes = [384, 128], strides = [1, 1]
+            : tensor<384x128xf32> -> !flow.dispatch.tensor<writeonly:384x128xf32>
+        return
+      }
+    }
+  }
+}
+
+//  CHECK-DAG: #[[CONFIG:.+]] =  #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0]]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
+//      CHECK: hal.executable.entry_point public @matmul_static
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//      CHECK: linalg.matmul
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
+
+// -----
+
+#executable_layout = #hal.executable.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>
+  ]>
+]>
+hal.executable @copy_op_dynamic {
+  hal.executable.variant @vmvx_bytecode_fb, target = <"vmvx", "vmvx-bytecode-fb"> {
+    hal.executable.entry_point @copy_op_dynamic layout(#executable_layout)
+    builtin.module {
+      func.func @copy_op_dynamic() {
+        %d0 = hal.interface.constant.load[0] : index
+        %d1 = hal.interface.constant.load[1] : index
+        %d2 = hal.interface.constant.load[2] : index
+        %d3 = hal.interface.constant.load[3] : index
+        %o0 = hal.interface.constant.load[4] : index
+        %o1 = hal.interface.constant.load[5] : index
+        %source = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<?x?xi32>{%d0, %d1}
+        %dest = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<?x?xi32>{%d2, %d3}
+        %dest_view = memref.subview %dest[%o0, %o1] [%d0, %d1] [1, 1] : memref<?x?xi32> to memref<?x?xi32, offset : ?, strides : [?, ?]>
+        linalg.generic {
+            indexing_maps = [affine_map<(d0, d1) -> (d0, d1)> , affine_map<(d0, d1) -> (d0, d1)>],
+            iterator_types = ["parallel", "parallel"]}
+            ins(%source : memref<?x?xi32>) outs(%dest_view : memref<?x?xi32, offset : ?, strides : [?, ?]>) {
+          ^bb0(%arg0 : i32, %arg1 : i32):
+            linalg.yield %arg0 : i32
+          }
+        return
+      }
+    }
+  }
+}
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64]]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUBufferOpsDefault>
+//      CHECK: hal.executable.entry_point public @copy_op_dynamic
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//      CHECK:   linalg.generic
+// CHECK-SAME:       lowering_config = #[[CONFIG]]
+
+// -----
+
+#executable_layout = #hal.executable.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>
+  ]>
+]>
+hal.executable private @static_1d_fft_stage2  {
+  hal.executable.variant @vmvx_bytecode_fb, target = <"vmvx", "vmvx-bytecode-fb"> {
+    hal.executable.entry_point @static_1d_fft_stage2 layout(#executable_layout)
+    builtin.module {
+      func.func @static_1d_fft_stage2() {
+        %c0 = arith.constant 0 : index
+        %c2 = arith.constant 2 : index
+        %cst = arith.constant dense<[1.000000e+00, 6.12323426E-17]> : tensor<2xf32>
+        %cst_0 = arith.constant dense<[-0.000000e+00, -1.000000e+00]> : tensor<2xf32>
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readwrite:32xf32>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<readwrite:32xf32>
+        %2 = flow.dispatch.tensor.load %0, offsets = [0], sizes = [32], strides = [1] : !flow.dispatch.tensor<readwrite:32xf32> -> tensor<32xf32>
+        %3 = flow.dispatch.tensor.load %1, offsets = [0], sizes = [32], strides = [1] : !flow.dispatch.tensor<readwrite:32xf32> -> tensor<32xf32>
+        %4:2 = iree_linalg_ext.fft {__internal_linalg_transform__ = "workgroup"} ins(%c2, %cst, %cst_0 : index, tensor<2xf32>, tensor<2xf32>) outs(%2, %3 : tensor<32xf32>, tensor<32xf32>) : tensor<32xf32>, tensor<32xf32>
+        flow.dispatch.tensor.store %4#0, %0, offsets = [0], sizes = [32], strides = [1] : tensor<32xf32> -> !flow.dispatch.tensor<readwrite:32xf32>
+        flow.dispatch.tensor.store %4#1, %1, offsets = [0], sizes = [32], strides = [1] : tensor<32xf32> -> !flow.dispatch.tensor<readwrite:32xf32>
+        return
+      }
+    }
+  }
+}
+
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64]{{\]}}>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
+//       CHECK: hal.executable.entry_point public @static_1d_fft_stage2
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//       CHECK: func @static_1d_fft_stage2()
+//       CHECK:   iree_linalg_ext.fft
+//  CHECK-SAME:       lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -255,6 +255,11 @@ void populateUnfusedFMAOpsPassPatterns(MLIRContext *context,
 /// to memrefs
 void addCPUDefaultPassPipeline(OpPassManager &passManager);
 
+/// Populates the passes to lower to scalars operations for linalg based
+/// code-generation. Different from CPUDefault pipeline, this pipeline intends
+/// to handle early bufferized kernels.
+void addCPUBufferOpsDefaultPipeline(OpPassManager &passManager);
+
 /// Populates the passes to lower linalg ops on buffers. Currenly this pipeline
 /// is only used for dispatches that just copy data from input interfaces to
 /// output interface.


### PR DESCRIPTION
A new pipeline is created because the default pipeline can not handle early bufferized kernels. This can be addressed when switching to use IREEComprehensiveBufferize in BufferizeCopyOnlyDispatchesPass. See https://github.com/google/iree/issues/9047 for more details.

This also adds missing materialization tests for VMVX target.