### PR TITLE
Convert CHLO TopK To LinalgExt TopK

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
@@ -483,9 +483,9 @@ struct TopkOpConversion : public OpConversionPattern<chlo::TopKOp> {
     Location loc = op.getLoc();
     Value operand = adaptor.operand();
 
-    auto inputValuesType = operand.getType().dyn_cast<RankedTensorType>();
-    auto outputValuesType = op.getResultTypes()[0].dyn_cast<ShapedType>();
-    auto outputIndicesType = op.getResultTypes()[1].dyn_cast<ShapedType>();
+    auto inputValuesType = operand.getType().dyn_cast<ShapedType>();
+    auto outputValuesType = op.values().getType().dyn_cast<ShapedType>();
+    auto outputIndicesType = op.indices().getType().dyn_cast<ShapedType>();
     if (!inputValuesType || !outputValuesType || !outputIndicesType) {
       return failure();
     }

--- a/compiler/src/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
@@ -525,7 +525,7 @@ struct TopkOpConversion : public OpConversionPattern<chlo::TopKOp> {
     }
     Value negInf = rewriter.create<arith::ConstantOp>(loc, negInfAttr);
     Attribute posInfAttr = rewriter.getIntegerAttr(
-        rewriter.getI32Type(), APInt::getSignedMaxValue(32));
+        indicesElementType, APInt::getSignedMaxValue(32));
     Value posInf = rewriter.create<arith::ConstantOp>(loc, posInfAttr);
     Value negInfTensor =
         rewriter.create<linalg::FillOp>(loc, negInf, initTensorOutputValues)

