### PR TITLE
Disable TopK e2e test on Vulkan

### DIFF
--- a/iree/test/e2e/linalg_ext_ops/BUILD
+++ b/iree/test/e2e/linalg_ext_ops/BUILD
@@ -72,12 +72,14 @@ iree_check_single_backend_test_suite(
         # keep sorted
         [
             "reverse.mlir",
-            "top-k.mlir",
+            # Top-k test disabled due to miscompile on vulkan.
+            #    "top-k.mlir",
         ],
         include = ["*.mlir"],
         exclude = [
             # TODO(antiagainst): scan fails on Adreno GPUs due to driver bug.
             # Re-enable this once we have new devices with up-to-date drivers.
+            "top-k.mlir",
             "scan.mlir",
         ],
     ),

--- a/iree/test/e2e/linalg_ext_ops/CMakeLists.txt
+++ b/iree/test/e2e/linalg_ext_ops/CMakeLists.txt
@@ -60,7 +60,6 @@ iree_check_single_backend_test_suite(
     check_vulkan-spirv_vulkan
   SRCS
     "reverse.mlir"
-    "top-k.mlir"
   TARGET_BACKEND
     "vulkan-spirv"
   DRIVER


### PR DESCRIPTION
Disable e2e test while investigating vulkan failure.