### PR TITLE
Improve error message in generate_embed_data_main.

### DIFF
--- a/build_tools/embed_data/generate_embed_data_main.cc
+++ b/build_tools/embed_data/generate_embed_data_main.cc
@@ -112,7 +112,11 @@ static bool SlurpFile(const std::string& file_name, std::string* contents) {
   if (!f.good()) return false;
 
   if (length > kMaxSize) {
-    std::cerr << "File " << file_name << " is too large\n";
+    fprintf(stderr,
+            "File '%s' is too large to embed into a C file (%lld bytes > %lld "
+            "bytes). Consider other methods for packaging and loading on your "
+            "platform, such as using traditional file I/O\n",
+            file_name.c_str(), (long long)length, (long long)kMaxSize);
     return false;
   }
 


### PR DESCRIPTION
We had a user [asking about this on Discord](https://discord.com/channels/689900678990135345/689957613152239638/976903741116678194). They were trying to load a resnet50 model (~90MB source file), which was hitting this limit (~100MB).