### PR TITLE
Add tool to collect compilation statistics

### DIFF
--- a/build_tools/benchmarks/CMakeLists.txt
+++ b/build_tools/benchmarks/CMakeLists.txt
@@ -40,3 +40,10 @@ function(benchmark_tool_py_test)
 endfunction()
 
 add_subdirectory(common)
+
+benchmark_tool_py_test(
+  NAME
+    collect_compilation_statistics_test
+  SRC
+    "collect_compilation_statistics_test.py"
+)

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -4,7 +4,10 @@
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-"""Collect compilation statistics from benchmark suites."""
+"""Collect compilation statistics from benchmark suites.
+
+The benchmark suites need to be built with IREE_ENABLE_COMPILATION_BENCHMARKS.
+"""
 
 import argparse
 from dataclasses import dataclass

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -71,8 +71,6 @@ def parse_compilation_time_from_ninja_log(log_path: str) -> Dict[str, int]:
 
 
 def get_module_component_info(module_path: str) -> ModuleComponentSizes:
-  file_size = os.stat(module_path).st_size
-
   module_zipinfo = zipfile.ZipFile(module_path)
   size_map = dict(
       (info.filename, info.file_size) for info in module_zipinfo.infolist())
@@ -92,14 +90,14 @@ def get_module_component_info(module_path: str) -> ModuleComponentSizes:
         f"Unrecognized components in the module: {size_map.keys()}.")
 
   return ModuleComponentSizes(
-      file_size=file_size,
+      file_size=os.stat(module_path).st_size,
       vm_component_size=vm_component_size,
       const_component_size=const_component_size,
       total_dispatch_component_size=total_dispatch_component_size)
 
 
 def get_module_path(benchmark_case_dir: str) -> str:
-  """Retrieve the module path for compilation statistics from the flag file of a benchmark."""
+  """Retrieve the module path for compilation statistics from the flag file."""
 
   flagfile_path = os.path.join(benchmark_case_dir, BENCHMARK_FLAGFILE)
   module_path = None

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -6,7 +6,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Collect compilation statistics from benchmark suites.
 
-The benchmark suites need to be built with IREE_ENABLE_COMPILATION_BENCHMARKS.
+The benchmark suites need to be built with ninja and enable the CMake option
+IREE_ENABLE_COMPILATION_BENCHMARKS.
 """
 
 import argparse

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Collect compilation statistics from benchmark suites."""
+
+import argparse
+import json
+import os
+import re
+from typing import Dict, Optional
+from pathlib import PurePath
+
+from common.benchmark_definition import CompilationInfo, CompilationResults, CompilationStatistics, get_git_commit_hash
+from common.benchmark_suite import BENCHMARK_SUITE_REL_PATH, BenchmarkSuite
+
+BENCHMARK_FLAGFILE = "flagfile"
+MODULE_DIR = "vmfb"
+MODULE_FILE_EXTENSION = ".vmfb"
+NINJA_LOG_HEADER = "ninja log v5"
+NINJA_BUILD_LOG = ".ninja_log"
+
+
+def match_module_cmake_target(module_path: str) -> Optional[str]:
+  # Get the last 4 parts of module path. They are expected to be:
+  # benchmark_suites/<category>/vmfb/<module filename>.vmfb
+  path_parts = PurePath(module_path).parts[-4:]
+  if len(path_parts) < 4:
+    return None
+  if path_parts[0] != BENCHMARK_SUITE_REL_PATH:
+    return None
+  if path_parts[2] != MODULE_DIR:
+    return None
+  if os.path.splitext(path_parts[3])[1] != MODULE_FILE_EXTENSION:
+    return None
+  return os.path.join(*path_parts)
+
+
+def parse_compilation_time_from_ninja_log(log_path: str) -> Dict[str, int]:
+  """Retrieve the compilation time from the Ninja build log."""
+
+  target_build_time_map = {}
+  with open(log_path, "r") as f:
+    header = f.readline()
+    if NINJA_LOG_HEADER not in header:
+      raise NotImplementedError(f"Unsupported ninja log version: {header}")
+
+    for line in f:
+      start_time, end_time, _, target, _ = line.strip().split("\t")
+      cmake_target = match_module_cmake_target(target)
+      if cmake_target is None:
+        continue
+
+      start_time = int(start_time)
+      end_time = int(end_time)
+      target_build_time_map[cmake_target] = end_time - start_time
+
+  return target_build_time_map
+
+
+def get_module_path(benchmark_case_dir: str) -> str:
+  """Retrieve the module path from the flag file of a benchmark."""
+
+  flagfile_path = os.path.join(benchmark_case_dir, BENCHMARK_FLAGFILE)
+  module_path = None
+  with open(flagfile_path, "r") as f:
+    for line in f:
+      match = re.match("--module_file=(.+)", line.strip())
+      if match:
+        module_path = match.group(1)
+        break
+
+  if not module_path:
+    raise AssertionError(
+        f"Can't find the module file in the flagfile: {flagfile_path}")
+
+  return os.path.abspath(os.path.join(benchmark_case_dir, module_path))
+
+
+def parse_argument():
+  """Returns an argument parser with common options."""
+
+  def check_dir_path(path):
+    if os.path.isdir(path):
+      return path
+    else:
+      raise argparse.ArgumentTypeError(path)
+
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--output",
+                      required=True,
+                      help="Path to output JSON file.")
+  parser.add_argument(
+      "build_dir",
+      metavar="<build-dir>",
+      type=check_dir_path,
+      help="Path to the build directory containing benchmark suites.")
+  parser.add_argument("--verbose",
+                      action="store_true",
+                      help="Print internal information during execution.")
+
+  return parser.parse_args()
+
+
+def main(args: argparse.Namespace):
+  benchmark_suite_dir = os.path.join(args.build_dir, BENCHMARK_SUITE_REL_PATH)
+  benchmark_suite = BenchmarkSuite.load_from_benchmark_suite_dir(
+      benchmark_suite_dir)
+
+  target_build_time_map = parse_compilation_time_from_ninja_log(
+      os.path.join(args.build_dir, NINJA_BUILD_LOG))
+
+  compilation_statistics_list = []
+  for category, _ in benchmark_suite.list_categories():
+    benchmark_cases = benchmark_suite.filter_benchmarks_for_category(
+        category=category)
+    for benchmark_case in benchmark_cases:
+      module_path = get_module_path(benchmark_case.benchmark_case_dir)
+      module_size = os.stat(module_path).st_size
+
+      cmake_target = match_module_cmake_target(module_path)
+      if cmake_target is None:
+        raise AssertionError(
+            f"Module path isn't a module cmake target: {module_path}")
+      compilation_time = target_build_time_map[cmake_target]
+
+      compilation_info = CompilationInfo(model_name=benchmark_case.model_name,
+                                         model_tags=benchmark_case.model_tags,
+                                         model_source=category,
+                                         target_arch=benchmark_case.target_arch,
+                                         bench_mode=benchmark_case.bench_mode)
+      compilation_statistics = CompilationStatistics(
+          compilation_info=compilation_info,
+          module_size=module_size,
+          compilation_time=compilation_time)
+      compilation_statistics_list.append(compilation_statistics)
+
+  commit = get_git_commit_hash("HEAD")
+  compilation_results = CompilationResults(
+      commit=commit, compilation_statistics=compilation_statistics_list)
+
+  json_object = compilation_results.to_json_object()
+  with open(args.output, "w") as f:
+    json.dump(json_object, f)
+
+  if args.verbose:
+    print(json.dumps(json_object, indent=4))
+
+
+if __name__ == "__main__":
+  main(parse_argument())

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -81,9 +81,10 @@ def parse_compilation_time_from_ninja_log(log: TextIO) -> Dict[str, int]:
 
 def get_module_component_info(module: BinaryIO,
                               module_file_size: int) -> ModuleComponentSizes:
