### PR TITLE
Support running unregistered pipelines on presubmit

### DIFF
--- a/build_tools/buildkite/pipelines/untrusted/unregistered.yml
+++ b/build_tools/buildkite/pipelines/untrusted/unregistered.yml
@@ -1,0 +1,20 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Runs a pipeline that has not yet been registered with Buildkite. This allows
+# testing new pipelines on presubmit without having to register them. We don't
+# just do this for every pipeline because having pipelines registered groups
+# builds, enables looking at history, checking for existing builds, etc.
+
+agents:
+  queue: "orchestration"
+  security: "untrusted"
+
+steps:
+  - label: ":pipeline: Uploading unregistered pipeline ${REQUESTED_PIPELINE}"
+    commands: |
+      buildkite-agent pipeline upload
+          "build_tools/buildkite/pipelines/${REQUESTED_PIPELINE}.yml"

--- a/build_tools/buildkite/scripts/common/buildkite_utils.py
+++ b/build_tools/buildkite/scripts/common/buildkite_utils.py
@@ -6,6 +6,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from typing import Any, Dict, Optional
+
+import requests
 from pybuildkite import buildkite
 
 # Type signature of Buildkite build object.
@@ -29,3 +31,13 @@ def linkify(url: str, text: Optional[str] = None):
     text = url
 
   return f"\033]1339;url={url};content={text}\a"
+
+
+def pipeline_exists(bk, *, organization, pipeline):
+  try:
+    bk.pipelines().get_pipeline(organization, pipeline)
+  except requests.exceptions.HTTPError as e:
+    if e.response.status_code == 404:
+      return False
+    raise e
+  return True

--- a/build_tools/buildkite/scripts/wait_for_pipeline_success.py
+++ b/build_tools/buildkite/scripts/wait_for_pipeline_success.py
@@ -12,13 +12,15 @@ triggered (or pre-existing) build succeeds, otherwise fails.
 """
 
 import argparse
-import sys
 import json
+import sys
 from typing import Optional
 
 from pybuildkite import buildkite
+
 from common.buildkite_pipeline_manager import BuildkitePipelineManager
-from common.buildkite_utils import BuildObject, get_build_number, get_build_state, linkify
+from common.buildkite_utils import (BuildObject, get_build_number,
+                                    get_build_state, linkify)
 
 
 def should_create_new_build(bk: BuildkitePipelineManager,


### PR DESCRIPTION
This introduces a pipeline that can be used to run unregistered
pipeline configuration files on presubmit. The pipeline files still
have to come from the main repository.