### PR TITLE
Remove literal interpolation in Buildkite bootstrap pipeline

### DIFF
--- a/build_tools/buildkite/pipelines/fragment/bootstrap-trusted.yml
+++ b/build_tools/buildkite/pipelines/fragment/bootstrap-trusted.yml
@@ -22,7 +22,7 @@ steps:
   - label: ":hiking_boot: Bootstrapping pipeline from '${BUILDKITE_COMMIT:0:7}'"
     if: |
       !build.pull_request.repository.fork &&
-      ${MUST_BOOTSTRAP:-true} &&
+      ${MUST_BOOTSTRAP:-true} == 'true' &&
       organization.slug != 'local'
     env:
       MUST_BOOTSTRAP: false

--- a/build_tools/buildkite/pipelines/fragment/bootstrap-untrusted.yml
+++ b/build_tools/buildkite/pipelines/fragment/bootstrap-untrusted.yml
@@ -18,7 +18,7 @@ steps:
   # that would be bootstrapped.
   - label: ":hiking_boot: Bootstrapping pipeline from '${BUILDKITE_COMMIT:0:7}'"
     if: |
-      ${MUST_BOOTSTRAP:-true} &&
+      ${MUST_BOOTSTRAP:-true} == 'true' &&
       organization.slug != 'local'
     env:
       MUST_BOOTSTRAP: false

--- a/build_tools/buildkite/scripts/update_pipeline_configurations.py
+++ b/build_tools/buildkite/scripts/update_pipeline_configurations.py
@@ -120,12 +120,12 @@ def should_update(bk, *, organization, configuration, existing_pipeline,
 
   if previous_organization != organization:
     print(f"Build was previously updated by a pipeline from a different"
-          f"organization '{previous_organization}' not current organization"
+          f" organization '{previous_organization}' not current organization"
           f" '{organization}'")
     sys.exit(5)
   if previous_pipeline != running_pipeline:
-    print(f"Build was previously updated by a pipeline different pipeline"
-          f"'{previous_pipeline}' not current pipeline '{running_pipeline}'")
+    print(f"Build was previously updated by a different pipeline"
+          f" '{previous_pipeline}' not current pipeline '{running_pipeline}'")
     sys.exit(5)
 
   if previous_build_number > running_build_number:


### PR DESCRIPTION
Apparently when interpolated as the default, variables are typed as
strings, which is a bit confusing to me. We were getting
[422 errors](https://buildkite.com/iree/postsubmit/builds/412) in
the Postsubmit pipeline, which helpfully didn't include any error
message. I was able to get a more helpful message by trying to manually
update the steps in the UI.

Tested: Ran the API call to update the pipeline manually.