### PR TITLE
Set appropriate permissions when creating pipeline

### DIFF
--- a/build_tools/buildkite/pipelines/fragment/bootstrap-trusted.yml
+++ b/build_tools/buildkite/pipelines/fragment/bootstrap-trusted.yml
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Pipeline configuration to upload to the UI for trusted pipelines
+# Pipeline configuration to register with Buidlkite for trusted pipelines
 
 agents:
   queue: "orchestration"

--- a/build_tools/buildkite/pipelines/fragment/bootstrap-untrusted.yml
+++ b/build_tools/buildkite/pipelines/fragment/bootstrap-untrusted.yml
@@ -4,6 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+# Pipeline configuration to register with Buidlkite for untrusted pipelines
+
 agents:
   queue: "orchestration"
   security: "untrusted"

--- a/build_tools/buildkite/scripts/common/buildkite_pipeline_manager.py
+++ b/build_tools/buildkite/scripts/common/buildkite_pipeline_manager.py
@@ -12,7 +12,7 @@ from typing import List, Optional
 from pybuildkite import buildkite
 
 from common.buildkite_utils import (BuildObject, get_build_number,
-                                    get_build_state, linkify, pipeline_exists)
+                                    get_build_state, get_pipeline, linkify)
 
 # Fake build to return when running locally.
 FAKE_PASSED_BUILD = dict(number=42, state="passed")
@@ -58,9 +58,9 @@ class BuildkitePipelineManager(object):
     }
     # If the pipeline doesn't exist, then we run it on the "unregistered"
     # pipeline, which leverages the REQUESTED_PIPELINE env variable.
-    if not pipeline_exists(self._buildkite,
-                           organization=self._organization,
-                           pipeline=self._pipeline):
+    if not get_pipeline(self._buildkite,
+                        organization=self._organization,
+                        pipeline_slug=self._pipeline):
       self._pipeline = UNREGISTERED_PIPELINE_NAME
 
   @staticmethod

--- a/build_tools/buildkite/scripts/common/buildkite_utils.py
+++ b/build_tools/buildkite/scripts/common/buildkite_utils.py
@@ -33,11 +33,11 @@ def linkify(url: str, text: Optional[str] = None):
   return f"\033]1339;url={url};content={text}\a"
 
 
-def pipeline_exists(bk, *, organization, pipeline):
+def get_pipeline(bk, *, organization, pipeline_slug):
   try:
-    bk.pipelines().get_pipeline(organization, pipeline)
+    pipeline = bk.pipelines().get_pipeline(organization, pipeline_slug)
   except requests.exceptions.HTTPError as e:
     if e.response.status_code == 404:
-      return False
+      return None
     raise e
-  return True
+  return pipeline

--- a/build_tools/buildkite/scripts/set_buildkite_env.sh
+++ b/build_tools/buildkite/scripts/set_buildkite_env.sh
@@ -1,0 +1,17 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# *source* this file to set environment variables emulating the state when
+# running in a Buildkite job.
+
+export BUILDKITE_ORGANIZATION_SLUG="iree"
+export BUILDKITE_PIPELINE_SLUG="local-test"
+export BUILDKITE_BUILD_NUMBER=1
+export BUILDKITE_REPO="https://github.com/google/iree"
+export BUILDKITE_COMMIT="$(git rev-parse HEAD)"
+export BUILDKITE_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+export BUILDKITE_BUILD_AUTHOR="$(git log -n 1 --pretty="format:%aN" HEAD)"
+export BUILDKITE_BUILD_AUTHOR_EMAIL="$(git log -n 1 --pretty="format:%aE" HEAD)"

--- a/build_tools/buildkite/scripts/simulate_buildkite.sh
+++ b/build_tools/buildkite/scripts/simulate_buildkite.sh
@@ -6,12 +6,9 @@
 
 set -euo pipefail
 
-export BUILDKITE_ORGANIZATION_SLUG="local"
-export BUILDKITE_REPO="https://github.com/google/iree"
-export BUILDKITE_COMMIT="$(git rev-parse HEAD)"
-export BUILDKITE_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-export BUILDKITE_BUILD_AUTHOR="$(git log -n 1 --pretty="format:%aN" HEAD)"
-export BUILDKITE_BUILD_AUTHOR_EMAIL="$(git log -n 1 --pretty="format:%aE" HEAD)"
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
+
+source "${SCRIPT_DIR}/set_buildkite_env.sh"
 
 bk run \
   --env=BUILDKITE_ORGANIZATION_SLUG="${BUILDKITE_ORGANIZATION_SLUG}" \

--- a/build_tools/buildkite/scripts/update_pipeline_configurations.py
+++ b/build_tools/buildkite/scripts/update_pipeline_configurations.py
@@ -38,6 +38,10 @@ TRUSTED_BOOTSTRAP_PIPELINE_PATH = os.path.join(PIPELINE_ROOT_PATH, "fragment",
 UNTRUSTED_BOOTSTRAP_PIPELINE_PATH = os.path.join(PIPELINE_ROOT_PATH, "fragment",
                                                  "bootstrap-untrusted.yml")
 
+IREE_TEAM_REST_UUID = "1a2cbc72-2c8e-4375-821e-e3dfa1db96b5"
+
+FORCE_UPDATE_ENV_VAR = "IREE_FORCE_BUILDKITE_PIPELINE_UPDATE"
+
 BUILD_URL_PREAMBLE = "# Automatically updated by Buildkite pipeline"
 
 UPDATE_INFO_HEADER = f"""{BUILD_URL_PREAMBLE} {{build_url}}
@@ -147,7 +151,15 @@ def create_pipeline(bk, *, organization, pipeline_slug, configuration,
       "name": pipeline_slug,
       "repository": GIT_REPO,
       "configuration": configuration,
+      "visibility": "public",
+      # With the rest API, we can only give "Full Access", so this is limited to
+      # the IREE team. I'm talking to Buildkite support about this limitation.
+      # It also means that the iree-buildkite-submitted-bot is currently added
+      # to the IREE team rather than only being in its own team, as originally
+      # intended.
+      "team_uuids": [IREE_TEAM_REST_UUID],
       "provider_settings": {
+          # We don't want any automatic triggering from GitHub webhooks.
           "trigger_mode": "none"
       },
   }

--- a/build_tools/buildkite/scripts/update_pipeline_configurations.py
+++ b/build_tools/buildkite/scripts/update_pipeline_configurations.py
@@ -237,14 +237,18 @@ def update_pipelines(bk, pipeline_files, *, organization, running_pipeline,
 
 
 def parse_args():
+  force_update = os.environ.get(FORCE_UPDATE_ENV_VAR)
+  force_update = not (force_update is None or force_update == "0" or
+                      force_update.lower() == "false" or force_update == "")
   parser = argparse.ArgumentParser(
       description="Updates the configurations for all Buildkite pipelines.")
   parser.add_argument(
       "--force",
       action="store_true",
-      default=False,
-      help=("Force updates for all pipelines without checking the existing"
-            " configuration. Use with caution."))
+      default=force_update,
+      help=(f"Force updates for all pipelines without checking the existing"
+            f" configuration. Use with caution. Can also be set via the"
+            f" environment variable {FORCE_UPDATE_ENV_VAR}."))
   parser.add_argument(
       "pipelines",
       type=str,


### PR DESCRIPTION
I was tearing my hair out trying to figure out what's going wrong here.
There are limitations around setting teams in the Buildkite REST API,
which is pretty annoying. The best we can do is add the trusted bot to
IREE team and then give IREE team full access. The team needs some kind
of access to be able to trigger retries and such.

Also added some quality of life improvements to the scripting.