### PR TITLE
Check in configuration files for Buildkite agents

### DIFF
--- a/build_tools/buildkite/agent/configs/orchestration.cfg
+++ b/build_tools/buildkite/agent/configs/orchestration.cfg
@@ -1,0 +1,39 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Configuration for the orchestration agents.
+# See https://buildkite.com/docs/agent/v3/configuration
+
+# Note that placeholders must be filled in before this can be used.
+
+# The token from your Buildkite "Agents" page
+token="<AGENT-TOKEN-PLACEHOLDER>"
+
+# The name of the agent
+name="%hostname-%spawn"
+
+# The number of agents to spawn in parallel
+spawn=2
+
+# Custom tags for the agent
+tags="platform=gcp,queue=orchestration,security=<TRUST-LEVEL-PLACEHOLDER>"
+# Include the host's Google Cloud instance meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)
+tags-from-gcp=true
+# Include the host's meta-data as tags (hostname, machine-id, and OS).
+tags-from-host=true
+
+# Path to where the builds will run from
+build-path="/var/lib/buildkite-agent/builds"
+# Directory where the hook scripts are found
+hooks-path="/etc/buildkite-agent/hooks"
+# When plugins are installed they will be saved to this path
+plugins-path="/etc/buildkite-agent/plugins"
+
+git-fetch-flags="-v --prune --no-recurse-submodules"
+no-git-submodules=true
+
+# Prepend log lines with timestamps
+timestamp-lines=true

--- a/build_tools/buildkite/agent/hooks/README.md
+++ b/build_tools/buildkite/agent/hooks/README.md
@@ -1,0 +1,3 @@
+Hooks for the buildkite agents. See https://buildkite.com/docs/agent/v3/hooks.
+Each hook file is prefixed with the name of the hook. It should be deployed on
+agents under that name rather than its full name.

--- a/build_tools/buildkite/agent/hooks/pre-bootstrap-trusted-agent.py
+++ b/build_tools/buildkite/agent/hooks/pre-bootstrap-trusted-agent.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import json
+import os
+import sys
+
+ALLOWED_PIPELINES = ["presubmit", "postsubmit"]
+ALLOWED_PLUGINS = [
+    "github.com/GMNGeoffrey/smooth-checkout-buildkite-plugin#24e54e7729",
+]
+
+
+def main():
+  # See https://buildkite.com/docs/agent/v3/hooks#agent-lifecycle-hooks
+  buildkite_env_file = os.environ["BUILDKITE_ENV_FILE"]
+  buildkite_env = {}
+  with open(buildkite_env_file) as f:
+    for line in f:
+      key, val = line.split("=", maxsplit=1)
+      buildkite_env[key] = val
+
+  pipeline = buildkite_env["BUILDKITE_PIPELINE_SLUG"]
+  if pipeline not in ALLOWED_PIPELINES:
+    print(f"Pipeline '{pipeline}' is not allowed to run on this agent.",
+          file=sys.stderr)
+    sys.exit(2)
+
+  plugins = json.loads(buildkite_env["BUILDKITE_PLUGINS"])
+
+  for plugin in plugins:
+    if plugin not in ALLOWED_PLUGINS:
+      print(f"Plugin '{plugin}' is not allowed to run on this agent.",
+            file=sys.stderr)
+      sys.exit(2)
+
+
+if __name__ == "__main__":
+  main()

--- a/build_tools/buildkite/agent/hooks/pre-bootstrap-trusted-agent.py
+++ b/build_tools/buildkite/agent/hooks/pre-bootstrap-trusted-agent.py
@@ -16,8 +16,9 @@ from dotenv import dotenv_values
 
 ALLOWED_PIPELINES = ["presubmit", "postsubmit"]
 ALLOWED_PLUGINS = [
-    "github.com/GMNGeoffrey/smooth-checkout-buildkite-plugin#24e54e7729",
+    "https://github.com/GMNGeoffrey/smooth-checkout-buildkite-plugin#24e54e7729",
 ]
+
 
 def main():
   # See https://buildkite.com/docs/agent/v3/hooks#agent-lifecycle-hooks
@@ -26,8 +27,10 @@ def main():
 
   buildkite_env = dotenv_values(buildkite_env_file)
 
+  print("Buildkite environment:", file=sys.stderr)
   for k, v in buildkite_env.items():
     print(f"{k}: {v}", file=sys.stderr)
+
   pipeline = buildkite_env["BUILDKITE_PIPELINE_SLUG"]
   if pipeline not in ALLOWED_PIPELINES:
     print(f"Pipeline '{pipeline}' is not allowed to run on this agent.",
@@ -41,9 +44,16 @@ def main():
   plugins = json.loads(buildkite_env["BUILDKITE_PLUGINS"])
 
   for plugin in plugins:
-    if plugin not in ALLOWED_PLUGINS:
-      print(f"Plugin '{plugin}' is not allowed to run on this agent.",
-            file=sys.stderr)
+    plugin_keys = list(plugin.keys())
+    if len(plugin_keys) != 1:
+      print(f"Got plugin in unexpected format: '{plugin}'", file=sys.stderr)
+      sys.exit(3)
+    plugin_key = plugin_keys[0]
+    if plugin_key not in ALLOWED_PLUGINS:
+      print(
+          f"Plugin with key '{plugin_key}' is not allowed to run on this agent:"
+          f" '{plugin}'",
+          file=sys.stderr)
       sys.exit(2)
 
 


### PR DESCRIPTION
This includes a hook for the trusted agents to limit which pipelines
and plugins they will use. The plan for now is to just deploy these
configs manually, but I think it's useful to have them checked in. Note
that I've switched to slightly "trusted" and "untrusted" naming for the
security levels, which I think is clearer.

Tested: Copied the hook to the trusted orchestration agent and the
build passes: https://buildkite.com/iree/presubmit/builds/113