### PR TITLE
Stubs for mhlo with varadic scatter

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
@@ -276,12 +276,13 @@ struct ScatterOpConversion : public OpConversionPattern<mhlo::ScatterOp> {
       mhlo::ScatterOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
     if (!hasCanonicalDimensionNumbers(op)) return failure();
+    if (op.operands().size() != 1 || op.updates().size() != 1) return failure();
 
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
 
-    Value original = adaptor.operand();
+    Value original = adaptor.operands()[0];
     Value indices = adaptor.scatter_indices();
-    Value updates = adaptor.updates();
+    Value updates = adaptor.updates()[0];
 
     if (failed(collapseBatchDimsIfNeeded(indices, updates, b))) {
       return failure();


### PR DESCRIPTION
mhlo is adding variadic scatter, which breaks IREE's mhlo passes. This patch asserts makes IREE build again after this change, but does not implement support for scatter ops with more than 3 args.

cc @stellaraccident 