### PR TITLE
Add software pipeline depth to lowering config

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.cpp
@@ -75,12 +75,13 @@ namespace Codegen {
 
 TranslationInfoAttr TranslationInfoAttr::get(
     MLIRContext *context, DispatchLoweringPassPipeline passPipeline,
-    ArrayRef<int64_t> workloadPerWorkgroup) {
+    ArrayRef<int64_t> workloadPerWorkgroup, unsigned softwarePipelineDepth) {
   auto pipelineAttr =
       DispatchLoweringPassPipelineAttr::get(context, passPipeline);
   ArrayAttr workloadPerWorkgroupAttr =
       getI64IntegerArrayAttr(context, workloadPerWorkgroup);
-  return get(context, pipelineAttr, workloadPerWorkgroupAttr);
+  return get(context, pipelineAttr, workloadPerWorkgroupAttr,
+             softwarePipelineDepth);
 }
 
 DispatchLoweringPassPipeline
@@ -95,7 +96,7 @@ SmallVector<int64_t> TranslationInfoAttr::getWorkloadPerWorkgroupVals() {
 LogicalResult TranslationInfoAttr::verify(
     function_ref<InFlightDiagnostic()> emitError,
     IREE::Codegen::DispatchLoweringPassPipelineAttr passPipeline,
-    ArrayAttr workloadPerWorkgroup) {
+    ArrayAttr workloadPerWorkgroup, unsigned softwarePipelineDepth) {
   if (!passPipeline) {
     return emitError() << "missing pass pipeline specification";
   }
@@ -245,7 +246,8 @@ LogicalResult CompilationInfoAttr::verify(
   }
   if (failed(TranslationInfoAttr::verify(
           emitError, translationInfo.getPassPipeline(),
-          translationInfo.getWorkloadPerWorkgroup()))) {
+          translationInfo.getWorkloadPerWorkgroup(),
+          translationInfo.getSoftwarePipelineDepth()))) {
     return failure();
   }
   if (workgroupSize) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.h
@@ -84,7 +84,8 @@ inline void setTranslationInfo(
 inline void setTranslationInfo(
     func::FuncOp entryPointFn,
     IREE::Codegen::DispatchLoweringPassPipeline passPipeline,
-    ArrayRef<int64_t> workloadPerWorkgroup, ArrayRef<int64_t> workgroupSize) {
+    ArrayRef<int64_t> workloadPerWorkgroup, ArrayRef<int64_t> workgroupSize,
+    unsigned softwarePipelineDepth = 0) {
   auto entryPointOp = getEntryPoint(entryPointFn);
   MLIRContext *context = entryPointFn.getContext();
   auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
@@ -117,12 +118,12 @@ void setLoweringConfig(Operation *op, IREE::Codegen::LoweringConfigAttr config);
 inline LogicalResult setOpConfigAndEntryPointFnTranslation(
     func::FuncOp entryPointFn, Operation *op, TileSizesListTypeRef tileSizes,
     IREE::Codegen::DispatchLoweringPassPipeline passPipeline,
-    ArrayRef<int64_t> workgroupSize = {}) {
+    ArrayRef<int64_t> workgroupSize = {}, unsigned softwarePipelineDepth = 0) {
   MLIRContext *context = entryPointFn.getContext();
   auto config = IREE::Codegen::LoweringConfigAttr::get(context, tileSizes);
   setLoweringConfig(op, config);
   auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
-      entryPointFn->getContext(), passPipeline);
+      entryPointFn->getContext(), passPipeline, {}, softwarePipelineDepth);
   setTranslationInfo(entryPointFn, translationInfo, workgroupSize);
   return success();
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
@@ -104,18 +104,22 @@ def IREECodegen_TranslationInfoAttr :
   }];
 
   let assemblyFormat = [{
-    `<` `` $passPipeline (`workload_per_wg` `=` $workloadPerWorkgroup^)? `>`
+    `<` `` $passPipeline (`workload_per_wg` `=` $workloadPerWorkgroup^)?
+    (`pipeline_depth` `=` $softwarePipelineDepth^)? `>`
   }];
 
   let parameters = (ins
     AttrParameter<"IREE::Codegen::DispatchLoweringPassPipelineAttr",
         "Name of the pipeline to be invoked on the translation unit.">:$passPipeline,
     DefaultValuedParameter<"ArrayAttr", "ArrayAttr::get($_ctx, {})",
-        "The workload mapped to a single workgroup">:$workloadPerWorkgroup
+        "The workload mapped to a single workgroup">:$workloadPerWorkgroup,
+    DefaultValuedParameter<"unsigned", "1",
+        "The software pipeline depth to be used">:$softwarePipelineDepth
   );
   let builders = [
     AttrBuilder<(ins "DispatchLoweringPassPipeline":$passPipeline,
-        CArg<"ArrayRef<int64_t>", "{}">:$workloadPerWorkgroup)>
+        CArg<"ArrayRef<int64_t>", "{}">:$workloadPerWorkgroup,
+        CArg<"unsigned", "0">:$softwarePipelineDepth)>
   ];
   let extraClassDeclaration = [{
     // Returns the lowering pass pipeline set.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -155,7 +155,9 @@ void LLVMGPULowerExecutableTargetPass::runOnOperation() {
         addGPUMatmulSimtPassPipeline(nestedModulePM);
         break;
       case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUMatmulTensorCore:
-        addGPUMatmulTensorCorePassPipeline(nestedModulePM);
+        addGPUMatmulTensorCorePassPipeline(
+            nestedModulePM,
+            translationInfo.getValue().getSoftwarePipelineDepth());
         break;
       default:
         variantOp.emitOpError("Unsupported pipeline on GPU target.");

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -24,11 +24,6 @@
 namespace mlir {
 namespace iree_compiler {
 
-// TODO(thomasraoux): Add a new optional attribute to translate info.
-static llvm::cl::opt<unsigned> pipelineDepth("iree-codegen-cuda-pipeline-depth",
-                                             llvm::cl::desc("Pipeline depth"),
-                                             llvm::cl::init(4));
-
 static llvm::cl::opt<unsigned> logSwizzleTile(
     "iree-codegen-log-swizzle-tile", llvm::cl::desc("log swizzle tile value"),
     llvm::cl::init(0));
@@ -109,7 +104,8 @@ void addGPUMatmulSimtPassPipeline(OpPassManager &pm) {
   pm.addNestedPass<func::FuncOp>(createGPUPipeliningPass());
 }
 
-void addGPUMatmulTensorCorePassPipeline(OpPassManager &pm) {
+void addGPUMatmulTensorCorePassPipeline(OpPassManager &pm,
+                                        unsigned pipelineDepth) {
   tileAndBufferize(pm);
 
   // Distribute linalg onto warps within the workgroup.

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -327,7 +327,8 @@ LogicalResult verifyGPUMatmulTensorCorePipeline(
     Operation *op, IREE::Codegen::LoweringConfigAttr loweringConfig,
     IREE::Codegen::TranslationInfoAttr translationInfo,
     ArrayRef<int64_t> workgroupSize);
-void addGPUMatmulTensorCorePassPipeline(OpPassManager &pm);
+void addGPUMatmulTensorCorePassPipeline(OpPassManager &pm,
+                                        unsigned pipelineDepth);
 
 /// Simple lowering only distributute linalg ops on blocks and threads. This
 /// will result in scalar operations. Expects pass manager to be a module-level

--- a/iree/test/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/iree/test/e2e/matmul/generate_e2e_matmul_tests.py
@@ -77,6 +77,7 @@ class CompilationInfo:
   # Translation Info
   dispatch_lowering_pass_pipeline: str
   workload_per_wg: typing.List[int]
+  software_pipeline_depth: int
   # Compilation info
   workgroup_size: typing.List[int]
 
@@ -189,7 +190,8 @@ def get_test_compilation_infos(
             workload_per_wg=[
                 a for a in reversed(tile_workgroup_size_pair.tile_size[0:2])
             ],
-            workgroup_size=tile_workgroup_size_pair.workgroup_size))
+            workgroup_size=tile_workgroup_size_pair.workgroup_size,
+            software_pipeline_depth=4))
   return compilation_infos
 
 
@@ -355,7 +357,8 @@ def generate_function(
     compilation_info_string = (
         f"#compilation{generate_function.compilation_index} = #iree_codegen.compilation_info<\n"
         f"  lowering_config = <tile_sizes = [{compilation_info.tile_sizes}]>,\n"
-        f"  translation_info = <{compilation_info.dispatch_lowering_pass_pipeline}>,\n"
+        f"  translation_info = <{compilation_info.dispatch_lowering_pass_pipeline}\n"
+        f"  pipeline_depth = {compilation_info.software_pipeline_depth}>,\n"
         f"  workgroup_size = {compilation_info.workgroup_size_str()}>\n")
     compilation_info_attr = f"{{compilation_info = #compilation{generate_function.compilation_index}}} "
     func_definition = func_definition + compilation_info_string


### PR DESCRIPTION
- Add Pipelinedepth to translation_info
- Update the verifier and kernelconfig to disallow pipelining when first level tile K is same as matmul reduction dimension size
- Modify lit tests to account for default of softwarepipelinedepth=4