### PR TITLE
Switch the standard agent queue to be called "cpu"

### DIFF
--- a/build_tools/buildkite/agent/configs/cpu.cfg
+++ b/build_tools/buildkite/agent/configs/cpu.cfg
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Configuration for the standard build agents.
+# Configuration for the standard build agents used for their CPU capacity.
 # See https://buildkite.com/docs/agent/v3/configuration
 
 # Note that placeholders must be filled in before this can be used.
@@ -19,7 +19,7 @@ name="%hostname-%spawn"
 spawn=2
 
 # Custom tags for the agent
-tags="platform=gcp,queue=build,security=<TRUST-LEVEL-PLACEHOLDER>"
+tags="platform=gcp,queue=cpu,security=<TRUST-LEVEL-PLACEHOLDER>"
 # Include the host's Google Cloud instance meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)
 tags-from-gcp=true
 # Include the host's meta-data as tags (hostname, machine-id, and OS).

--- a/build_tools/buildkite/pipelines/untrusted/build-runtime-cmake.yml
+++ b/build_tools/buildkite/pipelines/untrusted/build-runtime-cmake.yml
@@ -7,7 +7,7 @@
 steps:
   - label: ":hammer_and_wrench: Build the runtime only"
     agents:
-      queue: "build"
+      queue: "cpu"
       security: "untrusted"
     env:
       IREE_DOCKER_WORKDIR: "/usr/src/github/iree"


### PR DESCRIPTION
The name build conflicts with the existing build queue for our legacy
Buildkite pipelines, which means these agents are always getting sent
the old jobs. It's also somewhat of a misnomer, since these agents will
also be getting test jobs. I think "cpu" correctly captures the aspect
of these agents that is not captured in other tags (like os) or
features (like priority), which is that they are intended for tasks that require large amounts of CPU. When we set up GPU tests, the agents
would analogously be in the "gpu" queue.
