### PR TITLE
Add workflow to add new issues to the IREE GitHub project

### DIFF
--- a/.github/workflows/process_opened_issues.yml
+++ b/.github/workflows/process_opened_issues.yml
@@ -11,7 +11,7 @@ jobs:
     name: Adding issue to the master project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@b56023be57e9c76f06e3844f18a1ab5dec7e7617
         with:
           project-url: https://github.com/orgs/google/projects/20
           github-token: ${{ secrets.WRITE_ACCESS_TOKEN }}

--- a/.github/workflows/process_opened_issues.yml
+++ b/.github/workflows/process_opened_issues.yml
@@ -1,4 +1,4 @@
-name: Process opened / reopened issues
+name: Process (re)opened issues
 
 on:
   issues:
@@ -7,21 +7,22 @@ on:
       - opened
 
 jobs:
-  label_issues:
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - name: Label issues
-        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
-        with:
-          add-labels: "awaiting-triage"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+#   label_issues:
+#     name: Add awaiting-triage label
+#     runs-on: ubuntu-latest
+#     permissions:
+#       issues: write
+#     steps:
+#       - name: Add awaiting-triage label
+#         uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
+#         with:
+#           add-labels: "awaiting-triage"
+#           repo-token: ${{ secrets.WRITE_ACCESS_TOKEN }}
   add-to-project:
-    name: Add all issues to the master project
+    name: Add to the master project
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/google/projects/20
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ secrets.WRITE_ACCESS_TOKEN }}

--- a/.github/workflows/process_opened_issues.yml
+++ b/.github/workflows/process_opened_issues.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   add-to-project:
-    name: Add to the master project
+    name: Adding issue to the master project
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@main

--- a/.github/workflows/process_opened_issues.yml
+++ b/.github/workflows/process_opened_issues.yml
@@ -1,0 +1,27 @@
+name: Process opened / reopened issues
+
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Label issues
+        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
+        with:
+          add-labels: "awaiting-triage"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+  add-to-project:
+    name: Add all issues to the master project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/google/projects/20
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/process_opened_issues.yml
+++ b/.github/workflows/process_opened_issues.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   add-to-project:
-    name: Adding issue to the master project
+    name: Adding issue to the IREE GitHub project
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@b56023be57e9c76f06e3844f18a1ab5dec7e7617

--- a/.github/workflows/process_opened_issues.yml
+++ b/.github/workflows/process_opened_issues.yml
@@ -7,17 +7,6 @@ on:
       - opened
 
 jobs:
-#   label_issues:
-#     name: Add awaiting-triage label
-#     runs-on: ubuntu-latest
-#     permissions:
-#       issues: write
-#     steps:
-#       - name: Add awaiting-triage label
-#         uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
-#         with:
-#           add-labels: "awaiting-triage"
-#           repo-token: ${{ secrets.WRITE_ACCESS_TOKEN }}
   add-to-project:
     name: Add to the master project
     runs-on: ubuntu-latest


### PR DESCRIPTION
We're trialing using a [master project](https://github.com/orgs/google/projects/20) (not yet publicly visible) for issue tracking/organization. This workflow will automatically add issues to the project so that early adopters don't have to do this manually for every issue.

I tested this successfully on my fork. However, we could run into issues with the `github_token`.