--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/convert_mhlo_to_linalg_ext.mlir
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/convert_mhlo_to_linalg_ext.mlir
@@ -542,3 +542,69 @@ func.func @reverse_multi_dim(%arg0: tensor<?x?xi32>) -> tensor<?x?xi32> {
 // CHECK-SAME:     ins(%[[IN]] : tensor<?x?xi32>)
 // CHECK-SAME:     outs(%[[INIT]] : tensor<?x?xi32>) : tensor<?x?xi32>
 // CHECK:        return %[[REV]]
+
+// -----
+
+func.func @chlo_top_k_int(%arg : tensor<16x16xi32>) -> (tensor<16x8xi32>, tensor<16x8xi32>) {
+  %1:2 = chlo.top_k(%arg, k=8) : tensor<16x16xi32> -> (tensor<16x8xi32>, tensor<16x8xi32>)
+  return %1#0, %1#1 : tensor<16x8xi32>, tensor<16x8xi32>
+}
+
+// CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK:       func.func @chlo_top_k_int
+// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:        %[[D0:.+]] = linalg.init_tensor [16, 16] : tensor<16x16xi32>
+// CHECK:        %[[D1:.+]] = linalg.generic
+// CHECK-SAME:   {indexing_maps = [#[[MAP0]]]
+// CHECK-SAME:   iterator_types = ["parallel", "parallel"]
+// CHECK-SAME:   outs(%[[D0]] : tensor<16x16xi32>)
+// CHECK:        %[[D7:.+]] = linalg.index 1 : index
+// CHECK:        %[[D8:.+]] = arith.index_cast %[[D7]] : index to i32
+// CHECK:        inalg.yield %[[D8]] : i32
+// CHECK:        %[[D2:.+]] = linalg.init_tensor [16, 8] : tensor<16x8xi32>
+// CHECK:        %[[D3:.+]] = linalg.init_tensor [16, 8] : tensor<16x8xi32>
+// CHECK-DAG:    %[[CNEG:.+]] = arith.constant -2147483648 : i32
+// CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : i32
+// CHECK-DAG:    %[[D4:.+]] = linalg.fill ins(%[[CNEG]] : i32) outs(%[[D2]]
+// CHECK-DAG:    %[[D5:.+]] = linalg.fill ins(%[[C0]] : i32) outs(%[[D3]]
+// CHECK:        %[[D6:.+]]:2 = iree_linalg_ext.topk
+// CHECK-SAME:     dimension(1)
+// CHECK-SAME:     ins(%[[ARG0]], %[[D1]]
+// CHECK-SAME:     outs(%[[D4]], %[[D5]]
+// CHECK:        ^bb0(%[[ARG1:.+]]: i32, %[[ARG2:.+]]: i32)
+// CHECK:        %[[D7:.+]] = arith.cmpi sge, %[[ARG1]], %[[ARG2]] : i32
+// CHECK:        iree_linalg_ext.yield %[[D7]] : i1
+// CHECK:        return %[[D6]]#0, %[[D6]]#1
+
+// -----
+
+func.func @chlo_top_k_float(%arg : tensor<16x16xf32>) -> (tensor<16x8xf32>, tensor<16x8xi32>) {
+  %1:2 = chlo.top_k(%arg, k=8) : tensor<16x16xf32> -> (tensor<16x8xf32>, tensor<16x8xi32>)
+  return %1#0, %1#1 : tensor<16x8xf32>, tensor<16x8xi32>
+}
+
+// CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK:       func.func @chlo_top_k_float
+// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:        %[[D0:.+]] = linalg.init_tensor [16, 16] : tensor<16x16xi32>
+// CHECK:        %[[D1:.+]] = linalg.generic
+// CHECK-SAME:   {indexing_maps = [#[[MAP0]]]
+// CHECK-SAME:   iterator_types = ["parallel", "parallel"]
+// CHECK-SAME:   outs(%[[D0]] : tensor<16x16xi32>)
+// CHECK:        %[[D7:.+]] = linalg.index 1 : index
+// CHECK:        %[[D8:.+]] = arith.index_cast %[[D7]] : index to i32
+// CHECK:        inalg.yield %[[D8]] : i32
+// CHECK:        %[[D2:.+]] = linalg.init_tensor [16, 8] : tensor<16x8xf32>
+// CHECK:        %[[D3:.+]] = linalg.init_tensor [16, 8] : tensor<16x8xi32>
+// CHECK-DAG:    %[[CNEG:.+]] = arith.constant 0xFF800000 : f32
+// CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : i32
+// CHECK-DAG:    %[[D4:.+]] = linalg.fill ins(%[[CNEG]] : f32) outs(%[[D2]]
+// CHECK-DAG:    %[[D5:.+]] = linalg.fill ins(%[[C0]] : i32) outs(%[[D3]]
+// CHECK:        %[[D6:.+]]:2 = iree_linalg_ext.topk
+// CHECK-SAME:     dimension(1)
+// CHECK-SAME:     ins(%[[ARG0]], %[[D1]]
+// CHECK-SAME:     outs(%[[D4]], %[[D5]]
+// CHECK:        ^bb0(%[[ARG1:.+]]: f32, %[[ARG2:.+]]: f32)
+// CHECK:        %[[D7:.+]] = arith.cmpf ogt, %[[ARG1]], %[[ARG2]] : f32
+// CHECK:        iree_linalg_ext.yield %[[D7]] : i1
+// CHECK:        return %[[D6]]#0, %[[D6]]#1

--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/convert_mhlo_to_linalg_ext.mlir
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/convert_mhlo_to_linalg_ext.mlir
@@ -564,9 +564,9 @@ func.func @chlo_top_k_int(%arg : tensor<16x16xi32>) -> (tensor<16x8xi32>, tensor
 // CHECK:        %[[D2:.+]] = linalg.init_tensor [16, 8] : tensor<16x8xi32>
 // CHECK:        %[[D3:.+]] = linalg.init_tensor [16, 8] : tensor<16x8xi32>
 // CHECK-DAG:    %[[CNEG:.+]] = arith.constant -2147483648 : i32
-// CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : i32
+// CHECK-DAG:    %[[CPOS:.+]] = arith.constant 2147483647 : i32
 // CHECK-DAG:    %[[D4:.+]] = linalg.fill ins(%[[CNEG]] : i32) outs(%[[D2]]
-// CHECK-DAG:    %[[D5:.+]] = linalg.fill ins(%[[C0]] : i32) outs(%[[D3]]
+// CHECK-DAG:    %[[D5:.+]] = linalg.fill ins(%[[CPOS]] : i32) outs(%[[D3]]
 // CHECK:        %[[D6:.+]]:2 = iree_linalg_ext.topk
 // CHECK-SAME:     dimension(1)
 // CHECK-SAME:     ins(%[[ARG0]], %[[D1]]
@@ -597,9 +597,9 @@ func.func @chlo_top_k_float(%arg : tensor<16x16xf32>) -> (tensor<16x8xf32>, tens
 // CHECK:        %[[D2:.+]] = linalg.init_tensor [16, 8] : tensor<16x8xf32>
 // CHECK:        %[[D3:.+]] = linalg.init_tensor [16, 8] : tensor<16x8xi32>
 // CHECK-DAG:    %[[CNEG:.+]] = arith.constant 0xFF800000 : f32
-// CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : i32
+// CHECK-DAG:    %[[CPOS:.+]] = arith.constant 2147483647 : i32
 // CHECK-DAG:    %[[D4:.+]] = linalg.fill ins(%[[CNEG]] : f32) outs(%[[D2]]
-// CHECK-DAG:    %[[D5:.+]] = linalg.fill ins(%[[C0]] : i32) outs(%[[D3]]
+// CHECK-DAG:    %[[D5:.+]] = linalg.fill ins(%[[CPOS]] : i32) outs(%[[D3]]
 // CHECK:        %[[D6:.+]]:2 = iree_linalg_ext.topk
 // CHECK-SAME:     dimension(1)
 // CHECK-SAME:     ins(%[[ARG0]], %[[D1]]

--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/convert_mhlo_to_linalg_ext.mlir
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/convert_mhlo_to_linalg_ext.mlir
@@ -550,17 +550,8 @@ func.func @chlo_top_k_int(%arg : tensor<16x16xi32>) -> (tensor<16x8xi32>, tensor
   return %1#0, %1#1 : tensor<16x8xi32>, tensor<16x8xi32>
 }
 
-// CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0, d1) -> (d0, d1)>
 // CHECK:       func.func @chlo_top_k_int
 // CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]
-// CHECK:        %[[D0:.+]] = linalg.init_tensor [16, 16] : tensor<16x16xi32>
-// CHECK:        %[[D1:.+]] = linalg.generic
-// CHECK-SAME:   {indexing_maps = [#[[MAP0]]]
-// CHECK-SAME:   iterator_types = ["parallel", "parallel"]
-// CHECK-SAME:   outs(%[[D0]] : tensor<16x16xi32>)
-// CHECK:        %[[D7:.+]] = linalg.index 1 : index
-// CHECK:        %[[D8:.+]] = arith.index_cast %[[D7]] : index to i32
-// CHECK:        inalg.yield %[[D8]] : i32
 // CHECK:        %[[D2:.+]] = linalg.init_tensor [16, 8] : tensor<16x8xi32>
 // CHECK:        %[[D3:.+]] = linalg.init_tensor [16, 8] : tensor<16x8xi32>
 // CHECK-DAG:    %[[CNEG:.+]] = arith.constant -2147483648 : i32
@@ -569,7 +560,7 @@ func.func @chlo_top_k_int(%arg : tensor<16x16xi32>) -> (tensor<16x8xi32>, tensor
 // CHECK-DAG:    %[[D5:.+]] = linalg.fill ins(%[[CPOS]] : i32) outs(%[[D3]]
 // CHECK:        %[[D6:.+]]:2 = iree_linalg_ext.topk
 // CHECK-SAME:     dimension(1)
-// CHECK-SAME:     ins(%[[ARG0]], %[[D1]]
+// CHECK-SAME:     ins(%[[ARG0]]
 // CHECK-SAME:     outs(%[[D4]], %[[D5]]
 // CHECK:        ^bb0(%[[ARG1:.+]]: i32, %[[ARG2:.+]]: i32)
 // CHECK:        %[[D7:.+]] = arith.cmpi sge, %[[ARG1]], %[[ARG2]] : i32
@@ -583,17 +574,8 @@ func.func @chlo_top_k_float(%arg : tensor<16x16xf32>) -> (tensor<16x8xf32>, tens
   return %1#0, %1#1 : tensor<16x8xf32>, tensor<16x8xi32>
 }
 
-// CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0, d1) -> (d0, d1)>
 // CHECK:       func.func @chlo_top_k_float
 // CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]
-// CHECK:        %[[D0:.+]] = linalg.init_tensor [16, 16] : tensor<16x16xi32>
-// CHECK:        %[[D1:.+]] = linalg.generic
-// CHECK-SAME:   {indexing_maps = [#[[MAP0]]]
-// CHECK-SAME:   iterator_types = ["parallel", "parallel"]
-// CHECK-SAME:   outs(%[[D0]] : tensor<16x16xi32>)
-// CHECK:        %[[D7:.+]] = linalg.index 1 : index
-// CHECK:        %[[D8:.+]] = arith.index_cast %[[D7]] : index to i32
-// CHECK:        inalg.yield %[[D8]] : i32
 // CHECK:        %[[D2:.+]] = linalg.init_tensor [16, 8] : tensor<16x8xf32>
 // CHECK:        %[[D3:.+]] = linalg.init_tensor [16, 8] : tensor<16x8xi32>
 // CHECK-DAG:    %[[CNEG:.+]] = arith.constant 0xFF800000 : f32
@@ -602,7 +584,7 @@ func.func @chlo_top_k_float(%arg : tensor<16x16xf32>) -> (tensor<16x8xf32>, tens
 // CHECK-DAG:    %[[D5:.+]] = linalg.fill ins(%[[CPOS]] : i32) outs(%[[D3]]
 // CHECK:        %[[D6:.+]]:2 = iree_linalg_ext.topk
 // CHECK-SAME:     dimension(1)
-// CHECK-SAME:     ins(%[[ARG0]], %[[D1]]
+// CHECK-SAME:     ins(%[[ARG0]]
 // CHECK-SAME:     outs(%[[D4]], %[[D5]]
 // CHECK:        ^bb0(%[[ARG1:.+]]: f32, %[[ARG2:.+]]: f32)
 // CHECK:        %[[D7:.+]] = arith.cmpf ogt, %[[ARG1]], %[[ARG2]] : f32

--- a/integrations/tensorflow/test/iree_tf_tests/math/llvmaot__top_k.run
+++ b/integrations/tensorflow/test/iree_tf_tests/math/llvmaot__top_k.run
@@ -1,3 +1,2 @@
 # REQUIRES: llvmaot
 # RUN: %PYTHON -m iree_tf_tests.math.math_test --target_backends=iree_llvmaot --dynamic_dims=false --functions=top_k --artifacts_dir=%t
-# XFAIL: *

--- a/integrations/tensorflow/test/iree_tf_tests/math/vulkan__top_k.run
+++ b/integrations/tensorflow/test/iree_tf_tests/math/vulkan__top_k.run
@@ -1,3 +1,2 @@
 # REQUIRES: vulkan
 # RUN: %PYTHON -m iree_tf_tests.math.math_test --target_backends=iree_vulkan --dynamic_dims=false --functions=top_k --artifacts_dir=%t
-# XFAIL: *

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1271,7 +1271,7 @@ LogicalResult TopkOp::verify() {
   }
   auto terminatorOp = llvm::dyn_cast<YieldOp>(block.getTerminator());
   if (!terminatorOp || !terminatorOp.getOperand(0).getType().isInteger(1)) {
-    return op->emitOpError("region block must end with a linalg_ext Yield i1!");
+    return op->emitOpError("region block must end with a linalg_ext.yield i1!");
   }
   return success();
 }

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1269,9 +1269,9 @@ LogicalResult TopkOp::verify() {
       block.getArgument(1).getType() != inputValuesType.getElementType()) {
     return op->emitOpError("region block types must match input");
   }
-  auto terminatorOp = llvm::cast<YieldOp>(block.getTerminator());
+  auto terminatorOp = llvm::dyn_cast<YieldOp>(block.getTerminator());
   if (!terminatorOp || !terminatorOp.getOperand(0).getType().isInteger(1)) {
-    return op->emitOpError("region block must end with a Yield i1!");
+    return op->emitOpError("region block must end with a linalg_ext Yield i1!");
   }
   return success();
 }


### PR DESCRIPTION
Maps a CHLO TopK To LinalgExt TopK. Additional steps during the conversion: 

- `chlo::topk` always computes `k` along the final dimension. `k` is set to the rank for `linalg_ext::topk`
- an input indices tensor is to accompany the input values is generated using a `linalg::generic` loop
- Output tensors for values and indices are initialized and filled with default values
- The `linalg_ext::topk` region is defined for a max k comparison