-  module_zipfile = zipfile.ZipFile(module)
-  size_map = dict(
-      (info.filename, info.file_size) for info in module_zipfile.infolist())
+  with zipfile.ZipFile(module) as module_zipfile:
+    size_map = dict(
+        (info.filename, info.file_size) for info in module_zipfile.infolist())
+
   vm_component_size = size_map[VM_COMPONENT_NAME]
   const_component_size = size_map[CONST_COMPONENT_NAME]
   identified_names = {VM_COMPONENT_NAME, CONST_COMPONENT_NAME}

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -23,12 +23,13 @@ MODULE_DIR = "vmfb"
 MODULE_FILE_EXTENSION = ".vmfb"
 NINJA_LOG_HEADER = "ninja log v5"
 NINJA_BUILD_LOG = ".ninja_log"
+COMPILATION_STATS_MODULE_SUFFIX = "compilation-stats"
 
 VM_COMPONENT_NAME = "module.fb"
 CONST_COMPONENT_NAME = "_const.bin"
 DISPATCH_COMPONENT_PATTERNS = [
-    ".+_embedded_elf_.+\\.so", ".+_vulkan_spirv_fb\\.fb",
-    ".+_vmvx_bytecode_fb\\.bin"
+    r".+_embedded_elf_.+\.so", r".+_vulkan_spirv_fb\.fb",
+    r".+_vmvx_bytecode_fb\.bin"
 ]
 
 
@@ -98,7 +99,7 @@ def get_module_component_info(module_path: str) -> ModuleComponentSizes:
 
 
 def get_module_path(benchmark_case_dir: str) -> str:
-  """Retrieve the module path from the flag file of a benchmark."""
+  """Retrieve the module path for compilation statistics from the flag file of a benchmark."""
 
   flagfile_path = os.path.join(benchmark_case_dir, BENCHMARK_FLAGFILE)
   module_path = None
@@ -106,7 +107,8 @@ def get_module_path(benchmark_case_dir: str) -> str:
     for line in f:
       match = re.match("--module_file=(.+)", line.strip())
       if match:
-        module_path = match.group(1)
+        module_name, module_ext = os.path.splitext(match.group(1))
+        module_path = f"{module_name}-{COMPILATION_STATS_MODULE_SUFFIX}{module_ext}"
         break
 
   if not module_path:

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -23,7 +23,7 @@ MODULE_DIR = "vmfb"
 MODULE_FILE_EXTENSION = ".vmfb"
 NINJA_LOG_HEADER = "ninja log v5"
 NINJA_BUILD_LOG = ".ninja_log"
-COMPILATION_STATS_MODULE_SUFFIX = "compilation-stats"
+COMPILATION_STATS_MODULE_SUFFIX = "compile-stats"
 
 VM_COMPONENT_NAME = "module.fb"
 CONST_COMPONENT_NAME = "_const.bin"

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -54,10 +54,10 @@ def match_module_cmake_target(module_path: str) -> Optional[str]:
 
 
 def parse_compilation_time_from_ninja_log(log: TextIO) -> Dict[str, int]:
-  """Retrieve the compilation time from the Ninja build log.
+  """Retrieve the compilation time (ms) from the Ninja build log.
   
   Returns:
