### PR TITLE
Update version of add-to-project action used in workflow

### DIFF
--- a/.github/workflows/process_opened_issues.yml
+++ b/.github/workflows/process_opened_issues.yml
@@ -11,7 +11,7 @@ jobs:
     name: Adding issue to the IREE GitHub project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@b56023be57e9c76f06e3844f18a1ab5dec7e7617
+      - uses: actions/add-to-project@7a0820f97673dfefc999713a9a6d6b7ee128bba5
         with:
           project-url: https://github.com/orgs/google/projects/20
           github-token: ${{ secrets.WRITE_ACCESS_TOKEN }}


### PR DESCRIPTION
We're seeing an error with this new workflow

```
2022-05-27T14:58:17.9026449Z Download action repository 'actions/add-to-project@b56023be57e9c76f06e3844f18a1ab5dec7e7617' (SHA:b56023be57e9c76f06e3844f18a1ab5dec7e7617)
2022-05-27T14:58:18.6434110Z ##[group]Run actions/add-to-project@b56023be57e9c76f06e3844f18a1ab5dec7e7617
2022-05-27T14:58:18.6435206Z with:
2022-05-27T14:58:18.6435793Z   project-url: https://github.com/orgs/google/projects/20
2022-05-27T14:58:18.6437264Z   github-token: ***
2022-05-27T14:58:18.6437944Z ##[endgroup]
2022-05-27T14:58:19.1810658Z ##[error]Cannot read properties of null (reading 'id')
```

I'm going to try setting the version of the action used to the [latest](https://github.com/actions/add-to-project/releases/tag/v0.0.3) instead of head to see if that makes a difference. (I've successfully used this version on my fork, but haven't tested head.)

