### PR TITLE
Add initial benchmarking features to WebAssembly experiments.

### DIFF
--- a/experimental/web/generate_web_metrics.sh
+++ b/experimental/web/generate_web_metrics.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Generate metrics for a set of programs using IREE's WebAssembly backend.
+#
+# Intended for interactive developer use, so this generates lots of output
+# files for manual inspection outside of the script.
+#
+# Script steps:
+#   * Install IREE tools into a Python virtual environment (venv)
+#   * Download program source files (.tflite files from GCS)
+#   * Import programs into MLIR (.tflite -> .mlir)
+#   * Compile programs for WebAssembly (.mlir -> .vmfb, intermediates)
+#   * (TODO) Print statistics that can be produced by a script (i.e. no
+#     launching a webpage and waiting for benchmark results there)
+#
+# Sample usage 1:
+#   generate_web_metrics.sh /tmp/iree/web_metrics/
+#
+#   then look in that directory for any files you want to process further,
+#   and/or run run_native_benchmarks.sh to get native metrics for comparison
+#
+# Sample usage 2:
+#   sample_dynamic/build_sample.sh (optional install path)
+#   generate_web_metrics.sh /tmp/iree/web_metrics/
+#   sample_dynamic/serve_sample.sh
+#
+#   then open http://localhost:8000/benchmarks.html (for automated benchmarks)
+#   or open http://localhost:8000/ (for interactive benchmarks)
+
+set -e
+
+TARGET_DIR="$1"
+if [ -z "$TARGET_DIR" ]; then
+  echo "ERROR: Expected target directory (e.g. /tmp/iree/web_metrics/)"
+  exit 1
+fi
+
+# If used in conjunction with sample_dynamic/build_sample.sh, this script can
+# copy compiled programs into that sample's build directory for benchmarking.
+ROOT_DIR=$(git rev-parse --show-toplevel)
+BUILD_DIR=${ROOT_DIR?}/build-emscripten
+SAMPLE_BINARY_DIR=${BUILD_DIR}/experimental/web/sample_dynamic/
+
+echo "Working in directory '$TARGET_DIR'"
+mkdir -p ${TARGET_DIR}
+cd ${TARGET_DIR}
+
+# Print all commands and the UTC time.
+# set -xeuo pipefail
+# export PS4='[$(date -u "+%T %Z")] '
+
+###############################################################################
+# Set up Python virtual environment                                           #
+###############################################################################
+
+python -m venv .venv
+source .venv/bin/activate
+trap "deactivate 2> /dev/null" EXIT
+
+# Skip package installs when you want by commenting this out. Freezing to a
+# specific version when iterating on metrics is useful, and fetching is slow.
+
+python -m pip install --upgrade \
+  --find-links https://github.com/google/iree/releases \
+  iree-compiler iree-tools-tflite iree-tools-xla
+
+###############################################################################
+# Download program source files                                               #
+###############################################################################
+
+wget -nc https://storage.googleapis.com/iree-model-artifacts/mobile_ssd_v2_float_coco.tflite
+wget -nc https://storage.googleapis.com/iree-model-artifacts/deeplabv3.tflite
+wget -nc https://storage.googleapis.com/iree-model-artifacts/posenet.tflite
+wget -nc https://storage.googleapis.com/iree-model-artifacts/mobilebert-baseline-tf2-float.tflite
+wget -nc https://storage.googleapis.com/iree-model-artifacts/mobilenet_v2_1.0_224.tflite
+wget -nc https://storage.googleapis.com/iree-model-artifacts/MobileNetV3SmallStaticBatch.tflite
+
+###############################################################################
+# Import programs into MLIR                                                   #
+###############################################################################
+
+# Note: you can also download imported programs from runs of the
+# https://buildkite.com/iree/iree-benchmark-android pipeline.
+
+IREE_IMPORT_TFLITE_PATH=iree-import-tflite
+
+# import_program helper
+#   Args: program_name, tflite_source_path
+#   Imports tflite_source_path to program_name.tflite.mlir
+function import_program {
+  OUTPUT_FILE=./$1.tflite.mlir
+  echo "Importing '$1' to '${OUTPUT_FILE}'..."
+  ${IREE_IMPORT_TFLITE_PATH?} $2 -o ${OUTPUT_FILE}
+}
+
+import_program "deeplabv3" "deeplabv3.tflite"
+import_program "mobile_ssd_v2_float_coco" "mobile_ssd_v2_float_coco.tflite"
+import_program "posenet" "posenet.tflite"
+import_program "mobilebertsquad" "./mobilebert-baseline-tf2-float.tflite"
+import_program "mobilenet_v2_1.0_224" "./mobilenet_v2_1.0_224.tflite"
+import_program "MobileNetV3SmallStaticBatch" "MobileNetV3SmallStaticBatch.tflite"
+
+###############################################################################
+# Compile programs                                                            #
+###############################################################################
+
+# Either build from source (setting this path), or use from the python packages.
+# IREE_COMPILE_PATH=~/code/iree-build/iree/tools/iree-compile
+IREE_COMPILE_PATH="D:\dev\projects\iree-build\iree\tools\iree-compile"
+# IREE_COMPILE_PATH=iree-compile
+
+# compile_program_wasm helper
+#   Args: program_name
+#   Compiles program_name.tflite.mlir to program_name_wasm.vmfb, dumping
+#   statistics and intermediate files to disk.
+function compile_program_wasm {
+  INPUT_FILE=./$1.tflite.mlir
+  OUTPUT_FILE=./$1_wasm.vmfb
+  echo "Compiling '${INPUT_FILE}' to '${OUTPUT_FILE}'..."
+
+  ARTIFACTS_DIR=./$1-wasm_artifacts/
+  mkdir -p ${ARTIFACTS_DIR}
+
+  # Compile from .mlir to .vmfb, dumping all the intermediate files and
+  # compile-time statistics that we can.
+  ${IREE_COMPILE_PATH?} ${INPUT_FILE} \
+    --iree-input-type=tosa \
+    --iree-hal-target-backends=llvm \
+    --iree-llvm-target-triple=wasm32-unknown-emscripten \
+    --iree-hal-dump-executable-sources-to=${ARTIFACTS_DIR} \
+    --iree-hal-dump-executable-binaries-to=${ARTIFACTS_DIR} \
+    --iree-scheduling-dump-statistics-format=csv \
+    --iree-scheduling-dump-statistics-file=${ARTIFACTS_DIR}/$1_statistics.csv \
+    --o ${OUTPUT_FILE}
+
+  # Compress the .vmfb file (ideally it would be compressed already, but we can
+  # expect some compression support from platforms like the web).
+  gzip -k -f ${OUTPUT_FILE}
+
+  if [ -d "$SAMPLE_BINARY_DIR" ]; then
+    echo "Copying '${OUTPUT_FILE}' to '${SAMPLE_BINARY_DIR}' for benchmarking"
+    cp ${OUTPUT_FILE} ${SAMPLE_BINARY_DIR}
+  fi
+}
+
+# compile_program_native helper
+#   Args: program_name
+#   Compiles program_name.tflite.mlir to program_name_native.vmfb, dumping
+#   statistics and intermediate files to disk.
+function compile_program_native {
+  INPUT_FILE=./$1.tflite.mlir
+  OUTPUT_FILE=./$1_native.vmfb
+  echo "Compiling '${INPUT_FILE}' to '${OUTPUT_FILE}'..."
+
+  ARTIFACTS_DIR=./$1-native_artifacts/
+  mkdir -p ${ARTIFACTS_DIR}
+
+  # Compile from .mlir to .vmfb, dumping all the intermediate files and
+  # compile-time statistics that we can.
+  ${IREE_COMPILE_PATH?} ${INPUT_FILE} \
+    --iree-input-type=tosa \
+    --iree-hal-target-backends=llvm \
+    --iree-hal-dump-executable-sources-to=${ARTIFACTS_DIR} \
+    --iree-hal-dump-executable-binaries-to=${ARTIFACTS_DIR} \
+    --iree-scheduling-dump-statistics-format=csv \
+    --iree-scheduling-dump-statistics-file=${ARTIFACTS_DIR}/$1_statistics.csv \
+    --o ${OUTPUT_FILE}
+
+  # Compress the .vmfb file (ideally it would be compressed already, but we can
+  # expect some compression support from platforms like the web).
+  gzip -k -f ${OUTPUT_FILE}
+}
+
+# compile_program helper
+#   Args: program_name
+#   Wraps compile_program_wasm and compile_program_native.
+function compile_program {
+  compile_program_wasm $1
+  compile_program_native $1
+}
+
+compile_program "deeplabv3"
+compile_program "mobile_ssd_v2_float_coco"
+compile_program "posenet"
+compile_program "mobilebertsquad"
+compile_program "mobilenet_v2_1.0_224"
+compile_program "MobileNetV3SmallStaticBatch"
+
+###############################################################################
+# TODO: collect/summarize statistics (manual inspection or scripted)
+#   * .vmfb size
+#   * number of executables
+#   * size of each executable (data size)
+#   * size of constants

