### PR TITLE
Fix release runtime package.

### DIFF
--- a/build_tools/cmake/iree_python.cmake
+++ b/build_tools/cmake/iree_python.cmake
@@ -33,65 +33,6 @@ endfunction()
 # Main user rules
 ###############################################################################
 
-# Declares that the current source directory is part of a python package
-# that will:
-#   - Will create an install target install-COMPONENT (global, not package
-#     scoped)
-#   - Be installed under python_packages/PACKAGE_NAME
-#   - Have a local path of MODULE_PATH (i.e. namespace package path)
-# Will set parent scope variables:
-#   - PY_INSTALL_COMPONENT: Install component. Echoed back from the argument
-#     for easier addition after this call.
-#   - PY_INSTALL_PACKAGES_DIR: The python_packages/PACKAGE_NAME path
-#   - PY_INSTALL_MODULE_DIR: The path to the module directory under
-#     INSTALL_PACKAGES_DIR.
-#
-# Add any built deps to DEPS (you will need to add install actions to them
-# after).
-#
-# Any python files in the source directory will be automatically installed
-# (recursive).
-#
-# Also adds a *-stripped target which strips any binaries that are
-# present.
-#
-# Arguments:
-#   AUGMENT_EXISTING_PACKAGE: Whether to add install artifacts to an existing
-#     package.
-#   COMPONENT: Install component
-#   PACKAGE_NAME: Name of the Python package in the install directory tree.
-#   MODULE_PATH: Relative path within the package to the module being installed.
-#   FILES_MATCHING: Explicit arguments to the install FILES_MATCHING directive.
-#     (Defaults to "PATTERN *.py")
-#   DEPS: Dependencies.
-function(iree_py_install_package)
-  cmake_parse_arguments(ARG
-    "AUGMENT_EXISTING_PACKAGE"
-    "COMPONENT;PACKAGE_NAME;MODULE_PATH"
-    "DEPS;ADDL_PACKAGE_FILES;FILES_MATCHING"
-    ${ARGN})
-  set(_INSTALL_COMPONENT ${ARG_COMPONENT})
-  set(_INSTALL_PACKAGES_DIR "python_packages/${ARG_PACKAGE_NAME}")
-  set(_INSTALL_MODULE_DIR "${_INSTALL_PACKAGES_DIR}/${ARG_MODULE_PATH}")
-
-  if(NOT FILES_MATCHING)
-    set(_FILES_MATCHING PATTERN "*.py")
-  else()
-    set(_FILES_MATCHING ${ARG_FILES_MATCHING})
-  endif()
-
-  install(
-    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
-    COMPONENT ${_INSTALL_COMPONENT}
-    DESTINATION "${_INSTALL_MODULE_DIR}"
-    FILES_MATCHING ${_FILES_MATCHING}
-  )
-
-  set(PY_INSTALL_COMPONENT ${_INSTALL_COMPONENT} PARENT_SCOPE)
-  set(PY_INSTALL_PACKAGES_DIR "${_INSTALL_PACKAGES_DIR}" PARENT_SCOPE)
-  set(PY_INSTALL_MODULE_DIR "${_INSTALL_MODULE_DIR}" PARENT_SCOPE)
-endfunction()
-
 # iree_pyext_module()
 #
 # Builds a native python module (.so/.dylib/.pyd).

--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -61,7 +61,7 @@ function run_on_host() {
     -v "${repo_root}:/main_checkout/iree" \
     -v "${output_dir}:/wheelhouse" \
     -e __MANYLINUX_BUILD_WHEELS_IN_DOCKER=1 \
-    -e "python_versions=${python_versions}" \
+    -e "override_python_versions=${python_versions}" \
     -e "packages=${packages}" \
     ${manylinux_docker_image} \
     -- bash /main_checkout/iree/build_tools/python_deploy/build_linux_packages.sh

--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -168,31 +168,29 @@ iree_py_test(
 # Install
 ################################################################################
 
-iree_py_install_package(
-  COMPONENT IreePythonPackage-runtime
-  PACKAGE_NAME iree_runtime
-  MODULE_PATH iree/runtime
-  DEPS
-    # TODO: Update CMake target/path mangling rules to make this syntactically
-    # rooted on "iree" in some way.
-    runtime_bindings_python_PyExtRt
-    iree_tools_iree-benchmark-module
-    iree_tools_iree-benchmark-trace
-    iree_tools_iree-run-module
-    iree_tools_iree-run-trace
-    ${_EXTRA_INSTALL_TOOL_TARGETS}
-  ADDL_PACKAGE_FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/README.md
+set(_INSTALL_DIR "python_packages/iree_runtime")
+set(_INSTALL_COMPONENT "IreePythonPackage-runtime")
+
+# Install iree/runtime/*.py files verbatim into the tree.
+# We do this at the package level so as to avoid any loose files
+# from outside (i.e. tests, etc).
+install(
+  DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/iree/runtime/"
+  COMPONENT "${_INSTALL_COMPONENT}"
+  DESTINATION "${_INSTALL_DIR}/iree/runtime/"
+  FILES_MATCHING PATTERN "*.py"
 )
 
+# _runtime.so -> python_packages/iree_runtime/iree/_runtime.so
 install(
   # TODO: Update CMake target/path mangling rules to make this syntactically
   # rooted on "iree" in some way.
   TARGETS runtime_bindings_python_PyExtRt
-  COMPONENT ${PY_INSTALL_COMPONENT}
-  DESTINATION "${PY_INSTALL_MODULE_DIR}"
+  DESTINATION "${_INSTALL_DIR}/iree"
+  COMPONENT "${_INSTALL_COMPONENT}"
 )
 
+# Install tools into python_packages/iree_runtime/iree/runtime
 install(
   TARGETS
     iree_tools_iree-benchmark-module
@@ -200,6 +198,6 @@ install(
     iree_tools_iree-run-module
     iree_tools_iree-run-trace
     ${_EXTRA_INSTALL_TOOL_TARGETS}
-  DESTINATION "${PY_INSTALL_MODULE_DIR}"
-  COMPONENT "${PY_INSTALL_COMPONENT}"
+  DESTINATION "${_INSTALL_DIR}/iree/runtime"
+  COMPONENT "${_INSTALL_COMPONENT}"
 )


### PR DESCRIPTION
When the runtime path was flattened, the install locations were not
updated to line up. They were also going through a really old macro that
had outlived its usefulness. Just added corrected, explicit install()
calls. Also fixed a typo in the build_linux_packages.sh script noticed
when trying to build just one python version to test.

It is now possible to test/repo this exactly as the CI does:

```
override_python_versions=cp39-cp39 packages=iree-runtime
./build_tools/python_deploy/build_linux_packages.sh
pip install
build_tools/python_deploy/wheelhouse/iree_runtime-0.dev0+4020b408be725b54b0266a2a9c3388b5c704ced4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
python runtime/bindings/python/tests/array_interop_test.py
iree-run-module
```

Fixes #9108