### PR TITLE
Integrate llvm-project at aed179f5f557664d6deb26ef6fdc6aa944af41af

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
@@ -186,6 +186,7 @@ class CUDATargetBackend final : public TargetBackend {
     // Perform the translation in a separate context to avoid any
     // multi-threading issues.
     llvm::LLVMContext context;
+    context.setOpaquePointers(false);
 
     // We name our files after the executable name so that they are easy to
     // track both during compilation (logs/artifacts/etc), as outputs (final

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp
@@ -220,6 +220,7 @@ class LLVMAOTTargetBackend final : public TargetBackend {
     // Perform the translation in a separate context to avoid any
     // multi-threading issues.
     llvm::LLVMContext context;
+    context.setOpaquePointers(false);
 
     // We name our files after the executable name so that they are easy to
     // track both during compilation (logs/artifacts/etc), as outputs (final
@@ -741,6 +742,7 @@ class LLVMAOTTargetBackend final : public TargetBackend {
     // Set the native vector size. This creates a dummy llvm module just to
     // build the TTI the right way.
     llvm::LLVMContext llvmContext;
+    llvmContext.setOpaquePointers(false);
     auto llvmModule =
         std::make_unique<llvm::Module>("dummy_module", llvmContext);
     llvm::Type *voidType = llvm::Type::getVoidTy(llvmContext);

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp
@@ -304,12 +304,14 @@ class LLVMAOTTargetBackend final : public TargetBackend {
 
       // Tag the function parameters in case they got removed during conversion.
       // (%arg0: environment, %arg1: dispatch_state, %arg2: workgroup_state)
+      static const char *structNames[] = {
+          "iree_hal_executable_environment_v0_t",
+          "iree_hal_executable_dispatch_state_v0_t",
+          "iree_hal_executable_workgroup_state_v0_t"};
       for (unsigned i = 0; i <= 2; ++i) {
         llvmFunc->addParamAttr(
             i, llvm::Attribute::getWithByRefType(
-                   context, llvmFunc->getArg(i)
-                                ->getType()
-                                ->getNonOpaquePointerElementType()));
+                   context, llvm::StructType::create(context, structNames[i])));
         llvmFunc->addParamAttr(i, llvm::Attribute::NonNull);
         llvmFunc->addParamAttr(i, llvm::Attribute::NoAlias);
         llvmFunc->addParamAttr(i, align16);

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp
@@ -304,14 +304,12 @@ class LLVMAOTTargetBackend final : public TargetBackend {
 
       // Tag the function parameters in case they got removed during conversion.
       // (%arg0: environment, %arg1: dispatch_state, %arg2: workgroup_state)
-      static const char *structNames[] = {
-          "iree_hal_executable_environment_v0_t",
-          "iree_hal_executable_dispatch_state_v0_t",
-          "iree_hal_executable_workgroup_state_v0_t"};
       for (unsigned i = 0; i <= 2; ++i) {
         llvmFunc->addParamAttr(
             i, llvm::Attribute::getWithByRefType(
-                   context, llvm::StructType::create(context, structNames[i])));
+                   context, llvmFunc->getArg(i)
+                                ->getType()
+                                ->getNonOpaquePointerElementType()));
         llvmFunc->addParamAttr(i, llvm::Attribute::NonNull);
         llvmFunc->addParamAttr(i, llvm::Attribute::NoAlias);
         llvmFunc->addParamAttr(i, align16);

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTarget.cpp
@@ -103,6 +103,7 @@ class ROCMTargetBackend final : public TargetBackend {
     // Perform the translation in a separate context to avoid any
     // multi-threading issues.
     llvm::LLVMContext context;
+    context.setOpaquePointers(false);
 
     // We name our files after the executable name so that they are easy to
     // track both during compilation (logs/artifacts/etc), as outputs (final

--- a/compiler/src/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
@@ -277,12 +277,16 @@ struct ScatterOpConversion : public OpConversionPattern<mhlo::ScatterOp> {
       mhlo::ScatterOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
     if (!hasCanonicalDimensionNumbers(op)) return failure();
+    if (llvm::size(op.operands()) != 1)
+      return op.emitError("NYI variadic operands scatter");
+    if (llvm::size(op.updates()) != 1)
+      return op.emitError("NYI variadic updates scatter");
 
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
 
-    Value original = adaptor.operand();
+    Value original = adaptor.operands().front();
     Value indices = adaptor.scatter_indices();
-    Value updates = adaptor.updates();
+    Value updates = adaptor.updates().front();
 
     if (failed(collapseBatchDimsIfNeeded(indices, updates, b))) {
       return failure();

--- a/integrations/tensorflow/WORKSPACE
+++ b/integrations/tensorflow/WORKSPACE
@@ -7,7 +7,7 @@
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-TENSORFLOW_COMMIT = "2c88b482da24fcb0771327d4be9f7f67059d11a2"
+TENSORFLOW_COMMIT = "eed69a9f9ba56ccfa9debae1b4dbc2a9cf9706fa"
 
 git_repository(
     name = "org_tensorflow",

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.td
@@ -91,7 +91,7 @@ def BufferizeOp : Op<Transform_Dialect, "bufferize",
   let cppNamespace = "transform_ext";
 }
 
-def DecomposeOp : Op<Transform_Dialect, "structured.decompose",
+def DecomposeOp : Op<Transform_Dialect, "structured2.decompose",
     [DeclareOpInterfaceMethods<TransformOpInterface>,
      MemoryEffectsOpInterface,
      FunctionalStyleMultiOperandMultiResultTransformOpTrait]> {

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/roundtrip.mlir
@@ -13,8 +13,8 @@ transform.structured.canonicalized_sequence {
   %2, %loops2:3  = transform.structured.tile %1 {sizes = [2, 2, 2]}
   // CHECK: %[[PADDED:.*]] = transform.structured.pad %[[TILED2]] {pack_paddings = [1, 1, 0]}
   %3 = transform.structured.pad %2 {pack_paddings = [1, 1, 0]}
-  // CHECK: transform.structured.decompose
-  transform.structured.decompose
+  // CHECK: transform.structured2.decompose
+  transform.structured2.decompose
   // CHECK: %{{.*}} = transform.structured2.vectorize %[[PADDED]] {vectorize_padding = true}
   %4 = transform.structured2.vectorize %3 {vectorize_padding = true}
   // CHECK: %[[OPS2:.*]] = pdl_match @{{.*}}

--- a/samples/simple_embedding/BUILD
+++ b/samples/simple_embedding/BUILD
@@ -79,8 +79,6 @@ cc_binary(
         "simple_embedding.c",
     ],
     deps = [
-        ":simple_embedding_test_bytecode_module_dylib_arm_32_c",
-        ":simple_embedding_test_bytecode_module_dylib_arm_64_c",
         ":simple_embedding_test_bytecode_module_dylib_riscv_32_c",
         ":simple_embedding_test_bytecode_module_dylib_riscv_64_c",
         ":simple_embedding_test_bytecode_module_dylib_x86_64_c",
@@ -146,37 +144,6 @@ iree_bytecode_module(
     ],
 )
 
-iree_bytecode_module(
-    name = "simple_embedding_test_bytecode_module_dylib_arm_32",
-    src = "simple_embedding_test.mlir",
-    c_identifier = "iree_samples_simple_embedding_test_module_dylib_arm_32",
-    flags = [
-        "--iree-input-type=mhlo",
-        "--iree-mlir-to-vm-bytecode-module",
-        "--iree-hal-target-backends=dylib-llvm-aot",
-        "--iree-llvm-target-triple=armv7a-pc-linux-elf",
-        "--iree-llvm-target-float-abi=hard",
-        "--iree-llvm-debug-symbols=false",
-        "--iree-vm-bytecode-module-strip-source-map=true",
-        "--iree-vm-emit-polyglot-zip=false",
-    ],
-)
-
-iree_bytecode_module(
-    name = "simple_embedding_test_bytecode_module_dylib_arm_64",
-    src = "simple_embedding_test.mlir",
-    c_identifier = "iree_samples_simple_embedding_test_module_dylib_arm_64",
-    flags = [
-        "--iree-input-type=mhlo",
-        "--iree-mlir-to-vm-bytecode-module",
-        "--iree-hal-target-backends=dylib-llvm-aot",
-        "--iree-llvm-target-triple=aarch64-pc-linux-elf",
-        "--iree-llvm-debug-symbols=false",
-        "--iree-vm-bytecode-module-strip-source-map=true",
-        "--iree-vm-emit-polyglot-zip=false",
-    ],
-)
-
 native_test(
     name = "simple_embedding_embedded_sync_test",
     src = ":simple_embedding_embedded_sync",
@@ -196,7 +163,6 @@ cc_binary(
         "simple_embedding.c",
     ],
     deps = [
-        ":simple_embedding_test_bytecode_module_dylib_arm_64_c",
         ":simple_embedding_test_bytecode_module_dylib_riscv_64_c",
         ":simple_embedding_test_bytecode_module_dylib_x86_64_c",
         "//runtime/src/iree/base",

--- a/samples/simple_embedding/BUILD
+++ b/samples/simple_embedding/BUILD
@@ -79,6 +79,7 @@ cc_binary(
         "simple_embedding.c",
     ],
     deps = [
+        ":simple_embedding_test_bytecode_module_dylib_arm_32_c",
         ":simple_embedding_test_bytecode_module_dylib_arm_64_c",
         ":simple_embedding_test_bytecode_module_dylib_riscv_32_c",
         ":simple_embedding_test_bytecode_module_dylib_riscv_64_c",
@@ -139,6 +140,22 @@ iree_bytecode_module(
         "--iree-llvm-target-cpu=generic-rv64",
         "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+c",
         "--iree-llvm-target-abi=lp64d",
+        "--iree-llvm-debug-symbols=false",
+        "--iree-vm-bytecode-module-strip-source-map=true",
+        "--iree-vm-emit-polyglot-zip=false",
+    ],
+)
+
+iree_bytecode_module(
+    name = "simple_embedding_test_bytecode_module_dylib_arm_32",
+    src = "simple_embedding_test.mlir",
+    c_identifier = "iree_samples_simple_embedding_test_module_dylib_arm_32",
+    flags = [
+        "--iree-input-type=mhlo",
+        "--iree-mlir-to-vm-bytecode-module",
+        "--iree-hal-target-backends=dylib-llvm-aot",
+        "--iree-llvm-target-triple=armv7a-pc-linux-elf",
+        "--iree-llvm-target-float-abi=hard",
         "--iree-llvm-debug-symbols=false",
         "--iree-vm-bytecode-module-strip-source-map=true",
         "--iree-vm-emit-polyglot-zip=false",

--- a/samples/simple_embedding/BUILD
+++ b/samples/simple_embedding/BUILD
@@ -79,6 +79,7 @@ cc_binary(
         "simple_embedding.c",
     ],
     deps = [
+        ":simple_embedding_test_bytecode_module_dylib_arm_64_c",
         ":simple_embedding_test_bytecode_module_dylib_riscv_32_c",
         ":simple_embedding_test_bytecode_module_dylib_riscv_64_c",
         ":simple_embedding_test_bytecode_module_dylib_x86_64_c",
@@ -144,6 +145,21 @@ iree_bytecode_module(
     ],
 )
 
+iree_bytecode_module(
+    name = "simple_embedding_test_bytecode_module_dylib_arm_64",
+    src = "simple_embedding_test.mlir",
+    c_identifier = "iree_samples_simple_embedding_test_module_dylib_arm_64",
+    flags = [
+        "--iree-input-type=mhlo",
+        "--iree-mlir-to-vm-bytecode-module",
+        "--iree-hal-target-backends=dylib-llvm-aot",
+        "--iree-llvm-target-triple=aarch64-pc-linux-elf",
+        "--iree-llvm-debug-symbols=false",
+        "--iree-vm-bytecode-module-strip-source-map=true",
+        "--iree-vm-emit-polyglot-zip=false",
+    ],
+)
+
 native_test(
     name = "simple_embedding_embedded_sync_test",
     src = ":simple_embedding_embedded_sync",
@@ -163,6 +179,7 @@ cc_binary(
         "simple_embedding.c",
     ],
     deps = [
+        ":simple_embedding_test_bytecode_module_dylib_arm_64_c",
         ":simple_embedding_test_bytecode_module_dylib_riscv_64_c",
         ":simple_embedding_test_bytecode_module_dylib_x86_64_c",
         "//runtime/src/iree/base",

--- a/samples/simple_embedding/CMakeLists.txt
+++ b/samples/simple_embedding/CMakeLists.txt
@@ -64,6 +64,7 @@ iree_cc_binary(
     "device_embedded_sync.c"
     "simple_embedding.c"
   DEPS
+    ::simple_embedding_test_bytecode_module_dylib_arm_64_c
     ::simple_embedding_test_bytecode_module_dylib_riscv_32_c
     ::simple_embedding_test_bytecode_module_dylib_riscv_64_c
     ::simple_embedding_test_bytecode_module_dylib_x86_64_c
@@ -137,6 +138,24 @@ iree_bytecode_module(
   PUBLIC
 )
 
+iree_bytecode_module(
+  NAME
+    simple_embedding_test_bytecode_module_dylib_arm_64
+  SRC
+    "simple_embedding_test.mlir"
+  C_IDENTIFIER
+    "iree_samples_simple_embedding_test_module_dylib_arm_64"
+  FLAGS
+    "--iree-input-type=mhlo"
+    "--iree-mlir-to-vm-bytecode-module"
+    "--iree-hal-target-backends=dylib-llvm-aot"
+    "--iree-llvm-target-triple=aarch64-pc-linux-elf"
+    "--iree-llvm-debug-symbols=false"
+    "--iree-vm-bytecode-module-strip-source-map=true"
+    "--iree-vm-emit-polyglot-zip=false"
+  PUBLIC
+)
+
 iree_native_test(
   NAME
     "simple_embedding_embedded_sync_test"
@@ -153,6 +172,7 @@ iree_cc_binary(
     "device_dylib.c"
     "simple_embedding.c"
   DEPS
+    ::simple_embedding_test_bytecode_module_dylib_arm_64_c
     ::simple_embedding_test_bytecode_module_dylib_riscv_64_c
     ::simple_embedding_test_bytecode_module_dylib_x86_64_c
     iree::base

--- a/samples/simple_embedding/CMakeLists.txt
+++ b/samples/simple_embedding/CMakeLists.txt
@@ -64,6 +64,7 @@ iree_cc_binary(
     "device_embedded_sync.c"
     "simple_embedding.c"
   DEPS
+    ::simple_embedding_test_bytecode_module_dylib_arm_32_c
     ::simple_embedding_test_bytecode_module_dylib_arm_64_c
     ::simple_embedding_test_bytecode_module_dylib_riscv_32_c
     ::simple_embedding_test_bytecode_module_dylib_riscv_64_c
@@ -132,6 +133,25 @@ iree_bytecode_module(
     "--iree-llvm-target-cpu=generic-rv64"
     "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+c"
     "--iree-llvm-target-abi=lp64d"
+    "--iree-llvm-debug-symbols=false"
+    "--iree-vm-bytecode-module-strip-source-map=true"
+    "--iree-vm-emit-polyglot-zip=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    simple_embedding_test_bytecode_module_dylib_arm_32
+  SRC
+    "simple_embedding_test.mlir"
+  C_IDENTIFIER
+    "iree_samples_simple_embedding_test_module_dylib_arm_32"
+  FLAGS
+    "--iree-input-type=mhlo"
+    "--iree-mlir-to-vm-bytecode-module"
+    "--iree-hal-target-backends=dylib-llvm-aot"
+    "--iree-llvm-target-triple=armv7a-pc-linux-elf"
+    "--iree-llvm-target-float-abi=hard"
     "--iree-llvm-debug-symbols=false"
     "--iree-vm-bytecode-module-strip-source-map=true"
     "--iree-vm-emit-polyglot-zip=false"

--- a/samples/simple_embedding/CMakeLists.txt
+++ b/samples/simple_embedding/CMakeLists.txt
@@ -64,8 +64,6 @@ iree_cc_binary(
     "device_embedded_sync.c"
     "simple_embedding.c"
   DEPS
-    ::simple_embedding_test_bytecode_module_dylib_arm_32_c
-    ::simple_embedding_test_bytecode_module_dylib_arm_64_c
     ::simple_embedding_test_bytecode_module_dylib_riscv_32_c
     ::simple_embedding_test_bytecode_module_dylib_riscv_64_c
     ::simple_embedding_test_bytecode_module_dylib_x86_64_c
@@ -139,43 +137,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-iree_bytecode_module(
-  NAME
-    simple_embedding_test_bytecode_module_dylib_arm_32
-  SRC
-    "simple_embedding_test.mlir"
-  C_IDENTIFIER
-    "iree_samples_simple_embedding_test_module_dylib_arm_32"
-  FLAGS
-    "--iree-input-type=mhlo"
-    "--iree-mlir-to-vm-bytecode-module"
-    "--iree-hal-target-backends=dylib-llvm-aot"
-    "--iree-llvm-target-triple=armv7a-pc-linux-elf"
-    "--iree-llvm-target-float-abi=hard"
-    "--iree-llvm-debug-symbols=false"
-    "--iree-vm-bytecode-module-strip-source-map=true"
-    "--iree-vm-emit-polyglot-zip=false"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    simple_embedding_test_bytecode_module_dylib_arm_64
-  SRC
-    "simple_embedding_test.mlir"
-  C_IDENTIFIER
-    "iree_samples_simple_embedding_test_module_dylib_arm_64"
-  FLAGS
-    "--iree-input-type=mhlo"
-    "--iree-mlir-to-vm-bytecode-module"
-    "--iree-hal-target-backends=dylib-llvm-aot"
-    "--iree-llvm-target-triple=aarch64-pc-linux-elf"
-    "--iree-llvm-debug-symbols=false"
-    "--iree-vm-bytecode-module-strip-source-map=true"
-    "--iree-vm-emit-polyglot-zip=false"
-  PUBLIC
-)
-
 iree_native_test(
   NAME
     "simple_embedding_embedded_sync_test"
@@ -192,7 +153,6 @@ iree_cc_binary(
     "device_dylib.c"
     "simple_embedding.c"
   DEPS
-    ::simple_embedding_test_bytecode_module_dylib_arm_64_c
     ::simple_embedding_test_bytecode_module_dylib_riscv_64_c
     ::simple_embedding_test_bytecode_module_dylib_x86_64_c
     iree::base


### PR DESCRIPTION
* Reset third_party/llvm-project: aed179f5f557664d6deb26ef6fdc6aa944af41af (2022-06-03 15:19:09 +0200): [lldb] [Process/FreeBSD] Do not send SIGSTOP to stopped process
* Update MHLO and TensorFlow
  * MHLO: cc46221a504bd56811b76ba7fb89ef618bdf5ba0
  * TensorFlow: eed69a9f9ba56ccfa9debae1b4dbc2a9cf9706fa
* Fix mhlo.scatter variadic operand/result APIs
* Rename `transform.structured.decompose` to avoid collision