### PR TITLE
HAL semaphore improvements and timepoint tracking support.

### DIFF
--- a/experimental/rocm/CMakeLists.txt
+++ b/experimental/rocm/CMakeLists.txt
@@ -55,6 +55,7 @@ iree_cc_library(
     iree::base::tracing
     iree::hal
     iree::hal::utils::buffer_transfer
+    iree::hal::utils::semaphore_base
     iree::schemas::rocm_executable_def_c_fbs
   PUBLIC
 )

--- a/experimental/rocm/event_semaphore.c
+++ b/experimental/rocm/event_semaphore.c
@@ -10,11 +10,11 @@
 
 #include "iree/base/api.h"
 #include "iree/base/tracing.h"
+#include "iree/hal/utils/semaphore_base.h"
 
 typedef struct iree_hal_rocm_semaphore_t {
-  iree_hal_resource_t resource;
+  iree_hal_semaphore_t base;
   iree_hal_rocm_context_wrapper_t* context;
-  uint64_t initial_value;
 } iree_hal_rocm_semaphore_t;
 
 static const iree_hal_semaphore_vtable_t iree_hal_rocm_semaphore_vtable;
@@ -36,11 +36,10 @@ iree_status_t iree_hal_rocm_semaphore_create(
   iree_status_t status = iree_allocator_malloc(
       context->host_allocator, sizeof(*semaphore), (void**)&semaphore);
   if (iree_status_is_ok(status)) {
-    iree_hal_resource_initialize(&iree_hal_rocm_semaphore_vtable,
-                                 &semaphore->resource);
+    iree_hal_semaphore_initialize(&iree_hal_rocm_semaphore_vtable,
+                                  &semaphore->base);
     semaphore->context = context;
-    semaphore->initial_value = initial_value;
-    *out_semaphore = (iree_hal_semaphore_t*)semaphore;
+    *out_semaphore = &semaphore->base;
   }
 
   IREE_TRACE_ZONE_END(z0);
@@ -54,6 +53,7 @@ static void iree_hal_rocm_semaphore_destroy(
   iree_allocator_t host_allocator = semaphore->context->host_allocator;
   IREE_TRACE_ZONE_BEGIN(z0);
 
+  iree_hal_semaphore_deinitialize(&semaphore->base);
   iree_allocator_free(host_allocator, semaphore);
 
   IREE_TRACE_ZONE_END(z0);
@@ -68,19 +68,31 @@ static iree_status_t iree_hal_rocm_semaphore_query(
 
 static iree_status_t iree_hal_rocm_semaphore_signal(
     iree_hal_semaphore_t* base_semaphore, uint64_t new_value) {
+  iree_hal_rocm_semaphore_t* semaphore =
+      iree_hal_rocm_semaphore_cast(base_semaphore);
   // TODO: Support semaphores completely. Return OK currently as everything is
   // synchronized for each submit to allow things to run.
+  iree_hal_semaphore_poll(&semaphore->base);
   return iree_ok_status();
 }
 
 static void iree_hal_rocm_semaphore_fail(iree_hal_semaphore_t* base_semaphore,
-                                         iree_status_t status) {}
+                                         iree_status_t status) {
+  iree_hal_rocm_semaphore_t* semaphore =
+      iree_hal_rocm_semaphore_cast(base_semaphore);
+  // TODO: save status and mark timepoint as failed.
+  iree_status_ignore(status);
+  iree_hal_semaphore_poll(&semaphore->base);
+}
 
 static iree_status_t iree_hal_rocm_semaphore_wait(
     iree_hal_semaphore_t* base_semaphore, uint64_t value,
     iree_timeout_t timeout) {
+  iree_hal_rocm_semaphore_t* semaphore =
+      iree_hal_rocm_semaphore_cast(base_semaphore);
   // TODO: Support semaphores completely. Return OK currently as everything is
   // synchronized for each submit to allow things to run.
+  iree_hal_semaphore_poll(&semaphore->base);
   return iree_ok_status();
 }
 

--- a/runtime/src/iree/base/internal/wait_handle.c
+++ b/runtime/src/iree/base/internal/wait_handle.c
@@ -55,7 +55,7 @@ iree_status_t iree_wait_handle_ctl(iree_wait_source_t wait_source,
               ((const iree_wait_source_wait_params_t*)params)->timeout));
     }
     case IREE_WAIT_SOURCE_COMMAND_EXPORT: {
-      iree_wait_primitive_type_t target_type =
+      const iree_wait_primitive_type_t target_type =
           ((const iree_wait_source_export_params_t*)params)->target_type;
       if (target_type != IREE_WAIT_PRIMITIVE_TYPE_ANY &&
           target_type != wait_handle->type) {

--- a/runtime/src/iree/base/internal/wait_handle.h
+++ b/runtime/src/iree/base/internal/wait_handle.h
@@ -232,7 +232,7 @@ void iree_event_set(iree_event_t* event);
 // Resetting an event that is already reset has no effect.
 void iree_event_reset(iree_event_t* event);
 
-// Returns a wait_source reference to |event|.
+// Returns a wait source reference to |event|.
 // The event must be kept live for as long as the reference is live.
 iree_wait_source_t iree_event_await(iree_event_t* event);
 

--- a/runtime/src/iree/hal/cuda/CMakeLists.txt
+++ b/runtime/src/iree/hal/cuda/CMakeLists.txt
@@ -60,6 +60,7 @@ iree_cc_library(
     iree::hal::utils::buffer_transfer
     iree::hal::utils::deferred_command_buffer
     iree::hal::utils::resource_set
+    iree::hal::utils::semaphore_base
     iree::schemas::cuda_executable_def_c_fbs
   PUBLIC
 )

--- a/runtime/src/iree/hal/local/BUILD
+++ b/runtime/src/iree/hal/local/BUILD
@@ -136,6 +136,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/base/internal:synchronization",
         "//runtime/src/iree/hal",
         "//runtime/src/iree/hal/utils:buffer_transfer",
+        "//runtime/src/iree/hal/utils:semaphore_base",
     ],
 )
 
@@ -190,6 +191,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal",
         "//runtime/src/iree/hal/utils:buffer_transfer",
         "//runtime/src/iree/hal/utils:resource_set",
+        "//runtime/src/iree/hal/utils:semaphore_base",
         "//runtime/src/iree/task",
     ],
 )

--- a/runtime/src/iree/hal/local/CMakeLists.txt
+++ b/runtime/src/iree/hal/local/CMakeLists.txt
@@ -127,6 +127,7 @@ iree_cc_library(
     iree::base::tracing
     iree::hal
     iree::hal::utils::buffer_transfer
+    iree::hal::utils::semaphore_base
   PUBLIC
 )
 
@@ -171,6 +172,7 @@ iree_cc_library(
     iree::hal
     iree::hal::utils::buffer_transfer
     iree::hal::utils::resource_set
+    iree::hal::utils::semaphore_base
     iree::task
   PUBLIC
 )

