### PR TITLE
Delete unneeded CompilationInfoAttr builders.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.cpp
@@ -194,33 +194,6 @@ LogicalResult LoweringConfigAttr::verify(
 // iree.compilation_info
 //===----------------------------------------------------------------------===//
 
-/// These builders are externally for auto-tuner to generate the attribute.
-CompilationInfoAttr CompilationInfoAttr::get(MLIRContext *context,
-                                             TileSizesListTypeRef tileSizes,
-                                             TileSizesListTypeRef interchange,
-                                             ArrayRef<int64_t> nativeVectorSize,
-                                             ArrayRef<int64_t> workgroupSize) {
-  LoweringConfigAttr configAttr = LoweringConfigAttr::get(
-      context, tileSizes, interchange, nativeVectorSize);
-  TranslationInfoAttr translationInfo =
-      TranslationInfoAttr::get(context, DispatchLoweringPassPipeline::None);
-  ArrayAttr workgroupSizeAttr = getI64IntegerArrayAttr(context, workgroupSize);
-  return get(context, configAttr, translationInfo, workgroupSizeAttr);
-}
-
-CompilationInfoAttr CompilationInfoAttr::get(
-    MLIRContext *context, TileSizesListTypeRef tileSizes,
-    TileSizesListTypeRef interchange, ArrayRef<int64_t> nativeVectorSize,
-    DispatchLoweringPassPipeline passPipeline,
-    ArrayRef<int64_t> workloadPerWorkgroup, ArrayRef<int64_t> workgroupSize) {
-  LoweringConfigAttr configAttr = LoweringConfigAttr::get(
-      context, tileSizes, interchange, nativeVectorSize);
-  TranslationInfoAttr translationInfoAttr =
-      TranslationInfoAttr::get(context, passPipeline, workloadPerWorkgroup);
-  ArrayAttr workgroupSizeAttr = getI64IntegerArrayAttr(context, workgroupSize);
-  return get(context, configAttr, translationInfoAttr, workgroupSizeAttr);
-}
-
 CompilationInfoAttr CompilationInfoAttr::get(
     MLIRContext *context, LoweringConfigAttr configAttr,
     TranslationInfoAttr translationInfo, ArrayRef<int64_t> workgroupSize) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
@@ -214,18 +214,8 @@ def IREECodegen_CompilationInfoAttr :
     (`,` `workgroup_size` `=` $workgroupSize^)? `>`
   }];
 
-  // These builders are externally for auto-tuner to generate the attribute.
+  // The builder is externally for auto-tuner to generate the attributes.
   let builders = [
-    AttrBuilder<(ins "TileSizesListTypeRef":$tileSizes,
-      "TileSizesListTypeRef":$tileInterchange,
-      CArg<"ArrayRef<int64_t>", "{}">:$nativeVectorSize,
-      CArg<"ArrayRef<int64_t>", "{}">:$workgroupSize)>,
-    AttrBuilder<(ins "TileSizesListTypeRef":$tileSizes,
-      "TileSizesListTypeRef":$tileInterchange,
-      "ArrayRef<int64_t>":$nativeVectorSize,
-      "DispatchLoweringPassPipeline":$passPipeline,
-      "ArrayRef<int64_t>":$workloadPerWorkgroup,
-      CArg<"ArrayRef<int64_t>", "{}">:$workgroupSize)>,
     AttrBuilder<(ins "LoweringConfigAttr":$configAttr,
       "TranslationInfoAttr":$translationInfo,
       "ArrayRef<int64_t>":$workloadPerWorkgroup)>,


### PR DESCRIPTION
We expect users to generate attributes in LoweringConfigAttr and
TranslationInfoAttr. This reduces maintenance work because we don't have
to update these builders when there are new attributes. We only have to
maintain the builders for LoweringConfigAttr and TranslationInfoAttr.