### PR TITLE
Fix install of Python tool binaries in iree-runtime package.

### DIFF
--- a/compiler/src/iree/compiler/API/python/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API/python/CMakeLists.txt
@@ -79,12 +79,7 @@ set(_SOURCE_COMPONENTS
   IREECompilerAPIPythonExtensions
   IREECompilerAPIPythonTools
 
-  # TODO: Core is now implicitly building/registering all dialects, increasing
-  # build burden by ~5x. Make it stop.
   MLIRPythonSources.Core
-
-  # Passes should also be disaggregated.
-  MLIRPythonSources.Passes
 
   # Core dialects (constrained to IREE input dialects).
   MLIRPythonSources.Dialects.arith

--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -197,7 +197,8 @@ install(
 # the end of the root file. While deferred calls are generally fragile, this
 # install is purely a leaf feature (with no other calls depending on its
 # sequencing), so this use is okay.
-cmake_language(DEFER DIRECTORY "${IREE_SOURCE_DIR}"
+cmake_language(EVAL CODE "
+cmake_language(DEFER DIRECTORY \"${IREE_SOURCE_DIR}\"
   CALL install
   TARGETS
     iree-benchmark-module
@@ -205,6 +206,7 @@ cmake_language(DEFER DIRECTORY "${IREE_SOURCE_DIR}"
     iree-run-module
     iree-run-trace
     ${_EXTRA_INSTALL_TOOL_TARGETS}
-  DESTINATION "${_INSTALL_DIR}/iree/runtime"
-  COMPONENT "${_INSTALL_COMPONENT}"
+  DESTINATION \"${_INSTALL_DIR}/iree/runtime\"
+  COMPONENT \"${_INSTALL_COMPONENT}\"
 )
+")

--- a/runtime/setup.py
+++ b/runtime/setup.py
@@ -259,23 +259,23 @@ def prepare_installation():
     else:
       print(f"Not re-configuring (already configured)", file=sys.stderr)
 
-    # Build.
+    # Build. Since we have restricted to just the runtime, build everything
+    # so as to avoid fragility with more targeted selection criteria.
     subprocess.check_call(
-        ["cmake", "--build", ".", "--target", "runtime/bindings/python/all"],
+        ["cmake", "--build", "."],
         cwd=IREE_BINARY_DIR)
     print("Build complete.", file=sys.stderr)
 
-  # Install the directory we care about.
-  install_subdirectory = os.path.join(IREE_BINARY_DIR, "runtime", "bindings",
-                                      "python")
+  # Install the component we care about.
   install_args = [
       "-DCMAKE_INSTALL_DO_STRIP=ON",
       f"-DCMAKE_INSTALL_PREFIX={CMAKE_INSTALL_DIR_ABS}/",
+      f"-DCMAKE_INSTALL_COMPONENT=IreePythonPackage-runtime",
       "-P",
-      os.path.join(install_subdirectory, "cmake_install.cmake"),
+      os.path.join(IREE_BINARY_DIR, "cmake_install.cmake"),
   ]
   print(f"Installing with: {install_args}", file=sys.stderr)
-  subprocess.check_call(["cmake"] + install_args, cwd=install_subdirectory)
+  subprocess.check_call(["cmake"] + install_args, cwd=IREE_BINARY_DIR)
 
   # Write version.py directly into install dir.
   version_py_file = os.path.join(CMAKE_INSTALL_DIR_ABS, "python_packages",

--- a/runtime/setup.py
+++ b/runtime/setup.py
@@ -261,9 +261,7 @@ def prepare_installation():
 
     # Build. Since we have restricted to just the runtime, build everything
     # so as to avoid fragility with more targeted selection criteria.
-    subprocess.check_call(
-        ["cmake", "--build", "."],
-        cwd=IREE_BINARY_DIR)
+    subprocess.check_call(["cmake", "--build", "."], cwd=IREE_BINARY_DIR)
     print("Build complete.", file=sys.stderr)
 
   # Install the component we care about.


### PR DESCRIPTION
It turned out that this not working was a comedy of errors. Verified from both the build directory and a clean build that the binaries are now included. I will enable a test in the validate releases script after tomorrow's build.

Fixes #9231