### PR TITLE
Make `InsertDistributionInfo` operate on `IREE::HAL::ExecutableVariantOp`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/SetNumWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/SetNumWorkgroupsPass.cpp
@@ -141,7 +141,10 @@ LogicalResult setNumWorkgroupsImpl(IREE::HAL::ExecutableVariantOp variantOp,
     }
 
     OpBuilder builder(context);
-    return defineWorkgroupCountRegion(builder, funcOp, regionBuilder);
+    if (failed(
+            defineWorkgroupCountRegion(builder, entryPointOp, regionBuilder))) {
+      return failure();
+    }
   }
 
   // Apply post distribution canonicalization passes.

--- a/compiler/src/iree/compiler/Codegen/Common/test/insert_distribution_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/insert_distribution_info.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline='hal.executable(hal.executable.variant(builtin.module(func.func(iree-codegen-insert-distribution-info))))' --split-input-file %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline='hal.executable(hal.executable.variant(iree-codegen-insert-distribution-info))' --split-input-file %s | FileCheck %s
 
 #config = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 0], [16, 4, 64], [4, 4, 4]]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -191,31 +191,31 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
       bool lowerToVectors = !isVMVXBackend(variantOp);
       bool lowerToAVX2 = hasAVX2Features(variantOp);
       if (!testLoweringConfiguration) {
-        OpPassManager &nestedModulePM =
-            executableLoweringPipeline.nest<ModuleOp>();
         switch (translationInfo.getValue().getDispatchLoweringPassPipeline()) {
           case IREE::Codegen::DispatchLoweringPassPipeline::CPUDefault:
           case IREE::Codegen::DispatchLoweringPassPipeline::None:
-            addCPUDefaultPassPipeline(nestedModulePM);
+            addCPUDefaultPassPipeline(executableLoweringPipeline);
             break;
           case IREE::Codegen::DispatchLoweringPassPipeline::CPUBufferOpsDefault:
-            addCPUBufferOpsDefaultPipeline(nestedModulePM);
+            addCPUBufferOpsDefaultPipeline(executableLoweringPipeline);
             break;
           case IREE::Codegen::DispatchLoweringPassPipeline::
               CPUBufferOpsTileAndVectorize:
-            addCPUBufferOpsTileAndVectorizePipeline(nestedModulePM);
+            addCPUBufferOpsTileAndVectorizePipeline(executableLoweringPipeline);
             break;
           case IREE::Codegen::DispatchLoweringPassPipeline::
               CPUDoubleTilingExpert:
-            addDoubleTilingExpertPassPipeline(nestedModulePM, lowerToAVX2);
+            addDoubleTilingExpertPassPipeline(executableLoweringPipeline,
+                                              lowerToAVX2);
             break;
           case IREE::Codegen::DispatchLoweringPassPipeline::
               CPUDoubleTilingPadExpert:
-            addDoubleTilingPadExpertPassPipeline(nestedModulePM);
+            addDoubleTilingPadExpertPassPipeline(executableLoweringPipeline);
             break;
           case IREE::Codegen::DispatchLoweringPassPipeline::
               CPUConvTileAndDecomposeExpert:
-            addConvTileAndDecomposeExpertPassPipeline(nestedModulePM);
+            addConvTileAndDecomposeExpertPassPipeline(
+                executableLoweringPipeline);
             break;
           case IREE::Codegen::DispatchLoweringPassPipeline::
               LinalgTransformInterpCodegen:
@@ -223,7 +223,8 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
             break;
           case IREE::Codegen::DispatchLoweringPassPipeline::
               CPUTileFuseAndVectorize:
-            addTileFuseAndVectorizePassPipeline(nestedModulePM, lowerToVectors);
+            addTileFuseAndVectorizePassPipeline(executableLoweringPipeline,
+                                                lowerToVectors);
             break;
           default:
             variantOp.emitOpError("Unsupported pipeline on CPU target.");

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -451,15 +451,14 @@ void addCPUDefaultPassPipeline(OpPassManager &passManager) {
 }
 
 void addLinalgTransformInterpPasses(OpPassManager &passManager) {
-  OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
   // Give control to the linalg_transform dialect.
-  nestedModulePM.addPass(createLinalgTransformInterpreterPass());
+  passManager.addPass(createLinalgTransformInterpreterPass());
 
   // Dropping the schedule is only needed if we want to embed the transform in
   // the module: we should drop the schedule once applied.
   // This pass does nothing in the case where we apply a separate policy
   // through a file.
-  nestedModulePM.addPass(createDropSchedulePass());
+  passManager.addPass(createDropSchedulePass());
 }
 
 static void addLowerToLLVMPasses(OpPassManager &passManager) {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -74,15 +74,18 @@ static void addCPUIREEComprehensiveBufferizePasses(OpPassManager &passManager) {
 
 static void addTileAndDistributePasses(OpPassManager &pm,
                                        bool convertToDestinationStyle) {
-  pm.addNestedPass<func::FuncOp>(createInsertDistributionInfoPass());
-  pm.addNestedPass<func::FuncOp>(createTileAndDistributeToWorkgroupsPass());
-  pm.addNestedPass<func::FuncOp>(createFoldAffineMinInDistributedLoopsPass());
-  pm.addPass(createCanonicalizerPass());
-  pm.addPass(createCSEPass());
+  pm.addPass(createInsertDistributionInfoPass());
+  auto &nestedModulePM = pm.nest<ModuleOp>();
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createTileAndDistributeToWorkgroupsPass());
   if (convertToDestinationStyle) {
-    pm.addNestedPass<func::FuncOp>(
+    nestedModulePM.addNestedPass<func::FuncOp>(
         createConvertToDestinationPassingStylePass());
   }
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createFoldAffineMinInDistributedLoopsPass());
+  nestedModulePM.addPass(createCanonicalizerPass());
+  nestedModulePM.addPass(createCSEPass());
 }
 
 //===---------------------------------------------------------------------===//
@@ -204,8 +207,10 @@ LogicalResult verifyDoubleTilingExpertPassPipelineConfig(
 //===---------------------------------------------------------------------===//
 
 void addCPUBufferOpsTileAndVectorizePipeline(OpPassManager &passManager) {
-  addTileAndDistributePasses(passManager, /*convertToDestinatinoStyle=*/false);
+  addTileAndDistributePasses(passManager,
+                             /*convertToDestinationPassingStyle=*/false);
 
+  OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
   {
     // Skip tiling reduction loops because this is expected to apply on copy ops
     // only.
@@ -213,19 +218,19 @@ void addCPUBufferOpsTileAndVectorizePipeline(OpPassManager &passManager) {
     options.tilingLevel =
         static_cast<int64_t>(StrategyTilingLevel::ParallelTiles);
     options.vectorize = true;
-    passManager.addNestedPass<func::FuncOp>(
+    nestedModulePM.addNestedPass<func::FuncOp>(
         createLinalgSingleTilingExpertPass(options));
-    passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
-    passManager.addNestedPass<func::FuncOp>(createCSEPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   }
 
   // Run IREE specific passes before vector lowering expert.
-  passManager.addNestedPass<func::FuncOp>(
+  nestedModulePM.addNestedPass<func::FuncOp>(
       createRemoveSingleIterationLoopPass());
 
   // Add the vector lowering expert.
   {
-    OpPassManager &nestedFuncPassManager = passManager.nest<func::FuncOp>();
+    OpPassManager &nestedFuncPassManager = nestedModulePM.nest<func::FuncOp>();
     LinalgVectorLoweringPassOptions options;
     options.splitVectorTransfersTo = "linalg-copy";
     addLowerToVectorTransforms(nestedFuncPassManager, options);
@@ -233,16 +238,17 @@ void addCPUBufferOpsTileAndVectorizePipeline(OpPassManager &passManager) {
 }
 
 void addDoubleTilingPadExpertPassPipeline(OpPassManager &passManager) {
-  passManager.addPass(createVerifyLinalgTransformLegalityPass());
-  addTileAndDistributePasses(passManager, /*convertToDestinatinoStyle=*/true);
+  addTileAndDistributePasses(passManager,
+                             /*convertToDestinationPassingStyle=*/true);
 
+  OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
   {
     LinalgFusePassOptions options;
     options.tilingLevel =
         static_cast<int64_t>(StrategyTilingLevel::ParallelTiles);
-    passManager.addNestedPass<func::FuncOp>(createLinalgFusePass(options));
-    passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
-    passManager.addNestedPass<func::FuncOp>(createCSEPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(createLinalgFusePass(options));
+    nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   }
 
   auto pad = [&](std::string anchorOpName, ArrayRef<int64_t> paddingDims) {
@@ -250,7 +256,7 @@ void addDoubleTilingPadExpertPassPipeline(OpPassManager &passManager) {
     options.pad = true;
     options.anchorOpName = anchorOpName;
     options.paddingDimensions.assign(paddingDims.begin(), paddingDims.end());
-    passManager.addNestedPass<func::FuncOp>(createLinalgFusePass(options));
+    nestedModulePM.addNestedPass<func::FuncOp>(createLinalgFusePass(options));
   };
 
   SmallVector<int64_t> paddingDims = {0, 1};
@@ -263,10 +269,10 @@ void addDoubleTilingPadExpertPassPipeline(OpPassManager &passManager) {
     LinalgSingleTilingExpertPassOptions options;
     options.tilingLevel =
         static_cast<int64_t>(StrategyTilingLevel::ReductionTiles);
-    passManager.addNestedPass<func::FuncOp>(
+    nestedModulePM.addNestedPass<func::FuncOp>(
         createLinalgSingleTilingExpertPass(options));
-    passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
-    passManager.addNestedPass<func::FuncOp>(createCSEPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   }
 
   paddingDims = {2};
@@ -280,33 +286,33 @@ void addDoubleTilingPadExpertPassPipeline(OpPassManager &passManager) {
   // options.hoistPaddings = SmallVector<int64_t>{2, 3, 0};
   // options.transposePaddings = SmallVector<std::string>{"0:1", "0:1",
   // "0:1"};
-  // passManager.addNestedPass<func::FuncOp>(createLinalgFusePass(options));
-  // passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
-  // passManager.addNestedPass<func::FuncOp>(createCSEPass());
+  // nestedModulePM.addNestedPass<func::FuncOp>(createLinalgFusePass(options));
+  // nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  // nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   //}
 
   // Fold dim(pad) away before vectorization.
-  passManager.addPass(memref::createResolveShapedTypeResultDimsPass());
+  nestedModulePM.addPass(memref::createResolveShapedTypeResultDimsPass());
 
   {
     LinalgSingleTilingExpertPassOptions options;
     options.vectorize = true;
     options.vectorizePadding = true;
-    passManager.addNestedPass<func::FuncOp>(
+    nestedModulePM.addNestedPass<func::FuncOp>(
         createLinalgSingleTilingExpertPass(options));
-    passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
-    passManager.addNestedPass<func::FuncOp>(createCSEPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   }
 
-  addCPUIREEComprehensiveBufferizePasses(passManager);
+  addCPUIREEComprehensiveBufferizePasses(nestedModulePM);
 
   // Run IREE specific passes before vector lowering expert.
-  passManager.addNestedPass<func::FuncOp>(
+  nestedModulePM.addNestedPass<func::FuncOp>(
       createRemoveSingleIterationLoopPass());
 
   // Add the vector lowering expert.
   {
-    OpPassManager &nestedFuncPassManager = passManager.nest<func::FuncOp>();
+    OpPassManager &nestedFuncPassManager = nestedModulePM.nest<func::FuncOp>();
     LinalgVectorLoweringPassOptions options;
     options.splitVectorTransfersTo = "linalg-copy";
     addLowerToVectorTransforms(nestedFuncPassManager, options);
@@ -315,9 +321,10 @@ void addDoubleTilingPadExpertPassPipeline(OpPassManager &passManager) {
 
 void addDoubleTilingExpertPassPipeline(OpPassManager &passManager,
                                        bool lowerToAVX2) {
-  passManager.addPass(createVerifyLinalgTransformLegalityPass());
-  addTileAndDistributePasses(passManager, /*convertToDestinatinoStyle=*/true);
+  addTileAndDistributePasses(passManager,
+                             /*convertToDestinationPassingStyle=*/true);
 
+  OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
   // Run LinalgFusePass firstly in case that we have fill + matmul + generic
   // ops. At this stage, we do not apply vectorization. The reduction dim won't
   // get tiled if the case is matmul + generic op. In this case, we have to tile
@@ -326,9 +333,9 @@ void addDoubleTilingExpertPassPipeline(OpPassManager &passManager,
     LinalgFusePassOptions options;
     options.tilingLevel =
         static_cast<int64_t>(StrategyTilingLevel::ParallelTiles);
-    passManager.addNestedPass<func::FuncOp>(createLinalgFusePass(options));
-    passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
-    passManager.addNestedPass<func::FuncOp>(createCSEPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(createLinalgFusePass(options));
+    nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   }
 
   // Add the sandbox single tiling expert to tile and vectorize.
@@ -340,21 +347,21 @@ void addDoubleTilingExpertPassPipeline(OpPassManager &passManager,
     options.vectorize = true;
     options.tilingLevel =
         static_cast<int64_t>(StrategyTilingLevel::ReductionTiles);
-    passManager.addNestedPass<func::FuncOp>(
+    nestedModulePM.addNestedPass<func::FuncOp>(
         createLinalgSingleTilingExpertPass(options));
-    passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
-    passManager.addNestedPass<func::FuncOp>(createCSEPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   }
 
-  addCPUIREEComprehensiveBufferizePasses(passManager);
+  addCPUIREEComprehensiveBufferizePasses(nestedModulePM);
 
   // Run IREE specific passes before vector lowering expert.
-  passManager.addNestedPass<func::FuncOp>(
+  nestedModulePM.addNestedPass<func::FuncOp>(
       createRemoveSingleIterationLoopPass());
 
   // Add the vector lowering expert.
   {
-    OpPassManager &nestedFuncPassManager = passManager.nest<func::FuncOp>();
+    OpPassManager &nestedFuncPassManager = nestedModulePM.nest<func::FuncOp>();
     LinalgVectorLoweringPassOptions options;
     options.lowerVectorTransposeToAVX2 = lowerToAVX2;
     options.splitVectorTransfersTo = "linalg-copy";
@@ -363,9 +370,10 @@ void addDoubleTilingExpertPassPipeline(OpPassManager &passManager,
 }
 
 void addConvTileAndDecomposeExpertPassPipeline(OpPassManager &passManager) {
-  passManager.addPass(createVerifyLinalgTransformLegalityPass());
-  addTileAndDistributePasses(passManager, /*convertToDestinatinoStyle=*/true);
+  addTileAndDistributePasses(passManager,
+                             /*convertToDestinationPassingStyle=*/true);
 
+  OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
   // Run LinalgFusePass firstly in case that we have fill + conv + generic
   // ops. At this stage, we do not apply vectorization. The reduction dim won't
   // get tiled if the case is conv + generic op. In this case, we have to tile
@@ -374,9 +382,9 @@ void addConvTileAndDecomposeExpertPassPipeline(OpPassManager &passManager) {
     LinalgFusePassOptions options;
     options.tilingLevel =
         static_cast<int64_t>(StrategyTilingLevel::ParallelTiles);
-    passManager.addNestedPass<func::FuncOp>(createLinalgFusePass(options));
-    passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
-    passManager.addNestedPass<func::FuncOp>(createCSEPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(createLinalgFusePass(options));
+    nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   }
 
   // Add the sandbox single tiling expert to tile and vectorize.
@@ -387,21 +395,21 @@ void addConvTileAndDecomposeExpertPassPipeline(OpPassManager &passManager) {
     options.vectorizePadding = true;
     options.tilingLevel =
         static_cast<int64_t>(StrategyTilingLevel::ReductionTiles);
-    passManager.addNestedPass<func::FuncOp>(
+    nestedModulePM.addNestedPass<func::FuncOp>(
         createLinalgSingleTilingExpertPass(options));
-    passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
-    passManager.addNestedPass<func::FuncOp>(createCSEPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+    nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   }
 
-  addCPUIREEComprehensiveBufferizePasses(passManager);
+  addCPUIREEComprehensiveBufferizePasses(nestedModulePM);
 
   // Run IREE specific passes before vector lowering expert.
-  passManager.addNestedPass<func::FuncOp>(
+  nestedModulePM.addNestedPass<func::FuncOp>(
       createRemoveSingleIterationLoopPass());
 
   // Add the vector lowering expert.
   {
-    OpPassManager &nestedFuncPassManager = passManager.nest<func::FuncOp>();
+    OpPassManager &nestedFuncPassManager = nestedModulePM.nest<func::FuncOp>();
     LinalgVectorLoweringPassOptions options;
     options.splitVectorTransfersTo = "shuffle";
     addLowerToVectorTransforms(nestedFuncPassManager, options);
@@ -410,40 +418,48 @@ void addConvTileAndDecomposeExpertPassPipeline(OpPassManager &passManager) {
 
 void addTileFuseAndVectorizePassPipeline(OpPassManager &passManager,
                                          bool lowerToVectors) {
-  addTileAndDistributePasses(passManager, /*convertToDestinatinoStyle=*/true);
+  addTileAndDistributePasses(passManager,
+                             /*convertToDestinationPassingStyle=*/true);
+
+  OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
 
   // Tile and vectorize linalg ops on tensors.
-  passManager.addNestedPass<func::FuncOp>(
+  nestedModulePM.addNestedPass<func::FuncOp>(
       createLLVMCPUTileFuseAndVectorizePass(lowerToVectors));
-  passManager.addNestedPass<func::FuncOp>(createCSEPass());
-  passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
 
-  addCPUIREEComprehensiveBufferizePasses(passManager);
-  passManager.addNestedPass<func::FuncOp>(createCSEPass());
-  passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  addCPUIREEComprehensiveBufferizePasses(nestedModulePM);
+  nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
 
-  passManager.addNestedPass<func::FuncOp>(createForOpCanonicalizationPass());
-  passManager.addNestedPass<func::FuncOp>(createOptimizeVectorTransferPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(createForOpCanonicalizationPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createOptimizeVectorTransferPass());
 }
 
 void addCPUBufferOpsDefaultPipeline(OpPassManager &passManager) {
-  addTileAndDistributePasses(passManager, /*convertToDestinatinoStyle=*/false);
+  addTileAndDistributePasses(passManager,
+                             /*convertToDestinationPassingStyle=*/false);
 }
 
 void addCPUDefaultPassPipeline(OpPassManager &passManager) {
-  addTileAndDistributePasses(passManager, /*convertToDestinatinoStyle=*/true);
-  addCPUIREEComprehensiveBufferizePasses(passManager);
+  addTileAndDistributePasses(passManager,
+                             /*convertToDestinationPassingStyle=*/true);
+  OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
+  addCPUIREEComprehensiveBufferizePasses(nestedModulePM);
 }
 
 void addLinalgTransformInterpPasses(OpPassManager &passManager) {
+  OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
   // Give control to the linalg_transform dialect.
-  passManager.addPass(createLinalgTransformInterpreterPass());
+  nestedModulePM.addPass(createLinalgTransformInterpreterPass());
 
   // Dropping the schedule is only needed if we want to embed the transform in
   // the module: we should drop the schedule once applied.
   // This pass does nothing in the case where we apply a separate policy
   // through a file.
-  passManager.addPass(createDropSchedulePass());
+  nestedModulePM.addPass(createDropSchedulePass());
 }
 
 static void addLowerToLLVMPasses(OpPassManager &passManager) {
@@ -490,9 +506,12 @@ static void addLowerToLLVMPasses(OpPassManager &passManager) {
 }
 
 void buildLLVMCPUCodegenPassPipeline(OpPassManager &passManager) {
-  passManager.nest<ModuleOp>().nest<func::FuncOp>().addPass(
+  passManager.addNestedPass<ModuleOp>(
+      createVerifyLinalgTransformLegalityPass());
+  passManager.nest<ModuleOp>().addNestedPass<func::FuncOp>(
       createTypePropagationPass());
-  passManager.nest<ModuleOp>().addPass(createBufferizeCopyOnlyDispatchesPass());
+  passManager.addNestedPass<ModuleOp>(createBufferizeCopyOnlyDispatchesPass());
+
   passManager.addPass(createLLVMCPULowerExecutableTargetPass());
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
   addLowerToLLVMPasses(nestedModulePM);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -143,20 +143,19 @@ void LLVMGPULowerExecutableTargetPass::runOnOperation() {
   }
 
   if (!testLoweringConfiguration && translationInfo.hasValue()) {
-    OpPassManager &nestedModulePM = executableLoweringPipeline.nest<ModuleOp>();
     switch (translationInfo.getValue().getDispatchLoweringPassPipeline()) {
       case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUDistribute:
-        addGPUSimpleDistributePassPipeline(nestedModulePM);
+        addGPUSimpleDistributePassPipeline(executableLoweringPipeline);
         break;
       case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUVectorize:
-        addGPUVectorizationPassPipeline(nestedModulePM);
+        addGPUVectorizationPassPipeline(executableLoweringPipeline);
         break;
       case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUMatmulSimt:
-        addGPUMatmulSimtPassPipeline(nestedModulePM);
+        addGPUMatmulSimtPassPipeline(executableLoweringPipeline);
         break;
       case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUMatmulTensorCore:
         addGPUMatmulTensorCorePassPipeline(
-            nestedModulePM,
+            executableLoweringPipeline,
             translationInfo.getValue().getSoftwarePipelineDepth());
         break;
       default:

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -125,7 +125,8 @@ std::unique_ptr<OperationPass<func::FuncOp>> createVectorizePadPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createOptimizeVectorTransferPass();
 
 /// Pass to insert workgroup count region and update translation info.
-std::unique_ptr<OperationPass<func::FuncOp>> createInsertDistributionInfoPass();
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
+createInsertDistributionInfoPass();
 
 /// Pass to tile and distribute to workgroups.
 std::unique_ptr<OperationPass<func::FuncOp>>

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -88,7 +88,7 @@ def OptimizeVectorTransfer :
 }
 
 def InsertDistributionInfo :
-    Pass<"iree-codegen-insert-distribution-info", "func::FuncOp"> {
+    Pass<"iree-codegen-insert-distribution-info", "IREE::HAL::ExecutableVariantOp"> {
   let summary = "Insert the workgroup count region and translation info";
   let constructor = "mlir::iree_compiler::createInsertDistributionInfoPass()";
 }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
@@ -96,21 +96,22 @@ void SPIRVLowerExecutableTargetPass::runOnOperation() {
   }
 
   if (!testLoweringConfiguration && passPipeline.hasValue()) {
-    OpPassManager &nestedModulePM = executableLoweringPipeline.nest<ModuleOp>();
     switch (*passPipeline) {
       case IREE::Codegen::DispatchLoweringPassPipeline::SPIRVDistribute:
-        addSPIRVTileAndDistributePassPipeline(nestedModulePM);
+        addSPIRVTileAndDistributePassPipeline(executableLoweringPipeline);
         break;
       case IREE::Codegen::DispatchLoweringPassPipeline::SPIRVVectorize:
-        addSPIRVTileAndVectorizePassPipeline(nestedModulePM);
+        addSPIRVTileAndVectorizePassPipeline(executableLoweringPipeline);
         break;
       case IREE::Codegen::DispatchLoweringPassPipeline::
           SPIRVVectorizeToCooperativeOps:
-        addSPIRVTileAndVectorizeToCooperativeOpsPassPipeline(nestedModulePM);
+        addSPIRVTileAndVectorizeToCooperativeOpsPassPipeline(
+            executableLoweringPipeline);
         break;
       case IREE::Codegen::DispatchLoweringPassPipeline::
           SPIRVVectorizeWithWorkgroupMemory:
-        addSPIRVTileAndVectorizeWithWorkgroupMemoryPassPipeline(nestedModulePM);
+        addSPIRVTileAndVectorizeWithWorkgroupMemoryPassPipeline(
+            executableLoweringPipeline);
         break;
       default:
         variantOp.emitOpError("Unsupported pipeline on GPU target.");

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -27,13 +27,9 @@ namespace iree_compiler {
 
 namespace {}  // namespace
 
-LogicalResult defineWorkgroupCountRegion(
-    OpBuilder &builder, func::FuncOp funcOp,
+FailureOr<IREE::HAL::ExecutableEntryPointOp> defineWorkgroupCountRegion(
+    OpBuilder &builder, IREE::HAL::ExecutableEntryPointOp entryPointOp,
     WorkgroupCountRegionBuilder regionBuilder) {
-  IREE::HAL::ExecutableEntryPointOp entryPointOp = getEntryPoint(funcOp);
-  if (!entryPointOp) {
-    return funcOp.emitOpError("unable to find corresponding entry point op");
-  }
   Location loc = entryPointOp.getLoc();
 
   OpBuilder::InsertionGuard guard(builder);
@@ -69,7 +65,7 @@ LogicalResult defineWorkgroupCountRegion(
       regionBuilder(builder, loc, device, workload);
   builder.create<IREE::HAL::ReturnOp>(loc, workgroupCount);
   entryPointOp.erase();
-  return success();
+  return clonedOp;
 }
 
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
@@ -12,6 +12,7 @@
 #ifndef IREE_COMPILER_CODEGEN_COMMON_TRANSFORMS_H_
 #define IREE_COMPILER_CODEGEN_COMMON_TRANSFORMS_H_
 
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
@@ -27,10 +28,12 @@ namespace iree_compiler {
 /// `hal.executable.entry_point` op for this operation. The method takes a
 /// callback function, which computes the workgroup count (x,y,z) given the
 /// workload along (x,y,z).
+/// Returns a new `hal.executable.entry_point` op. MLIR semantics requires
+/// creation of new ops when a region is added.
 using WorkgroupCountRegionBuilder = std::function<std::array<Value, 3>(
     OpBuilder &b, Location loc, Value device, std::array<Value, 3> workload)>;
-LogicalResult defineWorkgroupCountRegion(
-    OpBuilder &builder, func::FuncOp funcOp,
+FailureOr<IREE::HAL::ExecutableEntryPointOp> defineWorkgroupCountRegion(
+    OpBuilder &builder, IREE::HAL::ExecutableEntryPointOp entryPointOp,
     WorkgroupCountRegionBuilder regionBuilder);
 
 /// Insert patterns to perform folding of AffineMinOp by matching the pattern

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/Passes/TransformInterpreter.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/Passes/TransformInterpreter.cpp
@@ -74,8 +74,10 @@ public:
     if (clTransformFileName.empty()) {
       Block &body = topLevel->getRegion(0).front();
       for (auto op : body.getOps<transform::TransformOpInterface>()) {
-        if (failed(state.applyTransform(op)))
+        if (failed(state.applyTransform(op))) {
+          topLevel->emitError() << "failed to apply transform '" << op;
           return signalPassFailure();
+        }
       }
       return;
     }
@@ -84,7 +86,7 @@ public:
     std::string errorMessage;
     auto memoryBuffer = openInputFile(clTransformFileName, &errorMessage);
     if (!memoryBuffer) {
-      llvm::errs() << errorMessage << "\n";
+      topLevel->emitError() << errorMessage << "\n";
       return signalPassFailure();
     }
     // Tell sourceMgr about this buffer, the parser will pick it up.
@@ -94,8 +96,10 @@ public:
         parseSourceFile<ModuleOp>(sourceMgr, &getContext()));
     for (auto op : transformModule->getBody()
                        ->getOps<transform::TransformOpInterface>()) {
-      if (failed(state.applyTransform(op)))
+      if (failed(state.applyTransform(op))) {
+        topLevel->emitError() << "failed to apply transform '" << op;
         return signalPassFailure();
+      }
     }
   }
 

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/Passes/TransformInterpreter.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/Passes/TransformInterpreter.cpp
@@ -74,10 +74,8 @@ public:
     if (clTransformFileName.empty()) {
       Block &body = topLevel->getRegion(0).front();
       for (auto op : body.getOps<transform::TransformOpInterface>()) {
-        if (failed(state.applyTransform(op))) {
-          topLevel->emitError() << "failed to apply transform '" << op;
+        if (failed(state.applyTransform(op)))
           return signalPassFailure();
-        }
       }
       return;
     }
@@ -86,7 +84,7 @@ public:
     std::string errorMessage;
     auto memoryBuffer = openInputFile(clTransformFileName, &errorMessage);
     if (!memoryBuffer) {
-      topLevel->emitError() << errorMessage << "\n";
+      llvm::errs() << errorMessage << "\n";
       return signalPassFailure();
     }
     // Tell sourceMgr about this buffer, the parser will pick it up.
@@ -96,10 +94,8 @@ public:
         parseSourceFile<ModuleOp>(sourceMgr, &getContext()));
     for (auto op : transformModule->getBody()
                        ->getOps<transform::TransformOpInterface>()) {
-      if (failed(state.applyTransform(op))) {
-        topLevel->emitError() << "failed to apply transform '" << op;
+      if (failed(state.applyTransform(op)))
         return signalPassFailure();
-      }
     }
   }
 


### PR DESCRIPTION
Since this pass changes the `hal.executable.entry_point`, it should
work on `hal.executable.variant` ops (instead of `func.func`) ops it
is today.