### PR TITLE
Reorder CMake runtime include by deferring the Python install().

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -634,6 +634,8 @@ if(IREE_BUILD_COMPILER)
   add_subdirectory(compiler)
 endif()
 
+add_subdirectory(runtime)
+
 # tools/ can depend on compiler/ and runtime/
 add_subdirectory(iree/tools)
 
@@ -691,14 +693,8 @@ set(IREE_PUBLIC_INCLUDE_DIRS "${IREE_COMMON_INCLUDE_DIRS}"
 add_subdirectory(build_tools/benchmarks)
 
 #-------------------------------------------------------------------------------
-# Transitional directories
+# Samples
 #-------------------------------------------------------------------------------
-
-# The runtime uses tools and targets from elsewhere in the tree in a way
-# that is not supported by CMake, so we include it last (it aggregates
-# many things into top-level APIs). This should resolve once we finish
-# relayering everything.
-add_subdirectory(runtime)
 
 # samples/ can depend on anything, so we include it last
 if(IREE_BUILD_SAMPLES)

--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -191,7 +191,14 @@ install(
 )
 
 # Install tools into python_packages/iree_runtime/iree/runtime
-install(
+#
+# Our runtime/... directory is included by the root CMakeLists before the
+# tools/ directory which defines these targets, so we defer the install() to
+# the end of the root file. While deferred calls are generally fragile, this
+# install is purely a leaf feature (with no other calls depending on its
+# sequencing), so this use is okay.
+cmake_language(DEFER DIRECTORY "${IREE_SOURCE_DIR}"
+  CALL install
   TARGETS
     iree_tools_iree-benchmark-module
     iree_tools_iree-benchmark-trace


### PR DESCRIPTION
As discussed here: https://github.com/google/iree/pull/9118#discussion_r872875983