### PR TITLE
Use `ctest --test-dir` instead of `cd` in a few places.

### DIFF
--- a/build_tools/buildkite/cmake/android/arm64-v8a/pipeline.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/pipeline.yml
@@ -25,8 +25,7 @@ steps:
       - "buildkite-agent artifact download --step build build-artifacts.tgz ./"
       - "tar xzf build-artifacts.tgz"
       - "find build-android/ -name '*.cmake' -exec sed -i \"s!\\$IREE_DOCKER_WORKDIR/!\\$PWD/!g\" {} \\;"
-      - "cd build-android/"
-      - "ctest --timeout 900 --output-on-failure"
+      - "ctest --test-dir build-android/ --timeout 900 --output-on-failure"
     agents:
       - "android-soc=google-tensor"
       - "queue=test-android"
@@ -41,10 +40,9 @@ steps:
       - "buildkite-agent artifact download --step build build-artifacts.tgz ./"
       - "tar xzf build-artifacts.tgz"
       - "find build-android/ -name '*.cmake' -exec sed -i \"s!\\$IREE_DOCKER_WORKDIR/!\\$PWD/!g\" {} \\;"
-      - "cd build-android/"
       # Pixel 4 ships an old Adreno GPU driver. There are quite a few bugs triggered by our tests.
       # Disable running tests entirely on Pixel 4. Moto Edge X30 gets us covered on Adreno GPU.
-      - "ctest --timeout 900 --output-on-failure --label-exclude \"vulkan\""
+      - "ctest --test-dir build-android/ --timeout 900 --output-on-failure --label-exclude \"vulkan\""
     agents:
       - "android-soc=snapdragon-855"
       - "queue=test-android"
@@ -59,8 +57,7 @@ steps:
       - "buildkite-agent artifact download --step build build-artifacts.tgz ./"
       - "tar xzf build-artifacts.tgz"
       - "find build-android/ -name '*.cmake' -exec sed -i \"s!\\$IREE_DOCKER_WORKDIR/!\\$PWD/!g\" {} \\;"
-      - "cd build-android/"
-      - "ctest --timeout 900 --output-on-failure"
+      - "ctest --test-dir build-android/ --timeout 900 --output-on-failure"
     agents:
       - "android-soc=snapdragon-8gen1"
       - "queue=test-android"

--- a/docs/website/docs/building-from-source/android.md
+++ b/docs/website/docs/building-from-source/android.md
@@ -98,8 +98,7 @@ all built tests through
 [CTest](https://gitlab.kitware.com/cmake/community/-/wikis/doc/ctest/Testing-With-CTest):
 
 ``` shell
-cd ../iree-build-android/
-ctest --output-on-failure
+ctest --test-dir ../iree-build-android/ --output-on-failure
 ```
 
 This will automatically upload build artifacts to the connected Android device,

--- a/docs/website/docs/building-from-source/getting-started.md
+++ b/docs/website/docs/building-from-source/getting-started.md
@@ -113,8 +113,7 @@ Run all built tests through
 [CTest](https://gitlab.kitware.com/cmake/community/-/wikis/doc/ctest/Testing-With-CTest):
 
 ``` shell
-cd ../iree-build/
-ctest --output-on-failure
+ctest --test-dir ../iree-build/ --output-on-failure
 ```
 
 ### Take a look around


### PR DESCRIPTION
This argument is new since CMake 3.20, and we require at least CMake 3.21 now. Changing directories can be a source of confusion for users, so this changes some guides to stay in the repo root and be explicit with each command.

Our other uses in scripts interact with the build directory in other ways (such as "building" `check-iree-dialects` or running TF lit tests under Python), so I left them unchanged.