### PR TITLE
[LLVMGPU] Add path to use mma.sync op

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
@@ -17,6 +17,8 @@
 namespace mlir {
 namespace iree_compiler {
 
+extern llvm::cl::opt<bool> llvmgpuUseMMASync;
+
 //====---------------------------------------------------------------------===//
 // Patterns for vectorization
 //====---------------------------------------------------------------------===//
@@ -73,9 +75,13 @@ static Optional<SmallVector<int64_t, 4>> getGPUTCNativeVectorSize(
   // Currently hardcode the size of wmma operation. When more cases are
   // supported this should be picked based on what the backend supports.
   int64_t m = 16;
-  int64_t n = 16;
+  int64_t n = llvmgpuUseMMASync ? 8 : 16;
   if (auto contract = dyn_cast<vector::ContractionOp>(op)) {
-    int64_t k = contract.getLhsType().getElementType().isF16() ? 16 : 8;
+    int64_t k;
+    if (llvmgpuUseMMASync)
+      k = contract.getLhsType().getElementType().isF16() ? 8 : 4;
+    else
+      k = contract.getLhsType().getElementType().isF16() ? 16 : 8;
     SmallVector<int64_t, 4> nativeSize(contract.getIteratorTypes().size() - 3,
                                        1);
     nativeSize.append({m, n, k});

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
@@ -17,6 +17,7 @@
 namespace mlir {
 namespace iree_compiler {
 
+/// Flag defined in Passes.cpp.
 extern llvm::cl::opt<bool> llvmgpuUseMMASync;
 
 //====---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
@@ -32,6 +32,7 @@
 namespace mlir {
 namespace iree_compiler {
 
+/// Flag defined in Passes.cpp.
 extern llvm::cl::opt<bool> llvmgpuUseMMASync;
 
 /// Patterns for workgroup level tiling. Workgroup tiling is done at the flow

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
@@ -25,11 +25,14 @@
 #include "mlir/Support/MathExtras.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
+#include "mlir/Transforms/SideEffectUtils.h"
 
 #define DEBUG_TYPE "iree-llvmgpu-tile-and-distribute"
 
 namespace mlir {
 namespace iree_compiler {
+
+extern llvm::cl::opt<bool> llvmgpuUseMMASync;
 
 /// Patterns for workgroup level tiling. Workgroup tiling is done at the flow
 /// level but we may have extra tiling for the reduction dimension. Therefore we
@@ -56,8 +59,10 @@ static void populateTilingReductionPatterns(RewritePatternSet &patterns) {
   MLIRContext *context = patterns.getContext();
 
   linalg::LinalgTransformationFilter filter(
-      ArrayRef<StringAttr>{},
+      ArrayRef<StringAttr>{
+          StringAttr::get(context, getWorkgroupMemoryMarker())},
       StringAttr::get(context, getWorkgroupKTiledMarker()));
+  filter.setMatchByDefault();
   linalg::TilingPatterns<linalg::MatmulOp, linalg::BatchMatmulOp,
                          linalg::GenericOp>::insert(patterns, tilingOptions,
                                                     filter);
@@ -181,7 +186,8 @@ static LogicalResult copyToWorkgroupMemory(OpBuilder &b, Value src, Value dst) {
 }
 
 static void populatePromotionPatterns(MLIRContext *context,
-                                      RewritePatternSet &patterns) {
+                                      RewritePatternSet &patterns,
+                                      ArrayRef<int64_t> operandsToPromote) {
   patterns.insert<linalg::LinalgPromotionPattern<linalg::MatmulOp>,
                   linalg::LinalgPromotionPattern<linalg::BatchMatmulOp>,
                   linalg::LinalgPromotionPattern<linalg::GenericOp>>(
@@ -190,17 +196,48 @@ static void populatePromotionPatterns(MLIRContext *context,
           .setAllocationDeallocationFns(allocateWorkgroupMemory,
                                         deallocateWorkgroupMemory)
           .setCopyInOutFns(copyToWorkgroupMemory, copyToWorkgroupMemory)
-          .setOperandsToPromote({0, 1})
+          .setOperandsToPromote(operandsToPromote)
           .setUseFullTileBuffers({false, false}),
       linalg::LinalgTransformationFilter(
           {StringAttr::get(context, getWorkgroupKTiledMarker())},
           StringAttr::get(context, getWorkgroupMemoryMarker()))
+          .setMatchByDefault()
           .addFilter([](Operation *op) {
             auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
             if (!linalgOp) return failure();
             return success(linalg::isaContractionOpInterface(op) &&
                            linalgOp.getNumParallelLoops() >= 2);
           }));
+}
+
+/// Transformation to propagate FillOp + CopyOp to temp allocation.
+/// This is needed because we are doing promotion to shared memory on buffers.
+/// This is a fragile and temporary solution until we move to be able to do this
+/// kind of transformations on tensors.
+static void propagateFillIntoPromotionAlloc(func::FuncOp funcOp) {
+  SmallVector<Operation *> toDelete;
+  funcOp.walk([&toDelete](memref::CopyOp copyOp) {
+    if (hasMarker(copyOp, getCopyToWorkgroupMemoryMarker())) {
+      // Look for a fill Op writing into the copyOp source.
+      Operation *prevOp = copyOp->getPrevNode();
+      while (prevOp) {
+        if (isSideEffectFree(prevOp)) {
+          prevOp = prevOp->getPrevNode();
+          continue;
+        }
+
+        auto fillOp = dyn_cast<linalg::FillOp>(prevOp);
+        if (!fillOp) break;
+        if (fillOp.output() != copyOp.source()) break;
+        // Move the fillOp and change the destination to the copy destination.
+        fillOp->moveBefore(copyOp);
+        fillOp.outputsMutable().assign(copyOp.getTarget());
+        toDelete.push_back(copyOp.getOperation());
+        break;
+      }
+    }
+  });
+  for (Operation *op : toDelete) op->erase();
 }
 
 namespace {
@@ -220,6 +257,19 @@ struct LLVMGPUTileAndDistributePass
     MLIRContext *context = &getContext();
     auto funcOp = getOperation();
     if (!isEntryPoint(funcOp)) return;
+
+    // Promote C matrix and propagate the potential  fill producer into the temp
+    // allocation. This needs to be done before reduction tiling.
+    if (llvmgpuUseMMASync) {
+      RewritePatternSet promotionPatterns(&getContext());
+      populatePromotionPatterns(context, promotionPatterns, {2});
+      if (failed(applyPatternsAndFoldGreedily(funcOp,
+                                              std::move(promotionPatterns)))) {
+        return signalPassFailure();
+      }
+      propagateFillIntoPromotionAlloc(funcOp);
+    }
+
     {
       // Tile again at the workgroup level since redution dimension were
       // ignored. Dimensions already tiled will be ignore since we tile to the
@@ -257,7 +307,7 @@ struct LLVMGPUTileAndDistributePass
     // Only promote to workgroup size if there are multiple warps.
     if (flatWorkgroupSize > kWarpSize) {
       RewritePatternSet promotionPatterns(&getContext());
-      populatePromotionPatterns(context, promotionPatterns);
+      populatePromotionPatterns(context, promotionPatterns, {0, 1});
       if (failed(applyPatternsAndFoldGreedily(funcOp,
                                               std::move(promotionPatterns)))) {
         return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
@@ -17,6 +17,8 @@
 namespace mlir {
 namespace iree_compiler {
 
+extern llvm::cl::opt<bool> llvmgpuUseMMASync;
+
 /// Helper to convert copy to shared memory to async copy. This creates groups
 /// of consecutive copies and emit wait operation right after.
 static void createAsyncGroups(func::FuncOp funcOp) {
@@ -84,7 +86,7 @@ static void createAsyncGroups(func::FuncOp funcOp) {
           writeOp.getSource(), writeOp.getIndices(), readOp.getSource(),
           readOp.getIndices(),
           builder.getIndexAttr(readOp.getVectorType().getNumElements()),
-          /*bypassL1=*/builder.getUnitAttr());
+          /*bypassL1=*/llvmgpuUseMMASync ? builder.getUnitAttr() : UnitAttr());
       tokens.push_back(token);
     }
     // Create the group and wait for it right after.
@@ -235,10 +237,13 @@ struct LLVMGPUVectorToGPUPass
       return signalPassFailure();
     }
     RewritePatternSet patterns(funcOp.getContext());
-    populatePrepareVectorToMMAPatterns(patterns);
+    populatePrepareVectorToMMAPatterns(patterns, llvmgpuUseMMASync);
     (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
 
-    convertVectorToMMAOps(funcOp);
+    if (llvmgpuUseMMASync)
+      (void)convertVectorToNVVMCompatibleMMASync(funcOp);
+    else
+      convertVectorToMMAOps(funcOp);
     createAsyncGroups(funcOp);
   }
 };

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
@@ -17,6 +17,7 @@
 namespace mlir {
 namespace iree_compiler {
 
+/// Flag defined in Passes.cpp.
 extern llvm::cl::opt<bool> llvmgpuUseMMASync;
 
 /// Helper to convert copy to shared memory to async copy. This creates groups

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_to_gpu.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_to_gpu.mlir
@@ -6,12 +6,12 @@ func.func @copies_to_asyncs(%a: memref<1024x1024xf32>) {
   %c0 = arith.constant 0 : index
   %c4 = arith.constant 4 : index
   %cst_0 = arith.constant 0.000000e+00 : f32
-  // CHECK: %[[CP0:.*]] = nvgpu.device_async_copy {{.*}}, {{.*}}, 4 {bypassL1}
+  // CHECK: %[[CP0:.*]] = nvgpu.device_async_copy {{.*}}, {{.*}}, 4
   %1 = vector.transfer_read %a[%c0, %c0], %cst_0 {in_bounds = [true]} : memref<1024x1024xf32>, vector<4xf32>
   vector.transfer_write %1, %0[%c0, %c0, %c0] {in_bounds = [true]} : vector<4xf32>, memref<4x32x16xf32, 3>
   // CHECK-NOT: nvgpu.device_async_create_group
 
-  // CHECK: %[[CP1:.*]] = nvgpu.device_async_copy {{.*}}, {{.*}}, 1 {bypassL1}
+  // CHECK: %[[CP1:.*]] = nvgpu.device_async_copy {{.*}}, {{.*}}, 1
   %2 = vector.transfer_read %a[%c0, %c4], %cst_0 {in_bounds = [true]} : memref<1024x1024xf32>, vector<1xf32>
   vector.transfer_write %2, %0[%c0, %c4, %c0] {in_bounds = [true]} : vector<1xf32>, memref<4x32x16xf32, 3>
   // CHECK: %[[G:.*]] = nvgpu.device_async_create_group %[[CP0]], %[[CP1]]


### PR DESCRIPTION
This path is still disable by default as it would regress performance.
Once all the patches land and we get better performance this will be
enabled by default and the wmma path can be removed.