### PR TITLE
Add a pass to distribute the result computation to workgroups.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD
@@ -40,6 +40,7 @@ iree_compiler_cc_library(
         "CleanupBufferAllocViewPass.cpp",
         "ConvertToDestinationPassingStylePass.cpp",
         "DestructiveUpdateUtils.cpp",
+        "DistributeToWorkgroupsPass.cpp",
         "FlattenMemRefSubspanPass.cpp",
         "FoldAffineMinInDistributedLoops.cpp",
         "FoldTensorExtractOpPass.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -32,6 +32,7 @@ iree_cc_library(
     "CleanupBufferAllocViewPass.cpp"
     "ConvertToDestinationPassingStylePass.cpp"
     "DestructiveUpdateUtils.cpp"
+    "DistributeToWorkgroupsPass.cpp"
     "FlattenMemRefSubspanPass.cpp"
     "FoldAffineMinInDistributedLoops.cpp"
     "FoldTensorExtractOpPass.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/DistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DistributeToWorkgroupsPass.cpp
@@ -1,0 +1,225 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//=== DistributeToWorkgroupsPass.cpp - Disribute tiles to workgroups -----===//
+//
+// This pass distributes the computation to workgroups. Unlike tile
+// and distribute that tiles the computation to distribute the work, this pass
+// splits `flow.dispatch.tensor.store` to have each workgroup compute a tile
+// of the result.
+//
+//===---------------------------------------------------------------------===//
+
+#include "iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h"
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Passes.h"
+#include "iree/compiler/Codegen/Transforms/Transforms.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/MemRef/Transforms/Passes.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+
+/// When the dispatch is not yet distributed, distributes the
+/// `flow.dispatch.tensor.store` operation that writes out the result
+/// by writing just a slice of the store in each workgroup.
+struct ExtractResultSlice
+    : public OpRewritePattern<IREE::Flow::DispatchTensorStoreOp> {
+  ExtractResultSlice(MLIRContext *context, ArrayRef<int64_t> tileSizes,
+                     PatternBenefit benefit = 1)
+      : OpRewritePattern(context, benefit),
+        tileSizes(tileSizes.begin(), tileSizes.end()) {}
+
+  LogicalResult matchAndRewrite(IREE::Flow::DispatchTensorStoreOp storeOp,
+                                PatternRewriter &rewriter) const override {
+    Value source = storeOp.value();
+    auto sourceType = source.getType().dyn_cast<ShapedType>();
+    if (!sourceType) return failure();
+
+    auto entryPointOp = getEntryPoint(storeOp->getParentOfType<func::FuncOp>());
+    if (failed(entryPointOp)) return failure();
+
+    /// Only split the store if the workgroup count region is empty.
+    Region &workgroupCountRegion = entryPointOp.getValue().workgroup_count();
+    if (!workgroupCountRegion.empty()) return failure();
+
+    // Compute the slice to map to each workgroup.
+    // 1) If tile size is not zero,
+    //    - use that as the slice size
+    //    - offset is tile size * thread_id
+    // 2) If tile size is zero,
+    //    - use the dim of the source as the slice size
+    //    - offset is 0.
+    int64_t sourceRank = sourceType.getRank();
+    SmallVector<int64_t> filledTileSizes(tileSizes);
+    filledTileSizes.resize(sourceRank, 0);
+    Location loc = storeOp.getLoc();
+    auto tileSizeVals = llvm::to_vector(
+        llvm::map_range(filledTileSizes, [&](int64_t t) -> Value {
+          return rewriter.create<arith::ConstantIndexOp>(loc, t);
+        }));
+    auto extentVals = llvm::to_vector(llvm::map_range(
+        llvm::seq<int64_t>(0, sourceRank), [&](int64_t dim) -> Value {
+          return rewriter.create<tensor::DimOp>(loc, source, dim);
+        }));
+
+    AffineExpr sym0, sym1, sym2;
+    bindSymbols(rewriter.getContext(), sym0, sym1, sym2);
+    // Offset map is always
+    // affine_map<()[s0, s1] -> (s0 * s1)>()[%tileSize, %id]
+    AffineMap offsetMap = AffineMap::get(0, 2, sym0 * sym1);
+    // Size map is always
+    // affine_map<()[s0, s1, s2, s3] -> (s0, s1 - s2 * s0)>()
+    //     [%tileSize, %extent, %id]
+    AffineMap sizeMap =
+        AffineMap::get(0, 3, ArrayRef<AffineExpr>{sym0, sym1 - sym2 * sym0},
+                       rewriter.getContext());
+
+    Attribute zero = rewriter.getIndexAttr(0);
+    Attribute one = rewriter.getIndexAttr(1);
+    SmallVector<OpFoldResult> offsets(sourceRank, zero),
+        sizes(extentVals.begin(), extentVals.end()), strides(sourceRank, one);
+    unsigned mappedDim = 0;
+    SmallVector<int64_t> distributedTileSizes;
+    // Map the innermost tiled dimension to `x`, next innermost tiled dimension
+    // to `y` and so on.
+    for (auto dim : llvm::reverse(llvm::seq<int64_t>(0, sourceRank))) {
+      if (filledTileSizes[dim] && mappedDim < kNumMaxParallelDims) {
+        Value id =
+            rewriter.create<IREE::HAL::InterfaceWorkgroupIDOp>(loc, mappedDim);
+        auto offsetOp = rewriter.create<AffineApplyOp>(
+            loc, offsetMap, ValueRange{tileSizeVals[dim], id});
+        offsets[dim] = offsetOp.getResult();
+        auto sizeOp = rewriter.create<AffineMinOp>(
+            loc, sizeMap, ValueRange{tileSizeVals[dim], extentVals[dim], id});
+        sizes[dim] = sizeOp.getResult();
+        distributedTileSizes.push_back(filledTileSizes[dim]);
+        mappedDim++;
+      }
+    }
+
+    // Extract the slice of the source each workgroups writes.
+    auto sourceSlice = rewriter.create<tensor::ExtractSliceOp>(
+        loc, source, offsets, sizes, strides);
+
+    // Find the offset, size and stride into which the result is stored.
+    SmallVector<OpFoldResult> combinedOffsets, combinedSizes, combinedStrides;
+    if (failed(IREE::Flow::foldOffsetsSizesAndStrides(
+            rewriter, loc, storeOp, sourceSlice, storeOp.getDroppedDims(),
+            combinedOffsets, combinedSizes, combinedStrides))) {
+      return failure();
+    }
+
+    // Update the entry point op to specify the number of threads to use
+    // indicating that the code is distributed.
+    WorkgroupCountRegionBuilder regionBuilder =
+        [&distributedTileSizes](OpBuilder &builder, Location loc, Value device,
+                                std::array<Value, 3> workload) {
+          Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
+          std::array<Value, 3> numWorkgroups = {one, one, one};
+          for (auto ts : llvm::enumerate(distributedTileSizes)) {
+            AffineExpr num;
+            bindSymbols(builder.getContext(), num);
+            AffineExpr denom =
+                getAffineConstantExpr(ts.value(), builder.getContext());
+            AffineMap ceilDiv = AffineMap::get(
+                0, 1,
+                getAffineBinaryOpExpr(AffineExprKind::CeilDiv, num, denom));
+            numWorkgroups[ts.index()] = builder.create<AffineApplyOp>(
+                loc, ceilDiv, workload[ts.index()]);
+          }
+          return numWorkgroups;
+        };
+    if (failed(defineWorkgroupCountRegion(rewriter, entryPointOp.getValue(),
+                                          regionBuilder))) {
+      return failure();
+    }
+    rewriter.eraseOp(entryPointOp.getValue());
+
+    // Replace the full store with the store of the slice.
+    rewriter.replaceOpWithNewOp<IREE::Flow::DispatchTensorStoreOp>(
+        storeOp, sourceSlice.getResult(), storeOp.target(),
+        storeOp.target_dims(), combinedOffsets, combinedSizes, combinedStrides);
+    return success();
+  }
+
+ private:
+  // For now just use `int64_t` tile sizes. Eventually change these
+  // to use `linalg::LinalgTilingOptions` (maybe).
+  SmallVector<int64_t> tileSizes;
+};
+
+/// Folds the `flow.dispatch.tensor.load` -> `tensor.extract_slice` into
+/// a `flow.dispatch.tensor.load` of just the slice.
+struct FoldTensorLoadWithExtractSlice
+    : public OpRewritePattern<tensor::ExtractSliceOp> {
+  using OpRewritePattern<tensor::ExtractSliceOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
+                                PatternRewriter &rewriter) const override {
+    auto loadOp =
+        sliceOp.source().getDefiningOp<IREE::Flow::DispatchTensorLoadOp>();
+    if (!loadOp) {
+      return failure();
+    }
+
+    SmallVector<OpFoldResult> combinedOffsets, combinedSizes, combinedStrides;
+    Location loc = sliceOp->getLoc();
+    if (failed(IREE::Flow::foldOffsetsSizesAndStrides(
+            rewriter, loc, loadOp, sliceOp, loadOp.getDroppedDims(),
+            combinedOffsets, combinedSizes, combinedStrides))) {
+      return failure();
+    }
+    rewriter.replaceOpWithNewOp<IREE::Flow::DispatchTensorLoadOp>(
+        sliceOp, sliceOp.getType(), loadOp.source(), loadOp.source_dims(),
+        combinedOffsets, combinedSizes, combinedStrides);
+    return success();
+  }
+};
+
+/// Pass to distribute the dispatch to workgroups.
+struct DistributeToWorkgroupsPass
+    : DistributeToWorkgroupsBase<DistributeToWorkgroupsPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<arith::ArithmeticDialect, IREE::Flow::FlowDialect,
+                    IREE::HAL::HALDialect, linalg::LinalgDialect,
+                    scf::SCFDialect, tensor::TensorDialect>();
+  }
+
+  void runOnOperation() override;
+};
+}  // namespace
+
+void DistributeToWorkgroupsPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  RewritePatternSet patterns(context);
+  // Insert the split for the `flow.dispatch.tensor.store`
+  patterns.insert<ExtractResultSlice>(context, tileSizes);
+  patterns.insert<FoldTensorLoadWithExtractSlice,
+                  IREE::LinalgExt::SwapTilingInterfaceOp>(context);
+  memref::populateResolveRankedShapeTypeResultDimsPatterns(patterns);
+  linalg::populateLinalgTilingCanonicalizationPatterns(patterns);
+  if (failed(
+          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+    return signalPassFailure();
+  }
+}
+
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
+createDistributeToWorkgroupsPass() {
+  return std::make_unique<DistributeToWorkgroupsPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Common/InsertDistributionInfoPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/InsertDistributionInfoPass.cpp
@@ -168,6 +168,7 @@ void InsertDistributionInfoPass::runOnOperation() {
     if (failed(newEntryPointOp)) {
       return signalPassFailure();
     }
+    exportOp.erase();
 
     if (failed(updateTranslationInfoAttr(newEntryPointOp.getValue(),
                                          workloadPerWorkroup))) {

--- a/compiler/src/iree/compiler/Codegen/Common/SetNumWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/SetNumWorkgroupsPass.cpp
@@ -144,6 +144,8 @@ LogicalResult setNumWorkgroupsImpl(IREE::HAL::ExecutableVariantOp variantOp,
     if (failed(defineWorkgroupCountRegion(builder, exportOp, regionBuilder))) {
       return failure();
     }
+    exportOp.erase();
+    return success();
   }
 
   // Apply post distribution canonicalization passes.

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD
@@ -24,6 +24,7 @@ iree_lit_test_suite(
             "canonicalize_interface_load_store.mlir",
             "convert_to_destination_passing_style.mlir",
             "dead_alloc.mlir",
+            "distribute_to_workgroups.mlir",
             "distribute_gpu_shared_memory.mlir",
             "flatten_memref_subspan.mlir",
             "fold_affine_min_in_distributed_loops.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -20,6 +20,7 @@ iree_lit_test_suite(
     "convert_to_destination_passing_style.mlir"
     "dead_alloc.mlir"
     "distribute_gpu_shared_memory.mlir"
+    "distribute_to_workgroups.mlir"
     "flatten_memref_subspan.mlir"
     "fold_affine_min_in_distributed_loops.mlir"
     "fold_tensor_extract_op.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/distribute_to_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/distribute_to_workgroups.mlir
@@ -1,0 +1,73 @@
+// RUN: iree-opt -pass-pipeline="hal.executable(hal.executable.variant(iree-codegen-distribute-to-workgroups{tile-sizes=3,5})),cse" %s | FileCheck %s
+
+#executable_layout = #hal.executable.layout<push_constants = 3, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable @simple_distribute {
+  hal.executable.variant @llvm, target = <"llvm", "embedded-elf-arm_64", {}> {
+    hal.executable.export @simple_distribute layout(#executable_layout)
+    builtin.module {
+      func.func @simple_distribute() {
+        %m = hal.interface.constant.load[0] : index
+        %n = hal.interface.constant.load[1] : index
+        %k = hal.interface.constant.load[2] : index
+        %cst = arith.constant 0.0 : f32
+        %lhs_binding = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:?x?xf32>{%m, %k}
+        %rhs_binding = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<readonly:?x?xf32>{%k, %n}
+        %result_binding = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : !flow.dispatch.tensor<writeonly:?x?xf32>{%m, %n}
+        %lhs = flow.dispatch.tensor.load %lhs_binding, offsets = [0, 0], sizes = [%m, %k], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:?x?xf32>{%m, %k} -> tensor<?x?xf32>
+        %rhs = flow.dispatch.tensor.load %rhs_binding, offsets = [0, 0], sizes = [%k, %n], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:?x?xf32>{%k, %n} -> tensor<?x?xf32>
+        %init = linalg.init_tensor [%m, %n] : tensor<?x?xf32>
+        %fill = linalg.fill ins(%cst : f32) outs(%init : tensor<?x?xf32>) -> tensor<?x?xf32>
+        %gemm = linalg.matmul ins(%lhs, %rhs : tensor<?x?xf32>, tensor<?x?xf32>) outs(%fill : tensor<?x?xf32>) -> tensor<?x?xf32>
+        flow.dispatch.tensor.store %gemm, %result_binding, offsets = [0, 0], sizes = [%m, %n], strides = [1, 1]
+            : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:?x?xf32>{%m, %n}
+        return
+      }
+    }
+  }
+}
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 5)>
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 3)>
+//  CHECK-DAG: #[[MAP2:.+]] = affine_map<()[s0, s1] -> (5, s0 - s1 * 5)>
+//  CHECK-DAG: #[[MAP3:.+]] = affine_map<()[s0, s1] -> (3, s0 - s1 * 3)>
+//  CHECK-DAG: #[[MAP4:.+]] = affine_map<()[s0] -> (s0 * 3)>
+//  CHECK-DAG: #[[MAP5:.+]] = affine_map<()[s0] -> (s0 * 5)>
+//      CHECK: hal.executable.export public @simple_distribute
+// CHECK-NEXT:   ^bb0(%{{.+}}: !hal.device, %[[ARG1:[a-zA-Z0-9]+]]: index, %[[ARG2:[a-zA-Z0-9]+]]: index
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//  CHECK-DAG:   %[[NWG_X:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]]]
+//  CHECK-DAG:   %[[NWG_Y:.+]] = affine.apply #[[MAP1]]()[%[[ARG2]]]
+//      CHECK:   hal.return %[[NWG_X]], %[[NWG_Y]], %[[C1]]
+//      CHECK: func.func @simple_distribute()
+//  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//  CHECK-DAG:   %[[M:.+]] = hal.interface.constant.load[0] : index
+//  CHECK-DAG:   %[[N:.+]] = hal.interface.constant.load[1] : index
+//  CHECK-DAG:   %[[K:.+]] = hal.interface.constant.load[2] : index
+//  CHECK-DAG:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(0)
+//  CHECK-DAG:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(1)
+//  CHECK-DAG:   %[[RESULT_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(2)
+//  CHECK-DAG:   %[[WGID_X:.+]] = hal.interface.workgroup.id[0]
+//  CHECK-DAG:   %[[TS_X:.+]] = affine.min #[[MAP2]]()[%[[N]], %[[WGID_X]]]
+//  CHECK-DAG:   %[[WGID_Y:.+]] = hal.interface.workgroup.id[1]
+//  CHECK-DAG:   %[[TS_Y:.+]] = affine.min #[[MAP3]]()[%[[M]], %[[WGID_Y]]]
+//  CHECK-DAG:   %[[OFFSET_Y:.+]] = affine.apply #[[MAP4]]()[%[[WGID_Y]]]
+//  CHECK-DAG:   %[[LHS_TILE:.+]] = flow.dispatch.tensor.load %[[LHS_BINDING]]
+// CHECK-SAME:       offsets = [%[[OFFSET_Y]], %[[C0]]], sizes = [%[[TS_Y]], %[[K]]], strides = [%[[C1]], %[[C1]]]
+//  CHECK-DAG:   %[[OFFSET_X:.+]] = affine.apply #[[MAP5]]()[%[[WGID_X]]]
+//  CHECK-DAG:   %[[RHS_TILE:.+]] = flow.dispatch.tensor.load %[[RHS_BINDING]]
+// CHECK-SAME:       offsets = [%[[C0]], %[[OFFSET_X]]], sizes = [%[[K]], %[[TS_X]]], strides = [%[[C1]], %[[C1]]]
+//  CHECK-DAG:   %[[INIT_TILE:.+]] = linalg.init_tensor [%[[TS_Y]], %[[TS_X]]]
+//      CHECK:   %[[FILL_TILE:.+]] = linalg.fill
+// CHECK-SAME:       outs(%[[INIT_TILE]] :
+//      CHECK:   %[[GEMM_TILE:.+]] = linalg.matmul ins(%[[LHS_TILE]], %[[RHS_TILE]] :
+// CHECK-SAME:       outs(%[[FILL_TILE]] :
+//      CHECK:   flow.dispatch.tensor.store %[[GEMM_TILE]], %[[RESULT_BINDING]]
+// CHECK-SAME:       offsets = [%[[OFFSET_Y]], %[[OFFSET_X]]], sizes = [%[[TS_Y]], %[[TS_X]]], strides = [%[[C1]], %[[C1]]]

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -66,6 +66,12 @@ std::unique_ptr<OperationPass<func::FuncOp>> createCleanupBufferAllocViewPass();
 std::unique_ptr<OperationPass<ModuleOp>>
 createBufferizeCopyOnlyDispatchesPass();
 
+/// Distributes the computation amongst workgroups. Unlike
+/// `TileAndDistributeToWorkgroupsPass`, just splits the output of the
+/// dispatch such that each workgroups computes a slice of the outpt.
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
+createDistributeToWorkgroupsPass();
+
 /// Flattens n-D MemRef subspan ops to 1-D MemRef and folds the byte offsets on
 /// subspan ops to the consumer load/store ops, in preparation for lowering to
 /// backends that require linearized access.

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -27,6 +27,17 @@ def ConvertToDestinationPassingStyle :
   let constructor = "mlir::iree_compiler::createConvertToDestinationPassingStylePass()";
 }
 
+def DistributeToWorkgroups :
+  Pass<"iree-codegen-distribute-to-workgroups", "IREE::HAL::ExecutableVariantOp"> {
+  let summary = "Distribute a computation to workgroups";
+  let constructor = "mlir::iree_compiler::createDistributeToWorkgroupsPass()";
+  let options = [
+    ListOption<"tileSizes", "tile-sizes", "int64_t",
+               "List of tile sizes to use for distributing the computation",
+               "llvm::cl::ZeroOrMore">
+  ];
+}
+
 def FlattenMemRefSubspan :
   Pass<"iree-codegen-flatten-memref-subspan", "ModuleOp"> {
   let summary =

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -63,7 +63,6 @@ FailureOr<IREE::HAL::ExecutableExportOp> defineWorkgroupCountRegion(
   std::array<Value, 3> workgroupCount =
       regionBuilder(builder, loc, device, workload);
   builder.create<IREE::HAL::ReturnOp>(loc, workgroupCount);
-  exportOp.erase();
   return clonedOp;
 }
 

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
@@ -29,7 +29,11 @@ namespace iree_compiler {
 /// callback function, which computes the workgroup count (x,y,z) given the
 /// workload along (x,y,z).
 /// Returns a new `hal.executable.export` op. MLIR semantics requires
-/// creation of new ops when a region is added.
+/// creation of new ops when a region is added. At the same time the original
+/// operation is not deleted. Deleting the operation when the builder is
+/// a `PatternRewriter` is undefined behavior. In such cases, the `eraseOp`
+/// method of the `PatternRewriter` is to be used. The caller is incharge
+/// of erasing the original `exportOp`.
 using WorkgroupCountRegionBuilder = std::function<std::array<Value, 3>(
     OpBuilder &b, Location loc, Value device, std::array<Value, 3> workload)>;
 FailureOr<IREE::HAL::ExecutableExportOp> defineWorkgroupCountRegion(

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h
@@ -46,6 +46,20 @@ private:
   linalg::LinalgTilingOptions options;
 };
 
+/// Pattern to swap a `TilingInterface` op -> `tensor::ExtractSliceOp`.
+struct SwapTilingInterfaceOp : public OpRewritePattern<tensor::ExtractSliceOp> {
+  using OpRewritePattern<tensor::ExtractSliceOp>::OpRewritePattern;
+
+  FailureOr<Operation *>
+  returningMatchAndRewrite(tensor::ExtractSliceOp sliceOp,
+                           PatternRewriter &rewriter) const;
+
+  LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
+                                PatternRewriter &rewriter) const override {
+    return returningMatchAndRewrite(sliceOp, rewriter);
+  }
+};
+
 /// Pattern to rewrite a TileOp to an scf::ForOp.
 struct TileOpToSCFRewriter : public OpRewritePattern<TileOp> {
   using OpRewritePattern::OpRewritePattern;

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Tiling.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Tiling.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h"
 #include "iree-dialects/Dialect/LinalgExt/Transforms/Utils.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
@@ -181,35 +182,21 @@ private:
   linalg::LinalgTilingOptions options;
   linalg::LinalgTransformationFilter filter;
 };
+} // namespace
 
 /// Second pattern to implement the switch of `TilingInterface ->
 /// tensor.extract_slice` to `tensor.extract_slice -> `TilingInterface`.
-struct SliceOpTiledOpSwapPattern
-    : public OpRewritePattern<tensor::ExtractSliceOp> {
-  SliceOpTiledOpSwapPattern(MLIRContext *context,
-                            linalg::LinalgTilingOptions opt,
-                            linalg::LinalgTransformationFilter filt)
-      : OpRewritePattern<tensor::ExtractSliceOp>(context), options(opt),
-        filter(filt) {}
-
-  LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
-                                PatternRewriter &rewriter) const override {
-    auto sourceOp = sliceOp.source().getDefiningOp<TilingInterface>();
-    if (!sourceOp || !filter.hasReplacementFilter(sourceOp))
-      return failure();
-    SmallVector<Operation *> tiledOps = sourceOp.getTiledImplementation(
-        rewriter, sourceOp.getDestinationOperands(rewriter),
-        sliceOp.getMixedOffsets(), sliceOp.getMixedSizes(),
-        /*tileDestOperands=*/true);
-    assert(tiledOps.size() && "expected single tiled op");
-    Operation *tiledOp = tiledOps.front();
-    rewriter.replaceOp(sliceOp, tiledOp->getResults());
-    return success();
-  }
-
-private:
-  linalg::LinalgTilingOptions options;
-  linalg::LinalgTransformationFilter filter;
-};
-
-} // namespace
+FailureOr<Operation *> SwapTilingInterfaceOp::returningMatchAndRewrite(
+    tensor::ExtractSliceOp sliceOp, PatternRewriter &rewriter) const {
+  auto sourceOp = sliceOp.source().getDefiningOp<TilingInterface>();
+  if (!sourceOp)
+    return failure();
+  SmallVector<Operation *> tiledOps = sourceOp.getTiledImplementation(
+      rewriter, sourceOp.getDestinationOperands(rewriter),
+      sliceOp.getMixedOffsets(), sliceOp.getMixedSizes(),
+      /*tileDestOperands=*/true);
+  assert(tiledOps.size() && "expected single tiled op");
+  Operation *tiledOp = tiledOps.front();
+  rewriter.replaceOp(sliceOp, tiledOp->getResults());
+  return tiledOp;
+}


### PR DESCRIPTION
IREE uses tile and distribute to distribute a dispatch to
workgroups. In this PR, a new way to distribute is added distributes
the work within an undistributed dispatch by splitting distributing
the result computation across workgroups. The slice is then propageted
to the producers recursively to produce only the values needed to
compute the slice mapped to a workgroup.