--- a/experimental/web/run_native_benchmarks.sh
+++ b/experimental/web/run_native_benchmarks.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Run native benchmarks to compare with WebAssembly.
+#
+# Sample usage (after generate_web_metrics.sh):
+#   run_native_benchmarks.sh /tmp/iree/web_metrics/
+
+set -e
+
+TARGET_DIR="$1"
+if [ -z "$TARGET_DIR" ]; then
+  echo "ERROR: Expected target directory (e.g. /tmp/iree/web_metrics/)"
+  exit 1
+fi
+echo "Working in directory '$TARGET_DIR'"
+mkdir -p ${TARGET_DIR}
+cd ${TARGET_DIR}
+
+# Print all commands and the UTC time.
+# set -xeuo pipefail
+# export PS4='[$(date -u "+%T %Z")] '
+
+###############################################################################
+# Run benchmarks                                                              #
+###############################################################################
+
+# Either build from source (setting this path), or use from the python packages.
+# IREE_BENCHMARK_MODULE_PATH=~/code/iree-build/iree/tools/iree-benchmark-module
+IREE_BENCHMARK_MODULE_PATH="D:\dev\projects\iree-build\iree\tools\iree-benchmark-module"
+# IREE_BENCHMARK_MODULE_PATH=iree-benchmark-module
+
+echo "Benchmarking DeepLabV3..."
+${IREE_BENCHMARK_MODULE_PATH?} \
+    --module_file=./deeplabv3_native.vmfb \
+    --driver=dylib --task_topology_group_count=1 \
+    --entry_function=main --function_input=1x257x257x3xf32 \
+    --benchmark_min_time=3
+
+echo ""
+echo "Benchmarking MobileSSD..."
+${IREE_BENCHMARK_MODULE_PATH?} \
+    --module_file=./mobile_ssd_v2_float_coco_native.vmfb \
+    --driver=dylib --task_topology_group_count=1 \
+    --entry_function=main --function_input=1x320x320x3xf32 \
+    --benchmark_min_time=3
+
+echo ""
+echo "Benchmarking PoseNet..."
+${IREE_BENCHMARK_MODULE_PATH?} \
+    --module_file=./posenet_native.vmfb \
+    --driver=dylib --task_topology_group_count=1 \
+    --entry_function=main --function_input=1x353x257x3xf32 \
+    --benchmark_min_time=3
+
+echo ""
+echo "Benchmarking MobileBertSquad..."
+${IREE_BENCHMARK_MODULE_PATH?} \
+    --module_file=./mobilebertsquad_native.vmfb \
+    --driver=dylib --task_topology_group_count=1 \
+    --entry_function=main \
+    --function_input=1x384xi32 \
+    --function_input=1x384xi32 \
+    --function_input=1x384xi32 \
+    --benchmark_min_time=10
+
+echo ""
+echo "Benchmarking MobileNetV2..."
+${IREE_BENCHMARK_MODULE_PATH?} \
+    --module_file=./mobilenet_v2_1.0_224_native.vmfb \
+    --driver=dylib --task_topology_group_count=1 \
+    --entry_function=main --function_input=1x224x224x3xf32 \
+    --benchmark_min_time=3
+
+echo ""
+echo "Benchmarking MobileNetV3Small..."
+${IREE_BENCHMARK_MODULE_PATH?} \
+    --module_file=./MobileNetV3SmallStaticBatch_native.vmfb \
+    --driver=dylib --task_topology_group_count=1 \
+    --entry_function=main --function_input=1x224x224x3xf32 \
+    --benchmark_min_time=3