--- a/runtime/src/iree/hal/local/sync_semaphore.c
+++ b/runtime/src/iree/hal/local/sync_semaphore.c
@@ -195,6 +195,16 @@ static void iree_hal_sync_semaphore_fail(iree_hal_semaphore_t* base_semaphore,
 iree_status_t iree_hal_sync_semaphore_multi_signal(
     iree_hal_sync_semaphore_state_t* shared_state,
     const iree_hal_semaphore_list_t* semaphore_list) {
+  IREE_ASSERT_ARGUMENT(shared_state);
+  IREE_ASSERT_ARGUMENT(semaphore_list);
+  if (semaphore_list->count == 0) {
+    return iree_ok_status();
+  } else if (semaphore_list->count == 1) {
+    // Fast-path for a single semaphore.
+    return iree_hal_semaphore_signal(semaphore_list->semaphores[0],
+                                     semaphore_list->payload_values[0]);
+  }
+
   // Try to signal all semaphores, stopping if we encounter any issues.
   iree_status_t status = iree_ok_status();
   for (iree_host_size_t i = 0; i < semaphore_list->count; ++i) {

--- a/runtime/src/iree/hal/local/sync_semaphore.c
+++ b/runtime/src/iree/hal/local/sync_semaphore.c
@@ -132,7 +132,6 @@ static iree_status_t iree_hal_sync_semaphore_signal_unsafe(
     iree_hal_sync_semaphore_t* semaphore, uint64_t new_value) {
   if (new_value <= semaphore->current_value) {
     uint64_t current_value IREE_ATTRIBUTE_UNUSED = semaphore->current_value;
-    iree_slim_mutex_unlock(&semaphore->mutex);
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                             "semaphore values must be monotonically "
                             "increasing; current_value=%" PRIu64

--- a/runtime/src/iree/hal/local/task_queue.c
+++ b/runtime/src/iree/hal/local/task_queue.c
@@ -204,6 +204,8 @@ static iree_status_t iree_hal_task_queue_issue_cmd(
         status = iree_hal_task_command_buffer_issue(
             cmd->command_buffers[i], &cmd->queue->state,
             cmd->task.header.completion_task, cmd->arena, pending_submission);
+        iree_hal_command_buffer_release(cmd->command_buffers[i]);
+        cmd->command_buffers[i] = NULL;
       } else {
         status = iree_make_status(
             IREE_STATUS_UNIMPLEMENTED,
@@ -222,6 +224,12 @@ static iree_status_t iree_hal_task_queue_issue_cmd(
 static void iree_hal_task_queue_issue_cmd_cleanup(
     iree_task_t* task, iree_status_code_t status_code) {
   iree_hal_task_queue_issue_cmd_t* cmd = (iree_hal_task_queue_issue_cmd_t*)task;
+
+  // Release command buffers; some may have been released after issuing but this
+  // handles leftovers that may appear due to failures.
+  for (iree_host_size_t i = 0; i < cmd->command_buffer_count; ++i) {
+    iree_hal_command_buffer_release(cmd->command_buffers[i]);
+  }
 
   // Reset queue tail issue task if it was us.
   iree_slim_mutex_lock(&cmd->queue->mutex);
@@ -252,8 +260,10 @@ static iree_status_t iree_hal_task_queue_issue_cmd_allocate(
   cmd->queue = queue;
 
   cmd->command_buffer_count = command_buffer_count;
-  memcpy(cmd->command_buffers, command_buffers,
-         cmd->command_buffer_count * sizeof(*cmd->command_buffers));
+  for (iree_host_size_t i = 0; i < command_buffer_count; ++i) {
+    cmd->command_buffers[i] = command_buffers[i];
+    iree_hal_command_buffer_retain(cmd->command_buffers[i]);
+  }
 
   *out_cmd = cmd;
   return iree_ok_status();

--- a/runtime/src/iree/hal/local/task_queue.c
+++ b/runtime/src/iree/hal/local/task_queue.c
@@ -550,7 +550,7 @@ iree_status_t iree_hal_task_queue_submit_and_wait(
     // TODO(benvanik): get a wait_handle we can pass to
     // iree_task_executor_donate_caller - it'll flush + do work.
     iree_task_executor_flush(queue->executor);
-    status = iree_hal_task_queue_wait_idle(queue, timeout);
+    status = iree_hal_semaphore_wait(wait_semaphore, wait_value, timeout);
   }
 
   IREE_TRACE_ZONE_END(z0);

--- a/runtime/src/iree/hal/semaphore.c
+++ b/runtime/src/iree/hal/semaphore.c
@@ -105,6 +105,7 @@ iree_status_t iree_hal_semaphore_wait_source_ctl(
       iree_wait_primitive_t* out_wait_primitive =
           (iree_wait_primitive_t*)inout_ptr;
       memset(out_wait_primitive, 0, sizeof(*out_wait_primitive));
+      (void)target_type;
       return iree_make_status(IREE_STATUS_UNAVAILABLE,
                               "requested wait primitive type %d is unavailable",
                               (int)target_type);

--- a/runtime/src/iree/hal/semaphore.c
+++ b/runtime/src/iree/hal/semaphore.c
@@ -71,3 +71,56 @@ IREE_API_EXPORT iree_status_t iree_hal_semaphore_wait(
   IREE_TRACE_ZONE_END(z0);
   return status;
 }
+
+iree_status_t iree_hal_semaphore_wait_source_ctl(
+    iree_wait_source_t wait_source, iree_wait_source_command_t command,
+    const void* params, void** inout_ptr) {
+  iree_hal_semaphore_t* semaphore = (iree_hal_semaphore_t*)wait_source.self;
+  const uint64_t target_value = wait_source.data;
+  switch (command) {
+    case IREE_WAIT_SOURCE_COMMAND_QUERY: {
+      iree_status_code_t* out_wait_status_code = (iree_status_code_t*)inout_ptr;
+      uint64_t current_value = 0;
+      iree_status_t status =
+          iree_hal_semaphore_query(semaphore, &current_value);
+      if (!iree_status_is_ok(status)) {
+        *out_wait_status_code = iree_status_code(status);
+        iree_status_ignore(status);
+      } else {
+        *out_wait_status_code = current_value < target_value
+                                    ? IREE_STATUS_DEFERRED
+                                    : IREE_STATUS_OK;
+      }
+      return iree_ok_status();
+    }
+    case IREE_WAIT_SOURCE_COMMAND_WAIT_ONE: {
+      const iree_timeout_t timeout =
+          ((const iree_wait_source_wait_params_t*)params)->timeout;
+      return iree_hal_semaphore_wait(semaphore, target_value, timeout);
+    }
+    case IREE_WAIT_SOURCE_COMMAND_EXPORT: {
+      const iree_wait_primitive_type_t target_type =
+          ((const iree_wait_source_export_params_t*)params)->target_type;
+      // TODO(benvanik): support exporting semaphores to real wait handles.
+      iree_wait_primitive_t* out_wait_primitive =
+          (iree_wait_primitive_t*)inout_ptr;
+      memset(out_wait_primitive, 0, sizeof(*out_wait_primitive));
+      return iree_make_status(IREE_STATUS_UNAVAILABLE,
+                              "requested wait primitive type %d is unavailable",
+                              (int)target_type);
+    }
+    default:
+      return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                              "unimplemented wait_source command");
+  }
+}
+
+IREE_API_EXPORT iree_wait_source_t
+iree_hal_semaphore_await(iree_hal_semaphore_t* semaphore, uint64_t value) {
+  IREE_ASSERT_ARGUMENT(semaphore);
+  return (iree_wait_source_t){
+      .self = semaphore,
+      .data = value,
+      .ctl = iree_hal_semaphore_wait_source_ctl,
+  };
+}

--- a/runtime/src/iree/hal/semaphore.h
+++ b/runtime/src/iree/hal/semaphore.h
@@ -93,8 +93,8 @@ iree_hal_semaphore_signal(iree_hal_semaphore_t* semaphore, uint64_t new_value);
 IREE_API_EXPORT void iree_hal_semaphore_fail(iree_hal_semaphore_t* semaphore,
                                              iree_status_t status);
 
-// Blocks the caller until the semaphore reaches or exceedes the specified
-// payload value or the |timeout| elapses.
+// Blocks the caller until the semaphore reaches or exceeds the specified
+// payload |value| or the |timeout| elapses.
 //
 // Returns success if the wait is successful and the semaphore has met or
 // exceeded the required payload value.
@@ -108,6 +108,11 @@ IREE_API_EXPORT void iree_hal_semaphore_fail(iree_hal_semaphore_t* semaphore,
 // failed and get the status.
 IREE_API_EXPORT iree_status_t iree_hal_semaphore_wait(
     iree_hal_semaphore_t* semaphore, uint64_t value, iree_timeout_t timeout);
+
+// Returns a wait source reference to |semaphore| after it reaches or exceeds
+// the specified payload |value|.
+IREE_API_EXPORT iree_wait_source_t
+iree_hal_semaphore_await(iree_hal_semaphore_t* semaphore, uint64_t value);
 
 //===----------------------------------------------------------------------===//
 // iree_hal_semaphore_t implementation details

--- a/runtime/src/iree/hal/utils/BUILD
+++ b/runtime/src/iree/hal/utils/BUILD
@@ -75,3 +75,29 @@ iree_runtime_cc_test(
         "//runtime/src/iree/testing:gtest_main",
     ],
 )
+
+iree_runtime_cc_library(
+    name = "semaphore_base",
+    srcs = ["semaphore_base.c"],
+    hdrs = ["semaphore_base.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base:tracing",
+        "//runtime/src/iree/base/internal:synchronization",
+        "//runtime/src/iree/hal",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "semaphore_base_test",
+    srcs = ["semaphore_base_test.cc"],
+    deps = [
+        ":semaphore_base",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal:wait_handle",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)

--- a/runtime/src/iree/hal/utils/CMakeLists.txt
+++ b/runtime/src/iree/hal/utils/CMakeLists.txt
@@ -82,4 +82,33 @@ iree_cc_test(
     iree::testing::gtest_main
 )
 
+iree_cc_library(
+  NAME
+    semaphore_base
+  HDRS
+    "semaphore_base.h"
+  SRCS
+    "semaphore_base.c"
+  DEPS
+    iree::base
+    iree::base::internal::synchronization
+    iree::base::tracing
+    iree::hal
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    semaphore_base_test
+  SRCS
+    "semaphore_base_test.cc"
+  DEPS
+    ::semaphore_base
+    iree::base
+    iree::base::internal::wait_handle
+    iree::hal
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/runtime/src/iree/hal/utils/semaphore_base.c
+++ b/runtime/src/iree/hal/utils/semaphore_base.c
@@ -1,0 +1,307 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/utils/semaphore_base.h"
+
+#include <stddef.h>
+
+#include "iree/base/tracing.h"
+
+//===----------------------------------------------------------------------===//
+// Timepoint utilities
+//===----------------------------------------------------------------------===//
+
+// Returns true if the timepoint list is empty.
+static inline bool iree_hal_semaphore_timepoint_list_is_empty(
+    const iree_hal_semaphore_timepoint_list_t* list) {
+  return list->head == NULL;
+}
+
+// Pushes |timepoint| on to the end of the given timepoint |list|.
+static void iree_hal_semaphore_timepoint_list_push_back(
+    iree_hal_semaphore_timepoint_list_t* list,
+    iree_hal_semaphore_timepoint_t* timepoint) {
+  if (list->tail) {
+    list->tail->next = timepoint;
+  } else {
+    list->head = timepoint;
+  }
+  timepoint->next = NULL;
+  timepoint->prev = list->tail;
+  list->tail = timepoint;
+}
+
+// Erases |timepoint| from |list|.
+static void iree_hal_semaphore_timepoint_list_erase(
+    iree_hal_semaphore_timepoint_list_t* list,
+    iree_hal_semaphore_timepoint_t* timepoint) {
+  iree_hal_semaphore_timepoint_t* next = timepoint->next;
+  iree_hal_semaphore_timepoint_t* prev = timepoint->prev;
+  if (prev) {
+    prev->next = next;
+    timepoint->prev = NULL;
+  } else {
+    list->head = next;
+  }
+  if (next) {
+    next->prev = prev;
+    timepoint->next = NULL;
+  } else {
+    list->tail = prev;
+  }
+}
+
+// Takes all timepoints from |available_list| and moves them into |ready_list|.
+static void iree_hal_semaphore_timepoint_list_take_all(
+    iree_hal_semaphore_timepoint_list_t* available_list,
+    iree_hal_semaphore_timepoint_list_t* ready_list) {
+  IREE_ASSERT(available_list != ready_list);
+  ready_list->head = available_list->head;
+  ready_list->tail = available_list->tail;
+  available_list->head = NULL;
+  available_list->tail = NULL;
+}
+
+// Issues the callback for the given |timepoint| and resets it.
+static void iree_hal_semaphore_issue_timepoint_callback(
+    iree_hal_semaphore_t* semaphore, uint64_t new_value,
+    iree_status_code_t new_status_code,
+    iree_hal_semaphore_timepoint_t* timepoint) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Clean up the timepoint.
+  // We do this before the callback so that the handler can reuse the
+  // timepoint storage if it wants. After this we can't rely on it being
+  // valid.
+  iree_hal_semaphore_callback_t callback = timepoint->callback;
+  memset(timepoint, 0, sizeof(*timepoint));
+
+  // Issue the callback.
+  iree_status_ignore(
+      callback.fn(callback.user_data, semaphore, new_value, new_status_code));
+
+  // Release semaphore that was retained by the timepoint.
+  // This _shouldn't_ be the last owner as the caller has to have a reference.
+  iree_hal_semaphore_release(semaphore);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+// Issues callbacks for all timepoints in the |list|.
+// Timepoints are released and the list is emptied upon return.
+static void iree_hal_semaphore_issue_timepoint_callbacks(
+    iree_hal_semaphore_t* semaphore, uint64_t new_value,
+    iree_status_code_t new_status_code,
+    iree_hal_semaphore_timepoint_list_t* list) {
+  if (iree_hal_semaphore_timepoint_list_is_empty(list)) return;
+  for (iree_hal_semaphore_timepoint_t* timepoint = list->head;
+       timepoint != NULL;) {
+    list->head = timepoint->next;
+    timepoint->next = NULL;
+    timepoint->prev = NULL;
+    iree_hal_semaphore_issue_timepoint_callback(semaphore, new_value,
+                                                new_status_code, timepoint);
+    timepoint = list->head;
+  }
+  list->tail = NULL;
+}
+
+// NOTE: semaphore timepoint lock must not be held.
+static void iree_hal_semaphore_resolve_timepoints(
+    iree_hal_semaphore_t* semaphore, uint64_t new_value) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_hal_semaphore_timepoint_list_t pending_list = {NULL, NULL};
+  iree_hal_semaphore_timepoint_list_t ready_list = {NULL, NULL};
+  iree_hal_semaphore_timepoint_list_t expired_list = {NULL, NULL};
+
+  iree_slim_mutex_lock(&semaphore->timepoint_mutex);
+
+  if (iree_hal_semaphore_timepoint_list_is_empty(&semaphore->timepoint_list)) {
+    iree_slim_mutex_unlock(&semaphore->timepoint_mutex);
+    IREE_TRACE_ZONE_END(z0);
+    return;
+  }
+
+  // Scan through the list and divvy up timepoints into still-pending, ready to
+  // resolve, and expired buckets.
+  iree_time_t now_ns = iree_time_now();
+  for (iree_hal_semaphore_timepoint_t* timepoint =
+           semaphore->timepoint_list.head;
+       timepoint != NULL;) {
+    iree_hal_semaphore_timepoint_t* next_timepoint = timepoint->next;
+    timepoint->next = NULL;
+
+    if (timepoint->minimum_value <= new_value) {
+      // Reached the timepoint; even if the deadline has been reached we'll
+      // still consider this a hit.
+      iree_hal_semaphore_timepoint_list_push_back(&ready_list, timepoint);
+    } else if (timepoint->deadline_ns <= now_ns) {
+      // Deadline expired before the timepoint was reached.
+      iree_hal_semaphore_timepoint_list_push_back(&expired_list, timepoint);
+    } else {
+      // Still pending.
+      iree_hal_semaphore_timepoint_list_push_back(&pending_list, timepoint);
+    }
+
+    timepoint = next_timepoint;
+  }
+
+  // Preserve pending timepoints.
+  semaphore->timepoint_list = pending_list;
+
+  // Issue callbacks for all successes and failures.
+  iree_hal_semaphore_issue_timepoint_callbacks(semaphore, new_value,
+                                               IREE_STATUS_OK, &ready_list);
+  iree_hal_semaphore_issue_timepoint_callbacks(
+      semaphore, new_value, IREE_STATUS_DEADLINE_EXCEEDED, &expired_list);
+
+  iree_slim_mutex_unlock(&semaphore->timepoint_mutex);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+// NOTE: semaphore timepoint lock must not be held.
+static void iree_hal_semaphore_reject_timepoints(
+    iree_hal_semaphore_t* semaphore, iree_status_code_t new_status_code) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_slim_mutex_lock(&semaphore->timepoint_mutex);
+
+  // Take the entire timepoint list from the semaphore.
+  iree_hal_semaphore_timepoint_list_t failed_list = {NULL, NULL};
+  iree_hal_semaphore_timepoint_list_take_all(&semaphore->timepoint_list,
+                                             &failed_list);
+
+  // Issue failure callbacks for all timepoints.
+  iree_hal_semaphore_issue_timepoint_callbacks(semaphore, UINT64_MAX,
+                                               new_status_code, &failed_list);
+
+  iree_slim_mutex_unlock(&semaphore->timepoint_mutex);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_semaphore_t
+//===----------------------------------------------------------------------===//
+
+IREE_API_EXPORT void iree_hal_semaphore_initialize(
+    const iree_hal_semaphore_vtable_t* vtable,
+    iree_hal_semaphore_t* out_semaphore) {
+  IREE_ASSERT_ARGUMENT(out_semaphore);
+  iree_hal_resource_initialize(vtable, &out_semaphore->resource);
+  iree_slim_mutex_initialize(&out_semaphore->timepoint_mutex);
+  memset(&out_semaphore->timepoint_list, 0,
+         sizeof(out_semaphore->timepoint_list));
+}
+
+IREE_API_EXPORT void iree_hal_semaphore_deinitialize(
+    iree_hal_semaphore_t* semaphore) {
+  IREE_ASSERT_ARGUMENT(semaphore);
+  iree_slim_mutex_deinitialize(&semaphore->timepoint_mutex);
+}
+
+IREE_API_EXPORT void iree_hal_semaphore_acquire_timepoint(
+    iree_hal_semaphore_t* semaphore, uint64_t minimum_value,
+    iree_timeout_t timeout, iree_hal_semaphore_callback_t callback,
+    iree_hal_semaphore_timepoint_t* out_timepoint) {
+  IREE_ASSERT_ARGUMENT(semaphore);
+  IREE_ASSERT_ARGUMENT(out_timepoint);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Prepare timepoint structure.
+  // Note that we capture the timeout as an absolute deadline as we don't know
+  // how long it'll take to acquire the lock and how long it'll be pending.
+  out_timepoint->next = NULL;
+  out_timepoint->prev = NULL;
+  out_timepoint->semaphore = semaphore;
+  iree_hal_semaphore_retain(semaphore);
+  out_timepoint->minimum_value = minimum_value;
+  out_timepoint->deadline_ns = iree_timeout_as_deadline_ns(timeout);
+  out_timepoint->callback = callback;
+
+  // Insert into timepoint list.
+  // After we release the lock the callback may be issued immediately as another
+  // thread may be waiting to signal the timepoint.
+  iree_slim_mutex_lock(&semaphore->timepoint_mutex);
+  iree_hal_semaphore_timepoint_list_push_back(&semaphore->timepoint_list,
+                                              out_timepoint);
+  iree_slim_mutex_unlock(&semaphore->timepoint_mutex);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+IREE_API_EXPORT void iree_hal_semaphore_cancel_timepoint(
+    iree_hal_semaphore_t* semaphore,
+    iree_hal_semaphore_timepoint_t* timepoint) {
+  if (!semaphore || !timepoint) return;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_slim_mutex_lock(&semaphore->timepoint_mutex);
+
+  // NOTE: if the semaphore is NULL then the timepoint has already been issued.
+  // The caller is expected to know it's safe to still use the timepoint struct
+  // even if such a race is possible.
+  const bool needs_release = timepoint->semaphore != NULL;
+  if (needs_release) {
+    // Remove the timepoint from the list to ensure no other code can issue its
+    // callback.
+    iree_hal_semaphore_timepoint_list_erase(&semaphore->timepoint_list,
+                                            timepoint);
+
+    // Neuter the timepoint so that it is never called.
+    // Other threads may be sitting and waiting for the lock and we need to
+    // ensure that as soon as we unlock if they then try to operate on the
+    // timepoint it's easy to bail.
+    memset(timepoint, 0, sizeof(*timepoint));
+  }
+
+  iree_slim_mutex_unlock(&semaphore->timepoint_mutex);
+
+  // Release the semaphore outside of the lock as it may recursively release
+  // resources.
+  if (needs_release) {
+    iree_hal_semaphore_release(semaphore);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+IREE_API_EXPORT void iree_hal_semaphore_notify(
+    iree_hal_semaphore_t* semaphore, uint64_t new_value,
+    iree_status_code_t new_status_code) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // NOTE: because the timepoints may be the last owners of the semaphore we
+  // retain it so we can safely manage the lock.
+  iree_hal_semaphore_retain(semaphore);
+
+  if (new_status_code == IREE_STATUS_OK) {
+    // Semaphore is in a valid state and has reached some value.
+    // Resolve timepoints that have been hit (or have expired).
+    iree_hal_semaphore_resolve_timepoints(semaphore, new_value);
+  } else {
+    // Semaphore has failed and we need to reject all timepoints.
+    iree_hal_semaphore_reject_timepoints(semaphore, new_status_code);
+  }
+
+  // NOTE: semaphore may be destroyed after this!
+  iree_hal_semaphore_release(semaphore);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+IREE_API_EXPORT void iree_hal_semaphore_poll(iree_hal_semaphore_t* semaphore) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Query the current value of the semaphore and notify with the results.
+  uint64_t value = 0;
+  iree_status_t status = iree_hal_semaphore_query(semaphore, &value);
+  iree_hal_semaphore_notify(semaphore, value, iree_status_consume_code(status));
+
+  IREE_TRACE_ZONE_END(z0);
+}

--- a/runtime/src/iree/hal/utils/semaphore_base.h
+++ b/runtime/src/iree/hal/utils/semaphore_base.h
@@ -1,0 +1,180 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_UTILS_SEMAPHORE_BASE_H_
+#define IREE_HAL_UTILS_SEMAPHORE_BASE_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "iree/base/api.h"
+#include "iree/base/internal/synchronization.h"
+#include "iree/hal/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Callback handler for semaphore timepoints.
+// Handlers receive the semaphore, the current value, and the status code.
+//
+// The |value| is only valid if |status_code| is IREE_STATUS_OK.
+// In error cases handlers can query the status of the |semaphore| to receive
+// the full status if desired.
+//
+// Handlers run outside the semaphore lock but under the timepoint list lock
+// and may re-entrantly use the semaphore to query but not manage timepoints.
+typedef iree_status_t(IREE_API_PTR* iree_hal_semaphore_callback_fn_t)(
+    void* user_data, iree_hal_semaphore_t* semaphore, uint64_t value,
+    iree_status_code_t status_code);
+
+typedef struct iree_hal_semaphore_callback_t {
+  // Callback function pointer.
+  iree_hal_semaphore_callback_fn_t fn;
+  // User data passed to the callback function. Unowned.
+  void* user_data;
+} iree_hal_semaphore_callback_t;
+
+// Storage for a semaphore timepoint.
+// Each semaphore manages a list of active timepoints and issues their specified
+// callback when the semaphore is signaled to or beyond a given value.
+typedef struct iree_hal_semaphore_timepoint_t {
+  // Intrusive doubly-linked list next entry pointer.
+  // Guarded by the semaphore mutex.
+  struct iree_hal_semaphore_timepoint_t* next;
+  // Intrusive doubly-linked list previous entry pointer.
+  // Guarded by the semaphore mutex.
+  struct iree_hal_semaphore_timepoint_t* prev;
+
+  // Retained semaphore; this ensures the semaphore remains valid for the
+  // lifetime of the timepoint. The semaphore must be released by the underlying
+  // implementation or by the user with iree_hal_semaphore_release_timepoint.
+  struct iree_hal_semaphore_t* semaphore;
+
+  // Target value the semaphore must reach or exceed to trigger the timepoint.
+  uint64_t minimum_value;
+
+  // Absolute deadline after which the timepoint will expire if the semaphore
+  // has not reached the target value.
+  iree_time_t deadline_ns;
+
+  // Callback to issue when the timepoint is reached, the deadline is exceeded,
+  // or the semaphore fails.
+  iree_hal_semaphore_callback_t callback;
+} iree_hal_semaphore_timepoint_t;
+
+// A doubly-linked FIFO list of timepoints.
+// The order of the timepoints does *not* match increasing payload values but
+// instead the order they were added to the list.
+//
+// Note that the timepoints are not owned by the list - this just nicely
+// stitches together timepoints for easier management.
+typedef struct iree_hal_semaphore_timepoint_list_t {
+  iree_hal_semaphore_timepoint_t* head;
+  iree_hal_semaphore_timepoint_t* tail;
+} iree_hal_semaphore_timepoint_list_t;
+
+// Abstract base implementation of semaphores that perform timepoint tracking.
+//
+// Device implementations can acquire timepoints that provide low-latency
+// directed notification of when a semaphore timeline reaches a certain point
+// (or fails). The storage for the timepoints is managed by the requester and
+// can be allocation-free making the timepoint operations safe to perform from
+// driver threads/callbacks.
+//
+// Semaphore implementations need to notify the tracking semaphore of signal and
+// failure events using the iree_hal_semaphore_notify method. Any satisfied
+// timepoints will have their callback made immediately from the notifying
+// thread.
+struct iree_hal_semaphore_t {
+  iree_hal_resource_t resource;  // must be at 0
+
+  // Non-recursive mutex guarding access to the timepoint list.
+  iree_slim_mutex_t timepoint_mutex;
+
+  // Timepoint list in insertion order.
+  // There are probably better orderings we could use here that allow us to
+  // walk the entire list less frequently, though target payload value is not
+  // enough as deadlines still require the scan. We could sort by non-infinite
+  // deadlines first and then infinite ones last but given the common timepoint
+  // counts (0..1) it's not worth the complexity today.
+  iree_hal_semaphore_timepoint_list_t timepoint_list
+      IREE_GUARDED_BY(timepoint_mutex);
+};
+
+// Initializes the base |out_semaphore| resource.
+IREE_API_EXPORT void iree_hal_semaphore_initialize(
+    const iree_hal_semaphore_vtable_t* vtable,
+    iree_hal_semaphore_t* out_semaphore);
+
+// Deinitializes the |semaphore|.
+// Because timepoints retain their semaphore the timepoint list is known empty.
+IREE_API_EXPORT void iree_hal_semaphore_deinitialize(
+    iree_hal_semaphore_t* semaphore);
+
+// Acquires a timepoint on the semaphore timeline that issues the given
+// |callback| when the semaphore payload reaches or exceeds |minimum_value|. The
+// callback may be made from a random external thread and must avoid recursive
+// locks (such as managing timepoints).
+//
+// The caller provides storage in |out_timepoint| and it must remain valid until
+// either the callback is made or the timepoint is cancelled via
+// iree_hal_semaphore_cancel_timepoint.
+//
+// If the timepoint has already been reached the callback _may_ be issued prior
+// to the function returning. If the |timeout| has already been reached then the
+// callback _may_ be issued with IREE_STATUS_DEADLINE_EXCEEDED.
+//
+// NOTE: this behavior is due to racy multi-threaded behavior and not a
+// guarantee of the API: if there's only ever a single thread then acquiring a
+// timepoint that has been satisfied will *NOT* callback here.
+// iree_hal_semaphore_poll can be used to force a flush of any resolved
+// timepoints on-demand.
+//
+// Must not be called from a timepoint callback.
+IREE_API_EXPORT void iree_hal_semaphore_acquire_timepoint(
+    iree_hal_semaphore_t* semaphore, uint64_t minimum_value,
+    iree_timeout_t timeout, iree_hal_semaphore_callback_t callback,
+    iree_hal_semaphore_timepoint_t* out_timepoint);
+
+// Cancels a |timepoint| and prevents any future callbacks.
+// The timepoint is only considered cancelled once execution returns
+// to the caller; due to races it's possible for a callback to be made with
+// a different status code while releasing.
+//
+// Only the owner of the timepoint (whatever is listening for the callback)
+// should use this as otherwise the program may become desynchronized.
+//
+// Must not be called from a timepoint callback.
+IREE_API_EXPORT void iree_hal_semaphore_cancel_timepoint(
+    iree_hal_semaphore_t* semaphore, iree_hal_semaphore_timepoint_t* timepoint);
+
+// Used by implementations to notify when a new timepoint is reached.
+// Implementations must call this when they observe changes.
+// Calling this incorrectly will result in undefined behavior.
+//
+// Must not be called from a timepoint callback.
+// Must not be called with a semaphore lock held as notifications may
+// re-entrantly use the semaphore.
+IREE_API_EXPORT void iree_hal_semaphore_notify(
+    iree_hal_semaphore_t* semaphore, uint64_t new_value,
+    iree_status_code_t new_status_code);
+
+// Polls timepoints and issues callbacks for those already resolved.
+// This polling is performed internally on user calls such as signal and wait
+// but can be made more frequently to reduce latency in cases where users are
+// not making calls frequently enough. Implementations should always prefer to
+// notify directly with iree_hal_semaphore_notify to avoid additional
+// synchronization overheads.
+//
+// Must not be called from a timepoint callback.
+IREE_API_EXPORT void iree_hal_semaphore_poll(iree_hal_semaphore_t* semaphore);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_UTILS_SEMAPHORE_BASE_H_

--- a/runtime/src/iree/hal/utils/semaphore_base_test.cc
+++ b/runtime/src/iree/hal/utils/semaphore_base_test.cc
@@ -1,0 +1,379 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/utils/semaphore_base.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "iree/base/api.h"
+#include "iree/base/internal/wait_handle.h"
+#include "iree/hal/api.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace iree {
+namespace hal {
+namespace {
+
+using ::iree::testing::status::IsOkAndHolds;
+using ::iree::testing::status::StatusIs;
+using ::testing::Eq;
+
+namespace {
+extern const iree_hal_semaphore_vtable_t test_semaphore_vtable;
+}  // namespace
+
+struct TestSemaphore {
+  iree_hal_semaphore_t base;
+  iree_allocator_t host_allocator;
+  iree_slim_mutex_t mutex;
+  uint64_t current_value;
+  iree_status_t failure_status;
+  iree_notification_t notification;
+
+  static TestSemaphore* Create(uint64_t initial_value,
+                               iree_allocator_t host_allocator) {
+    TestSemaphore* semaphore = nullptr;
+    IREE_CHECK_OK(iree_allocator_malloc(host_allocator, sizeof(*semaphore),
+                                        (void**)&semaphore));
+    iree_hal_semaphore_initialize(&test_semaphore_vtable, &semaphore->base);
+    semaphore->host_allocator = host_allocator;
+    iree_slim_mutex_initialize(&semaphore->mutex);
+    iree_notification_initialize(&semaphore->notification);
+    return semaphore;
+  }
+
+  static TestSemaphore* Cast(iree_hal_semaphore_t* base_semaphore) {
+    return reinterpret_cast<TestSemaphore*>(base_semaphore);
+  }
+
+  static void Destroy(iree_hal_semaphore_t* base_semaphore) {
+    auto* semaphore = Cast(base_semaphore);
+    iree_status_ignore(semaphore->failure_status);
+    iree_notification_deinitialize(&semaphore->notification);
+    iree_slim_mutex_deinitialize(&semaphore->mutex);
+    iree_hal_semaphore_deinitialize(&semaphore->base);
+    iree_allocator_free(semaphore->host_allocator, semaphore);
+  }
+
+  static iree_status_t Query(iree_hal_semaphore_t* base_semaphore,
+                             uint64_t* out_value) {
+    auto* semaphore = Cast(base_semaphore);
+    iree_slim_mutex_lock(&semaphore->mutex);
+    iree_status_t status = iree_status_clone(semaphore->failure_status);
+    *out_value = semaphore->current_value;
+    iree_slim_mutex_unlock(&semaphore->mutex);
+    return status;
+  }
+
+  static iree_status_t Signal(iree_hal_semaphore_t* base_semaphore,
+                              uint64_t new_value) {
+    auto* semaphore = Cast(base_semaphore);
+    iree_slim_mutex_lock(&semaphore->mutex);
+    iree_status_t status = iree_ok_status();
+    semaphore->current_value = new_value;
+    iree_slim_mutex_unlock(&semaphore->mutex);
+    iree_hal_semaphore_notify(&semaphore->base, new_value, IREE_STATUS_OK);
+    iree_notification_post(&semaphore->notification, IREE_ALL_WAITERS);
+    return status;
+  }
+
+  static void Fail(iree_hal_semaphore_t* base_semaphore, iree_status_t status) {
+    auto* semaphore = Cast(base_semaphore);
+    iree_slim_mutex_lock(&semaphore->mutex);
+    iree_status_ignore(semaphore->failure_status);
+    semaphore->failure_status = status;
+    const iree_status_code_t status_code = iree_status_code(status);
+    iree_slim_mutex_unlock(&semaphore->mutex);
+    iree_hal_semaphore_notify(&semaphore->base, 0, status_code);
+    iree_notification_post(&semaphore->notification, IREE_ALL_WAITERS);
+  }
+
+  static iree_status_t Wait(iree_hal_semaphore_t* base_semaphore,
+                            uint64_t value, iree_timeout_t timeout) {
+    auto* semaphore = Cast(base_semaphore);
+    struct notify_state_t {
+      TestSemaphore* semaphore;
+      uint64_t value;
+    } notify_state = {semaphore, value};
+    iree_notification_await(
+        &semaphore->notification,
+        [](void* user_data) -> bool {
+          auto* state = reinterpret_cast<notify_state_t*>(user_data);
+          iree_slim_mutex_lock(&state->semaphore->mutex);
+          bool is_signaled =
+              state->semaphore->current_value >= state->value ||
+              !iree_status_is_ok(state->semaphore->failure_status);
+          iree_slim_mutex_unlock(&state->semaphore->mutex);
+          return is_signaled;
+        },
+        (void*)&notify_state, timeout);
+    return iree_ok_status();
+  }
+
+  constexpr operator iree_hal_semaphore_t*() noexcept { return &base; }
+};
+
+namespace {
+const iree_hal_semaphore_vtable_t test_semaphore_vtable = {
+    /*.destroy=*/TestSemaphore::Destroy,
+    /*.query=*/TestSemaphore::Query,
+    /*.signal=*/TestSemaphore::Signal,
+    /*.fail=*/TestSemaphore::Fail,
+    /*.wait=*/TestSemaphore::Wait,
+};
+}  // namespace
+
+struct CallbackState {
+  std::atomic<int> callback_count = {0};
+  std::atomic<uint64_t> value = {0ull};
+  std::atomic<iree_status_code_t> status_code = {IREE_STATUS_OK};
+  std::atomic<iree_status_code_t> callback_result = {IREE_STATUS_OK};
+};
+
+static iree_status_t SemaphoreTimepointHandler(void* user_data,
+                                               iree_hal_semaphore_t* semaphore,
+                                               uint64_t value,
+                                               iree_status_code_t status_code) {
+  auto* state = reinterpret_cast<CallbackState*>(user_data);
+  ++state->callback_count;
+  state->value = value;
+  state->status_code = status_code;
+  return iree_status_from_code(state->callback_result);
+}
+
+static iree_hal_semaphore_callback_t MakeCallback(CallbackState* state) {
+  return {
+      SemaphoreTimepointHandler,
+      state,
+  };
+}
+
+struct TrackingSemaphoreTest : public ::testing::Test {
+  // We could check the allocator to ensure all memory is freed if we wanted to
+  // reduce the reliance on asan.
+  iree_allocator_t host_allocator = iree_allocator_system();
+
+  void SetUp() override {}
+
+  void TearDown() override {}
+};
+
+// Tests the lifetime of an unsignaled semaphore.
+TEST_F(TrackingSemaphoreTest, Unsignaled) {
+  auto* semaphore = TestSemaphore::Create(0ull, host_allocator);
+  iree_hal_semaphore_release(*semaphore);
+}
+
+// Tests the lifetime of a signaled semaphore with no timepoints.
+TEST_F(TrackingSemaphoreTest, Signaled) {
+  auto* semaphore = TestSemaphore::Create(0ull, host_allocator);
+  IREE_ASSERT_OK(iree_hal_semaphore_signal(*semaphore, 1ull));
+  iree_hal_semaphore_release(*semaphore);
+}
+
+// Tests acquiring timepoints that are already resolved.
+TEST_F(TrackingSemaphoreTest, AcquireResolvedTimepoint) {
+  auto* semaphore = TestSemaphore::Create(0ull, host_allocator);
+
+  IREE_ASSERT_OK(iree_hal_semaphore_signal(*semaphore, 2ull));
+
+  CallbackState state;
+  iree_hal_semaphore_timepoint_t timepoint;
+  iree_hal_semaphore_acquire_timepoint(*semaphore, 1ull,
+                                       iree_infinite_timeout(),
+                                       MakeCallback(&state), &timepoint);
+  ASSERT_EQ(state.callback_count, 0);
+
+  // Callback happens here:
+  iree_hal_semaphore_poll(*semaphore);
+
+  ASSERT_EQ(state.callback_count, 1);
+  ASSERT_EQ(state.status_code, IREE_STATUS_OK);
+  ASSERT_EQ(state.value, 2ull);
+
+  iree_hal_semaphore_release(*semaphore);
+}
+
+// Tests acquiring timepoints that are already failed.
+TEST_F(TrackingSemaphoreTest, AcquireFailedTimepoint) {
+  auto* semaphore = TestSemaphore::Create(0ull, host_allocator);
+
+  iree_hal_semaphore_fail(*semaphore,
+                          iree_make_status(IREE_STATUS_DATA_LOSS, "whoops"));
+
+  CallbackState state;
+  iree_hal_semaphore_timepoint_t timepoint;
+  iree_hal_semaphore_acquire_timepoint(*semaphore, 1ull,
+                                       iree_infinite_timeout(),
+                                       MakeCallback(&state), &timepoint);
+  ASSERT_EQ(state.callback_count, 0);
+
+  // Callback happens here:
+  iree_hal_semaphore_poll(*semaphore);
+
+  ASSERT_EQ(state.callback_count, 1);
+  ASSERT_EQ(state.status_code, IREE_STATUS_DATA_LOSS);
+
+  iree_hal_semaphore_release(*semaphore);
+}
+
+// Tests acquiring timepoints that are resolved synchronously from the host.
+TEST_F(TrackingSemaphoreTest, AcquireUnresolvedSyncTimepoint) {
+  auto* semaphore = TestSemaphore::Create(0ull, host_allocator);
+
+  CallbackState state;
+  iree_hal_semaphore_timepoint_t timepoint;
+  iree_hal_semaphore_acquire_timepoint(*semaphore, 1ull,
+                                       iree_infinite_timeout(),
+                                       MakeCallback(&state), &timepoint);
+  ASSERT_EQ(state.callback_count, 0);
+
+  // Callback does not happen as timepoint has not been reached:
+  iree_hal_semaphore_poll(*semaphore);
+  ASSERT_EQ(state.callback_count, 0);
+
+  // Callback happens here:
+  IREE_ASSERT_OK(iree_hal_semaphore_signal(*semaphore, 2ull));
+
+  ASSERT_EQ(state.callback_count, 1);
+  ASSERT_EQ(state.status_code, IREE_STATUS_OK);
+  ASSERT_EQ(state.value, 2ull);
+
+  iree_hal_semaphore_release(*semaphore);
+}
+
+// Tests acquiring timepoints that are rejected synchronously from the host.
+TEST_F(TrackingSemaphoreTest, AcquireUnrejectedSyncTimepoint) {
+  auto* semaphore = TestSemaphore::Create(0ull, host_allocator);
+
+  CallbackState state;
+  iree_hal_semaphore_timepoint_t timepoint;
+  iree_hal_semaphore_acquire_timepoint(*semaphore, 1ull,
+                                       iree_infinite_timeout(),
+                                       MakeCallback(&state), &timepoint);
+  ASSERT_EQ(state.callback_count, 0);
+
+  // Callback does not happen as timepoint has not been reached:
+  iree_hal_semaphore_poll(*semaphore);
+  ASSERT_EQ(state.callback_count, 0);
+
+  // Callback happens here:
+  iree_hal_semaphore_fail(*semaphore,
+                          iree_make_status(IREE_STATUS_DATA_LOSS, "whoops"));
+
+  ASSERT_EQ(state.callback_count, 1);
+  ASSERT_EQ(state.status_code, IREE_STATUS_DATA_LOSS);
+
+  iree_hal_semaphore_release(*semaphore);
+}
+
+// Tests acquiring timepoints that are resolved asynchronously from the host.
+TEST_F(TrackingSemaphoreTest, AcquireUnresolvedAsyncTimepoint) {
+  iree_event_t ev0;
+  IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/false, &ev0));
+  auto* semaphore = TestSemaphore::Create(0ull, host_allocator);
+
+  CallbackState state;
+  iree_hal_semaphore_timepoint_t timepoint;
+  iree_hal_semaphore_acquire_timepoint(*semaphore, 1ull,
+                                       iree_infinite_timeout(),
+                                       MakeCallback(&state), &timepoint);
+  ASSERT_EQ(state.callback_count, 0);
+
+  // Callback does not happen as timepoint has not been reached:
+  iree_hal_semaphore_poll(*semaphore);
+  ASSERT_EQ(state.callback_count, 0);
+
+  // Thread acting as an external signaler.
+  std::thread thread([&]() {
+    // Block until the main thread catches up.
+    IREE_ASSERT_OK(iree_wait_one(&ev0, IREE_TIME_INFINITE_FUTURE));
+
+    // Callback happens here:
+    IREE_ASSERT_OK(iree_hal_semaphore_signal(*semaphore, 2ull));
+  });
+
+  // Unblock the thread and have it signal.
+  ASSERT_EQ(state.callback_count, 0);
+  iree_event_set(&ev0);
+
+  // Wait for the semaphore to be signaled.
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_wait(*semaphore, 1ull, iree_infinite_timeout()));
+
+  // Should have been called back on the thread.
+  ASSERT_EQ(state.callback_count, 1);
+  ASSERT_EQ(state.status_code, IREE_STATUS_OK);
+  ASSERT_EQ(state.value, 2ull);
+
+  thread.join();
+  iree_hal_semaphore_release(*semaphore);
+  iree_event_deinitialize(&ev0);
+}
+
+// Tests cancelling timepoints before they are resolved.
+TEST_F(TrackingSemaphoreTest, CancelUnresolvedTimepoint) {
+  auto* semaphore = TestSemaphore::Create(0ull, host_allocator);
+
+  CallbackState state;
+  iree_hal_semaphore_timepoint_t timepoint;
+  iree_hal_semaphore_acquire_timepoint(*semaphore, 1ull,
+                                       iree_infinite_timeout(),
+                                       MakeCallback(&state), &timepoint);
+  ASSERT_EQ(state.callback_count, 0);
+
+  // Callback does not happen as timepoint has not been reached:
+  iree_hal_semaphore_poll(*semaphore);
+  ASSERT_EQ(state.callback_count, 0);
+
+  // Cancel before signal.
+  iree_hal_semaphore_cancel_timepoint(*semaphore, &timepoint);
+  ASSERT_EQ(state.callback_count, 0);
+
+  // Callback should not happens here because we cancelled:
+  IREE_ASSERT_OK(iree_hal_semaphore_signal(*semaphore, 2ull));
+  ASSERT_EQ(state.callback_count, 0);
+
+  iree_hal_semaphore_release(*semaphore);
+}
+
+// Tests cancelling timepoints after they are resolved. Should be a no-op.
+TEST_F(TrackingSemaphoreTest, CancelResolvedTimepoint) {
+  auto* semaphore = TestSemaphore::Create(0ull, host_allocator);
+
+  CallbackState state;
+  iree_hal_semaphore_timepoint_t timepoint;
+  iree_hal_semaphore_acquire_timepoint(*semaphore, 1ull,
+                                       iree_infinite_timeout(),
+                                       MakeCallback(&state), &timepoint);
+  ASSERT_EQ(state.callback_count, 0);
+
+  // Callback does not happen as timepoint has not been reached:
+  iree_hal_semaphore_poll(*semaphore);
+  ASSERT_EQ(state.callback_count, 0);
+
+  // Callback happens here:
+  IREE_ASSERT_OK(iree_hal_semaphore_signal(*semaphore, 2ull));
+
+  ASSERT_EQ(state.callback_count, 1);
+  ASSERT_EQ(state.status_code, IREE_STATUS_OK);
+  ASSERT_EQ(state.value, 2ull);
+
+  // Cancel after signal, which should be a no-op.
+  iree_hal_semaphore_cancel_timepoint(*semaphore, &timepoint);
+  ASSERT_EQ(state.callback_count, 1);
+
+  iree_hal_semaphore_release(*semaphore);
+}
+
+}  // namespace
+}  // namespace hal
+}  // namespace iree

--- a/runtime/src/iree/hal/vulkan/BUILD
+++ b/runtime/src/iree/hal/vulkan/BUILD
@@ -91,6 +91,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal",
         "//runtime/src/iree/hal/utils:buffer_transfer",
         "//runtime/src/iree/hal/utils:resource_set",
+        "//runtime/src/iree/hal/utils:semaphore_base",
         "//runtime/src/iree/hal/vulkan/builtin",
         "//runtime/src/iree/hal/vulkan/util:arena",
         "//runtime/src/iree/hal/vulkan/util:intrusive_list",

--- a/runtime/src/iree/hal/vulkan/CMakeLists.txt
+++ b/runtime/src/iree/hal/vulkan/CMakeLists.txt
@@ -81,6 +81,7 @@ iree_cc_library(
     iree::hal
     iree::hal::utils::buffer_transfer
     iree::hal::utils::resource_set
+    iree::hal::utils::semaphore_base
     iree::hal::vulkan::builtin
     iree::hal::vulkan::util::arena
     iree::hal::vulkan::util::intrusive_list


### PR DESCRIPTION
This is a roll-up of tweaks/fixes and the groundwork for future submission management changes. The new base semaphore type helps implementations manage timepoint tracking and notification in a uniform way.

The tracking type is not part of the public API and only exposed for HAL implementations; this isn't great and may be cleaned up in the future by abstracting out timepoint logic into the semaphore vtable. Landing as-is to get out of some serious design paralysis.

There are some optimization opportunities but they'll be easier to analyze and prioritize once the higher-level layers are implemented using the tracking.