### PR TITLE
Escape benchmark comment title before matching

### DIFF
--- a/build_tools/benchmarks/post_benchmarks_as_pr_comment.py
+++ b/build_tools/benchmarks/post_benchmarks_as_pr_comment.py
@@ -246,7 +246,8 @@ def get_previous_comment_on_pr(pr_number: str,
   # Find the last comment from GITHUB_USER and has the ABBR_PR_COMMENT_TITILE
   # keyword.
   for comment in reversed(response):
-    if (comment["user"]["login"] == GITHUB_USER) and (comment_title
+    escaped_title = md.esc_format(comment_title)
+    if (comment["user"]["login"] == GITHUB_USER) and (escaped_title
                                                       in comment["body"]):
       return comment["id"]
   return None

--- a/build_tools/buildkite/cmake/linux/x86_64/benchmark.yml
+++ b/build_tools/buildkite/cmake/linux/x86_64/benchmark.yml
@@ -46,7 +46,7 @@ steps:
     commands:
       - "git clean -fdx"
       - "buildkite-agent artifact download benchmark-results-*.json ./"
-      - "python3 build_tools/benchmarks/post_benchmarks_as_pr_comment.py --verbose --query-base --comment-title=\"Abbreviated x86-64 Benchmark Summary (experimental)\" benchmark-results-*.json"
+      - "python3 build_tools/benchmarks/post_benchmarks_as_pr_comment.py --verbose --query-base --comment-title=\"Abbreviated x86_64 Benchmark Summary (experimental)\" benchmark-results-*.json"
     key: "post-on-pr-x86_64"
     if: "build.pull_request.id != null && (build.pull_request.labels includes 'buildkite:benchmark-x86_64')"
     agents:

--- a/build_tools/buildkite/cmake/linux/x86_64/benchmark.yml
+++ b/build_tools/buildkite/cmake/linux/x86_64/benchmark.yml
@@ -46,7 +46,7 @@ steps:
     commands:
       - "git clean -fdx"
       - "buildkite-agent artifact download benchmark-results-*.json ./"
-      - "python3 build_tools/benchmarks/post_benchmarks_as_pr_comment.py --verbose --query-base --comment-title=\"Abbreviated x86_64 Benchmark Summary (experimental)\" benchmark-results-*.json"
+      - "python3 build_tools/benchmarks/post_benchmarks_as_pr_comment.py --verbose --query-base --comment-title=\"Abbreviated x86-64 Benchmark Summary (experimental)\" benchmark-results-*.json"
     key: "post-on-pr-x86_64"
     if: "build.pull_request.id != null && (build.pull_request.labels includes 'buildkite:benchmark-x86_64')"
     agents:


### PR DESCRIPTION
Escape the title before matching with the previous comment posts, so the `_` in the title won't cause the matching failed.