### PR TITLE
IREE LinalgExt TopK e2e Tests

### DIFF
--- a/iree/test/e2e/linalg_ext_ops/BUILD
+++ b/iree/test/e2e/linalg_ext_ops/BUILD
@@ -20,6 +20,7 @@ iree_check_single_backend_test_suite(
         [
             "reverse.mlir",
             "scan.mlir",
+            "top-k.mlir",
         ],
         include = ["*.mlir"],
     ),
@@ -42,6 +43,7 @@ iree_check_single_backend_test_suite(
         [
             "reverse.mlir",
             "scan.mlir",
+            "top-k.mlir",
         ],
         include = ["*.mlir"],
     ),
@@ -56,6 +58,7 @@ iree_check_single_backend_test_suite(
         [
             "reverse.mlir",
             "scan.mlir",
+            "top-k.mlir",
         ],
         include = ["*.mlir"],
     ),
@@ -69,6 +72,7 @@ iree_check_single_backend_test_suite(
         # keep sorted
         [
             "reverse.mlir",
+            "top-k.mlir",
         ],
         include = ["*.mlir"],
         exclude = [

--- a/iree/test/e2e/linalg_ext_ops/CMakeLists.txt
+++ b/iree/test/e2e/linalg_ext_ops/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_check_single_backend_test_suite(
   SRCS
     "reverse.mlir"
     "scan.mlir"
+    "top-k.mlir"
   TARGET_BACKEND
     "cuda"
   DRIVER
@@ -34,6 +35,7 @@ iree_check_single_backend_test_suite(
   SRCS
     "reverse.mlir"
     "scan.mlir"
+    "top-k.mlir"
   TARGET_BACKEND
     "dylib-llvm-aot"
   DRIVER
@@ -46,6 +48,7 @@ iree_check_single_backend_test_suite(
   SRCS
     "reverse.mlir"
     "scan.mlir"
+    "top-k.mlir"
   TARGET_BACKEND
     "vmvx"
   DRIVER
@@ -57,6 +60,7 @@ iree_check_single_backend_test_suite(
     check_vulkan-spirv_vulkan
   SRCS
     "reverse.mlir"
+    "top-k.mlir"
   TARGET_BACKEND
     "vulkan-spirv"
   DRIVER

--- a/iree/test/e2e/linalg_ext_ops/top-k.mlir
+++ b/iree/test/e2e/linalg_ext_ops/top-k.mlir
@@ -1,0 +1,128 @@
+func.func @topk_1d_dim0_max() {
+  %input_values = util.unfoldable_constant dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]> : tensor<10xf32>
+  %input_indices = util.unfoldable_constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]> : tensor<10xi32>
+
+  %out_values_empty = linalg.init_tensor [3] : tensor<3xf32>
+  %out_indices_empty = linalg.init_tensor [3] : tensor<3xi32>
+  %neg_inf = arith.constant 0xFF800000 : f32
+  %c0 = arith.constant 0 : i32
+  %out_values = linalg.fill ins(%neg_inf : f32) outs(%out_values_empty : tensor<3xf32>) -> tensor<3xf32>
+  %out_indices = linalg.fill ins(%c0 : i32) outs(%out_indices_empty : tensor<3xi32>) -> tensor<3xi32>
+  %0:2 = iree_linalg_ext.topk
+        dimension(0)
+        ins(%input_values, %input_indices : tensor<10xf32> , tensor<10xi32>)
+        outs(%out_values, %out_indices : tensor<3xf32>, tensor<3xi32>) {
+        ^bb0(%arg0 : f32, %arg1 : f32):
+         %0 = arith.cmpf ogt, %arg0, %arg1 : f32
+         iree_linalg_ext.yield %0 : i1
+        } -> tensor<3xf32>, tensor<3xi32>
+
+  check.expect_almost_eq_const(
+      %0#0,
+      dense<[10.0, 9.0, 8.0]> : tensor<3xf32>
+  ) : tensor<3xf32>
+
+  check.expect_eq_const(
+      %0#1,
+      dense<[9, 8, 7]> : tensor<3xi32>
+  ) : tensor<3xi32>
+
+  return
+}
+
+func.func @topk_1d_dim0_min() {
+  %input_values = util.unfoldable_constant dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]> : tensor<10xf32>
+  %input_indices = util.unfoldable_constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]> : tensor<10xi32>
+
+  %out_values_empty = linalg.init_tensor [3] : tensor<3xf32>
+  %out_indices_empty = linalg.init_tensor [3] : tensor<3xi32>
+  %pos_inf = arith.constant 0x7F800000 : f32
+  %c0 = arith.constant 0 : i32
+  %out_values = linalg.fill ins(%pos_inf : f32) outs(%out_values_empty : tensor<3xf32>) -> tensor<3xf32>
+  %out_indices = linalg.fill ins(%c0 : i32) outs(%out_indices_empty : tensor<3xi32>) -> tensor<3xi32>
+  %0:2 = iree_linalg_ext.topk
+        dimension(0)
+        ins(%input_values, %input_indices : tensor<10xf32> , tensor<10xi32>)
+        outs(%out_values, %out_indices : tensor<3xf32>, tensor<3xi32>) {
+        ^bb0(%arg0 : f32, %arg1 : f32):
+         %0 = arith.cmpf olt, %arg0, %arg1 : f32
+         iree_linalg_ext.yield %0 : i1
+        } -> tensor<3xf32>, tensor<3xi32>
+
+  check.expect_almost_eq_const(
+      %0#0,
+      dense<[1.0, 2.0, 3.0]> : tensor<3xf32>
+  ) : tensor<3xf32>
+
+  check.expect_eq_const(
+      %0#1,
+      dense<[0, 1, 2]> : tensor<3xi32>
+  ) : tensor<3xi32>
+
+  return
+}
+
+
+func.func @topk_2d_dim1_max() {
+  %input_values = util.unfoldable_constant dense<[[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],[ 7.0, 8.0, 9.0, 10.0, 11.0, 12.0]]> : tensor<2x6xf32>
+  %input_indices = util.unfoldable_constant dense<[[0, 1, 2, 3, 4, 5],[6, 7, 8, 9, 10, 11]]> : tensor<2x6xi32>
+
+  %out_values_empty = linalg.init_tensor [2, 3] : tensor<2x3xf32>
+  %out_indices_empty = linalg.init_tensor [2, 3] : tensor<2x3xi32>
+  %neg_inf = arith.constant 0xFF800000 : f32
+  %c0 = arith.constant 0 : i32
+  %out_values = linalg.fill ins(%neg_inf : f32) outs(%out_values_empty : tensor<2x3xf32>) -> tensor<2x3xf32>
+  %out_indices = linalg.fill ins(%c0 : i32) outs(%out_indices_empty : tensor<2x3xi32>) -> tensor<2x3xi32>
+  %0:2 = iree_linalg_ext.topk
+        dimension(1)
+        ins(%input_values, %input_indices : tensor<2x6xf32> , tensor<2x6xi32>)
+        outs(%out_values_empty, %out_indices : tensor<2x3xf32>, tensor<2x3xi32>) {
+        ^bb0(%arg0 : f32, %arg1 : f32):
+         %0 = arith.cmpf ogt, %arg0, %arg1 : f32
+         iree_linalg_ext.yield %0 : i1
+        } -> tensor<2x3xf32>, tensor<2x3xi32>
+
+  check.expect_almost_eq_const(
+      %0#0,
+      dense<[[6.0, 5.0, 4.0],[12.0, 11.0, 10.0]]> : tensor<2x3xf32>
+  ) : tensor<2x3xf32>
+
+  check.expect_eq_const(
+      %0#1,
+      dense<[[5, 4, 3],[11, 10, 9]]> : tensor<2x3xi32>
+  ) : tensor<2x3xi32>
+
+  return
+}
+
+func.func @topk_2d_dim1_inverted_max() {
+  %input_values = util.unfoldable_constant dense<[[6.0, 5.0, 4.0, 3.0, 2.0, 1.0], [7.0, 8.0, 9.0, 10.0, 11.0, 12.0]]> : tensor<2x6xf32>
+  %input_indices = util.unfoldable_constant dense<[[0, 1, 2, 3, 4, 5],[6, 7, 8, 9, 10, 11]]> : tensor<2x6xi32>
+
+  %out_values_empty = linalg.init_tensor [2, 3] : tensor<2x3xf32>
+  %out_indices_empty = linalg.init_tensor [2, 3] : tensor<2x3xi32>
+  %neg_inf = arith.constant 0xFF800000 : f32
+  %c0 = arith.constant 0 : i32
+  %out_values = linalg.fill ins(%neg_inf : f32) outs(%out_values_empty : tensor<2x3xf32>) -> tensor<2x3xf32>
+  %out_indices = linalg.fill ins(%c0 : i32) outs(%out_indices_empty : tensor<2x3xi32>) -> tensor<2x3xi32>
+  %0:2 = iree_linalg_ext.topk
+        dimension(1)
+        ins(%input_values, %input_indices : tensor<2x6xf32> , tensor<2x6xi32>)
+        outs(%out_values, %out_indices : tensor<2x3xf32>, tensor<2x3xi32>) {
+        ^bb0(%arg0 : f32, %arg1 : f32):
+         %0 = arith.cmpf ogt, %arg0, %arg1 : f32
+         iree_linalg_ext.yield %0 : i1
+        } -> tensor<2x3xf32>, tensor<2x3xi32>
+
+  check.expect_almost_eq_const(
+      %0#0,
+      dense<[[6.0, 5.0, 4.0],[12.0, 11.0, 10.0]]> : tensor<2x3xf32>
+  ) : tensor<2x3xf32>
+
+  check.expect_eq_const(
+      %0#1,
+      dense<[[0, 1, 2],[11, 10, 9]]> : tensor<2x3xi32>
+  ) : tensor<2x3xi32>
+
+  return
+}

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -80,7 +80,7 @@ static Value getSlice(OpBuilder &b, Location loc, Value source,
       .Default([&](Type t) { return nullptr; });
 }
 
-/// Returns true if the dimensions of ShapedType are dynamic or equal.
+/// Returns true if the dimensions of ShapedType aren't dynamic or aren't equal.
 static bool isShapedTypeDimEqual(int64_t lhs, int64_t rhs) {
   return lhs != ShapedType::kDynamicSize && rhs != ShapedType::kDynamicSize &&
          lhs != rhs;
@@ -1421,7 +1421,8 @@ Operation *TopkOp::getTiledImplementation(OpBuilder &builder,
 
   for (auto result : llvm::enumerate(tiledTopkOp->getResults())) {
     auto insertSliceOp = builder.create<tensor::InsertSliceOp>(
-        loc, result.value(), outputs[result.index()], offsets, sizes, strides);
+        loc, result.value(), outputs[result.index()], offsets, outputSizes,
+        strides);
     results.push_back(insertSliceOp.getResult());
   }
   return tiledTopkOp;

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tiling.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tiling.mlir
@@ -842,8 +842,8 @@ func @topk_tile_tensor(%input_values: tensor<?x?xf32>, %input_indices: tensor<?x
 // CHECK-SAME:      dimension(1)
 // CHECK-SAME:      ins(%[[D4]], %[[D5]]
 // CHECK-SAME:      outs(%[[D6]], %[[D7]]
-// CHECK:           %[[D9:.+]] = tensor.insert_slice %[[D8]]#0 into %[[ARG5]][%[[ARG4]], 0] [%[[D3]], %[[D1]]] [1, 1]
-// CHECK:           %[[D10:.+]] = tensor.insert_slice %[[D8]]#1 into %[[ARG6]][%[[ARG4]], 0] [%[[D3]], %[[D1]]] [1, 1]
+// CHECK:           %[[D9:.+]] = tensor.insert_slice %[[D8]]#0 into %[[ARG5]][%[[ARG4]], 0] [%[[D3]], %[[C3]]] [1, 1]
+// CHECK:           %[[D10:.+]] = tensor.insert_slice %[[D8]]#1 into %[[ARG6]][%[[ARG4]], 0] [%[[D3]], %[[C3]]] [1, 1]
 // CHECK:           scf.yield %[[D9]], %[[D10]]
 // CHECK:           return %[[RESULT]]#0, %[[RESULT]]#1
 


### PR DESCRIPTION
In addition, resolves a bug where the return tensors were incorrectly using the input sizes for slicing instead of the output sizes. 