### PR TITLE
Improve the detection of previous benchmark

### DIFF
--- a/build_tools/benchmarks/post_benchmarks_as_pr_comment.py
+++ b/build_tools/benchmarks/post_benchmarks_as_pr_comment.py
@@ -148,17 +148,15 @@ def get_benchmark_result_markdown(benchmark_files: Sequence[str],
       base_commit = md.link(base_commit,
                             f"{GITHUB_IREE_REPO_PREFIX}/commit/{base_commit}")
 
-      # Update the aggregate benchmarks with base numbers.
-      any_matched_bench = False
-      for bench in base_benchmarks:
-        if bench in all_benchmarks:
-          any_matched_bench = True
-          all_benchmarks[bench].base_mean_time = base_benchmarks[bench]
-
-      if not any_matched_bench:
+      # Skip if the base doesn't contain all benchmarks to be compared.
+      if not (set(all_benchmarks.keys()) <= set(base_benchmarks.keys())):
         commit_info = (f"@ commit {pr_commit} (no previous benchmark results to"
                        f" compare against since {base_commit})")
         continue
+
+      # Update the aggregate benchmarks with base numbers.
+      for bench in all_benchmarks:
+        all_benchmarks[bench].base_mean_time = base_benchmarks[bench]
 
       commit_info = f"@ commit {pr_commit} (vs. base {base_commit})"
       break

--- a/build_tools/benchmarks/post_benchmarks_as_pr_comment.py
+++ b/build_tools/benchmarks/post_benchmarks_as_pr_comment.py
@@ -148,15 +148,18 @@ def get_benchmark_result_markdown(benchmark_files: Sequence[str],
       base_commit = md.link(base_commit,
                             f"{GITHUB_IREE_REPO_PREFIX}/commit/{base_commit}")
 
-      if len(base_benchmarks) == 0:
+      # Update the aggregate benchmarks with base numbers.
+      any_matched_bench = False
+      for bench in base_benchmarks:
+        if bench in all_benchmarks:
+          any_matched_bench = True
+          all_benchmarks[bench].base_mean_time = base_benchmarks[bench]
+
+      if not any_matched_bench:
         commit_info = (f"@ commit {pr_commit} (no previous benchmark results to"
                        f" compare against since {base_commit})")
         continue
 
-      # Update the aggregate benchmarks with base numbers.
-      for bench in base_benchmarks:
-        if bench in all_benchmarks:
-          all_benchmarks[bench].base_mean_time = base_benchmarks[bench]
       commit_info = f"@ commit {pr_commit} (vs. base {base_commit})"
       break
 


### PR DESCRIPTION
Since we upload the benchmark results for two platforms separately now, the build exists in the dashboard doesn't mean the related benchmark results have been uploaded for that build. This causes the problem where some result posts can't find the previous results to compare to (e.g., https://github.com/google/iree/pull/9096#issuecomment-1124597853).

The change improves the logic to check if there are any matched records from the dashboard and skips to the next build if not.

The eventual goal is only uploading results from a single pipeline, but this is still an enhancement.