### PR TITLE
Add Tablegen support for TransformDialectExtensions

### DIFF
--- a/compiler/src/iree/compiler/Codegen/TransformDialectExtensions/BUILD
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectExtensions/BUILD
@@ -4,7 +4,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@llvm-project//mlir:tblgen.bzl", "td_library")
 load("//build_tools/bazel:build_defs.oss.bzl", "iree_compiler_cc_library")
+load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
+load("//build_tools/bazel:iree_tablegen.bzl", "iree_gentbl_cc_library")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -12,15 +15,50 @@ package(
     licenses = ["notice"],  # Apache 2.0
 )
 
+td_library(
+    name = "td_files",
+    srcs = enforce_glob(
+        [
+            "TransformDialectExtensionsOps.td",
+        ],
+        include = ["*.td"],
+    ),
+    deps = [
+        "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:TransformDialectTdFiles",
+    ],
+)
+
+iree_gentbl_cc_library(
+    name = "TransformDialectExtensionsOpGen",
+    tbl_outs = [
+        (
+            ["--gen-op-decls"],
+            "TransformDialectExtensionsOps.h.inc",
+        ),
+        (
+            ["--gen-op-defs"],
+            "TransformDialectExtensionsOps.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "TransformDialectExtensionsOps.td",
+    deps = [":td_files"],
+)
+
 iree_compiler_cc_library(
     name = "TransformDialectExtensions",
     srcs = [
         "TransformDialectExtensions.cpp",
+        "TransformDialectExtensionsOps.cpp.inc",
     ],
     hdrs = [
         "TransformDialectExtensions.h",
+        "TransformDialectExtensionsOps.h.inc",
     ],
     deps = [
+        ":TransformDialectExtensionsOpGen",
         "//compiler/src/iree/compiler/Codegen",
         "//compiler/src/iree/compiler/Codegen:PassHeaders",
         "//compiler/src/iree/compiler/Codegen/Common",

--- a/compiler/src/iree/compiler/Codegen/TransformDialectExtensions/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectExtensions/CMakeLists.txt
@@ -10,14 +10,27 @@
 
 iree_add_all_subdirs()
 
+iree_tablegen_library(
+  NAME
+    TransformDialectExtensionsOpGen
+  TD_FILE
+    "TransformDialectExtensionsOps.td"
+  OUTS
+    --gen-op-decls TransformDialectExtensionsOps.h.inc
+    --gen-op-defs TransformDialectExtensionsOps.cpp.inc
+)
+
 iree_cc_library(
   NAME
     TransformDialectExtensions
   HDRS
     "TransformDialectExtensions.h"
+    "TransformDialectExtensionsOps.h.inc"
   SRCS
     "TransformDialectExtensions.cpp"
+    "TransformDialectExtensionsOps.cpp.inc"
   DEPS
+    ::TransformDialectExtensionsOpGen
     IREEDialectsTransforms
     IREELinalgExtDialect
     IREELinalgExtTransforms

--- a/compiler/src/iree/compiler/Codegen/TransformDialectExtensions/TransformDialectExtensions.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectExtensions/TransformDialectExtensions.h
@@ -8,12 +8,19 @@
 #define IREE_COMPILER_CODEGEN_COMMON_TRANSFORMDIALECTEXTENSIONS_H_
 
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree-dialects/Dialect/LinalgTransform/TransformOpTraits.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/PDL/IR/PDLTypes.h"
+#include "mlir/Dialect/Transform/IR/TransformDialect.h"
+#include "mlir/Dialect/Transform/IR/TransformInterfaces.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/Pass/Pass.h"
+
+#define GET_OP_CLASSES
+#include "iree/compiler/Codegen/TransformDialectExtensions/TransformDialectExtensionsOps.h.inc"
 
 namespace mlir {
 namespace iree_compiler {
@@ -22,6 +29,16 @@ namespace iree_compiler {
 /// LinalgTransform dialect.
 void registerLinalgTransformDialectExtension(DialectRegistry &registry);
 
+namespace IREE {
+namespace transform_dialect {
+// Hook to re
+class TransformDialectExtensions
+    : public transform::TransformDialectExtension<TransformDialectExtensions> {
+ public:
+  TransformDialectExtensions();
+};
+}  // namespace transform_dialect
+}  // namespace IREE
 }  // namespace iree_compiler
 }  // namespace mlir
 

--- a/compiler/src/iree/compiler/Codegen/TransformDialectExtensions/TransformDialectExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectExtensions/TransformDialectExtensionsOps.td
@@ -1,0 +1,49 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_TRANSFORMDIALECTEXTENSIONS
+#define IREE_COMPILER_CODEGEN_TRANSFORMDIALECTEXTENSIONS
+
+include "mlir/Dialect/PDL/IR/PDLTypes.td"
+include "mlir/Dialect/Transform/IR/TransformDialect.td"
+include "mlir/Dialect/Transform/IR/TransformInterfaces.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/IR/OpBase.td"
+
+def FunctionalStyleMultiOperandMultiResultTransformOpTrait
+    : NativeOpTrait<"FunctionalStyleMultiOperandMultiResultTransformOpTrait"> {
+  let cppNamespace = "::mlir::transform";
+}
+
+def IREEBufferizeOp : Op<Transform_Dialect, "iree.bufferize",
+    [FunctionalStyleMultiOperandMultiResultTransformOpTrait, 
+     MemoryEffectsOpInterface,
+     DeclareOpInterfaceMethods<TransformOpInterface>]> {
+  let description = [{Calls upstream comprehensive bufferize with extra IREE hooks.}];
+
+  let arguments = (ins);
+  let results = (outs);
+
+  let assemblyFormat = "attr-dict";
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+}
+
+def IREESetNumWorkgroupToOneOp : Op<Transform_Dialect, "iree.set_num_workgroups_to_one",
+    [FunctionalStyleMultiOperandMultiResultTransformOpTrait, 
+     MemoryEffectsOpInterface,
+     DeclareOpInterfaceMethods<TransformOpInterface>]> {
+  let description = [{Given a top-level HAL::ExecutableVariantOp, populates the
+   HAL::EntryPointOp with all 1s.
+  }];
+
+  let arguments = (ins);
+  let results = (outs);
+
+  let assemblyFormat = "attr-dict";
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+}
+
+#endif // IREE_COMPILER_CODEGEN_TRANSFORMDIALECTEXTENSIONS


### PR DESCRIPTION
This allows dropping C++ ops in favor of the standard MLIR auto-generation tools.