--- a/experimental/web/sample_dynamic/CMakeLists.txt
+++ b/experimental/web/sample_dynamic/CMakeLists.txt
@@ -35,7 +35,7 @@ target_link_libraries(${_NAME}
 
 target_link_options(${_NAME} PRIVATE
   # https://emscripten.org/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.html#interacting-with-code-ccall-cwrap
-  "-sEXPORTED_FUNCTIONS=['_setup_sample', '_cleanup_sample', '_load_program', '_unload_program', '_call_function']"
+  "-sEXPORTED_FUNCTIONS=['_setup_sample', '_cleanup_sample', '_load_program', '_inspect_program', '_unload_program', '_call_function']"
   "-sEXPORTED_RUNTIME_METHODS=['ccall','cwrap']"
   #
   "-sASSERTIONS=1"

--- a/experimental/web/sample_dynamic/benchmarks.html
+++ b/experimental/web/sample_dynamic/benchmarks.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html>
+
+<!--
+Copyright 2022 The IREE Authors
+
+Licensed under the Apache License v2.0 with LLVM Exceptions.
+See https://llvm.org/LICENSE.txt for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+<head>
+  <meta charset="utf-8" />
+  <title>IREE Dynamic Web Benchmarks</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" href="/ghost.svg" type="image/svg+xml">
+
+  <style>
+    body {
+      padding: 16px;
+    }
+  </style>
+
+  <!-- https://getbootstrap.com/ for some webpage styling-->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
+
+  <script src="./iree_api.js"></script>
+</head>
+
+<body>
+  <div class="container">
+    <h1>IREE Dynamic Web Benchmarks</h1>
+
+    <p>
+      <br><b>Note:</b> Some outputs are logged to the console.</p>
+    </p>
+
+    <!-- TODO: button to run startup benchmarks -->
+    <!-- TODO: button to run inference benchmarks -->
+    <!-- TODO: button to run all benchmarks -->
+    <!-- TODO: UI to set number of iterations -->
+
+  </div>
+
+  <script>
+
+    async function runProgramBenchmarks(programPath, functionName, inputs) {
+      // Program loading.
+      // The IREE runtime has already been initialized, so this:
+      //   * issues an XMLHttpRequest for the program data
+      //   * passes the program data in via the WebAssembly heap
+      //   * creates an IREE "runtime session" and loads the program into it
+      console.log("Running benchmarks for program '" + programPath +
+                  "' and function '" + functionName + "'");
+      const startLoadTime = performance.now();
+      const program = await ireeLoadProgram(programPath);
+      const totalLoadTime = performance.now() - startLoadTime;
+      console.log("  Application load time (including overheads): " +
+                  totalLoadTime.toFixed(3) + "ms");
+
+      // Function calling.
+      // The runtime is initialized and the program is loaded, so this:
+      //   * passes the inputs in as a string from JS to Wasm
+      //   * parses the inputs string into buffer data
+      //   * invokes the function
+      //   * formats the function outputs into a string and passes that to JS
+      const startCallTime = performance.now();
+      const iterations = 1;
+      const resultObject =
+          await ireeCallFunction(program, functionName, inputs, iterations);
+      const totalCallTime = performance.now() - startCallTime;
+      console.log("  Application call time (including overheads): " +
+                  totalCallTime.toFixed(3) + "ms");
+    }
+
+    async function runAllBenchmarks() {
+      await runProgramBenchmarks("deeplabv3_wasm.vmfb", "main", "1x257x257x3xf32");
+      await runProgramBenchmarks("mobile_ssd_v2_float_coco_wasm.vmfb", "main", "1x320x320x3xf32");
+      await runProgramBenchmarks("posenet_wasm.vmfb", "main", "1x353x257x3xf32");
+      await runProgramBenchmarks("mobilebertsquad_wasm.vmfb", "main", ["1x384xi32", "1x384xi32", "1x384xi32"]);
+      await runProgramBenchmarks("mobilenet_v2_1.0_224_wasm.vmfb", "main", "1x224x224x3xf32");
+      await runProgramBenchmarks("MobileNetV3SmallStaticBatch_wasm.vmfb", "main", "1x224x224x3xf32");
+    }
+
+    async function main() {
+      // General runtime initialization.
+      // The IREE API script has already been loaded, so this:
+      //   * initializes a Web Worker
+      //   * loads the IREE runtime worker script
+      //   * loads the IREE runtime JavaScript bundle (compiled via Emscripten)
+      //   * instantiates the IREE runtime WebAssembly module
+      //   * initializes the IREE runtime (runtime context, HAL devices, etc.)
+      //   * (if threading is enabled) creates worker thread Web Workers
+      const startInitTime = performance.now();
+      await ireeInitializeWorker();
+      const totalInitTime = performance.now() - startInitTime;
+      console.log("IREE runtime initialized after " + totalInitTime.toFixed(3) + "ms");
+
+      await runAllBenchmarks();
+    }
+
+    console.log("=== Running benchmarks ===");
+    main().then(() => { console.log("=== Finished running benchmarks ==="); })
+          .catch((error) => { console.error("Error: '" + error + "'"); });
+
+  </script>
+</body>
+
+</html>

--- a/experimental/web/sample_dynamic/build_sample.sh
+++ b/experimental/web/sample_dynamic/build_sample.sh
@@ -87,5 +87,6 @@ popd
 echo "=== Copying static files (.html, .js) to the build directory ==="
 
 cp ${SOURCE_DIR?}/index.html ${BINARY_DIR}
+cp ${ROOT_DIR?}/docs/website/overrides/ghost.svg ${BINARY_DIR}
 cp ${SOURCE_DIR?}/iree_api.js ${BINARY_DIR}
 cp ${SOURCE_DIR?}/iree_worker.js ${BINARY_DIR}

--- a/experimental/web/sample_dynamic/build_sample.sh
+++ b/experimental/web/sample_dynamic/build_sample.sh
@@ -87,6 +87,7 @@ popd
 echo "=== Copying static files (.html, .js) to the build directory ==="
 
 cp ${SOURCE_DIR?}/index.html ${BINARY_DIR}
+cp ${SOURCE_DIR?}/benchmarks.html ${BINARY_DIR}
 cp ${ROOT_DIR?}/docs/website/overrides/ghost.svg ${BINARY_DIR}
 cp ${SOURCE_DIR?}/iree_api.js ${BINARY_DIR}
 cp ${SOURCE_DIR?}/iree_worker.js ${BINARY_DIR}

--- a/experimental/web/sample_dynamic/index.html
+++ b/experimental/web/sample_dynamic/index.html
@@ -13,6 +13,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   <meta charset="utf-8" />
   <title>IREE Dynamic Web Sample</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" href="/ghost.svg" type="image/svg+xml">
 
   <style>
     body {

--- a/experimental/web/sample_dynamic/index.html
+++ b/experimental/web/sample_dynamic/index.html
@@ -73,8 +73,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <form>
       <p>
         <label for="function-name-input" class="form-label">Function name:</label>
-        <input type="text" id="function-name-input"
-              class="form-control" style="width:400px; font-family: monospace;" value="main"></input>
+        <input type="text" id="function-name-input" class="form-control"
+               style="width:400px; font-family: monospace;" value="main"></input>
       </p>
 
       <p>
@@ -82,6 +82,13 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <br><span class="form-text">In the form <code>dim1xdim2xtype=val1,val2,...</code>, one per line</span>
         <textarea type="text" id="function-arguments-input" spellcheck="false" class="form-control"
                   style="min-width:400px; width:initial; min-height:100px; resize:both; font-family: monospace;"></textarea>
+      </p>
+
+      <p>
+        <label for="benchmark-iterations-input" class="form-label">
+          Benchmark iterations (inner invoke call):</label>
+        <input type="number" id="benchmark-iterations-input" class="form-control"
+               style="width:400px; font-family: monospace;" value="1" min="1"></input>
       </p>
 
       <button id="call-function" class="btn btn-primary" type="button"
@@ -97,6 +104,11 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
       <textarea type="text" id="function-outputs" readonly spellcheck="false" class="form-control"
                 style="min-width:400px; width:initial; height:100px; resize:both; font-family: monospace;"></textarea>
     </p>
+
+    <p>Total time (including overheads):
+      <code id="benchmark-time-js-output" style="font-family: monospace;"></code></p>
+    <p>Mean inference time (Wasm only):
+      <code id="benchmark-time-wasm-output" style="font-family: monospace;"></code></p>
 
     <hr>
     <h2>Samples</h2>
@@ -163,7 +175,10 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     const callFunctionButton = document.getElementById("call-function");
     const functionNameInput = document.getElementById("function-name-input");
     const functionArgumentsInput = document.getElementById("function-arguments-input");
+    const benchmarkIterationsInput = document.getElementById("benchmark-iterations-input");
     const functionOutputsElement = document.getElementById("function-outputs");
+    const timeJsOutputElement = document.getElementById("benchmark-time-js-output");
+    const timeWasmOutputElement = document.getElementById("benchmark-time-wasm-output");
 
     async function finishLoadingProgram(newProgram, newProgramName) {
       if (loadedProgram !== null) {
@@ -171,6 +186,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         // and let users select between them.
         await ireeUnloadProgram(loadedProgram);
       }
+
+      await ireeInspectProgram(newProgram);
 
       loadedProgram = newProgram;
       programNameElement.innerText = newProgramName;
@@ -189,6 +206,10 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         functionArgumentsInput.value = searchParams.get("arguments");
       }
 
+      if (searchParams.has("iterations")) {
+        benchmarkIterationsInput.value = searchParams.get("iterations");
+      }
+
       if (searchParams.has("program")) {
         const programPath = searchParams.get("program");
 
@@ -201,6 +222,11 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     }
 
     async function tryLoadFromBuffer(programDataBuffer, programName) {
+      // Clear 'program' from the URL.
+      const searchParams = new URLSearchParams(window.location.search);
+      searchParams.delete("program");
+      replaceUrlWithSearchParams(searchParams);
+
       await initializePromise;
       const program = await ireeLoadProgram(programDataBuffer);
 
@@ -247,11 +273,23 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
       }
 
       const functionName = functionNameInput.value;
-      const functionArguments = functionArgumentsInput.value.split("\n");
+      const inputs = functionArgumentsInput.value.split("\n");
+      const iterations = benchmarkIterationsInput.value;
+      const startJsTime = performance.now();
 
-      ireeCallFunction(loadedProgram, functionName, functionArguments)
-          .then((result) => {
-            functionOutputsElement.value = result.replace(";", "\n");
+      ireeCallFunction(loadedProgram, functionName, inputs, iterations)
+          .then((resultObject) => {
+            functionOutputsElement.value =
+                resultObject['outputs'].replace(";", "\n");
+
+            const endJsTime = performance.now();
+            const totalJsTime = endJsTime - startJsTime;
+            timeJsOutputElement.textContent = totalJsTime.toFixed(3) + "ms";
+
+            const totalWasmTimeMs = resultObject['total_invoke_time_ms'];
+            const meanWasmTimeMs = totalWasmTimeMs / iterations;
+            timeWasmOutputElement.textContent = meanWasmTimeMs.toFixed(3) +
+                "ms / iteration over " + iterations + " iteration(s)";
           })
           .catch((error) => {
             console.error("Function call error: '" + error + "'");
@@ -270,6 +308,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
       const searchParams = new URLSearchParams(window.location.search);
       searchParams.set("function", functionNameInput.value);
       searchParams.set("arguments", functionArgumentsInput.value);
+      searchParams.set("iterations", benchmarkIterationsInput.value);
       replaceUrlWithSearchParams(searchParams);
     }
 
@@ -278,6 +317,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
       searchParams.delete("program");
       searchParams.delete("function");
       searchParams.delete("arguments");
+      searchParams.delete("iterations");
       replaceUrlWithSearchParams(searchParams);
     }
     // ------------------------------------------------------------------------

--- a/experimental/web/sample_dynamic/iree_api.js
+++ b/experimental/web/sample_dynamic/iree_api.js
@@ -86,6 +86,14 @@ function ireeLoadProgram(vmfbPathOrBuffer) {
   });
 }
 
+// Inspects a program, asynchronously.
+function ireeInspectProgram(programState) {
+  return _callIntoWorker({
+    'messageType': 'inspectProgram',
+    'payload': programState,
+  });
+}
+
 // Unloads a program, asynchronously.
 function ireeUnloadProgram(programState) {
   return _callIntoWorker({
@@ -96,14 +104,19 @@ function ireeUnloadProgram(programState) {
 
 // Calls a function on a loaded program, asynchronously.
 //
-// Returns a semicolon delimited list of formatted outputs on success.
-function ireeCallFunction(programState, functionName, inputs) {
+// Returns a parsed JSON object on success:
+// {
+//   "total_invoke_time_ms": [number],
+//   "outputs": [semicolon delimited list of formatted outputs]
+// }
+function ireeCallFunction(programState, functionName, inputs, iterations) {
   return _callIntoWorker({
     'messageType': 'callFunction',
     'payload': {
       'programState': programState,
       'functionName': functionName,
       'inputs': inputs,
+      'iterations': iterations !== undefined ? iterations : 1,
     },
   });
 }

--- a/experimental/web/sample_dynamic/serve_sample.sh
+++ b/experimental/web/sample_dynamic/serve_sample.sh
@@ -10,5 +10,6 @@ BUILD_DIR=${ROOT_DIR?}/build-emscripten
 BINARY_DIR=${BUILD_DIR}/experimental/web/sample_dynamic
 
 echo "=== Running local webserver, open at http://localhost:8000/ ==="
+echo "    For benchmarks, open http://localhost:8000/benchmarks.html"
 
 python3 ${ROOT_DIR?}/build_tools/scripts/local_web_server.py --directory ${BINARY_DIR}

--- a/experimental/web/sample_static/build_sample.sh
+++ b/experimental/web/sample_static/build_sample.sh
@@ -93,6 +93,7 @@ popd
 echo "=== Copying static files to the build directory ==="
 
 cp ${SOURCE_DIR}/index.html ${BINARY_DIR}
+cp ${ROOT_DIR?}/docs/website/overrides/ghost.svg ${BINARY_DIR}
 cp ${SOURCE_DIR}/iree_api.js ${BINARY_DIR}
 cp ${SOURCE_DIR}/iree_worker.js ${BINARY_DIR}
 

--- a/experimental/web/sample_static/index.html
+++ b/experimental/web/sample_static/index.html
@@ -13,6 +13,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   <meta charset="utf-8" />
   <title>IREE Static Web Sample</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" href="/ghost.svg" type="image/svg+xml">
 
   <script src="./easeljs.min.js"></script>
   <script src="./iree_api.js"></script>


### PR DESCRIPTION
### Background

I'm working towards identifying and quantifying key metrics for our web platform support. Metrics of interest thus far include:
* runtime binary size
* program binary size
* runtime startup time
* program load time
* total function call time (as seen from a JavaScript application)
* no-overhead function call time (`iree_runtime_call_invoke()`)

Once we have baselines for those, we can start deeper analysis and optimization work. Some optimization work may be purely in the IREE compiler (e.g. codegen, Flow/Stream/HAL dialects, etc.), while other work may be in the web port itself (e.g. Emscripten flags, use of web APIs, runtime JS bindings).

### Current Status

This is still all experimental, but I'd like to checkpoint what I've built so far and let other people try it out. Expect rough edges (e.g. some Windows/Linux paths specific to my setup that can be overwritten).

Summary of changes:

* `sample_dynamic/index.html` now supports interactive benchmarking
  * a "benchmark iterations" form input drives a loop around `iree_runtime_call_invoke()` down in C/Wasm
  * timing information is rendered onto the page itself, instead of being logged to stdout / the console
  * sample screenshot: https://user-images.githubusercontent.com/4010439/167958736-228a1541-8ed6-4b2c-9af9-55ef0b10bf74.png
* `generate_web_metrics.sh` imports and compiles programs from our existing benchmark suite, preserving all sorts of artifacts for further manual inspection or automated use
* `run_native_benchmarks.sh` executes the compiled native programs from `generate_web_metrics.sh`
* `sample_dynamic/benchmarks.html` loads and runs each compiled Wasm program from `generate_web_metrics.sh`
  * Sample output: https://gist.github.com/ScottTodd/f2bb1f274c5895c8f979400abd6d2b67

Also of note: I haven't really looked at the browser profiling tools yet. I expect those will help with detailed analysis while the general scaffolding and `performance.now()` measurements will help with comparisons between frameworks and across browsers/devices.