-    Map of target name and compilation time in milliseconds.
+    Map of target name and compilation time in ms.
   """
 
   target_build_time_map = {}

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -33,8 +33,9 @@ COMPILATION_STATS_MODULE_SUFFIX = "compile-stats"
 VM_COMPONENT_NAME = "module.fb"
 CONST_COMPONENT_NAME = "_const.bin"
 DISPATCH_COMPONENT_PATTERNS = [
-    r".+_embedded_elf_.+\.so", r".+_vulkan_spirv_fb\.fb",
-    r".+_vmvx_bytecode_fb\.bin"
+    r".+_embedded_elf_.+\.so",
+    r".+_vulkan_spirv_fb\.fb",
+    r".+_vmvx_bytecode_fb\.bin",
 ]
 
 

--- a/build_tools/benchmarks/collect_compilation_statistics_test.py
+++ b/build_tools/benchmarks/collect_compilation_statistics_test.py
@@ -5,10 +5,13 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import os
 import tempfile
 import unittest
+import zipfile
 
-from collect_compilation_statistics import match_module_cmake_target, parse_compilation_time_from_ninja_log
+from common.benchmark_definition import ModuleComponentSizes
+from collect_compilation_statistics import BENCHMARK_FLAGFILE, CONST_COMPONENT_NAME, VM_COMPONENT_NAME, get_module_component_info, get_module_path, match_module_cmake_target, parse_compilation_time_from_ninja_log
 
 
 class CollectCompilationStatistics(unittest.TestCase):
@@ -28,8 +31,8 @@ class CollectCompilationStatistics(unittest.TestCase):
     target1 = "benchmark_suites/TFLite/vmfb/deeplabv3.vmfb"
     target2 = "benchmark_suites/TFLite/vmfb/mobilessd.vmfb"
     ninja_log = ("# ninja log v5\n"
-                 f"0\t100\t100\tbuild/{target1}\t124\n"
-                 f"130\t200\t200\tbuild/{target2}\t224\n")
+                 f"0\t100\taaa\tbuild/{target1}\taaa\n"
+                 f"130\t200\tbbb\tbuild/{target2}\tbbb\n")
 
     with tempfile.NamedTemporaryFile("w") as f:
       f.write(ninja_log)
@@ -37,6 +40,46 @@ class CollectCompilationStatistics(unittest.TestCase):
       target_map = parse_compilation_time_from_ninja_log(f.name)
 
     self.assertEqual(target_map, {target1: 100, target2: 70})
+
+  def test_get_module_component_info(self):
+    with tempfile.NamedTemporaryFile() as module_file:
+      zip = zipfile.ZipFile(module_file, "w")
+      zip.writestr(VM_COMPONENT_NAME, b"abcd")
+      zip.writestr(CONST_COMPONENT_NAME, b"123")
+      zip.writestr("main_dispatch_0_vulkan_spirv_fb.fb", b"bindata1")
+      zip.writestr("main_dispatch_1_vulkan_spirv_fb.fb", b"bindata2")
+      zip.close()
+      module_file.flush()
+
+      component_sizes = get_module_component_info(module_file.name)
+      self.assertEqual(
+          component_sizes,
+          ModuleComponentSizes(file_size=os.stat(module_file.name).st_size,
+                               vm_component_size=4,
+                               const_component_size=3,
+                               total_dispatch_component_size=16))
+
+  def test_get_module_component_info_unknown_components(self):
+    with tempfile.NamedTemporaryFile() as module_file:
+      zip = zipfile.ZipFile(module_file, "w")
+      zip.writestr(VM_COMPONENT_NAME, b"abcd")
+      zip.writestr(CONST_COMPONENT_NAME, b"123")
+      zip.writestr("main_dispatch_0_unknown.fb", b"bindata")
+      zip.close()
+      module_file.flush()
+
+      self.assertRaises(AssertionError,
+                        lambda: get_module_component_info(module_file.name))
+
+  def test_get_module_path(self):
+    with tempfile.TemporaryDirectory() as case_dir:
+      flagfile = open(os.path.join(case_dir, BENCHMARK_FLAGFILE), "w")
+      flagfile.write(f"--function_inputs=1x2x3xf32\n--module_file=/abcd.vmfb")
+      flagfile.close()
+
+      moduel_path = get_module_path(case_dir)
+
+    self.assertEqual(moduel_path, "/abcd-compile-stats.vmfb")
 
 
 if __name__ == "__main__":

--- a/build_tools/benchmarks/collect_compilation_statistics_test.py
+++ b/build_tools/benchmarks/collect_compilation_statistics_test.py
@@ -40,12 +40,11 @@ class CollectCompilationStatistics(unittest.TestCase):
 
   def test_get_module_component_info(self):
     module_file = BytesIO()
-    zip = zipfile.ZipFile(module_file, "w")
-    zip.writestr(VM_COMPONENT_NAME, b"abcd")
-    zip.writestr(CONST_COMPONENT_NAME, b"123")
-    zip.writestr("main_dispatch_0_vulkan_spirv_fb.fb", b"bindata1")
-    zip.writestr("main_dispatch_1_vulkan_spirv_fb.fb", b"bindata2")
-    zip.close()
+    with zipfile.ZipFile(module_file, "w") as zip:
+      zip.writestr(VM_COMPONENT_NAME, b"abcd")
+      zip.writestr(CONST_COMPONENT_NAME, b"123")
+      zip.writestr("main_dispatch_0_vulkan_spirv_fb.fb", b"bindata1")
+      zip.writestr("main_dispatch_1_vulkan_spirv_fb.fb", b"bindata2")
     module_file_data = module_file.getvalue()
 
     component_sizes = get_module_component_info(BytesIO(module_file_data),
@@ -60,11 +59,10 @@ class CollectCompilationStatistics(unittest.TestCase):
 
   def test_get_module_component_info_unknown_components(self):
     module_file = BytesIO()
-    zip = zipfile.ZipFile(module_file, "w")
-    zip.writestr(VM_COMPONENT_NAME, b"abcd")
-    zip.writestr(CONST_COMPONENT_NAME, b"123")
-    zip.writestr("main_dispatch_0_unknown.fb", b"bindata")
-    zip.close()
+    with zipfile.ZipFile(module_file, "w") as zip:
+      zip.writestr(VM_COMPONENT_NAME, b"abcd")
+      zip.writestr(CONST_COMPONENT_NAME, b"123")
+      zip.writestr("main_dispatch_0_unknown.fb", b"bindata")
     module_file_data = module_file.getvalue()
 
     self.assertRaises(

--- a/build_tools/benchmarks/collect_compilation_statistics_test.py
+++ b/build_tools/benchmarks/collect_compilation_statistics_test.py
@@ -5,13 +5,13 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import os
-import tempfile
 import unittest
 import zipfile
 
+from io import BytesIO, StringIO
+
 from common.benchmark_definition import ModuleComponentSizes
-from collect_compilation_statistics import BENCHMARK_FLAGFILE, CONST_COMPONENT_NAME, VM_COMPONENT_NAME, get_module_component_info, get_module_path, match_module_cmake_target, parse_compilation_time_from_ninja_log
+from collect_compilation_statistics import CONST_COMPONENT_NAME, VM_COMPONENT_NAME, get_module_component_info, get_module_path, match_module_cmake_target, parse_compilation_time_from_ninja_log
 
 
 class CollectCompilationStatistics(unittest.TestCase):
@@ -30,54 +30,52 @@ class CollectCompilationStatistics(unittest.TestCase):
   def test_parse_compilation_time_from_ninja_log(self):
     target1 = "benchmark_suites/TFLite/vmfb/deeplabv3.vmfb"
     target2 = "benchmark_suites/TFLite/vmfb/mobilessd.vmfb"
-    ninja_log = ("# ninja log v5\n"
-                 f"0\t100\taaa\tbuild/{target1}\taaa\n"
-                 f"130\t200\tbbb\tbuild/{target2}\tbbb\n")
+    ninja_log = StringIO("# ninja log v5\n"
+                         f"0\t100\taaa\tbuild/{target1}\taaa\n"
+                         f"130\t200\tbbb\tbuild/{target2}\tbbb\n")
 
-    with tempfile.NamedTemporaryFile("w") as f:
-      f.write(ninja_log)
-      f.flush()
-      target_map = parse_compilation_time_from_ninja_log(f.name)
+    target_map = parse_compilation_time_from_ninja_log(ninja_log)
 
     self.assertEqual(target_map, {target1: 100, target2: 70})
 
   def test_get_module_component_info(self):
-    with tempfile.NamedTemporaryFile() as module_file:
-      zip = zipfile.ZipFile(module_file, "w")
-      zip.writestr(VM_COMPONENT_NAME, b"abcd")
-      zip.writestr(CONST_COMPONENT_NAME, b"123")
-      zip.writestr("main_dispatch_0_vulkan_spirv_fb.fb", b"bindata1")
-      zip.writestr("main_dispatch_1_vulkan_spirv_fb.fb", b"bindata2")
-      zip.close()
-      module_file.flush()
+    module_file = BytesIO()
+    zip = zipfile.ZipFile(module_file, "w")
+    zip.writestr(VM_COMPONENT_NAME, b"abcd")
+    zip.writestr(CONST_COMPONENT_NAME, b"123")
+    zip.writestr("main_dispatch_0_vulkan_spirv_fb.fb", b"bindata1")
+    zip.writestr("main_dispatch_1_vulkan_spirv_fb.fb", b"bindata2")
+    zip.close()
+    module_file_data = module_file.getvalue()
 
-      component_sizes = get_module_component_info(module_file.name)
-      self.assertEqual(
-          component_sizes,
-          ModuleComponentSizes(file_size=os.stat(module_file.name).st_size,
-                               vm_component_size=4,
-                               const_component_size=3,
-                               total_dispatch_component_size=16))
+    component_sizes = get_module_component_info(BytesIO(module_file_data),
+                                                len(module_file_data))
+
+    self.assertEqual(
+        component_sizes,
+        ModuleComponentSizes(file_size=len(module_file_data),
+                             vm_component_size=4,
+                             const_component_size=3,
+                             total_dispatch_component_size=16))
 
   def test_get_module_component_info_unknown_components(self):
-    with tempfile.NamedTemporaryFile() as module_file:
-      zip = zipfile.ZipFile(module_file, "w")
-      zip.writestr(VM_COMPONENT_NAME, b"abcd")
-      zip.writestr(CONST_COMPONENT_NAME, b"123")
-      zip.writestr("main_dispatch_0_unknown.fb", b"bindata")
-      zip.close()
-      module_file.flush()
+    module_file = BytesIO()
+    zip = zipfile.ZipFile(module_file, "w")
+    zip.writestr(VM_COMPONENT_NAME, b"abcd")
+    zip.writestr(CONST_COMPONENT_NAME, b"123")
+    zip.writestr("main_dispatch_0_unknown.fb", b"bindata")
+    zip.close()
+    module_file_data = module_file.getvalue()
 
-      self.assertRaises(AssertionError,
-                        lambda: get_module_component_info(module_file.name))
+    self.assertRaises(
+        RuntimeError, lambda: get_module_component_info(
+            BytesIO(module_file_data), len(module_file_data)))
 
   def test_get_module_path(self):
-    with tempfile.TemporaryDirectory() as case_dir:
-      flagfile = open(os.path.join(case_dir, BENCHMARK_FLAGFILE), "w")
-      flagfile.write(f"--function_inputs=1x2x3xf32\n--module_file=/abcd.vmfb")
-      flagfile.close()
+    flag_file = StringIO(
+        f"--function_inputs=1x2x3xf32\n--module_file=/abcd.vmfb")
 
-      moduel_path = get_module_path(case_dir)
+    moduel_path = get_module_path(flag_file)
 
     self.assertEqual(moduel_path, "/abcd-compile-stats.vmfb")
 

--- a/build_tools/benchmarks/collect_compilation_statistics_test.py
+++ b/build_tools/benchmarks/collect_compilation_statistics_test.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import tempfile
+import unittest
+
+from collect_compilation_statistics import match_module_cmake_target, parse_compilation_time_from_ninja_log
+
+
+class CollectCompilationStatistics(unittest.TestCase):
+
+  def test_match_module_cmake_target(self):
+    target = match_module_cmake_target(
+        "iree/iree-build/benchmark_suites/TFLite/vmfb/test.vmfb")
+
+    self.assertEqual(target, "benchmark_suites/TFLite/vmfb/test.vmfb")
+
+  def test_match_module_cmake_target_not_match(self):
+    target = match_module_cmake_target("benchmark_suites/TFLite/vmfb/test.mlir")
+
+    self.assertIsNone(target)
+
+  def test_parse_compilation_time_from_ninja_log(self):
+    target1 = "benchmark_suites/TFLite/vmfb/deeplabv3.vmfb"
+    target2 = "benchmark_suites/TFLite/vmfb/mobilessd.vmfb"
+    ninja_log = ("# ninja log v5\n"
+                 f"0\t100\t100\tbuild/{target1}\t124\n"
+                 f"130\t200\t200\tbuild/{target2}\t224\n")
+
+    with tempfile.NamedTemporaryFile("w") as f:
+      f.write(ninja_log)
+      f.flush()
+      target_map = parse_compilation_time_from_ninja_log(f.name)
+
+    self.assertEqual(target_map, {target1: 100, target2: 70})
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -471,48 +471,21 @@ class CompilationInfo(object):
     bench_mode_str = ",".join(self.bench_mode)
     return f"{model_part} {self.target_arch} {bench_mode_str}"
 
-  def to_json_object(self) -> Dict[str, Any]:
-    return {
-        "model_name": self.model_name,
-        "model_tags": self.model_tags,
-        "model_source": self.model_source,
-        "target_arch": self.target_arch,
-        "bench_mode": self.bench_mode,
-    }
-
   @staticmethod
   def from_json_object(json_object: Dict[str, Any]):
-    return CompilationInfo(model_name=json_object["model_name"],
-                           model_tags=json_object["model_tags"],
-                           model_source=json_object["model_source"],
-                           target_arch=json_object["target_arch"],
-                           bench_mode=json_object["bench_mode"])
+    return CompilationInfo(**json_object)
 
 
-@dataclass
+@dataclass(frozen=True)
 class ModuleComponentSizes(object):
   file_size: int
   vm_component_size: int
   const_component_size: int
   total_dispatch_component_size: int
 
-  def to_json_object(self) -> Dict[str, Any]:
-    return {
-        "file_size": self.file_size,
-        "vm_component_size": self.vm_component_size,
-        "const_component_size": self.const_component_size,
-        "total_dispatch_component_size": self.total_dispatch_component_size,
-    }
-
   @staticmethod
   def from_json_object(json_object: Dict[str, Any]):
-    return ModuleComponentSizes(
-        file_size=json_object["file_size"],
-        vm_component_size=json_object["vm_component_size"],
-        const_component_size=json_object["const_component_size"],
-        total_dispatch_component_size=json_object[
-            "total_dispatch_component_size"],
-    )
+    return ModuleComponentSizes(**json_object)
 
 
 @dataclass(frozen=True)
@@ -522,13 +495,6 @@ class CompilationStatistics(object):
   module_component_sizes: ModuleComponentSizes
   # Module compilation time in ms.
   compilation_time: int
-
-  def to_json_object(self) -> Dict[str, Any]:
-    return {
-        "compilation_info": self.compilation_info.to_json_object(),
-        "module_component_sizes": self.module_component_sizes.to_json_object(),
-        "compilation_time": self.compilation_time,
-    }
 
   @staticmethod
   def from_json_object(json_object: Dict[str, Any]):
@@ -544,15 +510,6 @@ class CompilationStatistics(object):
 class CompilationResults(object):
   commit: str
   compilation_statistics: Sequence[CompilationStatistics]
-
-  def to_json_object(self) -> Dict[str, Any]:
-    return {
-        "commit":
-            self.commit,
-        "compilation_statistics": [
-            obj.to_json_object() for obj in self.compilation_statistics
-        ]
-    }
 
   @staticmethod
   def from_json_object(json_object: Dict[str, Any]):

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -501,7 +501,7 @@ class ModuleComponentSizes(object):
         "file_size": self.file_size,
         "vm_component_size": self.vm_component_size,
         "const_component_size": self.const_component_size,
-        "total_dispatch_component": self.total_dispatch_component_size,
+        "total_dispatch_component_size": self.total_dispatch_component_size,
     }
 
   @staticmethod

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -489,18 +489,44 @@ class CompilationInfo(object):
                            bench_mode=json_object["bench_mode"])
 
 
+@dataclass
+class ModuleComponentSizes(object):
+  file_size: int
+  vm_component_size: int
+  const_component_size: int
+  total_dispatch_component_size: int
+
+  def to_json_object(self) -> Dict[str, Any]:
+    return {
+        "file_size": self.file_size,
+        "vm_component_size": self.vm_component_size,
+        "const_component_size": self.const_component_size,
+        "total_dispatch_component": self.total_dispatch_component_size,
+    }
+
+  @staticmethod
+  def from_json_object(json_object: Dict[str, Any]):
+    return ModuleComponentSizes(
+        file_size=json_object["file_size"],
+        vm_component_size=json_object["vm_component_size"],
+        const_component_size=json_object["const_component_size"],
+        total_dispatch_component_size=json_object[
+            "total_dispatch_component_size"],
+    )
+
+
 @dataclass(frozen=True)
 class CompilationStatistics(object):
   compilation_info: CompilationInfo
-  # Module binary size in bytes.
-  module_size: int
+  # Module file and component sizes.
+  module_component_sizes: ModuleComponentSizes
   # Module compilation time in ms.
   compilation_time: int
 
   def to_json_object(self) -> Dict[str, Any]:
     return {
         "compilation_info": self.compilation_info.to_json_object(),
-        "module_size": self.module_size,
+        "module_component_sizes": self.module_component_sizes.to_json_object(),
         "compilation_time": self.compilation_time,
     }
 
@@ -509,7 +535,8 @@ class CompilationStatistics(object):
     return CompilationStatistics(
         compilation_info=CompilationInfo.from_json_object(
             json_object["compilation_info"]),
-        module_size=json_object["module_size"],
+        module_component_sizes=ModuleComponentSizes.from_json_object(
+            json_object["module_component_sizes"]),
         compilation_time=json_object["compilation_info"])
 
 

--- a/build_tools/benchmarks/common/benchmark_driver.py
+++ b/build_tools/benchmarks/common/benchmark_driver.py
@@ -206,15 +206,8 @@ class BenchmarkDriver(object):
 
   def __get_benchmark_info_from_case(
       self, category: str, benchmark_case: BenchmarkCase) -> BenchmarkInfo:
-    model_name_with_tags = benchmark_case.model_name_with_tags
-    model_name_parts = model_name_with_tags.split("-", 1)
-    model_name = model_name_parts[0]
-    if len(model_name_parts) == 2:
-      model_tags = model_name_parts[1].split(",")
-    else:
-      model_tags = []
-    return BenchmarkInfo(model_name=model_name,
-                         model_tags=model_tags,
+    return BenchmarkInfo(model_name=benchmark_case.model_name,
+                         model_tags=benchmark_case.model_tags,
                          model_source=category,
                          bench_mode=benchmark_case.bench_mode,
                          runner=benchmark_case.config,

--- a/build_tools/benchmarks/common/benchmark_driver_test.py
+++ b/build_tools/benchmarks/common/benchmark_driver_test.py
@@ -73,13 +73,15 @@ class BenchmarkDriverTest(unittest.TestCase):
                                   cpu_features=["sha2"],
                                   gpu_name="Mali-G78")
 
-    case1 = BenchmarkCase(model_name_with_tags="DeepNet",
+    case1 = BenchmarkCase(model_name="DeepNet",
+                          model_tags=[],
                           bench_mode=["1-thread", "full-inference"],
                           target_arch="CPU-ARM64-v8A",
                           config="iree-dylib",
                           benchmark_case_dir="case1",
                           benchmark_tool_name="tool")
-    case2 = BenchmarkCase(model_name_with_tags="DeepNetv2-f32",
+    case2 = BenchmarkCase(model_name="DeepNetv2",
+                          model_tags=["f32"],
                           bench_mode=["full-inference"],
                           target_arch="CPU-ARM64-v8A",
                           config="iree-dylib-sync",

--- a/build_tools/benchmarks/common/benchmark_suite.py
+++ b/build_tools/benchmarks/common/benchmark_suite.py
@@ -114,7 +114,7 @@ class BenchmarkSuite(object):
         model_name_filter: model name regex.
       Returns:
         A list of matched benchmark cases.
-    """
+    """,
 
     category_dir = self.category_map.get(category)
     if category_dir is None:
@@ -125,11 +125,11 @@ class BenchmarkSuite(object):
       config_info = IREE_DRIVERS_INFOS[benchmark_case.config.lower()]
 
       driver_name = config_info.driver_name
-      available_driver_matched = (available_drivers is None or
+      matched_available_driver = (available_drivers is None or
                                   driver_name in available_drivers)
-      drivler_filter_matched = driver_filter is None or re.match(
+      matched_drivler_filter = driver_filter is None or re.match(
           driver_filter, driver_name) is not None
-      matched_driver = available_driver_matched and drivler_filter_matched
+      matched_driver = matched_available_driver and matched_drivler_filter
 
       matched_loader = not config_info.loader_name or available_loaders is None or (
           config_info.loader_name in available_loaders)

--- a/build_tools/benchmarks/common/benchmark_suite.py
+++ b/build_tools/benchmarks/common/benchmark_suite.py
@@ -103,8 +103,10 @@ class BenchmarkSuite(object):
     """Filters benchmarks in a specific category for the given device.
       Args:
         category: the specific benchmark category.
