### PR TITLE
Remove legacy code that didnt lower code for `func.func` that arent public

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPUDistributeSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUDistributeSharedMemoryCopy.cpp
@@ -211,9 +211,10 @@ class GPUDistributeSharedMemoryCopyPass
   }
   void runOnOperation() override {
     func::FuncOp funcOp = getOperation();
-    auto entryPointOp = getEntryPoint(funcOp);
-    if (!entryPointOp) return;
-    auto workgroupSize = getWorkgroupSize(entryPointOp);
+    FailureOr<IREE::HAL::ExecutableEntryPointOp> entryPointOp =
+        getEntryPoint(funcOp);
+    if (failed(entryPointOp)) return;
+    auto workgroupSize = getWorkgroupSize(entryPointOp.getValue());
     workgroupSize.resize(3, 1);
     MLIRContext *context = &getContext();
     SmallVector<linalg::GenericOp> copiesToWorkgroupMem;

--- a/compiler/src/iree/compiler/Codegen/Common/RemoveTrivialLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/RemoveTrivialLoops.cpp
@@ -154,11 +154,12 @@ class RemoveSingleIterationLoopPass final
     : public RemoveSingleIterationLoopBase<RemoveSingleIterationLoopPass> {
   void runOnOperation() override {
     func::FuncOp funcOp = getOperation();
-    auto entryPointOp = getEntryPoint(funcOp);
-    if (!entryPointOp) return;
+    FailureOr<IREE::HAL::ExecutableEntryPointOp> entryPointOp =
+        getEntryPoint(funcOp);
+    if (failed(entryPointOp)) return;
 
-    SmallVector<int64_t> workgroupSize = getWorkgroupSize(entryPointOp);
-    SmallVector<int64_t> numWorkgroups = getNumWorkgroup(funcOp, entryPointOp);
+    SmallVector<int64_t> workgroupSize = getWorkgroupSize(*entryPointOp);
+    SmallVector<int64_t> numWorkgroups = getNumWorkgroup(funcOp, *entryPointOp);
 
     if (failed(removeOneTripTiledLoops(funcOp, workgroupSize, numWorkgroups))) {
       return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/Common/RewriteLinalgDestructiveUpdatesPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/RewriteLinalgDestructiveUpdatesPass.cpp
@@ -35,7 +35,6 @@ struct RewriteLinalgDestructiveUpdatesPass
 void RewriteLinalgDestructiveUpdatesPass::runOnOperation() {
   MLIRContext *context = &getContext();
   func::FuncOp funcOp = getOperation();
-  if (!isEntryPoint(funcOp)) return;
 
   // Rewrite destructive updates and ensure no remaining store remains to the
   // full output.

--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.h
@@ -52,9 +52,10 @@ IREE::Codegen::TranslationInfoAttr getTranslationInfo(
 /// point). Returns `nullptr` on failure.
 inline IREE::Codegen::TranslationInfoAttr getTranslationInfo(
     func::FuncOp funcOp) {
-  auto entryPointOp = getEntryPoint(funcOp);
-  if (!entryPointOp) return nullptr;
-  return getTranslationInfo(entryPointOp);
+  FailureOr<IREE::HAL::ExecutableEntryPointOp> entryPointOp =
+      getEntryPoint(funcOp);
+  if (failed(entryPointOp)) return nullptr;
+  return getTranslationInfo(*entryPointOp);
 }
 
 /// Returns the workgroup size specified on the `entryPointOp`.
@@ -73,8 +74,9 @@ inline void setTranslationInfo(
     func::FuncOp entryPointFn,
     IREE::Codegen::TranslationInfoAttr translationInfo,
     ArrayRef<int64_t> workgroupSize = {}) {
-  auto entryPointOp = getEntryPoint(entryPointFn);
-  return setTranslationInfo(entryPointOp, translationInfo, workgroupSize);
+  FailureOr<IREE::HAL::ExecutableEntryPointOp> entryPointOp =
+      getEntryPoint(entryPointFn);
+  return setTranslationInfo(*entryPointOp, translationInfo, workgroupSize);
 }
 
 /// Sets the translation info on the `hal.executable.entry_point` op
@@ -86,11 +88,12 @@ inline void setTranslationInfo(
     IREE::Codegen::DispatchLoweringPassPipeline passPipeline,
     ArrayRef<int64_t> workloadPerWorkgroup, ArrayRef<int64_t> workgroupSize,
     unsigned softwarePipelineDepth = 0) {
-  auto entryPointOp = getEntryPoint(entryPointFn);
+  FailureOr<IREE::HAL::ExecutableEntryPointOp> entryPointOp =
+      getEntryPoint(entryPointFn);
   MLIRContext *context = entryPointFn.getContext();
   auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
       context, passPipeline, workloadPerWorkgroup);
-  setTranslationInfo(entryPointOp, translationInfo, workgroupSize);
+  setTranslationInfo(*entryPointOp, translationInfo, workgroupSize);
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -993,22 +993,6 @@ void ConvertToLLVMPass::runOnOperation() {
                            math::MathDialect, tosa::TosaDialect>();
   target.addIllegalOp<UnrealizedConversionCastOp>();
 
-  // Don't apply patterns to private function (e.g num_workgroups func).
-  target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp funcOp) {
-    if (isEntryPoint(funcOp)) return false;
-    return true;
-  });
-  target.addDynamicallyLegalDialect<func::FuncDialect, mlir::math::MathDialect,
-                                    mlir::arith::ArithmeticDialect,
-                                    IREE::Util::UtilDialect,
-                                    IREE::HAL::HALDialect, math::MathDialect>(
-      [&](Operation *op) {
-        auto funcParent = op->getParentOfType<func::FuncOp>();
-        if (!funcParent) return false;
-        if (isEntryPoint(funcParent)) return false;
-        return true;
-      });
-
   if (failed(applyPartialConversion(module, target, std::move(patterns)))) {
     signalPassFailure();
     return;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD
@@ -21,6 +21,7 @@ iree_lit_test_suite(
         # keep sorted
         [
             "check_ir_before_llvm_conversion.mlir",
+            "convert_to_llvm.mlir",
             "hal_interface_bindings.mlir",
             "hal_interface_constants.mlir",
             "hal_interface_workgroup_info.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "check_ir_before_llvm_conversion.mlir"
+    "convert_to_llvm.mlir"
     "hal_interface_bindings.mlir"
     "hal_interface_constants.mlir"
     "hal_interface_workgroup_info.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/convert_to_llvm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/convert_to_llvm.mlir
@@ -1,0 +1,15 @@
+// RUN: iree-opt -iree-convert-to-llvm %s | FileCheck %s
+
+builtin.module {
+  func.func private @extern_public()
+  func.func @entry_point() {
+    return
+  }
+}
+//      CHECK: llvm.func @extern_public()
+//      CHECK: llvm.func internal @entry_point(
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]:  !llvm.ptr<struct<"iree_hal_executable_environment_v0_t", opaque>> {llvm.align = 16 : i64, llvm.noalias}
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]:  !llvm.ptr<struct<"iree_hal_executable_dispatch_state_v0_t", opaque>> {llvm.align = 16 : i64, llvm.noalias}
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]:  !llvm.ptr<struct<"iree_hal_executable_workgroup_state_v0_t", opaque>> {llvm.align = 16 : i64, llvm.noalias}) -> i32
+//      CHECK:     llvm.return %{{.+}} : i32
+

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
@@ -249,7 +249,7 @@ struct LLVMGPUTileAndDistributePass
     });
 
     auto workgroupSize = llvm::to_vector<4>(llvm::map_range(
-        getEntryPoint(funcOp).workgroup_size().getValue(),
+        getEntryPoint(funcOp)->workgroup_size().getValue(),
         [&](Attribute attr) { return attr.cast<IntegerAttr>().getInt(); }));
 
     int64_t flatWorkgroupSize =

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
@@ -1,23 +1,38 @@
-// RUN: iree-opt --iree-convert-to-rocdl %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="hal.executable(hal.executable.variant(builtin.module(iree-convert-to-rocdl)))" %s | FileCheck %s
 
 // Test that that standard and GPU ops are converted to LLVM and NVVM.
-func.func @abs_ex_dispatch_0() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<16xf32>
-  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<16xf32>
-  %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<16xf32>
-  %3 = gpu.block_id x
-  %4 = gpu.block_dim x
-  %5 = gpu.thread_id x
-  %6 = arith.muli %3, %4 : index
-  %7 = arith.addi %6, %5 : index
-  %9 = memref.load %1[%7] : memref<16xf32>
-  %10 = memref.load %2[%7] : memref<16xf32>
-  %11 = arith.addf %9, %10 : f32
-  memref.store %11, %0[%7] : memref<16xf32>
-  return
+#executable_layout = #hal.executable.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<4, storage_buffer>
+  ]>,
+  #hal.descriptor_set.layout<1, bindings = [
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable @abs_ex_dispatch_0 {
+  hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
+    hal.executable.entry_point @abs_ex_dispatch_0 layout(#executable_layout)
+    builtin.module {
+      func.func @abs_ex_dispatch_0() {
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<16xf32>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<16xf32>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<16xf32>
+        %3 = gpu.block_id x
+        %4 = gpu.block_dim x
+        %5 = gpu.thread_id x
+        %6 = arith.muli %3, %4 : index
+        %7 = arith.addi %6, %5 : index
+        %9 = memref.load %1[%7] : memref<16xf32>
+        %10 = memref.load %2[%7] : memref<16xf32>
+        %11 = arith.addf %9, %10 : f32
+        memref.store %11, %0[%7] : memref<16xf32>
+        return
+      }
+    }
+  }
 }
-
 // CHECK-LABEL: llvm.func @abs_ex_dispatch_0
 //  CHECK-SAME: (%{{.*}}: !llvm.ptr<f32> {llvm.align = 16 : i32}, %{{.*}}: !llvm.ptr<f32> {llvm.align = 16 : i32},
 //  CHECK-SAME:  %{{.*}}: !llvm.ptr<f32> {llvm.align = 16 : i32})

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndDistribute.cpp
@@ -136,8 +136,7 @@ class SPIRVTileAndDistributePass
 void SPIRVTileAndDistributePass::runOnOperation() {
   MLIRContext *context = &getContext();
   func::FuncOp funcOp = getOperation();
-  auto entryPointOp = getEntryPoint(funcOp);
-  if (!entryPointOp) return;
+  if (!isEntryPoint(funcOp)) return;
 
   {  // Tile and distribute to invocations.
     RewritePatternSet invocationTilingPatterns(context);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndPromote.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndPromote.cpp
@@ -147,8 +147,9 @@ struct SPIRVTileAndPromotePass final
 void SPIRVTileAndPromotePass::runOnOperation() {
   MLIRContext *context = &getContext();
   func::FuncOp funcOp = getOperation();
-  auto entryPointOp = getEntryPoint(funcOp);
-  if (!entryPointOp) return;
+  FailureOr<IREE::HAL::ExecutableEntryPointOp> entryPointOp =
+      getEntryPoint(funcOp);
+  if (failed(entryPointOp)) return;
 
   {  // Tile reduction dimensions.
     RewritePatternSet tilingPatterns(context);
@@ -178,7 +179,7 @@ void SPIRVTileAndPromotePass::runOnOperation() {
   });
 
   auto workgroupSize = llvm::to_vector<4>(llvm::map_range(
-      entryPointOp.workgroup_size().getValue(),
+      entryPointOp->workgroup_size().getValue(),
       [&](Attribute attr) { return attr.cast<IntegerAttr>().getInt(); }));
   int64_t flatWorkgroupSize =
       workgroupSize[0] * workgroupSize[1] * workgroupSize[2];

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -59,9 +59,10 @@ llvm::SmallVector<mlir::linalg::ProcInfo, 2> getSubgroupIdsAndCounts(
 
 std::array<int64_t, 3> getWorkgroupSize(mlir::func::FuncOp funcOp) {
   std::array<int64_t, 3> workgroupSize;
-  auto entryPointOp = mlir::iree_compiler::getEntryPoint(funcOp);
+  FailureOr<IREE::HAL::ExecutableEntryPointOp> entryPointOp =
+      mlir::iree_compiler::getEntryPoint(funcOp);
   llvm::Optional<mlir::ArrayAttr> workgroupSizeAttr =
-      entryPointOp.workgroup_size();
+      entryPointOp->workgroup_size();
   assert(workgroupSizeAttr.hasValue());
   for (auto it : llvm::enumerate(workgroupSizeAttr.getValue())) {
     workgroupSize[it.index()] =

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -33,16 +33,21 @@ namespace iree_compiler {
 // Utility functions to get entry points
 //===----------------------------------------------------------------------===//
 
-bool isEntryPoint(func::FuncOp func) { return func.isPublic(); }
-
-IREE::HAL::ExecutableEntryPointOp getEntryPoint(func::FuncOp funcOp) {
+FailureOr<IREE::HAL::ExecutableEntryPointOp> getEntryPoint(
+    func::FuncOp funcOp) {
   auto variantOp = funcOp->getParentOfType<IREE::HAL::ExecutableVariantOp>();
+  if (!variantOp) return failure();
+
   for (auto op : variantOp.getOps<IREE::HAL::ExecutableEntryPointOp>()) {
     if (op.sym_name() == funcOp.getName()) {
       return op;
     }
   }
-  return nullptr;
+  return failure();
+}
+
+bool isEntryPoint(func::FuncOp func) {
+  return func.isPublic() && succeeded(getEntryPoint(func));
 }
 
 llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> getAllEntryPoints(

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -37,7 +37,7 @@ llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> getAllEntryPoints(
     ModuleOp module);
 
 /// Returns the entry point op for the `funcOp`. Returns `nullptr` on failure.
-IREE::HAL::ExecutableEntryPointOp getEntryPoint(func::FuncOp funcOp);
+FailureOr<IREE::HAL::ExecutableEntryPointOp> getEntryPoint(func::FuncOp funcOp);
 
 /// Methods to get backend information.
 bool isX86(IREE::HAL::ExecutableVariantOp variantOp);


### PR DESCRIPTION
The `func.func` code within functions not entry point were treated as
dynamically legal. This requirement is legacy. Dropping it.