### PR TITLE
Adding iree_hal_device_query_semaphore_compatibility.

### DIFF
--- a/experimental/rocm/rocm_device.c
+++ b/experimental/rocm/rocm_device.c
@@ -247,6 +247,13 @@ static iree_status_t iree_hal_rocm_device_create_semaphore(
                                         out_semaphore);
 }
 
+static iree_hal_semaphore_compatibility_t
+iree_hal_rocm_device_query_semaphore_compatibility(
+    iree_hal_device_t* base_device, iree_hal_semaphore_t* semaphore) {
+  // TODO: implement ROCM semaphores.
+  return IREE_HAL_SEMAPHORE_COMPATIBILITY_HOST_ONLY;
+}
+
 static iree_status_t iree_hal_rocm_device_queue_submit(
     iree_hal_device_t* base_device,
     iree_hal_command_category_t command_categories,
@@ -312,6 +319,8 @@ static const iree_hal_device_vtable_t iree_hal_rocm_device_vtable = {
     .create_executable_cache = iree_hal_rocm_device_create_executable_cache,
     .create_executable_layout = iree_hal_rocm_device_create_executable_layout,
     .create_semaphore = iree_hal_rocm_device_create_semaphore,
+    .query_semaphore_compatibility =
+        iree_hal_rocm_device_query_semaphore_compatibility,
     .transfer_range = iree_hal_device_submit_transfer_range_and_wait,
     .queue_submit = iree_hal_rocm_device_queue_submit,
     .submit_and_wait = iree_hal_rocm_device_submit_and_wait,

--- a/runtime/src/iree/hal/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/cuda/cuda_device.c
@@ -316,6 +316,13 @@ static iree_status_t iree_hal_cuda_device_create_semaphore(
                                         out_semaphore);
 }
 
+static iree_hal_semaphore_compatibility_t
+iree_hal_cuda_device_query_semaphore_compatibility(
+    iree_hal_device_t* base_device, iree_hal_semaphore_t* semaphore) {
+  // TODO: implement CUDA semaphores.
+  return IREE_HAL_SEMAPHORE_COMPATIBILITY_HOST_ONLY;
+}
+
 static iree_status_t iree_hal_cuda_device_queue_submit(
     iree_hal_device_t* base_device,
     iree_hal_command_category_t command_categories,
@@ -399,6 +406,8 @@ static const iree_hal_device_vtable_t iree_hal_cuda_device_vtable = {
     .create_executable_cache = iree_hal_cuda_device_create_executable_cache,
     .create_executable_layout = iree_hal_cuda_device_create_executable_layout,
     .create_semaphore = iree_hal_cuda_device_create_semaphore,
+    .query_semaphore_compatibility =
+        iree_hal_cuda_device_query_semaphore_compatibility,
     .transfer_range = iree_hal_device_submit_transfer_range_and_wait,
     .queue_submit = iree_hal_cuda_device_queue_submit,
     .submit_and_wait = iree_hal_cuda_device_submit_and_wait,

--- a/runtime/src/iree/hal/device.c
+++ b/runtime/src/iree/hal/device.c
@@ -61,6 +61,15 @@ IREE_API_EXPORT iree_status_t iree_hal_device_query_i32(
   return _VTABLE_DISPATCH(device, query_i32)(device, category, key, out_value);
 }
 
+IREE_API_EXPORT iree_hal_semaphore_compatibility_t
+iree_hal_device_query_semaphore_compatibility(iree_hal_device_t* device,
+                                              iree_hal_semaphore_t* semaphore) {
+  IREE_ASSERT_ARGUMENT(device);
+  IREE_ASSERT_ARGUMENT(semaphore);
+  return _VTABLE_DISPATCH(device, query_semaphore_compatibility)(device,
+                                                                 semaphore);
+}
+
 IREE_API_EXPORT iree_status_t iree_hal_device_transfer_range(
     iree_hal_device_t* device, iree_hal_transfer_buffer_t source,
     iree_device_size_t source_offset, iree_hal_transfer_buffer_t target,

--- a/runtime/src/iree/hal/local/sync_device.c
+++ b/runtime/src/iree/hal/local/sync_device.c
@@ -239,6 +239,13 @@ static iree_status_t iree_hal_sync_device_create_semaphore(
                                         device->host_allocator, out_semaphore);
 }
 
+static iree_hal_semaphore_compatibility_t
+iree_hal_sync_device_query_semaphore_compatibility(
+    iree_hal_device_t* base_device, iree_hal_semaphore_t* semaphore) {
+  // The synchronous submission queue handles all semaphores as if host-side.
+  return IREE_HAL_SEMAPHORE_COMPATIBILITY_HOST_ONLY;
+}
+
 static iree_status_t iree_hal_sync_device_queue_submit(
     iree_hal_device_t* base_device,
     iree_hal_command_category_t command_categories,
@@ -316,6 +323,8 @@ static const iree_hal_device_vtable_t iree_hal_sync_device_vtable = {
     .create_executable_cache = iree_hal_sync_device_create_executable_cache,
     .create_executable_layout = iree_hal_sync_device_create_executable_layout,
     .create_semaphore = iree_hal_sync_device_create_semaphore,
+    .query_semaphore_compatibility =
+        iree_hal_sync_device_query_semaphore_compatibility,
     .transfer_range = iree_hal_device_transfer_mappable_range,
     .queue_submit = iree_hal_sync_device_queue_submit,
     .submit_and_wait = iree_hal_sync_device_submit_and_wait,

--- a/runtime/src/iree/hal/local/task_device.c
+++ b/runtime/src/iree/hal/local/task_device.c
@@ -304,6 +304,21 @@ static iree_status_t iree_hal_task_device_create_semaphore(
       device->host_allocator, out_semaphore);
 }
 
+static iree_hal_semaphore_compatibility_t
+iree_hal_task_device_query_semaphore_compatibility(
+    iree_hal_device_t* base_device, iree_hal_semaphore_t* semaphore) {
+  if (iree_hal_task_semaphore_isa(semaphore)) {
+    // Fast-path for semaphores related to this device.
+    // TODO(benvanik): ensure the creating devices are compatible as if
+    // independent task systems are used things may not work right (ownership
+    // confusion).
+    return IREE_HAL_SEMAPHORE_COMPATIBILITY_ALL;
+  }
+  // For now we support all semaphore types as we only need wait sources and
+  // all semaphores can be wrapped in those.
+  return IREE_HAL_SEMAPHORE_COMPATIBILITY_ALL;
+}
+
 static iree_status_t iree_hal_task_device_queue_submit(
     iree_hal_device_t* base_device,
     iree_hal_command_category_t command_categories,
@@ -369,6 +384,8 @@ static const iree_hal_device_vtable_t iree_hal_task_device_vtable = {
     .create_executable_cache = iree_hal_task_device_create_executable_cache,
     .create_executable_layout = iree_hal_task_device_create_executable_layout,
     .create_semaphore = iree_hal_task_device_create_semaphore,
+    .query_semaphore_compatibility =
+        iree_hal_task_device_query_semaphore_compatibility,
     .transfer_range = iree_hal_device_transfer_mappable_range,
     .queue_submit = iree_hal_task_device_queue_submit,
     .submit_and_wait = iree_hal_task_device_submit_and_wait,

--- a/runtime/src/iree/hal/local/task_semaphore.c
+++ b/runtime/src/iree/hal/local/task_semaphore.c
@@ -120,6 +120,11 @@ static void iree_hal_task_semaphore_destroy(
   IREE_TRACE_ZONE_END(z0);
 }
 
+bool iree_hal_task_semaphore_isa(iree_hal_semaphore_t* semaphore) {
+  return iree_hal_resource_is(&semaphore->resource,
+                              &iree_hal_task_semaphore_vtable);
+}
+
 static iree_status_t iree_hal_task_semaphore_query(
     iree_hal_semaphore_t* base_semaphore, uint64_t* out_value) {
   iree_hal_task_semaphore_t* semaphore =

--- a/runtime/src/iree/hal/local/task_semaphore.h
+++ b/runtime/src/iree/hal/local/task_semaphore.h
@@ -26,6 +26,9 @@ iree_status_t iree_hal_task_semaphore_create(
     iree_event_pool_t* event_pool, uint64_t initial_value,
     iree_allocator_t host_allocator, iree_hal_semaphore_t** out_semaphore);
 
+// Returns true if |semaphore| is a task system semaphore.
+bool iree_hal_task_semaphore_isa(iree_hal_semaphore_t* semaphore);
+
 // Reserves a new timepoint in the timeline for the given minimum payload value.
 // |issue_task| will wait until the timeline semaphore is signaled to at least
 // |minimum_value| before proceeding, with a possible wait task generated and

--- a/runtime/src/iree/hal/vulkan/native_semaphore.cc
+++ b/runtime/src/iree/hal/vulkan/native_semaphore.cc
@@ -121,6 +121,11 @@ static void iree_hal_vulkan_native_semaphore_destroy(
   IREE_TRACE_ZONE_END(z0);
 }
 
+bool iree_hal_vulkan_native_semaphore_isa(iree_hal_semaphore_t* semaphore) {
+  return iree_hal_resource_is(&semaphore->resource,
+                              &iree_hal_vulkan_native_semaphore_vtable);
+}
+
 VkSemaphore iree_hal_vulkan_native_semaphore_handle(
     iree_hal_semaphore_t* base_semaphore) {
   iree_hal_vulkan_native_semaphore_t* semaphore =

--- a/runtime/src/iree/hal/vulkan/native_semaphore.h
+++ b/runtime/src/iree/hal/vulkan/native_semaphore.h
@@ -22,6 +22,9 @@ iree_status_t iree_hal_vulkan_native_semaphore_create(
     iree::hal::vulkan::VkDeviceHandle* logical_device, uint64_t initial_value,
     iree_hal_semaphore_t** out_semaphore);
 
+// Returns true if |semaphore| is a Vulkan native semaphore.
+bool iree_hal_vulkan_native_semaphore_isa(iree_hal_semaphore_t* semaphore);
+
 // Returns the Vulkan timeline semaphore handle.
 VkSemaphore iree_hal_vulkan_native_semaphore_handle(
     iree_hal_semaphore_t* semaphore);

--- a/runtime/src/iree/hal/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/vulkan/vulkan_device.cc
@@ -1045,6 +1045,20 @@ static iree_status_t iree_hal_vulkan_device_create_semaphore(
                                                  initial_value, out_semaphore);
 }
 
+static iree_hal_semaphore_compatibility_t
+iree_hal_vulkan_device_query_semaphore_compatibility(
+    iree_hal_device_t* base_device, iree_hal_semaphore_t* semaphore) {
+  if (iree_hal_vulkan_native_semaphore_isa(semaphore)) {
+    // Fast-path for semaphores related to this device.
+    // TODO(benvanik): ensure the creating devices are compatible in cases where
+    // multiple devices are used.
+    return IREE_HAL_SEMAPHORE_COMPATIBILITY_ALL;
+  }
+  // TODO(benvanik): semaphore APIs for querying allowed export formats. We
+  // can check device caps to see what external semaphore types are supported.
+  return IREE_HAL_SEMAPHORE_COMPATIBILITY_HOST_ONLY;
+}
+
 static iree_status_t iree_hal_vulkan_device_queue_submit(
     iree_hal_device_t* base_device,
     iree_hal_command_category_t command_categories,
@@ -1110,6 +1124,8 @@ const iree_hal_device_vtable_t iree_hal_vulkan_device_vtable = {
     /*.create_executable_layout=*/
     iree_hal_vulkan_device_create_executable_layout,
     /*.create_semaphore=*/iree_hal_vulkan_device_create_semaphore,
+    /*.query_semaphore_compatibility=*/
+    iree_hal_vulkan_device_query_semaphore_compatibility,
     /*.transfer_range=*/iree_hal_device_submit_transfer_range_and_wait,
     /*.queue_submit=*/iree_hal_vulkan_device_queue_submit,
     /*.submit_and_wait=*/


### PR DESCRIPTION
This allows for devices to report whether a semaphore is usable for
host- and device-side waits and signals. When we have semaphores from
differing devices or HAL implementations being used in submissions this
will allow us to change scheduling behavior (optimistically always doing
device-side waits/signals).