-        available_drivers: list of drivers supported by the tools.
+        available_drivers: list of drivers supported by the tools. None means to
+          match any driver.
         available_loaders: list of executable loaders supported by the tools.
+          None means to match any loader.
         cpu_target_arch_filter: CPU target architecture filter regex.
         gpu_target_arch_filter: GPU target architecture filter regex.
         driver_filter: driver filter regex.
@@ -123,12 +125,14 @@ class BenchmarkSuite(object):
       config_info = IREE_DRIVERS_INFOS[benchmark_case.config.lower()]
 
       driver_name = config_info.driver_name
-      available_driver_matched = available_drivers is None or driver_name in available_drivers
-      drivler_filter_matched = driver_filter is None or re.match(driver_filter, driver_name) is not None
+      available_driver_matched = (available_drivers is None or
+                                  driver_name in available_drivers)
+      drivler_filter_matched = driver_filter is None or re.match(
+          driver_filter, driver_name) is not None
       matched_driver = available_driver_matched and drivler_filter_matched
 
-      matched_loader = not config_info.loader_name or available_loaders is None or (config_info.loader_name
-                                                       in available_loaders)
+      matched_loader = not config_info.loader_name or available_loaders is None or (
+          config_info.loader_name in available_loaders)
 
       target_arch = benchmark_case.target_arch.lower()
       matched_cpu_arch = (cpu_target_arch_filter is not None and re.match(

--- a/build_tools/benchmarks/common/benchmark_suite.py
+++ b/build_tools/benchmarks/common/benchmark_suite.py
@@ -47,8 +47,9 @@ MODEL_TOOLFILE_NAME = "tool"
 @dataclass
 class BenchmarkCase:
   """Represents a benchmark case.
-
-    model_name_with_tags: the source model with tags, e.g., 'MobileSSD-fp32'.
+  
+    model_name: the source model, e.g., 'MobileSSD'.
+    model_tags: the source model tags, e.g., ['f32'].
     bench_mode: the benchmark mode, e.g., '1-thread,big-core'.
     target_arch: the target CPU/GPU architature, e.g., 'GPU-Adreno'.
     config: the IREE runtime configuration, e.g., 'dylib'.
@@ -56,7 +57,8 @@ class BenchmarkCase:
     benchmark_tool_name: the benchmark tool, e.g., 'iree-benchmark-module'.
   """
 
-  model_name_with_tags: str
+  model_name: str
+  model_tags: Sequence[str]
   bench_mode: Sequence[str]
   target_arch: str
   config: str
@@ -91,10 +93,10 @@ class BenchmarkSuite(object):
   def filter_benchmarks_for_category(
       self,
       category: str,
-      available_drivers: Sequence[str],
-      available_loaders: Sequence[str],
-      cpu_target_arch_filter: str,
-      gpu_target_arch_filter: str,
+      available_drivers: Optional[Sequence[str]] = None,
+      available_loaders: Optional[Sequence[str]] = None,
+      cpu_target_arch_filter: Optional[str] = None,
+      gpu_target_arch_filter: Optional[str] = None,
       driver_filter: Optional[str] = None,
       mode_filter: Optional[str] = None,
       model_name_filter: Optional[str] = None) -> Sequence[BenchmarkCase]:
@@ -121,24 +123,31 @@ class BenchmarkSuite(object):
       config_info = IREE_DRIVERS_INFOS[benchmark_case.config.lower()]
 
       driver_name = config_info.driver_name
-      matched_driver = (driver_name in available_drivers) and (
-          driver_filter is None or
-          re.match(driver_filter, driver_name) is not None)
+      available_driver_matched = available_drivers is None or driver_name in available_drivers
+      drivler_filter_matched = driver_filter is None or re.match(driver_filter, driver_name) is not None
+      matched_driver = available_driver_matched and drivler_filter_matched
 
-      matched_loader = not config_info.loader_name or (config_info.loader_name
+      matched_loader = not config_info.loader_name or available_loaders is None or (config_info.loader_name
                                                        in available_loaders)
 
       target_arch = benchmark_case.target_arch.lower()
-      matched_arch = (re.match(cpu_target_arch_filter,
-                               target_arch) is not None or
-                      re.match(gpu_target_arch_filter, target_arch) is not None)
+      matched_cpu_arch = (cpu_target_arch_filter is not None and re.match(
+          cpu_target_arch_filter, target_arch) is not None)
+      matched_gpu_arch = (gpu_target_arch_filter is not None and re.match(
+          gpu_target_arch_filter, target_arch) is not None)
+      matched_arch = (matched_cpu_arch or matched_gpu_arch or
+                      (cpu_target_arch_filter is None and
+                       gpu_target_arch_filter is None))
       bench_mode = ','.join(benchmark_case.bench_mode)
       matched_mode = (mode_filter is None or
                       re.match(mode_filter, bench_mode) is not None)
 
       # For backward compatibility, model_name_filter matches against the string:
       #   <model name with tags>/<benchmark case name>
-      model_and_case_name = f"{benchmark_case.model_name_with_tags}/{os.path.basename(benchmark_case.benchmark_case_dir)}"
+      model_name_with_tags = benchmark_case.model_name
+      if len(benchmark_case.model_tags) > 0:
+        model_name_with_tags += f"-{','.join(benchmark_case.model_tags)}"
+      model_and_case_name = f"{model_name_with_tags}/{os.path.basename(benchmark_case.benchmark_case_dir)}"
       matched_model_name = (model_name_filter is None or re.match(
           model_name_filter, model_and_case_name) is not None)
 
@@ -168,13 +177,20 @@ class BenchmarkSuite(object):
       # The path of model_dir is expected to be:
       #   <benchmark_suite_dir>/<category>/<model_name>-<model_tags>
       category_dir, model_name_with_tags = os.path.split(model_dir)
+      model_name_parts = model_name_with_tags.split("-", 1)
+      model_name = model_name_parts[0]
+      if len(model_name_parts) == 2:
+        model_tags = model_name_parts[1].split(",")
+      else:
+        model_tags = []
 
       with open(os.path.join(benchmark_case_dir, MODEL_TOOLFILE_NAME),
                 "r") as f:
         tool_name = f.read().strip()
 
       suite_map[category_dir].append(
-          BenchmarkCase(model_name_with_tags=model_name_with_tags,
+          BenchmarkCase(model_name=model_name,
+                        model_tags=model_tags,
                         bench_mode=bench_mode,
                         target_arch=target_arch,
                         config=config,

--- a/build_tools/benchmarks/common/benchmark_suite_test.py
+++ b/build_tools/benchmarks/common/benchmark_suite_test.py
@@ -42,7 +42,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
                           model_tags=["f32"],
                           bench_mode=["full-inference"],
                           target_arch="CPU-x86_64",
-                          driver="dylib-sync",
+                          config="iree-dylib-sync",
                           benchmark_case_dir="case3",
                           benchmark_tool_name="tool")
     suite = BenchmarkSuite({

--- a/build_tools/benchmarks/common/benchmark_suite_test.py
+++ b/build_tools/benchmarks/common/benchmark_suite_test.py
@@ -24,23 +24,32 @@ class BenchmarkSuiteTest(unittest.TestCase):
                                                ("TFLite", "suite/TFLite")])
 
   def test_filter_benchmarks_for_category(self):
-    case1 = BenchmarkCase(model_name_with_tags="deepnet",
+    case1 = BenchmarkCase(model_name="deepnet",
+                          model_tags=[],
                           bench_mode=["1-thread", "full-inference"],
                           target_arch="CPU-ARMv8",
                           config="iree-dylib",
                           benchmark_case_dir="case1",
                           benchmark_tool_name="tool")
-    case2 = BenchmarkCase(model_name_with_tags="deepnetv2-f32",
+    case2 = BenchmarkCase(model_name="deepnetv2",
+                          model_tags=["f32"],
                           bench_mode=["full-inference"],
                           target_arch="GPU-Mali",
                           config="iree-vulkan",
                           benchmark_case_dir="case2",
                           benchmark_tool_name="tool")
+    case3 = BenchmarkCase(model_name="deepnetv3",
+                          model_tags=["f32"],
+                          bench_mode=["full-inference"],
+                          target_arch="CPU-x86_64",
+                          driver="dylib-sync",
+                          benchmark_case_dir="case3",
+                          benchmark_tool_name="tool")
     suite = BenchmarkSuite({
-        "suite/TFLite": [case1, case2],
+        "suite/TFLite": [case1, case2, case3],
     })
 
-    both_benchmarks = suite.filter_benchmarks_for_category(
+    cpu_and_gpu_benchmarks = suite.filter_benchmarks_for_category(
         category="TFLite",
         available_drivers=["local-task", "vulkan"],
         available_loaders=["embedded-elf"],
@@ -58,9 +67,18 @@ class BenchmarkSuiteTest(unittest.TestCase):
         driver_filter="vulkan",
         mode_filter=".*full-inference.*",
         model_name_filter="deepnet.*/case2")
+    all_benchmarks = suite.filter_benchmarks_for_category(
+        category="TFLite",
+        available_drivers=None,
+        cpu_target_arch_filter=None,
+        gpu_target_arch_filter=None,
+        driver_filter=None,
+        mode_filter=None,
+        model_name_filter=None)
 
-    self.assertEqual(both_benchmarks, [case1, case2])
+    self.assertEqual(cpu_and_gpu_benchmarks, [case1, case2])
     self.assertEqual(gpu_benchmarks, [case2])
+    self.assertEqual(all_benchmarks, [case1, case2, case3])
 
   def test_filter_benchmarks_for_nonexistent_category(self):
     suite = BenchmarkSuite({
@@ -81,13 +99,15 @@ class BenchmarkSuiteTest(unittest.TestCase):
       tflite_dir = os.path.join(tmp_dir, "TFLite")
       pytorch_dir = os.path.join(tmp_dir, "PyTorch")
       BenchmarkSuiteTest.__create_bench(tflite_dir,
-                                        model="DeepNet",
+                                        model_name="DeepNet",
+                                        model_tags=["f32"],
                                         bench_mode=["4-thread", "full"],
                                         target_arch="CPU-ARMv8",
                                         config="iree-dylib",
                                         tool="run-cpu-bench")
       case2 = BenchmarkSuiteTest.__create_bench(pytorch_dir,
-                                                model="DeepNetv2",
+                                                model_name="DeepNetv2",
+                                                model_tags=[],
                                                 bench_mode=["full-inference"],
                                                 target_arch="GPU-Mali",
                                                 config="iree-vulkan",
@@ -106,15 +126,20 @@ class BenchmarkSuiteTest(unittest.TestCase):
               gpu_target_arch_filter="gpu-mali"), [case2])
 
   @staticmethod
-  def __create_bench(dir_path: str, model: str, bench_mode: Sequence[str],
-                     target_arch: str, config: str, tool: str):
+  def __create_bench(dir_path: str, model_name: str, model_tags: Sequence[str],
+                     bench_mode: Sequence[str], target_arch: str, config: str,
+                     tool: str):
     case_name = f"{config}__{target_arch}__{','.join(bench_mode)}"
-    bench_path = os.path.join(dir_path, model, case_name)
+    model_name_with_tags = model_name
+    if len(model_tags) > 0:
+      model_name_with_tags += f"-{','.join(model_tags)}"
+    bench_path = os.path.join(dir_path, model_name_with_tags, case_name)
     os.makedirs(bench_path)
     with open(os.path.join(bench_path, "tool"), "w") as f:
       f.write(tool)
 
-    return BenchmarkCase(model_name_with_tags=model,
+    return BenchmarkCase(model_name=model_name,
+                         model_tags=model_tags,
                          bench_mode=bench_mode,
                          target_arch=target_arch,
                          config=config,


### PR DESCRIPTION
Inspired by #9167, this tool parses the zip info of vmfb and the ninja build log to get the binary size (dispatch libraries) and the module compilation time.

There are 4 sizes to be retrieved:
1. Module file size
2. VM bytecode size in the module.
3. Const binary size in the module.
4. Total size of all dispatch libraries in the module.

The class `BenchmarkCase` now also parses the model name into the name and tags.