### PR TITLE
Adding support for flow->stream->hal workgroup count regions.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/DestructiveUpdateUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DestructiveUpdateUtils.cpp
@@ -343,14 +343,12 @@ LogicalResult rewriteDestructiveUpdateInPlace<tensor::InsertSliceOp>(
   return failure();
 }
 
-// Return true if any control flow is found in the DispatchWorkgroupsOp besides
-// scf::ForOp.
+// Return true if any control flow is found in the workgroup besides scf::ForOp.
 static bool hasNonScfForControlFlow(func::FuncOp funcOp) {
   return funcOp
       ->walk([&](Operation *op) {
         if (isa<BranchOpInterface>(op) || isa<RegionBranchOpInterface>(op)) {
-          if (!isa<scf::ForOp, scf::IfOp>(op) && !isa<linalg::LinalgOp>(op) &&
-              !isa<IREE::Flow::DispatchWorkgroupsOp>(op))
+          if (!isa<scf::ForOp, scf::IfOp>(op) && !isa<linalg::LinalgOp>(op))
             return WalkResult::interrupt();
         }
         return WalkResult::advance();

--- a/compiler/src/iree/compiler/Codegen/Common/GPUDistributeSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUDistributeSharedMemoryCopy.cpp
@@ -211,10 +211,9 @@ class GPUDistributeSharedMemoryCopyPass
   }
   void runOnOperation() override {
     func::FuncOp funcOp = getOperation();
-    FailureOr<IREE::HAL::ExecutableEntryPointOp> entryPointOp =
-        getEntryPoint(funcOp);
-    if (failed(entryPointOp)) return;
-    auto workgroupSize = getWorkgroupSize(entryPointOp.getValue());
+    FailureOr<IREE::HAL::ExecutableExportOp> exportOp = getEntryPoint(funcOp);
+    if (failed(exportOp)) return;
+    auto workgroupSize = getWorkgroupSize(exportOp.getValue());
     workgroupSize.resize(3, 1);
     MLIRContext *context = &getContext();
     SmallVector<linalg::GenericOp> copiesToWorkgroupMem;

--- a/compiler/src/iree/compiler/Codegen/Common/test/distribute_gpu_shared_memory.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/distribute_gpu_shared_memory.mlir
@@ -17,7 +17,7 @@
 ]>
 hal.executable private @shared_mem_cpy  {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @shared_mem_cpy layout(#executable_layout) {
+    hal.executable.export @shared_mem_cpy layout(#executable_layout) {
       workgroup_size = [32: index, 4: index, 1:index]
     }
     builtin.module {

--- a/compiler/src/iree/compiler/Codegen/Common/test/insert_distribution_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/insert_distribution_info.mlir
@@ -17,7 +17,7 @@
 #translation = #iree_codegen.translation_info<CPUTileFuseAndVectorize>
 hal.executable private @matmul_tensors {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_arm_64_ {
-    hal.executable.entry_point public @matmul_tensors layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @matmul_tensors layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @matmul_tensors() {
         %0 = hal.interface.constant.load[0] : index
@@ -48,7 +48,7 @@ hal.executable private @matmul_tensors {
 }
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUTileFuseAndVectorize workload_per_wg = [64, 64]>
-//      CHECK: hal.executable.entry_point public @matmul_tensors
+//      CHECK: hal.executable.export public @matmul_tensors
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
@@ -80,7 +80,7 @@ hal.executable private @matmul_tensors {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @add {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @add layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @add layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @add() {
         %0 = hal.interface.constant.load[0] : index
@@ -114,7 +114,7 @@ hal.executable private @add {
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert workload_per_wg = [64, 64]>
 //      CHECK: hal.executable private @add
-//      CHECK: hal.executable.entry_point public @add
+//      CHECK: hal.executable.export public @add
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
@@ -145,7 +145,7 @@ hal.executable private @add {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @add4D {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @add4D layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @add4D layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @add4D() {
         %0 = hal.interface.constant.load[0] : index
@@ -179,7 +179,7 @@ hal.executable private @add4D {
 }
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert workload_per_wg = [64, 64, 64]>
-//      CHECK: hal.executable.entry_point public @add4D
+//      CHECK: hal.executable.export public @add4D
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
@@ -208,7 +208,7 @@ hal.executable private @add4D {
 #translation = #iree_codegen.translation_info<CPUTileFuseAndVectorize>
 hal.executable private @batch_matmul_tensors {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_arm_64_ {
-    hal.executable.entry_point public @batch_matmul_tensors layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @batch_matmul_tensors layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @batch_matmul_tensors() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -239,7 +239,7 @@ hal.executable private @batch_matmul_tensors {
 }
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUTileFuseAndVectorize workload_per_wg = [64, 64, 1]>
-//      CHECK: hal.executable.entry_point public @batch_matmul_tensors
+//      CHECK: hal.executable.export public @batch_matmul_tensors
 // CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_Y:[a-zA-Z0-9_]+]]: index
@@ -263,7 +263,7 @@ hal.executable private @batch_matmul_tensors {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @preset_config_matmul_tensors {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @preset_config layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @preset_config layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @preset_config() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -291,7 +291,7 @@ hal.executable private @preset_config_matmul_tensors {
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 16)>
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 32)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert workload_per_wg = [16, 32]>
-//      CHECK: hal.executable.entry_point public @preset_config
+//      CHECK: hal.executable.export public @preset_config
 // CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_Y:[a-zA-Z0-9_]+]]: index
@@ -315,7 +315,7 @@ hal.executable private @preset_config_matmul_tensors {
 #translation = #iree_codegen.translation_info<CPUBufferOpsTileAndVectorize>
 hal.executable public @copy_op {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @copy_op layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @copy_op layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @copy_op() {
         %source_size_y = hal.interface.constant.load[0] : index
@@ -348,7 +348,7 @@ hal.executable public @copy_op {
 }
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUBufferOpsTileAndVectorize workload_per_wg = [64, 64]>
-//      CHECK: hal.executable.entry_point public @copy_op
+//      CHECK: hal.executable.export public @copy_op
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
@@ -372,7 +372,7 @@ hal.executable public @copy_op {
 #translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @static_1d_fft_stage2 {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @static_1d_fft_stage2 layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @static_1d_fft_stage2 layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @static_1d_fft_stage2() {
         %c2 = arith.constant 2 : index
@@ -400,7 +400,7 @@ hal.executable private @static_1d_fft_stage2 {
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault workload_per_wg = [64]>
 //      CHECK: hal.executable private @static_1d_fft_stage2
-//      CHECK: hal.executable.entry_point public @static_1d_fft_stage2
+//      CHECK: hal.executable.export public @static_1d_fft_stage2
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
@@ -424,7 +424,7 @@ hal.executable private @static_1d_fft_stage2 {
 #translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @static_3d_fft_stage3 {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @static_3d_fft_stage3 layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @static_3d_fft_stage3 layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @static_3d_fft_stage3() {
         %c3 = arith.constant 3 : index
@@ -444,7 +444,7 @@ hal.executable private @static_3d_fft_stage3 {
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault workload_per_wg = [64, 64, 64]>
 //      CHECK: hal.executable private @static_3d_fft_stage3
-//      CHECK: hal.executable.entry_point public @static_3d_fft_stage3
+//      CHECK: hal.executable.export public @static_3d_fft_stage3
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
@@ -474,7 +474,7 @@ hal.executable private @static_3d_fft_stage3 {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @outs_fusion {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @outs_fusion_fn layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @outs_fusion_fn layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @outs_fusion_fn() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -514,7 +514,7 @@ hal.executable private @outs_fusion {
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert workload_per_wg = [64, 64]>
 //      CHECK: hal.executable private @outs_fusion
-//      CHECK: hal.executable.entry_point public @outs_fusion_fn
+//      CHECK: hal.executable.export public @outs_fusion_fn
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
@@ -543,7 +543,7 @@ hal.executable private @outs_fusion {
 #translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @conv {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @conv layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @conv layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @conv() {
         %0 = hal.interface.constant.load[0] : index
@@ -579,7 +579,7 @@ hal.executable private @conv {
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault workload_per_wg = [64, 64, 64]>
 //      CHECK: hal.executable private @conv
-//      CHECK: hal.executable.entry_point public @conv
+//      CHECK: hal.executable.export public @conv
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
@@ -608,7 +608,7 @@ hal.executable private @conv {
 #translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @conv_static {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @conv_static layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @conv_static layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @conv_static() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -638,7 +638,7 @@ hal.executable private @conv_static {
 //  CHECK-DAG: #[[MAP2:.+]] = affine_map<()[s0] -> (s0 ceildiv 20)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault workload_per_wg = [48, 40, 20]>
 //      CHECK: hal.executable private @conv_static
-//      CHECK: hal.executable.entry_point public @conv_static
+//      CHECK: hal.executable.export public @conv_static
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
@@ -668,7 +668,7 @@ hal.executable private @conv_static {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @generic_static {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @generic_static layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @generic_static layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @generic_static() {
         %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
@@ -695,7 +695,7 @@ hal.executable private @generic_static {
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 16)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert workload_per_wg = [32, 16]>
 //      CHECK: hal.executable private @generic_static
-//      CHECK: hal.executable.entry_point public @generic_static
+//      CHECK: hal.executable.export public @generic_static
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
@@ -724,7 +724,7 @@ hal.executable private @generic_static {
 #translation = #iree_codegen.translation_info<CPUTileFuseAndVectorize>
 hal.executable private @matmul_static {
   hal.executable.variant public @system_elf_arm_64, target = #executable_target_system_elf_arm_64_ {
-    hal.executable.entry_point public @matmul_static layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @matmul_static layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @matmul_static() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -753,7 +753,7 @@ hal.executable private @matmul_static {
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 28)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUTileFuseAndVectorize workload_per_wg = [8, 28]>
 //      CHECK: hal.executable private @matmul_static
-//      CHECK: hal.executable.entry_point public @matmul_static
+//      CHECK: hal.executable.export public @matmul_static
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
@@ -781,7 +781,7 @@ hal.executable private @matmul_static {
 #translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @restrict_num_workgroups {
   hal.executable.variant public @system_elf_arm_64, target = #executable_target_system_elf_arm_64_ {
-    hal.executable.entry_point public @restrict_num_workgroups layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @restrict_num_workgroups layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @restrict_num_workgroups() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -810,7 +810,7 @@ hal.executable private @restrict_num_workgroups {
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 7)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault workload_per_wg = [64, 7, 1]>
 //      CHECK: hal.executable private @restrict_num_workgroups
-//      CHECK: hal.executable.entry_point public @restrict_num_workgroups
+//      CHECK: hal.executable.export public @restrict_num_workgroups
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
@@ -840,7 +840,7 @@ hal.executable private @restrict_num_workgroups {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @reduction {
   hal.executable.variant public @reduction, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @reduction ordinal(0) layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @reduction ordinal(0) layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @reduction(%arg0 : !flow.dispatch.tensor<readonly:7x7x2048xf32>,
           %arg1 : !flow.dispatch.tensor<writeonly:7xf32>) {
@@ -874,7 +874,7 @@ hal.executable private @reduction {
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 4)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert workload_per_wg = [4]>
 //      CHECK: hal.executable private @reduction
-//      CHECK: hal.executable.entry_point public @reduction
+//      CHECK: hal.executable.export public @reduction
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
@@ -902,7 +902,7 @@ hal.executable private @reduction {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @gemm_unit_N {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @gemm_unit_N ordinal(0) layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @gemm_unit_N ordinal(0) layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @gemm_unit_N() {
         %c0 = arith.constant 0 : index
@@ -932,7 +932,7 @@ hal.executable private @gemm_unit_N {
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert workload_per_wg = [64]>
 //      CHECK: hal.executable private @gemm_unit_N
-//      CHECK: hal.executable.entry_point public @gemm_unit_N
+//      CHECK: hal.executable.export public @gemm_unit_N
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
@@ -960,7 +960,7 @@ hal.executable private @gemm_unit_N {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @gemm_unit_M_unit_N {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @gemm_unit_M_unit_N ordinal(0) layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @gemm_unit_M_unit_N ordinal(0) layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @gemm_unit_M_unit_N() {
         %c0 = arith.constant 0 : index
@@ -988,7 +988,7 @@ hal.executable private @gemm_unit_M_unit_N {
 }
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable private @gemm_unit_M_unit_N
-//      CHECK: hal.executable.entry_point public @gemm_unit_M_unit_N
+//      CHECK: hal.executable.export public @gemm_unit_M_unit_N
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
@@ -1016,7 +1016,7 @@ hal.executable private @gemm_unit_M_unit_N {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @generic_unit_dims {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @generic_unit_dims layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @generic_unit_dims layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @generic_unit_dims() {
         %0 = hal.interface.constant.load[0] : index
@@ -1047,7 +1047,7 @@ hal.executable private @generic_unit_dims {
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert workload_per_wg = [64, 64, 64]>
 //      CHECK: hal.executable private @generic_unit_dims
-//      CHECK: hal.executable.entry_point public @generic_unit_dims
+//      CHECK: hal.executable.export public @generic_unit_dims
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
@@ -1078,7 +1078,7 @@ hal.executable private @generic_unit_dims {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @reduce_to_scalar {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @reduce_to_scalar layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @reduce_to_scalar layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @reduce_to_scalar() {
         %0 = hal.interface.constant.load[0] : index
@@ -1106,7 +1106,7 @@ hal.executable private @reduce_to_scalar {
 }
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable private @reduce_to_scalar
-//      CHECK: hal.executable.entry_point public @reduce_to_scalar
+//      CHECK: hal.executable.export public @reduce_to_scalar
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
@@ -1133,7 +1133,7 @@ hal.executable private @reduce_to_scalar {
 #translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @scalar {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @scalar layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @scalar layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @scalar() {
         %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
@@ -1160,7 +1160,7 @@ hal.executable private @scalar {
 }
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
 //      CHECK: hal.executable private @scalar
-//      CHECK: hal.executable.entry_point public @scalar
+//      CHECK: hal.executable.export public @scalar
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index
@@ -1188,7 +1188,7 @@ hal.executable private @scalar {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @matmul_interchange {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @matmul_interchange layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @matmul_interchange layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @matmul_interchange() {
         %0 = hal.interface.constant.load[0] : index
@@ -1220,7 +1220,7 @@ hal.executable private @matmul_interchange {
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 32)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert workload_per_wg = [64, 32]>
-//      CHECK: hal.executable.entry_point public @matmul_interchange
+//      CHECK: hal.executable.export public @matmul_interchange
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_X:[a-zA-Z0-9_]+]]: index

--- a/compiler/src/iree/compiler/Codegen/Common/test/remove_trivial_loops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/remove_trivial_loops.mlir
@@ -10,7 +10,7 @@
 // CHECK-LABEL: func.func @dispatch_0()
 hal.executable private @dispatch_0  {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @dispatch_0 layout(#executable_layout) {
+    hal.executable.export @dispatch_0 layout(#executable_layout) {
       workgroup_size = [64: index, 1: index, 1:index]
     }
     builtin.module {
@@ -57,7 +57,7 @@ hal.executable private @dispatch_0  {
 #translation = #iree_codegen.translation_info<LLVMGPUDistribute workload_per_wg = [32]>
 hal.executable private @workgroup_tile_loop  {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @workgroup_tile_loop layout(#executable_layout) {
+    hal.executable.export @workgroup_tile_loop layout(#executable_layout) {
       translation_info = #translation
     }
     builtin.module {
@@ -91,7 +91,7 @@ hal.executable private @workgroup_tile_loop  {
 #translation = #iree_codegen.translation_info<LLVMGPUDistribute workload_per_wg = [16]>
 hal.executable private @workgroup_tile_loop_negative  {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @workgroup_tile_loop_negative layout(#executable_layout)  {
+    hal.executable.export @workgroup_tile_loop_negative layout(#executable_layout)  {
       translation_info = #translation
     }
     builtin.module {
@@ -127,7 +127,7 @@ hal.executable private @workgroup_tile_loop_negative  {
 #translation = #iree_codegen.translation_info<LLVMGPUDistribute workload_per_wg = [32, 8, 1]>
 hal.executable private @both_workgroup_and_workitem  {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @both_workgroup_and_workitem layout(#executable_layout)  {
+    hal.executable.export @both_workgroup_and_workitem layout(#executable_layout)  {
       translation_info = #translation,
       workgroup_size = [8: index, 2: index, 1: index]
     }
@@ -189,7 +189,7 @@ hal.executable private @both_workgroup_and_workitem  {
 module attributes {hal.device.targets = [#device_target_cpu]} {
   hal.executable private @simple_mul {
     hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-      hal.executable.entry_point public @simple_mul ordinal(0) layout(#executable_layout) {translation_info = #translation} {
+      hal.executable.export public @simple_mul ordinal(0) layout(#executable_layout) {translation_info = #translation} {
       ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
         %c1 = arith.constant 1 : index
         %0 = affine.apply #map0()[%arg1]

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
@@ -17,7 +17,7 @@
 #translation = #iree_codegen.translation_info<CPUTileFuseAndVectorize>
 hal.executable private @matmul_tensors {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_arm_64_ {
-    hal.executable.entry_point public @matmul_tensors layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @matmul_tensors layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @matmul_tensors() {
         %0 = hal.interface.constant.load[0] : index
@@ -49,7 +49,7 @@ hal.executable private @matmul_tensors {
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 * 64)>
 //  CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0)[s0] -> (-d0 + s0, 64)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUTileFuseAndVectorize>
-//      CHECK: hal.executable.entry_point public @matmul_tensors
+//      CHECK: hal.executable.export public @matmul_tensors
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 //      CHECK: func.func @matmul_tensors()
 //  CHECK-DAG:   %[[M:.+]] = hal.interface.constant.load[0]
@@ -103,7 +103,7 @@ hal.executable private @matmul_tensors {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @add {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @add layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @add layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @add() {
         %0 = hal.interface.constant.load[0] : index
@@ -136,7 +136,7 @@ hal.executable private @add {
 }
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable private @add
-//      CHECK: hal.executable.entry_point public @add
+//      CHECK: hal.executable.export public @add
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 //      CHECK: func.func @add()
 //      CHECK:   scf.for %[[IV0:.+]] =
@@ -163,7 +163,7 @@ hal.executable private @add {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @add4D {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @add4D layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @add4D layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @add4D() {
         %0 = hal.interface.constant.load[0] : index
@@ -196,7 +196,7 @@ hal.executable private @add4D {
   }
 }
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
-//      CHECK: hal.executable.entry_point public @add4D
+//      CHECK: hal.executable.export public @add4D
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 //      CHECK: func.func @add4D()
 //      CHECK:   %[[C0:.+]] = arith.constant 0 : index
@@ -224,7 +224,7 @@ hal.executable private @add4D {
 #translation = #iree_codegen.translation_info<CPUTileFuseAndVectorize>
 hal.executable private @batch_matmul_tensors {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_arm_64_ {
-    hal.executable.entry_point public @batch_matmul_tensors layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @batch_matmul_tensors layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @batch_matmul_tensors() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -254,7 +254,7 @@ hal.executable private @batch_matmul_tensors {
   }
 }
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUTileFuseAndVectorize>
-//      CHECK: hal.executable.entry_point public @batch_matmul_tensors
+//      CHECK: hal.executable.export public @batch_matmul_tensors
 //      CHECK: func.func @batch_matmul_tensors()
 //      CHECK:   scf.for %[[IV0:.+]] =
 //      CHECK:     scf.for %[[IV1:.+]] =
@@ -278,7 +278,7 @@ hal.executable private @batch_matmul_tensors {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @preset_config_matmul_tensors {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @preset_config layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @preset_config layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @preset_config() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -304,7 +304,7 @@ hal.executable private @preset_config_matmul_tensors {
   }
 }
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
-//      CHECK: hal.executable.entry_point public @preset_config
+//      CHECK: hal.executable.export public @preset_config
 //      CHECK: func.func @preset_config()
 //      CHECK:   scf.for %[[IV0:.+]] =
 //      CHECK:     scf.for %[[IV1:.+]] =
@@ -331,7 +331,7 @@ hal.executable private @preset_config_matmul_tensors {
 #translation = #iree_codegen.translation_info<CPUBufferOpsTileAndVectorize workload_per_wg = [64, 64]>
 hal.executable public @copy_op {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @copy_op layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @copy_op layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @copy_op() {
         %source_size_y = hal.interface.constant.load[0] : index
@@ -410,7 +410,7 @@ hal.executable public @copy_op {
 #translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @static_1d_fft_stage2 {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @static_1d_fft_stage2 layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @static_1d_fft_stage2 layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @static_1d_fft_stage2() {
         %c2 = arith.constant 2 : index
@@ -437,7 +437,7 @@ hal.executable private @static_1d_fft_stage2 {
 }
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
 //      CHECK: hal.executable private @static_1d_fft_stage2
-//      CHECK: hal.executable.entry_point public @static_1d_fft_stage2
+//      CHECK: hal.executable.export public @static_1d_fft_stage2
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 //      CHECK: func.func @static_1d_fft_stage2()
 //      CHECK:   scf.for %[[IV0:.+]] =
@@ -458,7 +458,7 @@ hal.executable private @static_1d_fft_stage2 {
 #translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @static_3d_fft_stage3 {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @static_3d_fft_stage3 layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @static_3d_fft_stage3 layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @static_3d_fft_stage3() {
         %c3 = arith.constant 3 : index
@@ -477,7 +477,7 @@ hal.executable private @static_3d_fft_stage3 {
 }
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
 //      CHECK: hal.executable private @static_3d_fft_stage3
-//      CHECK: hal.executable.entry_point public @static_3d_fft_stage3
+//      CHECK: hal.executable.export public @static_3d_fft_stage3
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 //      CHECK: func.func @static_3d_fft_stage3()
 //      CHECK:   scf.for %[[IV0:.+]] =
@@ -506,7 +506,7 @@ hal.executable private @static_3d_fft_stage3 {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @outs_fusion {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @outs_fusion_fn layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @outs_fusion_fn layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @outs_fusion_fn() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -570,7 +570,7 @@ hal.executable private @outs_fusion {
 #translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @conv {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @conv layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @conv layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @conv() {
         %0 = hal.interface.constant.load[0] : index
@@ -605,7 +605,7 @@ hal.executable private @conv {
 }
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
 //      CHECK: hal.executable private @conv
-//      CHECK: hal.executable.entry_point public @conv
+//      CHECK: hal.executable.export public @conv
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 //      CHECK: func.func @conv()
 //      CHECK:   %[[C0:.+]] = arith.constant 0
@@ -635,7 +635,7 @@ hal.executable private @conv {
 #translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @conv_static {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @conv_static layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @conv_static layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @conv_static() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -662,7 +662,7 @@ hal.executable private @conv_static {
 }
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
 //      CHECK: hal.executable private @conv_static
-//      CHECK: hal.executable.entry_point public @conv_static
+//      CHECK: hal.executable.export public @conv_static
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 //      CHECK: func.func @conv_static()
 //      CHECK:   %[[C0:.+]] = arith.constant 0 : index
@@ -694,7 +694,7 @@ hal.executable private @conv_static {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @generic_static {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.entry_point public @generic_static layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @generic_static layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @generic_static() {
         %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
@@ -719,7 +719,7 @@ hal.executable private @generic_static {
 }
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable private @generic_static
-//      CHECK: hal.executable.entry_point public @generic_static
+//      CHECK: hal.executable.export public @generic_static
 //      CHECK: func.func @generic_static()
 //      CHECK:   scf.for %[[IV0:.+]] =
 //      CHECK:     scf.for %[[IV1:.+]] =
@@ -743,7 +743,7 @@ hal.executable private @generic_static {
 #translation = #iree_codegen.translation_info<CPUTileFuseAndVectorize>
 hal.executable private @matmul_static {
   hal.executable.variant public @system_elf_arm_64, target = #executable_target_system_elf_arm_64_ {
-    hal.executable.entry_point public @matmul_static layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @matmul_static layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @matmul_static() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -770,7 +770,7 @@ hal.executable private @matmul_static {
 }
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUTileFuseAndVectorize>
 //      CHECK: hal.executable private @matmul_static
-//      CHECK: hal.executable.entry_point public @matmul_static
+//      CHECK: hal.executable.export public @matmul_static
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 
 // -----
@@ -790,7 +790,7 @@ hal.executable private @matmul_static {
 #translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @restrict_num_workgroups {
   hal.executable.variant public @system_elf_arm_64, target = #executable_target_system_elf_arm_64_ {
-    hal.executable.entry_point public @restrict_num_workgroups layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @restrict_num_workgroups layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @restrict_num_workgroups() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -817,7 +817,7 @@ hal.executable private @restrict_num_workgroups {
 }
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
 //      CHECK: hal.executable private @restrict_num_workgroups
-//      CHECK: hal.executable.entry_point public @restrict_num_workgroups
+//      CHECK: hal.executable.export public @restrict_num_workgroups
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 
 // -----
@@ -840,7 +840,7 @@ hal.executable private @restrict_num_workgroups {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @reduction {
   hal.executable.variant public @reduction, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @reduction ordinal(0) layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @reduction ordinal(0) layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @reduction(%arg0 : !flow.dispatch.tensor<readonly:7x7x2048xf32>,
           %arg1 : !flow.dispatch.tensor<writeonly:7xf32>) {
@@ -873,7 +873,7 @@ hal.executable private @reduction {
 }
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable private @reduction
-//      CHECK: hal.executable.entry_point public @reduction
+//      CHECK: hal.executable.export public @reduction
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 //      CHECK: func.func @reduction
 //      CHECK:   scf.for %[[IV0:.+]] =
@@ -902,7 +902,7 @@ hal.executable private @reduction {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @gemm_unit_N {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @gemm_unit_N ordinal(0) layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @gemm_unit_N ordinal(0) layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @gemm_unit_N() {
         %c0 = arith.constant 0 : index
@@ -932,7 +932,7 @@ hal.executable private @gemm_unit_N {
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 * 64)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable private @gemm_unit_N
-//      CHECK: hal.executable.entry_point public @gemm_unit_N
+//      CHECK: hal.executable.export public @gemm_unit_N
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 //      CHECK: func.func @gemm_unit_N()
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
@@ -963,7 +963,7 @@ hal.executable private @gemm_unit_N {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @gemm_unit_M_unit_N {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @gemm_unit_M_unit_N ordinal(0) layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @gemm_unit_M_unit_N ordinal(0) layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @gemm_unit_M_unit_N() {
         %c0 = arith.constant 0 : index
@@ -991,7 +991,7 @@ hal.executable private @gemm_unit_M_unit_N {
 }
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable private @gemm_unit_M_unit_N
-//      CHECK: hal.executable.entry_point public @gemm_unit_M_unit_N
+//      CHECK: hal.executable.export public @gemm_unit_M_unit_N
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 //      CHECK: func.func @gemm_unit_M_unit_N()
 //  CHECK-NOT:   scf.for
@@ -1016,7 +1016,7 @@ hal.executable private @gemm_unit_M_unit_N {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @generic_unit_dims {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @generic_unit_dims layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @generic_unit_dims layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @generic_unit_dims() {
         %0 = hal.interface.constant.load[0] : index
@@ -1046,7 +1046,7 @@ hal.executable private @generic_unit_dims {
 }
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable private @generic_unit_dims
-//      CHECK: hal.executable.entry_point public @generic_unit_dims
+//      CHECK: hal.executable.export public @generic_unit_dims
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 //      CHECK: func.func @generic_unit_dims()
 //      CHECK:   %[[C0:.+]] = arith.constant 0 : index
@@ -1075,7 +1075,7 @@ hal.executable private @generic_unit_dims {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @reduce_to_scalar {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @reduce_to_scalar layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @reduce_to_scalar layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @reduce_to_scalar() {
         %0 = hal.interface.constant.load[0] : index
@@ -1103,7 +1103,7 @@ hal.executable private @reduce_to_scalar {
 }
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable private @reduce_to_scalar
-//      CHECK: hal.executable.entry_point public @reduce_to_scalar
+//      CHECK: hal.executable.export public @reduce_to_scalar
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 //      CHECK: func.func @reduce_to_scalar()
 //  CHECK-NOT:   scf.for
@@ -1125,7 +1125,7 @@ hal.executable private @reduce_to_scalar {
 #translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @scalar {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @scalar layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @scalar layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @scalar() {
         %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
@@ -1152,7 +1152,7 @@ hal.executable private @scalar {
 }
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
 //      CHECK: hal.executable private @scalar
-//      CHECK: hal.executable.entry_point public @scalar
+//      CHECK: hal.executable.export public @scalar
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
 //      CHECK: func.func @scalar()
 //  CHECK-NOT:   scf.for
@@ -1174,7 +1174,7 @@ hal.executable private @scalar {
 #translation = #iree_codegen.translation_info<CPUTileFuseAndVectorize>
 hal.executable private @rank_reduced_slice {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_arm_64_ {
-    hal.executable.entry_point public @rank_reduced_slice layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @rank_reduced_slice layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @rank_reduced_slice() {
         %in_binding = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
@@ -1230,7 +1230,7 @@ hal.executable private @rank_reduced_slice {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @matmul_interchange {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @matmul_interchange layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @matmul_interchange layout(#executable_layout) {translation_info = #translation}
     builtin.module {
       func.func @matmul_interchange() {
         %0 = hal.interface.constant.load[0] : index
@@ -1260,7 +1260,7 @@ hal.executable private @matmul_interchange {
   }
 }
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
-//      CHECK: hal.executable.entry_point public @matmul_interchange
+//      CHECK: hal.executable.export public @matmul_interchange
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 //      CHECK: func.func @matmul_interchange()
 //  CHECK-DAG:   %[[D0:.+]] = hal.interface.constant.load[0] : index

--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.cpp
@@ -264,33 +264,31 @@ LogicalResult IREECodegenDialect::printCodegenAttrs(
 
 //===----------------------------------------------------------------------===//
 // Helpers for getting/setting iree_codegen.translation_info attribute on the
-// `hal.executable.entry_point`
+// `hal.executable.export`
 // ===----------------------------------------------------------------------===//
 
 IREE::Codegen::TranslationInfoAttr getTranslationInfo(
-    IREE::HAL::ExecutableEntryPointOp entryPointOp) {
-  return entryPointOp->getAttrOfType<IREE::Codegen::TranslationInfoAttr>(
+    IREE::HAL::ExecutableExportOp exportOp) {
+  return exportOp->getAttrOfType<IREE::Codegen::TranslationInfoAttr>(
       kTranslationInfoAttrName);
 }
 
-SmallVector<int64_t> getWorkgroupSize(
-    IREE::HAL::ExecutableEntryPointOp entryPointOp) {
-  if (Optional<ArrayAttr> workgroupSizeAttrList =
-          entryPointOp.workgroup_size()) {
+SmallVector<int64_t> getWorkgroupSize(IREE::HAL::ExecutableExportOp exportOp) {
+  if (Optional<ArrayAttr> workgroupSizeAttrList = exportOp.workgroup_size()) {
     return getIntegerVals(*workgroupSizeAttrList);
   }
   return {};
 }
 
-void setTranslationInfo(IREE::HAL::ExecutableEntryPointOp entryPointOp,
+void setTranslationInfo(IREE::HAL::ExecutableExportOp exportOp,
                         IREE::Codegen::TranslationInfoAttr translationInfo,
                         ArrayRef<int64_t> workgroupSize) {
-  entryPointOp->setAttr(kTranslationInfoAttrName, translationInfo);
+  exportOp->setAttr(kTranslationInfoAttrName, translationInfo);
   // The workgroup size is set on the entry point op directly.
   if (!workgroupSize.empty()) {
-    MLIRContext *context = entryPointOp->getContext();
+    MLIRContext *context = exportOp->getContext();
     auto attrs = getIndexIntegerArrayAttr(context, workgroupSize);
-    entryPointOp.workgroup_sizeAttr(attrs);
+    exportOp.workgroup_sizeAttr(attrs);
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.h
@@ -40,46 +40,44 @@ namespace mlir {
 namespace iree_compiler {
 //===----------------------------------------------------------------------===//
 // Helpers for getting/setting iree_codegen.translation_info attribute on the
-// `hal.executable.entry_point`
+// `hal.executable.export`
 // ===----------------------------------------------------------------------===//
 
 /// Gets the translate executable info attribute value associated with
-/// `entryPointOp`. It expects that the attribute is stored using the identifier
+/// `exportOp`. It expects that the attribute is stored using the identifier
 /// `translation_info`.
 IREE::Codegen::TranslationInfoAttr getTranslationInfo(
-    IREE::HAL::ExecutableEntryPointOp entryPointOp);
+    IREE::HAL::ExecutableExportOp exportOp);
 /// Returns the translation info for the `funcOp` (by looking at the entry
 /// point). Returns `nullptr` on failure.
 inline IREE::Codegen::TranslationInfoAttr getTranslationInfo(
     func::FuncOp funcOp) {
-  FailureOr<IREE::HAL::ExecutableEntryPointOp> entryPointOp =
-      getEntryPoint(funcOp);
-  if (failed(entryPointOp)) return nullptr;
-  return getTranslationInfo(*entryPointOp);
+  FailureOr<IREE::HAL::ExecutableExportOp> exportOp = getEntryPoint(funcOp);
+  if (failed(exportOp)) return nullptr;
+  return getTranslationInfo(*exportOp);
 }
 
-/// Returns the workgroup size specified on the `entryPointOp`.
-SmallVector<int64_t> getWorkgroupSize(
-    IREE::HAL::ExecutableEntryPointOp entryPointOp);
+/// Returns the workgroup size specified on the `exportOp`.
+SmallVector<int64_t> getWorkgroupSize(IREE::HAL::ExecutableExportOp exportOp);
 
 /// Set the translate executable info with the entry point op. Overwrites the
 /// existing attributes.
 // TODO(ravishankarm, benvanik): Eventually all the information needed for the
 // lowering will be consolidated into a single attribute with richer
 // information.
-void setTranslationInfo(IREE::HAL::ExecutableEntryPointOp entryPointOp,
+void setTranslationInfo(IREE::HAL::ExecutableExportOp exportOp,
                         IREE::Codegen::TranslationInfoAttr translationInfo,
                         ArrayRef<int64_t> workgroupSize = {});
 inline void setTranslationInfo(
     func::FuncOp entryPointFn,
     IREE::Codegen::TranslationInfoAttr translationInfo,
     ArrayRef<int64_t> workgroupSize = {}) {
-  FailureOr<IREE::HAL::ExecutableEntryPointOp> entryPointOp =
+  FailureOr<IREE::HAL::ExecutableExportOp> exportOp =
       getEntryPoint(entryPointFn);
-  return setTranslationInfo(*entryPointOp, translationInfo, workgroupSize);
+  return setTranslationInfo(*exportOp, translationInfo, workgroupSize);
 }
 
-/// Sets the translation info on the `hal.executable.entry_point` op
+/// Sets the translation info on the `hal.executable.export` op
 /// corresponding to the `entryPointFn`. Returns failure if a translation info
 /// is already set on the entry point op and is incompatible with what is being
 /// set.
@@ -88,12 +86,12 @@ inline void setTranslationInfo(
     IREE::Codegen::DispatchLoweringPassPipeline passPipeline,
     ArrayRef<int64_t> workloadPerWorkgroup, ArrayRef<int64_t> workgroupSize,
     unsigned softwarePipelineDepth = 0) {
-  FailureOr<IREE::HAL::ExecutableEntryPointOp> entryPointOp =
+  FailureOr<IREE::HAL::ExecutableExportOp> exportOp =
       getEntryPoint(entryPointFn);
   MLIRContext *context = entryPointFn.getContext();
   auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
       context, passPipeline, workloadPerWorkgroup);
-  setTranslationInfo(*entryPointOp, translationInfo, workgroupSize);
+  setTranslationInfo(*exportOp, translationInfo, workgroupSize);
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
@@ -82,7 +82,7 @@ def IREECodegen_TranslationInfoAttr :
     Specifies the information that is used to drive the translation of
     an entry point function using Linalg based structured-op
     lowering.. During executable translation this is attached to the
-    `hal.executable.entry_point` operation.
+    `hal.executable.export` operation.
 
     If this operation is already set on the root operation (as part of
     `iree_codegen.compilation_info`) that drives the compilation of a

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1127,12 +1127,12 @@ static LogicalResult setTranslationInfoAndRootConfig(
 }
 
 LogicalResult initCPULaunchConfig(ModuleOp moduleOp) {
-  llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> entryPointOps =
+  llvm::StringMap<IREE::HAL::ExecutableExportOp> exportOps =
       getAllEntryPoints(moduleOp);
   for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {
-    auto entryPointOp = entryPointOps.lookup(funcOp.getName());
-    if (!entryPointOp) continue;
-    if (getTranslationInfo(entryPointOp)) continue;
+    auto exportOp = exportOps.lookup(funcOp.getName());
+    if (!exportOp) continue;
+    if (getTranslationInfo(exportOp)) continue;
 
     // If using sandbox passes, currently set the workload_per_wg to be
     // empty for single-threaded execution.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -154,13 +154,13 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
     // to invoke separate dynamic pass pipelines on  entry point functions, when
     // the passes might have module level changes. For now this restriction
     // is fine.
-    llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> entryPoints =
+    llvm::StringMap<IREE::HAL::ExecutableExportOp> exportOps =
         getAllEntryPoints(moduleOp);
     Optional<IREE::Codegen::TranslationInfoAttr> translationInfo;
-    for (auto &it : entryPoints) {
-      auto entryPointOp = it.second;
+    for (auto &it : exportOps) {
+      auto exportOp = it.second;
       if (IREE::Codegen::TranslationInfoAttr currTranslationInfo =
-              getTranslationInfo(entryPointOp)) {
+              getTranslationInfo(exportOp)) {
         if (translationInfo) {
           if (currTranslationInfo != translationInfo.getValue()) {
             moduleOp.emitOpError(

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/illegal_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/illegal_configuration.mlir
@@ -11,7 +11,7 @@
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
-    hal.executable.entry_point @illegal layout(#executable_layout)  {
+    hal.executable.export @illegal layout(#executable_layout)  {
       translation_info = #translation
     }
     builtin.module {
@@ -42,7 +42,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
-    hal.executable.entry_point @illegal layout(#executable_layout)  {
+    hal.executable.export @illegal layout(#executable_layout)  {
       translation_info = #translation
     }
     builtin.module {
@@ -73,7 +73,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
-    hal.executable.entry_point @illegal layout(#executable_layout)  {
+    hal.executable.export @illegal layout(#executable_layout)  {
       translation_info = #translation
     }
     builtin.module {
@@ -104,7 +104,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
-    hal.executable.entry_point @illegal layout(#executable_layout)  {
+    hal.executable.export @illegal layout(#executable_layout)  {
       translation_info = #translation
     }
     builtin.module {
@@ -135,7 +135,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
-    hal.executable.entry_point @illegal layout(#executable_layout)  {
+    hal.executable.export @illegal layout(#executable_layout)  {
       translation_info = #translation
     }
     builtin.module {
@@ -168,7 +168,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
-    hal.executable.entry_point @illegal layout(#executable_layout)  {
+    hal.executable.export @illegal layout(#executable_layout)  {
       translation_info = #translation
     }
     builtin.module {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/linalg_transform.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/linalg_transform.mlir
@@ -6,7 +6,7 @@
 
 hal.executable private @pad_matmul_static_dispatch_0 {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @pad_matmul_static_dispatch_0 ordinal(0) layout(#executable_layout)
+    hal.executable.export public @pad_matmul_static_dispatch_0 ordinal(0) layout(#executable_layout)
     builtin.module {
       func.func @pad_matmul_static_dispatch_0() {
         %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_aarch64_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_aarch64_launch_configuration.mlir
@@ -14,7 +14,7 @@ hal.executable private @matmul_tensors  {
     native_vector_size = 16 : index,
     target_triple = "aarch64-unknown-unknown-eabi-elf"
   }> {
-    hal.executable.entry_point @matmul_tensors layout(#executable_layout)
+    hal.executable.export @matmul_tensors layout(#executable_layout)
     builtin.module {
       func.func @matmul_tensors() {
         %c0 = arith.constant 0 : index
@@ -46,7 +46,7 @@ hal.executable private @matmul_tensors  {
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0], [16, 4, 64], [4, 4, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUTileFuseAndVectorize>
-//      CHECK: hal.executable.entry_point public @matmul_tensors
+//      CHECK: hal.executable.export public @matmul_tensors
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.matmul
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -66,7 +66,7 @@ hal.executable private @batch_matmul_tensors {
     native_vector_size = 16 : index,
     target_triple = "aarch64-unknown-unknown-eabi-elf"
   }> {
-    hal.executable.entry_point @batch_matmul_tensors layout(#executable_layout)
+    hal.executable.export @batch_matmul_tensors layout(#executable_layout)
     builtin.module {
       func.func @batch_matmul_tensors() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -97,7 +97,7 @@ hal.executable private @batch_matmul_tensors {
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 64, 0], [1, 16, 4, 64], [1, 4, 4, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUTileFuseAndVectorize>
-//      CHECK: hal.executable.entry_point public @batch_matmul_tensors
+//      CHECK: hal.executable.export public @batch_matmul_tensors
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:  linalg.batch_matmul
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -117,7 +117,7 @@ hal.executable private @matmul_static {
     native_vector_size = 16 : index,
     target_triple = "aarch64-none-linux-android30"
   }> {
-    hal.executable.entry_point public @matmul_static layout(#executable_layout)
+    hal.executable.export public @matmul_static layout(#executable_layout)
     builtin.module {
       func.func @matmul_static() {
         %cst = arith.constant 0.0 : f32
@@ -145,7 +145,7 @@ hal.executable private @matmul_static {
 
 //   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[49, 8, 0], [7, 4, 60], [4, 4, 4]{{\]}}>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUTileFuseAndVectorize>
-//       CHECK: hal.executable.entry_point public @matmul_static
+//       CHECK: hal.executable.export public @matmul_static
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: linalg.matmul
 //  CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -165,7 +165,7 @@ hal.executable private @restrict_num_workgroups {
     native_vector_size = 16 : index,
     target_triple = "aarch64-none-linux-android30"
   }> {
-    hal.executable.entry_point public @restrict_num_workgroups layout(#executable_layout)
+    hal.executable.export public @restrict_num_workgroups layout(#executable_layout)
     builtin.module {
       func.func @restrict_num_workgroups() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -193,7 +193,7 @@ hal.executable private @restrict_num_workgroups {
 }
 //   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 7, 64, 0, 0], [1, 1, 7, 8, 0, 0], [0, 0, 0, 0, 1, 1]]>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUConvTileAndDecomposeExpert>
-//       CHECK: hal.executable.entry_point public @restrict_num_workgroups
+//       CHECK: hal.executable.export public @restrict_num_workgroups
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: linalg.depthwise_conv_2d_nhwc_hwc
 //  CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -214,7 +214,7 @@ hal.executable private @matmul_aarch_i8_i8_i32_static  {
     native_vector_size = 16 : index,
     target_triple = "aarch64-none-linux-android30"
   }> {
-  hal.executable.entry_point public @matmul_aarch_i8_i8_i32_static layout(#executable_layout)
+  hal.executable.export public @matmul_aarch_i8_i8_i32_static layout(#executable_layout)
     builtin.module {
       func.func @matmul_aarch_i8_i8_i32_static() {
         %c0_i32 = arith.constant 0 : i32
@@ -236,7 +236,7 @@ hal.executable private @matmul_aarch_i8_i8_i32_static  {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0], [4, 16, 0], [0, 0, 4]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingPadExpert>
-//      CHECK: hal.executable.entry_point public @matmul_aarch_i8_i8_i32_static
+//      CHECK: hal.executable.export public @matmul_aarch_i8_i8_i32_static
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.matmul
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
@@ -256,7 +256,7 @@ hal.executable private @matmul_aarch_i8_i8_i32_dynamic  {
     native_vector_size = 16 : index,
     target_triple = "aarch64-none-linux-android30"
   }> {
-  hal.executable.entry_point public @matmul_aarch_i8_i8_i32_dynamic layout(#executable_layout)
+  hal.executable.export public @matmul_aarch_i8_i8_i32_dynamic layout(#executable_layout)
     builtin.module {
       func.func @matmul_aarch_i8_i8_i32_dynamic() {
         %c0 = arith.constant 0 : index
@@ -286,7 +286,7 @@ hal.executable private @matmul_aarch_i8_i8_i32_dynamic  {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0], [4, 16, 0], [0, 0, 4]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingPadExpert>
-//      CHECK: hal.executable.entry_point public @matmul_aarch_i8_i8_i32_dynamic
+//      CHECK: hal.executable.export public @matmul_aarch_i8_i8_i32_dynamic
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.matmul
 // CHECK-SAME:       lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_riscv_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_riscv_launch_configuration.mlir
@@ -16,7 +16,7 @@ hal.executable private @matmul_riscv  {
       native_vector_size = 0 : index,
       target_triple = "riscv32-unknown-unknown-eabi-elf"
     }> {
-    hal.executable.entry_point public @matmul_riscv layout(#executable_layout)
+    hal.executable.export public @matmul_riscv layout(#executable_layout)
     builtin.module {
       func.func @matmul_riscv() {
         %cst = arith.constant 0.0 : f32
@@ -41,7 +41,7 @@ hal.executable private @matmul_riscv  {
 
 //  CHECK-DAG: #[[CONFIG:.+]] =  #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 64, 0], [8, 32, 0], [0, 0, 16]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingPadExpert>
-//      CHECK: hal.executable.entry_point public @matmul_riscv
+//      CHECK: hal.executable.export public @matmul_riscv
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.matmul
 // CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_vmvx_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_vmvx_launch_configuration.mlir
@@ -9,7 +9,7 @@
 ]>
 hal.executable private @matmul_static  {
   hal.executable.variant @vmvx_bytecode_fb, target = <"vmvx", "vmvx-bytecode-fb"> {
-    hal.executable.entry_point public @matmul_static layout(#executable_layout)
+    hal.executable.export public @matmul_static layout(#executable_layout)
     builtin.module {
       func.func @matmul_static() {
         %cst = arith.constant 0.0 : f32
@@ -34,7 +34,7 @@ hal.executable private @matmul_static  {
 
 //  CHECK-DAG: #[[CONFIG:.+]] =  #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
-//      CHECK: hal.executable.entry_point public @matmul_static
+//      CHECK: hal.executable.export public @matmul_static
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.matmul
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -49,7 +49,7 @@ hal.executable private @matmul_static  {
 ]>
 hal.executable @copy_op_dynamic {
   hal.executable.variant @vmvx_bytecode_fb, target = <"vmvx", "vmvx-bytecode-fb"> {
-    hal.executable.entry_point @copy_op_dynamic layout(#executable_layout)
+    hal.executable.export @copy_op_dynamic layout(#executable_layout)
     builtin.module {
       func.func @copy_op_dynamic() {
         %d0 = hal.interface.constant.load[0] : index
@@ -75,7 +75,7 @@ hal.executable @copy_op_dynamic {
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
-//      CHECK: hal.executable.entry_point public @copy_op_dynamic
+//      CHECK: hal.executable.export public @copy_op_dynamic
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
@@ -90,7 +90,7 @@ hal.executable @copy_op_dynamic {
 ]>
 hal.executable private @static_1d_fft_stage2  {
   hal.executable.variant @vmvx_bytecode_fb, target = <"vmvx", "vmvx-bytecode-fb"> {
-    hal.executable.entry_point @static_1d_fft_stage2 layout(#executable_layout)
+    hal.executable.export @static_1d_fft_stage2 layout(#executable_layout)
     builtin.module {
       func.func @static_1d_fft_stage2() {
         %c0 = arith.constant 0 : index
@@ -112,7 +112,7 @@ hal.executable private @static_1d_fft_stage2  {
 
 //   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64]{{\]}}>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
-//       CHECK: hal.executable.entry_point public @static_1d_fft_stage2
+//       CHECK: hal.executable.export public @static_1d_fft_stage2
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: func.func @static_1d_fft_stage2()
 //       CHECK:   iree_linalg_ext.fft

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_x86_64_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_x86_64_launch_configuration.mlir
@@ -13,7 +13,7 @@ hal.executable private @matvec_static  {
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
   }> {
-    hal.executable.entry_point @matvec_static layout(#executable_layout)
+    hal.executable.export @matvec_static layout(#executable_layout)
     builtin.module {
       func.func @matvec_static() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -34,7 +34,7 @@ hal.executable private @matvec_static  {
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 0], [32, 0], [0, 16]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
-//      CHECK: hal.executable.entry_point public @matvec_static
+//      CHECK: hal.executable.export public @matvec_static
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.matvec
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -54,7 +54,7 @@ hal.executable private @matvec_dynamic  {
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
   }> {
-    hal.executable.entry_point @matvec_dynamic layout(#executable_layout)
+    hal.executable.export @matvec_dynamic layout(#executable_layout)
     builtin.module {
       func.func @matvec_dynamic() {
         %c0 = arith.constant 0 : index
@@ -83,7 +83,7 @@ hal.executable private @matvec_dynamic  {
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 0], [1, 0], [0, 1]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
-//      CHECK: hal.executable.entry_point public @matvec_dynamic
+//      CHECK: hal.executable.export public @matvec_dynamic
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.matvec
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -103,7 +103,7 @@ hal.executable private @dot_static  {
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
   }> {
-    hal.executable.entry_point @dot_static layout(#executable_layout)
+    hal.executable.export @dot_static layout(#executable_layout)
     builtin.module {
       func.func @dot_static() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -124,7 +124,7 @@ hal.executable private @dot_static  {
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0], [0], [16]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
-//      CHECK: hal.executable.entry_point public @dot_static
+//      CHECK: hal.executable.export public @dot_static
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.dot
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -144,7 +144,7 @@ hal.executable private @dot_dynamic  {
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
   }> {
-    hal.executable.entry_point @dot_dynamic layout(#executable_layout)
+    hal.executable.export @dot_dynamic layout(#executable_layout)
     builtin.module {
       func.func @dot_dynamic() {
         %c0 = arith.constant 0 : index
@@ -169,7 +169,7 @@ hal.executable private @dot_dynamic  {
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0], [0], [1]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
-//      CHECK: hal.executable.entry_point public @dot_dynamic
+//      CHECK: hal.executable.export public @dot_dynamic
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.dot
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -189,7 +189,7 @@ hal.executable private @add {
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
   }> {
-    hal.executable.entry_point @add layout(#executable_layout)
+    hal.executable.export @add layout(#executable_layout)
     builtin.module {
       func.func @add() {
         %c0 = arith.constant 0 : index
@@ -219,7 +219,7 @@ hal.executable private @add {
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64], [1, 1], [0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
-//      CHECK: hal.executable.entry_point public @add
+//      CHECK: hal.executable.export public @add
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.generic
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -241,7 +241,7 @@ hal.executable private @add4D  {
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
   }> {
-    hal.executable.entry_point @add4D layout(#executable_layout)
+    hal.executable.export @add4D layout(#executable_layout)
     builtin.module {
       func.func @add4D() {
         %d0 = hal.interface.constant.load[0] : index
@@ -277,7 +277,7 @@ hal.executable private @add4D  {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 64, 64, 64], [1, 1, 1, 1], [0, 0, 0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
-//      CHECK: hal.executable.entry_point public @add4D
+//      CHECK: hal.executable.export public @add4D
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.generic
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -297,7 +297,7 @@ hal.executable private @add_static {
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
   }> {
-    hal.executable.entry_point @add_static layout(#executable_layout)
+    hal.executable.export @add_static layout(#executable_layout)
     builtin.module {
       func.func @add_static() {
         %c0 = arith.constant 0 : index
@@ -318,7 +318,7 @@ hal.executable private @add_static {
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 8, 16, 64], [1, 1, 1, 4], [0, 0, 0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
-//      CHECK: hal.executable.entry_point public @add_static
+//      CHECK: hal.executable.export public @add_static
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.generic
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -338,7 +338,7 @@ hal.executable private @add_static {
 ]>
 hal.executable private @preset_config_matmul_tensors  {
   hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
-    hal.executable.entry_point @preset_config layout(#executable_layout)
+    hal.executable.export @preset_config layout(#executable_layout)
     builtin.module {
       func.func @preset_config() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -367,7 +367,7 @@ hal.executable private @preset_config_matmul_tensors  {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0], [32, 32, 0], [0, 0, 32]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
-//      CHECK: hal.executable.entry_point
+//      CHECK: hal.executable.export
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: func.func @preset_config
 //      CHECK:   linalg.matmul
@@ -383,7 +383,7 @@ hal.executable private @preset_config_matmul_tensors  {
 ]>
 hal.executable @copy_op_dynamic {
   hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
-    hal.executable.entry_point @copy_op_dynamic layout(#executable_layout)
+    hal.executable.export @copy_op_dynamic layout(#executable_layout)
     builtin.module {
       func.func @copy_op_dynamic() {
         %d0 = hal.interface.constant.load[0] : index
@@ -410,7 +410,7 @@ hal.executable @copy_op_dynamic {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64], [1, 1], [0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUBufferOpsTileAndVectorize>
-//      CHECK: hal.executable.entry_point public @copy_op_dynamic
+//      CHECK: hal.executable.export public @copy_op_dynamic
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
@@ -425,7 +425,7 @@ hal.executable @copy_op_dynamic {
 ]>
 hal.executable private @static_1d_fft_stage2  {
   hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
-    hal.executable.entry_point @static_1d_fft_stage2 layout(#executable_layout)
+    hal.executable.export @static_1d_fft_stage2 layout(#executable_layout)
     builtin.module {
       func.func @static_1d_fft_stage2() {
         %c0 = arith.constant 0 : index
@@ -447,7 +447,7 @@ hal.executable private @static_1d_fft_stage2  {
 
 //   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64]{{\]}}>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
-//       CHECK: hal.executable.entry_point public @static_1d_fft_stage2
+//       CHECK: hal.executable.export public @static_1d_fft_stage2
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: func.func @static_1d_fft_stage2()
 //       CHECK:   iree_linalg_ext.fft
@@ -463,7 +463,7 @@ hal.executable private @static_1d_fft_stage2  {
 ]>
 hal.executable private @static_3d_fft_stage3  {
   hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
-    hal.executable.entry_point @static_3d_fft_stage3 layout(#executable_layout)
+    hal.executable.export @static_3d_fft_stage3 layout(#executable_layout)
     builtin.module {
       func.func @static_3d_fft_stage3() {
         %c3 = arith.constant 3 : index
@@ -484,7 +484,7 @@ hal.executable private @static_3d_fft_stage3  {
 
 //   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 64]{{\]}}>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
-//       CHECK: hal.executable.entry_point public @static_3d_fft_stage3
+//       CHECK: hal.executable.export public @static_3d_fft_stage3
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: func.func @static_3d_fft_stage3()
 //       CHECK:   iree_linalg_ext.fft
@@ -501,7 +501,7 @@ hal.executable private @static_3d_fft_stage3  {
 ]>
 hal.executable private @outs_fusion {
   hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
-    hal.executable.entry_point @outs_fusion_fn layout(#executable_layout)
+    hal.executable.export @outs_fusion_fn layout(#executable_layout)
     builtin.module {
       func.func @outs_fusion_fn() {
         %cst = arith.constant 0.0 : f32
@@ -546,7 +546,7 @@ hal.executable private @outs_fusion {
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0], [1, 1, 0], [0, 0, 1]{{\]}}>
 //      CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
-//      CHECK: hal.executable.entry_point public @outs_fusion_fn
+//      CHECK: hal.executable.export public @outs_fusion_fn
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 //      CHECK: func.func @outs_fusion_fn()
 //      CHECK:   linalg.generic
@@ -569,7 +569,7 @@ hal.executable private @conv_dynamic {
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
   }> {
-    hal.executable.entry_point public @conv_dynamic layout(#executable_layout)
+    hal.executable.export public @conv_dynamic layout(#executable_layout)
     builtin.module {
       func.func @conv_dynamic() {
         %N = hal.interface.constant.load[0] : index
@@ -606,7 +606,7 @@ hal.executable private @conv_dynamic {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 64, 64, 64, 0, 0, 0], [1, 1, 1, 1, 0, 0, 0], [0, 0, 0, 0, 1, 1, 1]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUConvTileAndDecomposeExpert>
-//      CHECK: hal.executable.entry_point public @conv_dynamic
+//      CHECK: hal.executable.export public @conv_dynamic
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:     linalg.conv_2d_nhwc_hwcf
 //      CHECK:         lowering_config = #[[CONFIG]]
@@ -626,7 +626,7 @@ hal.executable private @conv_static {
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
   }> {
-    hal.executable.entry_point public @conv_static layout(#executable_layout)
+    hal.executable.export public @conv_static layout(#executable_layout)
     builtin.module {
       func.func @conv_static() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -648,7 +648,7 @@ hal.executable private @conv_static {
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 28, 28, 16, 0, 0, 0], [1, 1, 4, 8, 0, 0, 0], [0, 0, 0, 0, 1, 1, 3]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUConvTileAndDecomposeExpert>
-//      CHECK: hal.executable.entry_point public @conv_static
+//      CHECK: hal.executable.export public @conv_static
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:     linalg.conv_2d_nhwc_hwcf
 
@@ -668,7 +668,7 @@ hal.executable private @depthwise_conv_static {
     native_vector_size = 64 : index,
     target_triple = "x86_64-unknown-linux-gnu"
   }> {
-    hal.executable.entry_point public @depthwise_conv_static layout(#executable_layout)
+    hal.executable.export public @depthwise_conv_static layout(#executable_layout)
     builtin.module {
       func.func @depthwise_conv_static() {
         %cst = arith.constant 0.0 : f32
@@ -695,7 +695,7 @@ hal.executable private @depthwise_conv_static {
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 40, 40, 48, 0, 0], [1, 1, 8, 16, 0, 0], [0, 0, 0, 0, 1, 3]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUConvTileAndDecomposeExpert>
-//      CHECK: hal.executable.entry_point public @depthwise_conv_static
+//      CHECK: hal.executable.export public @depthwise_conv_static
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:     linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK-SAME:       lowering_config  = #[[CONFIG]]
@@ -714,7 +714,7 @@ hal.executable private @generic_static {
     native_vector_size = 64 : index,
     target_triple = "x86_64-pc-linux-gnu"
   }> {
-    hal.executable.entry_point public @generic_static layout(#executable_layout)
+    hal.executable.export public @generic_static layout(#executable_layout)
     builtin.module {
       func.func @generic_static() {
         %input_binding = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
@@ -740,7 +740,7 @@ hal.executable private @generic_static {
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[16, 32], [16, 16], [0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
-//      CHECK: hal.executable.entry_point public @generic_static
+//      CHECK: hal.executable.export public @generic_static
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
 //      CHECK:       lowering_config = #[[CONFIG]]
@@ -762,7 +762,7 @@ hal.executable private @matmul_static  {
       native_vector_size = 16 : index,
       target_triple = "x86_64-unknown-unknown-eabi-elf"
     }> {
-    hal.executable.entry_point public @matmul_static layout(#executable_layout)
+    hal.executable.export public @matmul_static layout(#executable_layout)
     builtin.module {
       func.func @matmul_static() {
         %cst = arith.constant 0.0 : f32
@@ -787,7 +787,7 @@ hal.executable private @matmul_static  {
 
 //  CHECK-DAG: #[[CONFIG:.+]] =  #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 64, 0], [8, 32, 0], [0, 0, 16]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingPadExpert>
-//      CHECK: hal.executable.entry_point public @matmul_static
+//      CHECK: hal.executable.export public @matmul_static
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.matmul
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -810,7 +810,7 @@ hal.executable private @matmul_static  {
 >
 hal.executable private @reduction {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @predict_dispatch_86 ordinal(0) layout(#executable_layout)
+    hal.executable.export public @predict_dispatch_86 ordinal(0) layout(#executable_layout)
     builtin.module  {
       func.func @predict_dispatch_86(%arg0: !flow.dispatch.tensor<readonly:7x7x2048xf32>,
           %arg1: !flow.dispatch.tensor<writeonly:7xf32>) {
@@ -845,7 +845,7 @@ hal.executable private @reduction {
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 0, 0], [1, 0, 0], [0, 1, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
-//      CHECK: hal.executable.entry_point public @predict_dispatch_86
+//      CHECK: hal.executable.export public @predict_dispatch_86
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.generic {indexing_maps = [#{{.+}}, #{{.+}}], iterator_types = ["parallel", "reduction", "reduction"]}
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -867,7 +867,7 @@ hal.executable private @matmul_i8_i8_i32_static  {
       native_vector_size = 4 : index,
       target_triple = "x86_64-unknown-unknown-eabi-elf"
     }> {
-    hal.executable.entry_point public @matmul_i8_i8_i32_static layout(#executable_layout)
+    hal.executable.export public @matmul_i8_i8_i32_static layout(#executable_layout)
     builtin.module {
       func.func @matmul_i8_i8_i32_static() {
         %c0_i32 = arith.constant 0 : i32
@@ -889,7 +889,7 @@ hal.executable private @matmul_i8_i8_i32_static  {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 128, 0], [8, 32, 0], [0, 0, 16]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingPadExpert>
-//      CHECK: hal.executable.entry_point public @matmul_i8_i8_i32_static
+//      CHECK: hal.executable.export public @matmul_i8_i8_i32_static
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.matmul
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
@@ -914,7 +914,7 @@ hal.executable private @matmul_i8_i8_i32_static  {
 #map1 = affine_map<(d0)[s0, s1] -> (s1, -d0 + s0)>
 hal.executable private @gemm_unit_N {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @gemm_unit_N ordinal(0) layout(#executable_layout)
+    hal.executable.export public @gemm_unit_N ordinal(0) layout(#executable_layout)
     builtin.module  {
       func.func @gemm_unit_N() {
         %c0 = arith.constant 0 : index
@@ -942,7 +942,7 @@ hal.executable private @gemm_unit_N {
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 0, 0], [8, 32, 0], [0, 0, 16]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingPadExpert>
-//      CHECK: hal.executable.entry_point public @gemm_unit_N
+//      CHECK: hal.executable.export public @gemm_unit_N
 // CHECK-SAME:       translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.matmul
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
@@ -965,7 +965,7 @@ hal.executable private @gemm_unit_N {
 >
 hal.executable private @gemm_unit_M_unit_N {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @gemm_unit_M_unit_N ordinal(0) layout(#executable_layout)
+    hal.executable.export public @gemm_unit_M_unit_N ordinal(0) layout(#executable_layout)
     builtin.module  {
       func.func @gemm_unit_M_unit_N() {
         %c0 = arith.constant 0 : index
@@ -989,7 +989,7 @@ hal.executable private @gemm_unit_M_unit_N {
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 0], [8, 32, 0], [0, 0, 16]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingPadExpert>
-//      CHECK: hal.executable.entry_point public @gemm_unit_M_unit_N
+//      CHECK: hal.executable.export public @gemm_unit_M_unit_N
 // CHECK-SAME:       translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.matmul
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
@@ -1012,7 +1012,7 @@ hal.executable private @gemm_unit_M_unit_N {
 >
 hal.executable private @matmul_odd {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @matmul_odd ordinal(0) layout(#executable_layout)
+    hal.executable.export public @matmul_odd ordinal(0) layout(#executable_layout)
     builtin.module {
       func.func @matmul_odd() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -1035,7 +1035,7 @@ hal.executable private @matmul_odd {
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[11, 7, 0], [8, 32, 0], [0, 0, 16]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingPadExpert>
-//      CHECK: hal.executable.entry_point public @matmul_odd
+//      CHECK: hal.executable.export public @matmul_odd
 // CHECK-SAME:       translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.matmul
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
@@ -1055,7 +1055,7 @@ hal.executable private @generic_unit_dims_dynamic {
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
   }> {
-    hal.executable.entry_point @generic_unit_dims_dynamic layout(#executable_layout)
+    hal.executable.export @generic_unit_dims_dynamic layout(#executable_layout)
     builtin.module {
       func.func @generic_unit_dims_dynamic() {
         %c0 = arith.constant 0 : index
@@ -1090,7 +1090,7 @@ hal.executable private @generic_unit_dims_dynamic {
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 0, 0, 64, 64, 0, 64], [0, 1, 0, 0, 1, 1, 0, 1], [0, 0, 0, 0, 0, 0, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
-//      CHECK: hal.executable.entry_point public @generic_unit_dims_dynamic
+//      CHECK: hal.executable.export public @generic_unit_dims_dynamic
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.generic
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -1110,7 +1110,7 @@ hal.executable private @reduce_to_scalar_static {
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
   }> {
-    hal.executable.entry_point @reduce_to_scalar_static layout(#executable_layout)
+    hal.executable.export @reduce_to_scalar_static layout(#executable_layout)
     builtin.module {
       func.func @reduce_to_scalar_static() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -1133,7 +1133,7 @@ hal.executable private @reduce_to_scalar_static {
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0], [0], [4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
-//      CHECK: hal.executable.entry_point public @reduce_to_scalar_static
+//      CHECK: hal.executable.export public @reduce_to_scalar_static
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.generic
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -1153,7 +1153,7 @@ hal.executable private @reduce_to_scalar_dynamic {
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
   }> {
-    hal.executable.entry_point @reduce_to_scalar_dynamic layout(#executable_layout)
+    hal.executable.export @reduce_to_scalar_dynamic layout(#executable_layout)
     builtin.module {
       func.func @reduce_to_scalar_dynamic() {
         %c0 = arith.constant 0 : index
@@ -1178,7 +1178,7 @@ hal.executable private @reduce_to_scalar_dynamic {
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0], [0], [1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
-//      CHECK: hal.executable.entry_point public @reduce_to_scalar_dynamic
+//      CHECK: hal.executable.export public @reduce_to_scalar_dynamic
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.generic
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -1198,7 +1198,7 @@ hal.executable private @scalar {
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
   }> {
-    hal.executable.entry_point @scalar layout(#executable_layout)
+    hal.executable.export @scalar layout(#executable_layout)
     builtin.module {
       func.func @scalar() {
         %c0 = arith.constant 0 : index
@@ -1222,7 +1222,7 @@ hal.executable private @scalar {
   }
 }
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
-//      CHECK: hal.executable.entry_point public @scalar
+//      CHECK: hal.executable.export public @scalar
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 
 // -----
@@ -1245,7 +1245,7 @@ hal.executable private @scalar {
 
 hal.executable private @transpose_8x8 {
   hal.executable.variant @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point @transpose_8x8 layout(#executable_layout)
+    hal.executable.export @transpose_8x8 layout(#executable_layout)
     builtin.module {
       func.func @transpose_8x8() {
         %cst = arith.constant 0.000000e+00 : f32

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
@@ -22,7 +22,7 @@
   >]>
 hal.executable private @check_no_cse {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @check_no_cse ordinal(0) layout(#executable_layout5)
+    hal.executable.export public @check_no_cse ordinal(0) layout(#executable_layout5)
     builtin.module {
       func.func @check_no_cse() {
         %cst = arith.constant 3.840000e+02 : f32
@@ -77,7 +77,7 @@ hal.executable private @check_no_cse {
 ]>
 hal.executable private @preset_config_matmul  {
   hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
-    hal.executable.entry_point @preset_config_matmul layout(#executable_layout)
+    hal.executable.export @preset_config_matmul layout(#executable_layout)
     builtin.module {
       func.func @preset_config_matmul() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -123,7 +123,7 @@ hal.executable private @preset_config_matmul  {
   >]>
 hal.executable private @check_buffer_ops_vectorization {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point public @check_buffer_ops_vectorization ordinal(0) layout(#executable_layout)
+    hal.executable.export public @check_buffer_ops_vectorization ordinal(0) layout(#executable_layout)
     builtin.module {
       func.func @check_buffer_ops_vectorization() {
         %c0 = arith.constant 0 : index
@@ -158,7 +158,7 @@ hal.executable private @vectorize_fill_conv2d_generic {
       native_vector_size = 16 : index,
       target_triple = "x86_64-unknown-unknown-eabi-elf"
     }> {
-    hal.executable.entry_point public @vectorize_fill_conv2d_generic ordinal(0) layout(
+    hal.executable.export public @vectorize_fill_conv2d_generic ordinal(0) layout(
       #hal.executable.layout<push_constants = 0, sets = [
         #hal.descriptor_set.layout<0, bindings = [
           #hal.descriptor_set.binding<0, storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/test_config_mmt4d.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/test_config_mmt4d.mlir
@@ -13,7 +13,7 @@
 #map4 = affine_map<(d0)[s0] -> (s0, -d0 + 128)>
 hal.executable private @mmt4d_384x384x512_4x1x4_dispatch_0 {
   hal.executable.variant public @embedded_elf_arm_64, target = #executable_target_embedded_elf_arm_64_ {
-    hal.executable.entry_point public @mmt4d_384x384x512_4x1x4_dispatch_0 layout(#executable_layout)
+    hal.executable.export public @mmt4d_384x384x512_4x1x4_dispatch_0 layout(#executable_layout)
     builtin.module  {
       func.func @mmt4d_384x384x512_4x1x4_dispatch_0() {
         %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transpose_avx2_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transpose_avx2_lowering.mlir
@@ -18,7 +18,7 @@
 
 hal.executable private @transpose_10_8x8_pattern {
   hal.executable.variant @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point @transpose_10_8x8_pattern layout(#executable_layout)
+    hal.executable.export @transpose_10_8x8_pattern layout(#executable_layout)
     builtin.module {
       func.func @transpose_10_8x8_pattern() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -72,7 +72,7 @@ hal.executable private @transpose_10_8x8_pattern {
 
 hal.executable private @transpose_021_8x8_pattern {
   hal.executable.variant @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point @transpose_021_8x8_pattern layout(#executable_layout)
+    hal.executable.export @transpose_021_8x8_pattern layout(#executable_layout)
     builtin.module {
       func.func @transpose_021_8x8_pattern() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -126,7 +126,7 @@ hal.executable private @transpose_021_8x8_pattern {
 
 hal.executable private @transpose_201_8x8_pattern {
   hal.executable.variant @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point @transpose_201_8x8_pattern layout(#executable_layout)
+    hal.executable.export @transpose_201_8x8_pattern layout(#executable_layout)
     builtin.module {
       func.func @transpose_201_8x8_pattern() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -180,7 +180,7 @@ hal.executable private @transpose_201_8x8_pattern {
 
 hal.executable private @transpose_210_8x8_pattern {
   hal.executable.variant @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point @transpose_210_8x8_pattern layout(#executable_layout)
+    hal.executable.export @transpose_210_8x8_pattern layout(#executable_layout)
     builtin.module {
       func.func @transpose_210_8x8_pattern() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -234,7 +234,7 @@ hal.executable private @transpose_210_8x8_pattern {
 
 hal.executable private @transpose_120_8x8_pattern {
   hal.executable.variant @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point @transpose_120_8x8_pattern layout(#executable_layout)
+    hal.executable.export @transpose_120_8x8_pattern layout(#executable_layout)
     builtin.module {
       func.func @transpose_120_8x8_pattern() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -288,7 +288,7 @@ hal.executable private @transpose_120_8x8_pattern {
 
 hal.executable private @transpose_102 {
   hal.executable.variant @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point @transpose_102 layout(#executable_layout)
+    hal.executable.export @transpose_102 layout(#executable_layout)
     builtin.module {
       func.func @transpose_102() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -334,7 +334,7 @@ hal.executable private @transpose_102 {
 
 hal.executable private @test_no_avx2_feature {
   hal.executable.variant @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.entry_point @test_no_avx2_feature layout(#executable_layout)
+    hal.executable.export @test_no_avx2_feature layout(#executable_layout)
     builtin.module {
       func.func @test_no_avx2_feature() {
         %cst = arith.constant 0.000000e+00 : f32

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
@@ -82,10 +82,9 @@ void ConvertToDynamicSharedMemory(ModuleOp moduleOp) {
   // Add the amount of shared memory required as an attribute.
   auto variantOp = moduleOp->getParentOfType<IREE::HAL::ExecutableVariantOp>();
   if (variantOp != nullptr) {
-    for (auto entryPointOp :
-         variantOp.getOps<IREE::HAL::ExecutableEntryPointOp>()) {
-      entryPointOp->setAttr(entryPointOp.workgroup_local_memoryAttrName(),
-                            builder.getIndexAttr(numberOfBytes));
+    for (auto exportOp : variantOp.getOps<IREE::HAL::ExecutableExportOp>()) {
+      exportOp->setAttr(exportOp.workgroup_local_memoryAttrName(),
+                        builder.getIndexAttr(numberOfBytes));
     }
   }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -443,13 +443,13 @@ namespace mlir {
 namespace iree_compiler {
 
 LogicalResult initGPULaunchConfig(ModuleOp moduleOp) {
-  llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> entryPointOps =
+  llvm::StringMap<IREE::HAL::ExecutableExportOp> exportOps =
       getAllEntryPoints(moduleOp);
 
   for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {
-    auto entryPointOp = entryPointOps.lookup(funcOp.getName());
-    if (!entryPointOp) continue;
-    if (getTranslationInfo(entryPointOp)) continue;
+    auto exportOp = exportOps.lookup(funcOp.getName());
+    if (!exportOp) continue;
+    if (getTranslationInfo(exportOp)) continue;
     SmallVector<Operation *> computeOps;
     SmallVector<LoopTilingAndDistributionInfo> tiledLoops;
     if (failed(getComputeOps(funcOp, computeOps, tiledLoops))) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
@@ -12,7 +12,7 @@
 ]>
 hal.executable @abs_ex_dispatch_0 {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @abs_ex_dispatch_0 layout(#executable_layout)
+    hal.executable.export @abs_ex_dispatch_0 layout(#executable_layout)
     builtin.module {
       func.func @abs_ex_dispatch_0() {
         %c0 = arith.constant 0 : index
@@ -61,7 +61,7 @@ hal.executable @abs_ex_dispatch_0 {
 ]>
 hal.executable @abs_dynamic {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @abs_dynamic layout(#executable_layout)
+    hal.executable.export @abs_dynamic layout(#executable_layout)
     builtin.module {
       func.func @abs_dynamic() {
         %c0 = arith.constant 0 : index
@@ -113,7 +113,7 @@ hal.executable @abs_dynamic {
 ]>
 hal.executable @dead_symbol {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @dead_symbol layout(#executable_layout)
+    hal.executable.export @dead_symbol layout(#executable_layout)
     builtin.module {
       func.func @dead_symbol() {
         %c0 = arith.constant 0 : index
@@ -151,7 +151,7 @@ hal.executable @dead_symbol {
 ]>
 hal.executable @mixed_type {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @mixed_type layout(#executable_layout)
+    hal.executable.export @mixed_type layout(#executable_layout)
     builtin.module {
       func.func @mixed_type() {
         %c0 = arith.constant 0 : index
@@ -196,7 +196,7 @@ hal.executable @mixed_type {
 ]>
 hal.executable @shared_memory_lowering {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @shared_memory_lowering layout(#executable_layout)
+    hal.executable.export @shared_memory_lowering layout(#executable_layout)
     builtin.module {
       func.func @shared_memory_lowering() {
         %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
@@ -12,7 +12,7 @@
 ]>
 hal.executable @abs_ex_dispatch_0 {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @abs_ex_dispatch_0 layout(#executable_layout)
+    hal.executable.export @abs_ex_dispatch_0 layout(#executable_layout)
     builtin.module {
       func.func @abs_ex_dispatch_0() {
         %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/distribute_to_thread.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/distribute_to_thread.mlir
@@ -17,7 +17,7 @@
 #map4 = affine_map<(d0, d1)[s0] -> (d0 * 1024 + s0 + d1)>
 hal.executable private @dot_dispatch_0  {
   hal.executable.variant @cuda, target = #executable_target_cuda_nvptx_fb {
-    hal.executable.entry_point @dot_dispatch_0 layout(#executable_layout) {
+    hal.executable.export @dot_dispatch_0 layout(#executable_layout) {
       translation_info = #translation,
       workgroup_size = [64 : index, 1 : index, 1 : index]
     }
@@ -96,7 +96,7 @@ hal.executable private @dot_dispatch_0  {
 ]>
 hal.executable private @batch_matmul_func  {
   hal.executable.variant @cuda, target = #executable_target_cuda_nvptx_fb {
-    hal.executable.entry_point @batch_matmul_func layout(#executable_layout) {
+    hal.executable.export @batch_matmul_func layout(#executable_layout) {
       translation_info = #translation,
       workgroup_size = [8 : index, 8 : index, 1 : index]
     }
@@ -176,7 +176,7 @@ builtin.module {
 #map4 = affine_map<(d0, d1)[s0] -> (d0 * 1024 + s0 + d1)>
 hal.executable private @dot_dispatch_0  {
   hal.executable.variant @cuda, target = #executable_target_cuda_nvptx_fb {
-    hal.executable.entry_point @dot_dispatch_0 layout(#executable_layout) {
+    hal.executable.export @dot_dispatch_0 layout(#executable_layout) {
       translation_info = #translation,
       workgroup_size = [64 : index, 8 : index, 1 : index]
     }
@@ -258,7 +258,7 @@ hal.executable private @dot_dispatch_0  {
 // Pure reducion case, skip tiling.
 hal.executable @reduction_dispatch {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @predict_dispatch_153 layout(#executable_layout) {
+    hal.executable.export @predict_dispatch_153 layout(#executable_layout) {
       translation_info = #translation,
       workgroup_size = [1: index, 1: index, 1: index]
     }
@@ -305,7 +305,7 @@ hal.executable @reduction_dispatch {
 ]>
 hal.executable private @conv_dispatch  {
   hal.executable.variant @cuda, target = #executable_target_cuda_nvptx_fb {
-    hal.executable.entry_point @conv_dispatch layout(#executable_layout) {
+    hal.executable.export @conv_dispatch layout(#executable_layout) {
       translation_info = #translation,
       workgroup_size = [64 : index, 1 : index, 1 : index]
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
@@ -9,7 +9,7 @@
 ]>
 hal.executable @add_dispatch_0 {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-  hal.executable.entry_point @add_dispatch_0 layout(#executable_layout)
+  hal.executable.export @add_dispatch_0 layout(#executable_layout)
   builtin.module {
     func.func @add_dispatch_0() {
       %c0 = arith.constant 0 : index
@@ -33,7 +33,7 @@ hal.executable @add_dispatch_0 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[256]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorize>
-//      CHECK: hal.executable.entry_point public @add_dispatch_0
+//      CHECK: hal.executable.export public @add_dispatch_0
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 // CHECK-SAME:     workgroup_size = [64 : index, 1 : index, 1 : index]
 //      CHECK: func.func @add_dispatch_0
@@ -51,7 +51,7 @@ hal.executable @add_dispatch_0 {
 ]>
 hal.executable private @dot_dispatch_1  {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @dot_dispatch_1 layout(#executable_layout)
+    hal.executable.export @dot_dispatch_1 layout(#executable_layout)
     builtin.module {
       func.func @dot_dispatch_1() {
         %c0 = arith.constant 0 : index
@@ -71,7 +71,7 @@ hal.executable private @dot_dispatch_1  {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[4, 2, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUMatmulSimt>
-//      CHECK: hal.executable.entry_point public @dot_dispatch_1
+//      CHECK: hal.executable.export public @dot_dispatch_1
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 // CHECK-SAME:     workgroup_size = [2 : index, 4 : index, 1 : index]
 //      CHECK: func.func @dot_dispatch_1
@@ -90,7 +90,7 @@ hal.executable private @dot_dispatch_1  {
 ]>
 hal.executable @reduction_dispatch {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @predict_dispatch_153 layout(#executable_layout)
+    hal.executable.export @predict_dispatch_153 layout(#executable_layout)
     builtin.module {
       func.func @predict_dispatch_153() {
         %c0 = arith.constant 0 : index
@@ -115,7 +115,7 @@ hal.executable @reduction_dispatch {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUDistribute>
-//      CHECK: hal.executable.entry_point public @predict_dispatch_153
+//      CHECK: hal.executable.export public @predict_dispatch_153
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.fill
 // CHECK-SAME:   lowering_config = #[[CONFIG]]
@@ -131,7 +131,7 @@ hal.executable @reduction_dispatch {
 ]>
 hal.executable private @reduction_aligned2 {
   hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point public @reduction_aligned2 ordinal(0) layout(#executable_layout)
+    hal.executable.export public @reduction_aligned2 ordinal(0) layout(#executable_layout)
     builtin.module {
       func.func @reduction_aligned2() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -159,7 +159,7 @@ hal.executable private @reduction_aligned2 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 128, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorize>
-//      CHECK: hal.executable.entry_point public @reduction_aligned2
+//      CHECK: hal.executable.export public @reduction_aligned2
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.fill
 // CHECK-SAME:   lowering_config = #[[CONFIG]]
@@ -176,7 +176,7 @@ hal.executable private @reduction_aligned2 {
 ]>
 hal.executable @copy_as_generic {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @copy_as_generic layout(#executable_layout)
+    hal.executable.export @copy_as_generic layout(#executable_layout)
     builtin.module {
       func.func @copy_as_generic() {
         %c0 = arith.constant 0 : index
@@ -197,7 +197,7 @@ hal.executable @copy_as_generic {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorize>
-//      CHECK: hal.executable.entry_point public @copy_as_generic
+//      CHECK: hal.executable.export public @copy_as_generic
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.generic
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -212,7 +212,7 @@ hal.executable @copy_as_generic {
 ]>
 hal.executable private @static_1d_fft_stage2 {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @static_1d_fft_stage2 layout(#executable_layout)
+    hal.executable.export @static_1d_fft_stage2 layout(#executable_layout)
     builtin.module {
       func.func @static_1d_fft_stage2() {
         %c0 = arith.constant 0 : index
@@ -234,7 +234,7 @@ hal.executable private @static_1d_fft_stage2 {
 
 //   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[4]{{\]}}>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUDistribute>
-//       CHECK: hal.executable.entry_point public @static_1d_fft_stage2
+//       CHECK: hal.executable.export public @static_1d_fft_stage2
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: iree_linalg_ext.fft
 //  CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -249,7 +249,7 @@ hal.executable private @static_1d_fft_stage2 {
 ]>
 hal.executable private @static_3d_fft_stage3 {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @static_3d_fft_stage3 layout(#executable_layout)
+    hal.executable.export @static_3d_fft_stage3 layout(#executable_layout)
     builtin.module {
       func.func @static_3d_fft_stage3() {
         %c0 = arith.constant 0 : index
@@ -274,7 +274,7 @@ hal.executable private @static_3d_fft_stage3 {
 
 //   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 1, 8]{{\]}}>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUDistribute>
-//       CHECK: hal.executable.entry_point public @static_3d_fft_stage3
+//       CHECK: hal.executable.export public @static_3d_fft_stage3
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: iree_linalg_ext.fft
 //  CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -294,7 +294,7 @@ hal.executable private @static_3d_fft_stage3 {
 ]>
 hal.executable @user_config {
 hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb"> {
-  hal.executable.entry_point public @_lowering_config_test_dispatch_1 layout(#executable_layout)
+  hal.executable.export public @_lowering_config_test_dispatch_1 layout(#executable_layout)
   builtin.module {
     func.func @_lowering_config_test_dispatch_1() {
       %cst = arith.constant 0.000000e+00 : f32
@@ -321,7 +321,7 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb">
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 128, 64]{{\]}}
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUMatmulSimt workload_per_wg = [256, 32]>
-//      CHECK: hal.executable.entry_point public @_lowering_config_test_dispatch_1
+//      CHECK: hal.executable.export public @_lowering_config_test_dispatch_1
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 // CHECK-SAME:     workgroup_size = [16 : index, 8 : index, 1 : index]
 //      CHECK: linalg.fill
@@ -341,7 +341,7 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb">
 ]>
 hal.executable private @sort_op {
   hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_35"}> {
-    hal.executable.entry_point public @sort_op layout(#executable_layout)
+    hal.executable.export public @sort_op layout(#executable_layout)
     builtin.module {
       func.func @sort_op() {
         %c1 = arith.constant 1 : index
@@ -370,7 +370,7 @@ hal.executable private @sort_op {
 
 //   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64]{{\]}}>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUDistribute>
-//       CHECK: hal.executable.entry_point public @sort_op
+//       CHECK: hal.executable.export public @sort_op
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: iree_linalg_ext.sort
 //  CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/illegal_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/illegal_configuration.mlir
@@ -11,7 +11,7 @@
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @illegal layout(#executable_layout) {
+    hal.executable.export @illegal layout(#executable_layout) {
       translation_info = #translation,
       workgroup_size = [32 : index, 8 : index, 8 : index]
     }
@@ -43,7 +43,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @illegal layout(#executable_layout) {
+    hal.executable.export @illegal layout(#executable_layout) {
       translation_info = #translation,
       workgroup_size = [32 : index, 8 : index, 2 : index]
     }
@@ -75,7 +75,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @illegal layout(#executable_layout) {
+    hal.executable.export @illegal layout(#executable_layout) {
       translation_info = #translation,
       workgroup_size = [64 : index, 2 : index, 10 : index]
     }
@@ -107,7 +107,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @illegal layout(#executable_layout) {
+    hal.executable.export @illegal layout(#executable_layout) {
       translation_info = #translation,
       workgroup_size = [48 : index, 2 : index, 1 : index]
     }
@@ -139,7 +139,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @illegal layout(#executable_layout) {
+    hal.executable.export @illegal layout(#executable_layout) {
       translation_info = #translation,
       workgroup_size = [64 : index, 2 : index, 2 : index]
     }
@@ -171,7 +171,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @illegal layout(#executable_layout) {
+    hal.executable.export @illegal layout(#executable_layout) {
       translation_info = #translation,
       workgroup_size = [64 : index, 2 : index, 1 : index]
     }
@@ -203,7 +203,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @illegal layout(#executable_layout) {
+    hal.executable.export @illegal layout(#executable_layout) {
       translation_info = #translation,
       workgroup_size = [128 : index, 1 : index, 1 : index]
     }
@@ -235,7 +235,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @illegal layout(#executable_layout) {
+    hal.executable.export @illegal layout(#executable_layout) {
       translation_info = #translation,
       workgroup_size = [64 : index, 2 : index, 1 : index]
     }
@@ -267,7 +267,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @illegal layout(#executable_layout) {
+    hal.executable.export @illegal layout(#executable_layout) {
       translation_info = #translation,
       workgroup_size = [64 : index, 2 : index, 1 : index]
     }
@@ -300,7 +300,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @batch_matmul_func  {
   hal.executable.variant @cuda, target = #executable_target_cuda_nvptx_fb {
-    hal.executable.entry_point @illegal layout(#executable_layout) {
+    hal.executable.export @illegal layout(#executable_layout) {
       translation_info = #translation,
       workgroup_size = [64 : index, 2 : index, 1 : index]
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
@@ -13,7 +13,7 @@
 ]>
 hal.executable @simpleMath_ex_dispatch_0 {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-  hal.executable.entry_point @add_dispatch_0 layout(#executable_layout)
+  hal.executable.export @add_dispatch_0 layout(#executable_layout)
   builtin.module {
     func.func @add_dispatch_0() {
       %c0 = arith.constant 0 : index
@@ -53,7 +53,7 @@ hal.executable @simpleMath_ex_dispatch_0 {
 ]>
 hal.executable @dot_dispatch_0 {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @dot_dispatch_0 layout(#executable_layout)
+    hal.executable.export @dot_dispatch_0 layout(#executable_layout)
     builtin.module {
       func.func @dot_dispatch_0() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -120,7 +120,7 @@ hal.executable @dot_dispatch_0 {
 ]>
 hal.executable @dot_dispatch_0 {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @dot_dispatch_0 layout(#executable_layout)
+    hal.executable.export @dot_dispatch_0 layout(#executable_layout)
     builtin.module {
       func.func @dot_dispatch_0() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -169,7 +169,7 @@ hal.executable @dot_dispatch_0 {
 ]>
 hal.executable @conv2d_dispatch_0 {
 hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-  hal.executable.entry_point @conv2d_dispatch_0 layout(#executable_layout)
+  hal.executable.export @conv2d_dispatch_0 layout(#executable_layout)
   builtin.module {
     func.func @conv2d_dispatch_0() {
       %c0 = arith.constant 0 : index
@@ -213,7 +213,7 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 ]>
 hal.executable @simpleMath_ex_dispatch_0 {
 hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-  hal.executable.entry_point @add_dispatch_0 layout(#executable_layout)
+  hal.executable.export @add_dispatch_0 layout(#executable_layout)
   builtin.module {
     func.func @add_dispatch_0() {
       %c0 = arith.constant 0 : index
@@ -249,7 +249,7 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 ]>
 hal.executable @reduction_dispatch {
 hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-  hal.executable.entry_point @reduction layout(#executable_layout)
+  hal.executable.export @reduction layout(#executable_layout)
   builtin.module {
     func.func @reduction() {
       %c0 = arith.constant 0 : index
@@ -292,7 +292,7 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 ]>
 hal.executable @vector_add_dispatch {
 hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-  hal.executable.entry_point @vector_add_dispatch layout(#executable_layout)
+  hal.executable.export @vector_add_dispatch layout(#executable_layout)
   builtin.module {
     func.func @vector_add_dispatch() {
       %c0 = arith.constant 0 : index
@@ -341,7 +341,7 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 ]>
 hal.executable @vector_reduction_dispatch {
 hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-  hal.executable.entry_point @vector_reduction_dispatch layout(#executable_layout)
+  hal.executable.export @vector_reduction_dispatch layout(#executable_layout)
   builtin.module {
     func.func @vector_reduction_dispatch() {
       %c0 = arith.constant 0 : index
@@ -384,7 +384,7 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 ]>
 hal.executable @mma_fused {
   hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}> {
-  hal.executable.entry_point public @_large_aligned_dispatch_0 ordinal(0) layout(#hal.executable.layout<push_constants = 0, sets = [#hal.descriptor_set.layout<0, bindings = [#hal.descriptor_set.binding<0, storage_buffer>, #hal.descriptor_set.binding<1, storage_buffer>, #hal.descriptor_set.binding<2, storage_buffer>]>]>)
+  hal.executable.export public @_large_aligned_dispatch_0 ordinal(0) layout(#hal.executable.layout<push_constants = 0, sets = [#hal.descriptor_set.layout<0, bindings = [#hal.descriptor_set.binding<0, storage_buffer>, #hal.descriptor_set.binding<1, storage_buffer>, #hal.descriptor_set.binding<2, storage_buffer>]>]>)
   builtin.module {
     func.func @_large_aligned_dispatch_0() {
       %c0 = arith.constant 0 : index
@@ -509,7 +509,7 @@ hal.executable @mma_fused {
 ]>
 hal.executable @mma_fused_fp16 {
   hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}> {
-  hal.executable.entry_point public @_large_aligned_dispatch_0 ordinal(0) layout(#hal.executable.layout<push_constants = 0, sets = [#hal.descriptor_set.layout<0, bindings = [#hal.descriptor_set.binding<0, storage_buffer>, #hal.descriptor_set.binding<1, storage_buffer>, #hal.descriptor_set.binding<2, storage_buffer>]>]>)
+  hal.executable.export public @_large_aligned_dispatch_0 ordinal(0) layout(#hal.executable.layout<push_constants = 0, sets = [#hal.descriptor_set.layout<0, bindings = [#hal.descriptor_set.binding<0, storage_buffer>, #hal.descriptor_set.binding<1, storage_buffer>, #hal.descriptor_set.binding<2, storage_buffer>]>]>)
   builtin.module {
     func.func @_large_aligned_dispatch_0() {
       %c0 = arith.constant 0 : index
@@ -523,9 +523,9 @@ hal.executable @mma_fused_fp16 {
       %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 1024], strides = [1, 1]
           : !flow.dispatch.tensor<readonly:2048x1024xf16> -> tensor<2048x1024xf16>
       %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [1024, 512], strides = [1, 1]
-          : !flow.dispatch.tensor<readonly:1024x512xf16> -> tensor<1024x512xf16>   
+          : !flow.dispatch.tensor<readonly:1024x512xf16> -> tensor<1024x512xf16>
       %d = flow.dispatch.tensor.load %di, offsets = [0, 0], sizes = [2048, 512], strides = [1, 1]
-          : !flow.dispatch.tensor<readonly:2048x512xf16> -> tensor<2048x512xf16>             
+          : !flow.dispatch.tensor<readonly:2048x512xf16> -> tensor<2048x512xf16>
       %init = linalg.init_tensor [2048, 512] : tensor<2048x512xf16>
       %f = linalg.fill ins(%cst : f16) outs(%init : tensor<2048x512xf16>) -> tensor<2048x512xf16>
       %m = linalg.matmul ins(%3, %4 : tensor<2048x1024xf16>, tensor<1024x512xf16>) outs(%f : tensor<2048x512xf16>) -> tensor<2048x512xf16>
@@ -634,7 +634,7 @@ hal.executable @mma_fused_fp16 {
 #map6 = affine_map<(d0)[s0] -> (-d0 + 64, s0)>
   hal.executable @large_dot_general_dispatch_0 {
     hal.executable.variant public @cuda, target = #executable_target_cuda_nvptx_fb {
-      hal.executable.entry_point @large_dot_general_dispatch_0 layout(#executable_layout)
+      hal.executable.export @large_dot_general_dispatch_0 layout(#executable_layout)
       builtin.module {
         func.func @large_dot_general_dispatch_0() {
           %c64 = arith.constant 64 : index
@@ -716,7 +716,7 @@ hal.executable @mma_fused_fp16 {
 #map6 = affine_map<(d0, d1, d2) -> (d2, d0, d1)>
   hal.executable public @split_k_gemm {
     hal.executable.variant public @cuda_nvptx_fb, target = #executable_target_cuda_nvptx_fb {
-      hal.executable.entry_point public @split_k_gemm ordinal(0) layout(#executable_layout)
+      hal.executable.export public @split_k_gemm ordinal(0) layout(#executable_layout)
       builtin.module {
         func.func @split_k_gemm() {
           %cst = arith.constant 0.000000e+00 : f32

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_pipeline_test.mlir
@@ -12,7 +12,7 @@
 ]>
 hal.executable @simpleMath_ex_dispatch_0 {
   hal.executable.variant @rocm, target = <"rocm", "rocm-hsaco-fb"> {
-  hal.executable.entry_point @add_dispatch_0 layout(#executable_layout)
+  hal.executable.export @add_dispatch_0 layout(#executable_layout)
   builtin.module {
     func.func @add_dispatch_0() {
       %c0 = arith.constant 0 : index
@@ -52,7 +52,7 @@ hal.executable @simpleMath_ex_dispatch_0 {
 ]>
 hal.executable @dot_dispatch_0 {
   hal.executable.variant @rocm, target = <"rocm", "rocm-hsaco-fb"> {
-    hal.executable.entry_point @dot_dispatch_0 layout(#executable_layout)
+    hal.executable.export @dot_dispatch_0 layout(#executable_layout)
     builtin.module {
       func.func @dot_dispatch_0() {
         %cst = arith.constant 0.000000e+00 : f32

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -619,7 +619,7 @@ static LogicalResult setSPIRVOpConfig(const spirv::TargetEnv &targetEnv,
 //===----------------------------------------------------------------------===//
 
 LogicalResult initSPIRVLaunchConfig(ModuleOp module) {
-  llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> entryPointOps =
+  llvm::StringMap<IREE::HAL::ExecutableExportOp> exportOps =
       getAllEntryPoints(module);
   spirv::TargetEnvAttr targetEnvAttr = getSPIRVTargetEnvAttr(module);
   if (!targetEnvAttr) {
@@ -631,8 +631,8 @@ LogicalResult initSPIRVLaunchConfig(ModuleOp module) {
   spirv::ResourceLimitsAttr limits = targetEnv.getResourceLimits();
 
   for (auto funcOp : module.getOps<func::FuncOp>()) {
-    auto entryPointOp = entryPointOps.lookup(funcOp.getName());
-    if (!entryPointOp) continue;
+    auto exportOp = exportOps.lookup(funcOp.getName());
+    if (!exportOp) continue;
 
     SmallVector<Operation *> computeOps;
     SmallVector<LoopTilingAndDistributionInfo> tiledLoops;

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
@@ -73,13 +73,13 @@ void SPIRVLowerExecutableTargetPass::runOnOperation() {
   // TODO(ravishankarm): This is strange that this is not enforced
   // structurally, but something to address later on. For now this restriction
   // is fine.
-  llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> entryPoints =
+  llvm::StringMap<IREE::HAL::ExecutableExportOp> exportOps =
       getAllEntryPoints(moduleOp);
   Optional<IREE::Codegen::DispatchLoweringPassPipeline> passPipeline;
-  for (auto &it : entryPoints) {
-    auto entryPointOp = it.second;
+  for (auto &it : exportOps) {
+    auto exportOp = it.second;
     if (IREE::Codegen::TranslationInfoAttr translationInfo =
-            getTranslationInfo(entryPointOp)) {
+            getTranslationInfo(exportOp)) {
       IREE::Codegen::DispatchLoweringPassPipeline currPipeline =
           translationInfo.getDispatchLoweringPassPipeline();
       if (passPipeline) {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndPromote.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndPromote.cpp
@@ -147,9 +147,8 @@ struct SPIRVTileAndPromotePass final
 void SPIRVTileAndPromotePass::runOnOperation() {
   MLIRContext *context = &getContext();
   func::FuncOp funcOp = getOperation();
-  FailureOr<IREE::HAL::ExecutableEntryPointOp> entryPointOp =
-      getEntryPoint(funcOp);
-  if (failed(entryPointOp)) return;
+  FailureOr<IREE::HAL::ExecutableExportOp> exportOp = getEntryPoint(funcOp);
+  if (failed(exportOp)) return;
 
   {  // Tile reduction dimensions.
     RewritePatternSet tilingPatterns(context);
@@ -179,7 +178,7 @@ void SPIRVTileAndPromotePass::runOnOperation() {
   });
 
   auto workgroupSize = llvm::to_vector<4>(llvm::map_range(
-      entryPointOp->workgroup_size().getValue(),
+      exportOp->workgroup_size().getValue(),
       [&](Attribute attr) { return attr.cast<IntegerAttr>().getInt(); }));
   int64_t flatWorkgroupSize =
       workgroupSize[0] * workgroupSize[1] * workgroupSize[2];

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_adreno_conv.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_adreno_conv.mlir
@@ -17,7 +17,7 @@ hal.executable @conv_112x112x512 {
         max_compute_workgroup_size = dense<[1024, 1024, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point public @conv_112x112x512 layout(#executable_layout)
+    hal.executable.export public @conv_112x112x512 layout(#executable_layout)
     builtin.module {
       func.func @conv_112x112x512() {
         %c0 = arith.constant 0 : index
@@ -45,7 +45,7 @@ hal.executable @conv_112x112x512 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 8, 256], [0, 1, 8, 4], [0, 0, 0, 0, 1, 1, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @conv_112x112x512
+//      CHECK: hal.executable.export public @conv_112x112x512
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [64 : index, 1 : index, 1 : index]
 //      CHECK: func.func @conv_112x112x512()
@@ -71,7 +71,7 @@ hal.executable @conv_112x112x32 {
         max_compute_workgroup_size = dense<[1024, 1024, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point public @conv_112x112x32 layout(#executable_layout)
+    hal.executable.export public @conv_112x112x32 layout(#executable_layout)
     builtin.module {
       func.func @conv_112x112x32() {
         %c0 = arith.constant 0 : index
@@ -99,7 +99,7 @@ hal.executable @conv_112x112x32 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 16, 32], [0, 4, 2, 4], [0, 0, 0, 0, 1, 1, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @conv_112x112x32
+//      CHECK: hal.executable.export public @conv_112x112x32
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [8 : index, 8 : index, 1 : index]
 //      CHECK: func.func @conv_112x112x32()
@@ -125,7 +125,7 @@ hal.executable @conv_16x16x16 {
         max_compute_workgroup_size = dense<[1024, 1024, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point public @conv_16x16x16 layout(#executable_layout)
+    hal.executable.export public @conv_16x16x16 layout(#executable_layout)
     builtin.module {
       func.func @conv_16x16x16() {
         %c0 = arith.constant 0 : index
@@ -152,7 +152,7 @@ hal.executable @conv_16x16x16 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 8, 8, 16], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @conv_16x16x16
+//      CHECK: hal.executable.export public @conv_16x16x16
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [4 : index, 4 : index, 4 : index]
 
@@ -179,7 +179,7 @@ hal.executable @dwconv_28x28x144 {
         max_compute_workgroup_size = dense<[1024, 1024, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point public @dwconv_28x28x144 layout(#executable_layout)
+    hal.executable.export public @dwconv_28x28x144 layout(#executable_layout)
     builtin.module {
       func.func @dwconv_28x28x144() {
         %c0 = arith.constant 0 : index
@@ -207,7 +207,7 @@ hal.executable @dwconv_28x28x144 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 16], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @dwconv_28x28x144
+//      CHECK: hal.executable.export public @dwconv_28x28x144
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [4 : index, 4 : index, 4 : index]
 //      CHECK: func.func @dwconv_28x28x144()
@@ -233,7 +233,7 @@ hal.executable @dwconv_4x4x8 {
         max_compute_workgroup_size = dense<[1024, 1024, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point public @dwconv_4x4x8 layout(#executable_layout)
+    hal.executable.export public @dwconv_4x4x8 layout(#executable_layout)
     builtin.module {
       func.func @dwconv_4x4x8() {
         %c0 = arith.constant 0 : index
@@ -260,7 +260,7 @@ hal.executable @dwconv_4x4x8 {
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 8], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @dwconv_4x4x8
+//      CHECK: hal.executable.export public @dwconv_4x4x8
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [2 : index, 4 : index, 4 : index]
 //      CHECK: func.func @dwconv_4x4x8()

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_adreno_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_adreno_matmul.mlir
@@ -17,7 +17,7 @@ hal.executable @matmul_1024x2048x512 {
         max_compute_workgroup_size = dense<[1024, 1024, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point @matmul_1024x2048x512 layout(#executable_layout)
+    hal.executable.export @matmul_1024x2048x512 layout(#executable_layout)
     builtin.module {
       func.func @matmul_1024x2048x512() {
         %c0 = arith.constant 0 : index
@@ -45,7 +45,7 @@ hal.executable @matmul_1024x2048x512 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 128], [16, 4], [0, 0, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @matmul_1024x2048x512
+//      CHECK: hal.executable.export public @matmul_1024x2048x512
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [32 : index, 2 : index, 1 : index]
 //      CHECK: func.func @matmul_1024x2048x512()
@@ -71,7 +71,7 @@ hal.executable @matmul_3136x24x96 {
         max_compute_workgroup_size = dense<[1024, 1024, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point @matmul_3136x24x96 layout(#executable_layout)
+    hal.executable.export @matmul_3136x24x96 layout(#executable_layout)
     builtin.module {
       func.func @matmul_3136x24x96() {
         %c0 = arith.constant 0 : index
@@ -99,7 +99,7 @@ hal.executable @matmul_3136x24x96 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[448, 8], [14, 4], [0, 0, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @matmul_3136x24x96
+//      CHECK: hal.executable.export public @matmul_3136x24x96
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [2 : index, 32 : index, 1 : index]
 //      CHECK: func.func @matmul_3136x24x96()
@@ -125,7 +125,7 @@ hal.executable @matmul_196x64x192 {
         max_compute_workgroup_size = dense<[1024, 1024, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point @matmul_196x64x192 layout(#executable_layout)
+    hal.executable.export @matmul_196x64x192 layout(#executable_layout)
     builtin.module {
       func.func @matmul_196x64x192() {
         %c0 = arith.constant 0 : index
@@ -153,7 +153,7 @@ hal.executable @matmul_196x64x192 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[28, 64], [7, 4], [0, 0, 8]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @matmul_196x64x192
+//      CHECK: hal.executable.export public @matmul_196x64x192
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [16 : index, 4 : index, 1 : index]
 //      CHECK: func.func @matmul_196x64x192()
@@ -179,7 +179,7 @@ hal.executable @matmul_12544x96x16 {
         max_compute_workgroup_size = dense<[1024, 1024, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point @matmul_12544x96x16 layout(#executable_layout)
+    hal.executable.export @matmul_12544x96x16 layout(#executable_layout)
     builtin.module {
       func.func @matmul_12544x96x16() {
         %c0 = arith.constant 0 : index
@@ -199,7 +199,7 @@ hal.executable @matmul_12544x96x16 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 32], [16, 4], [0, 0, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @matmul_12544x96x16
+//      CHECK: hal.executable.export public @matmul_12544x96x16
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [8 : index, 8 : index, 1 : index]
 //      CHECK: func.func @matmul_12544x96x16()
@@ -225,7 +225,7 @@ hal.executable @matmul_49x160x576 {
         max_compute_workgroup_size = dense<[1024, 1024, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point @matmul_49x160x576 layout(#executable_layout)
+    hal.executable.export @matmul_49x160x576 layout(#executable_layout)
     builtin.module {
       func.func @matmul_49x160x576() {
         %c0 = arith.constant 0 : index
@@ -251,7 +251,7 @@ hal.executable @matmul_49x160x576 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[7, 32], [7, 4], [0, 0, 8]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @matmul_49x160x576
+//      CHECK: hal.executable.export public @matmul_49x160x576
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [8 : index, 1 : index, 1 : index]
 //      CHECK: func.func @matmul_49x160x576()
@@ -277,7 +277,7 @@ hal.executable @batch_matmul_4x384x384 {
         max_compute_workgroup_size = dense<[1024, 1024, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point @batch_matmul_4x384x384 layout(#executable_layout)
+    hal.executable.export @batch_matmul_4x384x384 layout(#executable_layout)
     builtin.module {
       func.func @batch_matmul_4x384x384() {
         %c0 = arith.constant 0 : index
@@ -305,7 +305,7 @@ hal.executable @batch_matmul_4x384x384 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 32, 128], [1, 16, 4], [0, 0, 0, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @batch_matmul_4x384x384
+//      CHECK: hal.executable.export public @batch_matmul_4x384x384
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [32 : index, 2 : index, 1 : index]
 //      CHECK: func.func @batch_matmul_4x384x384()
@@ -331,7 +331,7 @@ hal.executable @batch_matmul_4x8x8 {
         max_compute_workgroup_size = dense<[1024, 1024, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point @batch_matmul_4x8x8 layout(#executable_layout)
+    hal.executable.export @batch_matmul_4x8x8 layout(#executable_layout)
     builtin.module {
       func.func @batch_matmul_4x8x8() {
         %c0 = arith.constant 0 : index
@@ -359,7 +359,7 @@ hal.executable @batch_matmul_4x8x8 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 8, 8], [1, 1, 4], [0, 0, 0, 16]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @batch_matmul_4x8x8
+//      CHECK: hal.executable.export public @batch_matmul_4x8x8
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [2 : index, 8 : index, 1 : index]
 //      CHECK: func.func @batch_matmul_4x8x8()

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_conv.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_conv.mlir
@@ -26,7 +26,7 @@ hal.executable private @conv_pointwise_112x112x32 {
         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>,
         subgroup_size = 32 : i32}>
     }> {
-    hal.executable.entry_point public @conv_pointwise_112x112x32 layout(#executable_layout)
+    hal.executable.export public @conv_pointwise_112x112x32 layout(#executable_layout)
     builtin.module {
       func.func @conv_pointwise_112x112x32() {
         %c0 = arith.constant 0 : index
@@ -64,7 +64,7 @@ hal.executable private @conv_pointwise_112x112x32 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 32], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @conv_pointwise_112x112x32
+//      CHECK: hal.executable.export public @conv_pointwise_112x112x32
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [8 : index, 2 : index, 2 : index]
 //      CHECK: func.func @conv_pointwise_112x112x32()

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ext_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ext_ops.mlir
@@ -13,7 +13,7 @@ hal.executable private @static_1d_sort {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @static_1d_sort layout(#executable_layout)
+    hal.executable.export @static_1d_sort layout(#executable_layout)
     builtin.module {
       func.func @static_1d_sort() {
         %c0 = arith.constant 0 : index
@@ -35,7 +35,7 @@ hal.executable private @static_1d_sort {
 
 //   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = []>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
-//       CHECK: hal.executable.entry_point public @static_1d_sort
+//       CHECK: hal.executable.export public @static_1d_sort
 //  CHECK-SAME:   translation_info = #[[TRANSLATION]]
 //  CHECK-SAME:   workgroup_size = [1 : index, 1 : index, 1 : index]
 //       CHECK: func.func @static_1d_sort()
@@ -58,7 +58,7 @@ hal.executable private @static_3d_sort {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @static_3d_sort layout(#executable_layout)
+    hal.executable.export @static_3d_sort layout(#executable_layout)
     builtin.module {
       func.func @static_3d_sort() {
         %c64 = arith.constant 64 : index
@@ -84,7 +84,7 @@ hal.executable private @static_3d_sort {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 0, 16], [1, 0, 1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
-//      CHECK: hal.executable.entry_point public @static_3d_sort
+//      CHECK: hal.executable.export public @static_3d_sort
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [16 : index, 1 : index, 1 : index]
 //      CHECK: func.func @static_3d_sort()
@@ -107,7 +107,7 @@ hal.executable private @static_1d_fft_stage2 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @static_1d_fft_stage2 layout(#executable_layout)
+    hal.executable.export @static_1d_fft_stage2 layout(#executable_layout)
     builtin.module {
       func.func @static_1d_fft_stage2() {
         %c0 = arith.constant 0 : index
@@ -129,7 +129,7 @@ hal.executable private @static_1d_fft_stage2 {
 
 //   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[4]{{\]}}>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
-//       CHECK: hal.executable.entry_point public @static_1d_fft_stage2
+//       CHECK: hal.executable.export public @static_1d_fft_stage2
 //  CHECK-SAME:   translation_info = #[[TRANSLATION]]
 //  CHECK-SAME:   workgroup_size = [16 : index, 1 : index, 1 : index]
 //       CHECK: func.func @static_1d_fft_stage2()
@@ -152,7 +152,7 @@ hal.executable private @static_3d_fft_stage3 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @static_3d_fft_stage3 layout(#executable_layout)
+    hal.executable.export @static_3d_fft_stage3 layout(#executable_layout)
     builtin.module {
       func.func @static_3d_fft_stage3() {
         %c0 = arith.constant 0 : index
@@ -178,7 +178,7 @@ hal.executable private @static_3d_fft_stage3 {
 
 //   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 1, 8]{{\]}}>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
-//       CHECK: hal.executable.entry_point public @static_3d_fft_stage3
+//       CHECK: hal.executable.export public @static_3d_fft_stage3
 //  CHECK-SAME:   translation_info = #[[TRANSLATION]]
 //  CHECK-SAME:   workgroup_size = [16 : index, 1 : index, 1 : index]
 //       CHECK: func.func @static_3d_fft_stage3()

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ops.mlir
@@ -14,7 +14,7 @@ hal.executable @copy_as_generic {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @copy_as_generic layout(#executable_layout)
+    hal.executable.export @copy_as_generic layout(#executable_layout)
     builtin.module {
       func.func @copy_as_generic() {
         %c0 = arith.constant 0 : index
@@ -37,7 +37,7 @@ hal.executable @copy_as_generic {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 16], [1, 1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
-//      CHECK: hal.executable.entry_point public @copy_as_generic
+//      CHECK: hal.executable.export public @copy_as_generic
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -58,7 +58,7 @@ hal.executable @tensor_insert {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point @copy layout(#executable_layout)
+    hal.executable.export @copy layout(#executable_layout)
     builtin.module {
       func.func @copy() {
         %c0 = arith.constant 0 : index
@@ -81,7 +81,7 @@ hal.executable @tensor_insert {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 2, 32, 1], [0, 1, 1, 1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
-//      CHECK: hal.executable.entry_point public @copy
+//      CHECK: hal.executable.export public @copy
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -104,7 +104,7 @@ hal.executable @avg_pool {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 32 : i32}>
     }> {
-    hal.executable.entry_point public @avg_pool layout(#executable_layout)
+    hal.executable.export public @avg_pool layout(#executable_layout)
     builtin.module {
       func.func @avg_pool() {
         %c0 = arith.constant 0 : index
@@ -131,7 +131,7 @@ hal.executable @avg_pool {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 2, 2, 8], [0, 1, 1, 1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
-//      CHECK: hal.executable.entry_point public @avg_pool
+//      CHECK: hal.executable.export public @avg_pool
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.pooling_nhwc_sum
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -154,7 +154,7 @@ hal.executable @avg_pool {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 4 : i32}>
     }> {
-    hal.executable.entry_point public @avg_pool layout(#executable_layout)
+    hal.executable.export public @avg_pool layout(#executable_layout)
     builtin.module {
       func.func @avg_pool() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -188,7 +188,7 @@ hal.executable @avg_pool {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 0, 4], [0, 0, 0, 1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
-//      CHECK: hal.executable.entry_point public @avg_pool
+//      CHECK: hal.executable.export public @avg_pool
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.pooling_nhwc_sum
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -211,7 +211,7 @@ hal.executable @max_pool {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 32 : i32}>
     }> {
-    hal.executable.entry_point public @max_pool layout(#executable_layout)
+    hal.executable.export public @max_pool layout(#executable_layout)
     builtin.module  {
       func.func @max_pool() {
         %cst = arith.constant 0xFF800000 : f32
@@ -239,7 +239,7 @@ hal.executable @max_pool {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 32], [0, 1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
-//      CHECK: hal.executable.entry_point public @max_pool
+//      CHECK: hal.executable.export public @max_pool
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [32 : index, 1 : index, 1 : index]
 //      CHECK:   linalg.pooling_nhwc_max
@@ -265,7 +265,7 @@ hal.executable @elementwise {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 32 : i32}>
     }> {
-    hal.executable.entry_point public @elementwise layout(#executable_layout)
+    hal.executable.export public @elementwise layout(#executable_layout)
     builtin.module {
       func.func @elementwise() {
         %c0 = arith.constant 0 : index
@@ -295,7 +295,7 @@ hal.executable @elementwise {
 }
 
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
-//      CHECK: hal.executable.entry_point public @elementwise
+//      CHECK: hal.executable.export public @elementwise
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 
 // -----
@@ -318,7 +318,7 @@ hal.executable @dwconv_elementwise {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 32 : i32}>
     }> {
-    hal.executable.entry_point public @dwconv_elementwise layout(#executable_layout)
+    hal.executable.export public @dwconv_elementwise layout(#executable_layout)
     builtin.module  {
       func.func @dwconv_elementwise() {
         %cst = arith.constant opaque<"_", "0xDEADBEEF"> : tensor<3x3x1x4xf32>
@@ -356,7 +356,7 @@ hal.executable @dwconv_elementwise {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 2, 0, 4], [0, 1, 1, 0, 1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
-//      CHECK: hal.executable.entry_point public @dwconv_elementwise
+//      CHECK: hal.executable.export public @dwconv_elementwise
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -381,7 +381,7 @@ hal.executable @outermost_reduction {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 32 : i32}>
     }> {
-    hal.executable.entry_point @outermost_reduction layout(#executable_layout)
+    hal.executable.export @outermost_reduction layout(#executable_layout)
     builtin.module {
       func.func @outermost_reduction() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -408,7 +408,7 @@ hal.executable @outermost_reduction {
 
 //   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 128], [1, 4],  [0, 0, 4]{{\]}}>
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-// CHECK-LABEL: hal.executable.entry_point public @outermost_reduction
+// CHECK-LABEL: hal.executable.export public @outermost_reduction
 //  CHECK-SAME:   translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:     lowering_config = #[[$CONFIG]]
@@ -432,7 +432,7 @@ hal.executable private @innermost_reduction {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 32 : i32}>
     }> {
-    hal.executable.entry_point public @innermost_reduction ordinal(0) layout(#executable_layout)
+    hal.executable.export public @innermost_reduction ordinal(0) layout(#executable_layout)
     builtin.module {
       func.func @innermost_reduction() {
         %cst = arith.constant -0.000000e+00 : f32
@@ -468,7 +468,7 @@ hal.executable private @innermost_reduction {
 
 //   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128], [4],  [0, 4]{{\]}}>
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-// CHECK-LABEL: hal.executable.entry_point public @innermost_reduction
+// CHECK-LABEL: hal.executable.export public @innermost_reduction
 //  CHECK-SAME:   translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:     lowering_config = #[[$CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_matmul.mlir
@@ -17,7 +17,7 @@ hal.executable @batch_matmul_1x3x32 {
         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>,
         subgroup_size = 32 : i32}>
     }> {
-    hal.executable.entry_point public @batch_matmul_1x3x32 layout(#executable_layout)
+    hal.executable.export public @batch_matmul_1x3x32 layout(#executable_layout)
     builtin.module {
       func.func @batch_matmul_1x3x32() {
         %c0 = arith.constant 0 : index
@@ -46,7 +46,7 @@ hal.executable @batch_matmul_1x3x32 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 32], [0, 1, 1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
-//      CHECK: hal.executable.entry_point public @batch_matmul_1x3x32
+//      CHECK: hal.executable.export public @batch_matmul_1x3x32
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [32 : index, 1 : index, 1 : index]
 //      CHECK: func.func @batch_matmul_1x3x32()
@@ -72,7 +72,7 @@ hal.executable private @matmul_64x16 {
         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
   }> {
-    hal.executable.entry_point public @matmul_64x16 layout(#executable_layout)
+    hal.executable.export public @matmul_64x16 layout(#executable_layout)
     builtin.module {
       func.func @matmul_64x16() {
         %c0 = arith.constant 0 : index
@@ -100,7 +100,7 @@ hal.executable private @matmul_64x16 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[4, 16], [1, 1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
-//      CHECK: hal.executable.entry_point public @matmul_64x16
+//      CHECK: hal.executable.export public @matmul_64x16
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [16 : index, 4 : index, 1 : index]
 //      CHECK: func.func @matmul_64x16()
@@ -126,7 +126,7 @@ hal.executable @matmul_400x273 {
         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point public @matmul_400x273 layout(#executable_layout)
+    hal.executable.export public @matmul_400x273 layout(#executable_layout)
     builtin.module {
       func.func @matmul_400x273() {
         %c0 = arith.constant 0 : index
@@ -165,7 +165,7 @@ hal.executable @matmul_400x273 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[2, 32], [1, 1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
-//      CHECK: hal.executable.entry_point public @matmul_400x273
+//      CHECK: hal.executable.export public @matmul_400x273
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [32 : index, 2 : index, 1 : index]
 //      CHECK: func.func @matmul_400x273()
@@ -191,7 +191,7 @@ hal.executable @matmul_25x546 {
         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
   }> {
-    hal.executable.entry_point public @matmul_25x546 layout(#executable_layout)
+    hal.executable.export public @matmul_25x546 layout(#executable_layout)
     builtin.module {
       func.func @matmul_25x546() {
         %c0 = arith.constant 0 : index
@@ -231,7 +231,7 @@ hal.executable @matmul_25x546 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 2], [1, 1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVDistribute>
-//      CHECK: hal.executable.entry_point public @matmul_25x546
+//      CHECK: hal.executable.export public @matmul_25x546
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [2 : index, 32 : index, 1 : index]
 //      CHECK: func.func @matmul_25x546()
@@ -265,7 +265,7 @@ hal.executable private @matmul_pointwise_256x1024 {
         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>,
         subgroup_size = 32 : i32}>
     }> {
-    hal.executable.entry_point public @matmul_pointwise_256x1024 layout(#executable_layout)
+    hal.executable.export public @matmul_pointwise_256x1024 layout(#executable_layout)
     builtin.module {
       func.func @matmul_pointwise_256x1024() {
         %c0 = arith.constant 0 : index
@@ -307,7 +307,7 @@ hal.executable private @matmul_pointwise_256x1024 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[16, 256], [8, 8], [0, 0, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @matmul_pointwise_256x1024
+//      CHECK: hal.executable.export public @matmul_pointwise_256x1024
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [32 : index, 2 : index, 1 : index]
 //      CHECK: func.func @matmul_pointwise_256x1024()

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_mali_conv.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_mali_conv.mlir
@@ -17,7 +17,7 @@ hal.executable @conv_112x112x512 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point public @conv_112x112x512 layout(#executable_layout)
+    hal.executable.export public @conv_112x112x512 layout(#executable_layout)
     builtin.module {
       func.func @conv_112x112x512() {
         %c0 = arith.constant 0 : index
@@ -46,7 +46,7 @@ hal.executable @conv_112x112x512 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 4, 64], [0, 1, 4, 4], [0, 0, 0, 0, 1, 1, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @conv_112x112x512
+//      CHECK: hal.executable.export public @conv_112x112x512
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [16 : index, 1 : index, 1 : index]
 //      CHECK: func.func @conv_112x112x512()
@@ -72,7 +72,7 @@ hal.executable @conv_112x112x32 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point public @conv_112x112x32 layout(#executable_layout)
+    hal.executable.export public @conv_112x112x32 layout(#executable_layout)
     builtin.module {
       func.func @conv_112x112x32() {
         %c0 = arith.constant 0 : index
@@ -100,7 +100,7 @@ hal.executable @conv_112x112x32 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 8, 32], [0, 1, 4, 4], [0, 0, 0, 0, 1, 1, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @conv_112x112x32
+//      CHECK: hal.executable.export public @conv_112x112x32
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [8 : index, 2 : index, 1 : index]
 //      CHECK: func.func @conv_112x112x32()
@@ -126,7 +126,7 @@ hal.executable @conv_16x16x16 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point public @conv_16x16x16 layout(#executable_layout)
+    hal.executable.export public @conv_16x16x16 layout(#executable_layout)
     builtin.module {
       func.func @conv_16x16x16() {
         %c0 = arith.constant 0 : index
@@ -153,7 +153,7 @@ hal.executable @conv_16x16x16 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 16], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @conv_16x16x16
+//      CHECK: hal.executable.export public @conv_16x16x16
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [4 : index, 2 : index, 2 : index]
 //      CHECK: func.func @conv_16x16x16()
@@ -179,7 +179,7 @@ hal.executable @dwconv_28x28x144 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point public @dwconv_28x28x144 layout(#executable_layout)
+    hal.executable.export public @dwconv_28x28x144 layout(#executable_layout)
     builtin.module {
       func.func @dwconv_28x28x144() {
         %c0 = arith.constant 0 : index
@@ -207,7 +207,7 @@ hal.executable @dwconv_28x28x144 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 16], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @dwconv_28x28x144
+//      CHECK: hal.executable.export public @dwconv_28x28x144
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [4 : index, 2 : index, 2 : index]
 //      CHECK: func.func @dwconv_28x28x144()
@@ -233,7 +233,7 @@ hal.executable @dwconv_1x2x8 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point public @dwconv_1x2x8 layout(#executable_layout)
+    hal.executable.export public @dwconv_1x2x8 layout(#executable_layout)
     builtin.module {
       func.func @dwconv_1x2x8() {
         %c0 = arith.constant 0 : index
@@ -262,7 +262,7 @@ hal.executable @dwconv_1x2x8 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 2, 8], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @dwconv_1x2x8
+//      CHECK: hal.executable.export public @dwconv_1x2x8
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [2 : index, 2 : index, 1 : index]
 //      CHECK: func.func @dwconv_1x2x8()

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_mali_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_mali_matmul.mlir
@@ -17,7 +17,7 @@ hal.executable @matmul_1024x2048x512 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @matmul_1024x2048x512 layout(#executable_layout)
+    hal.executable.export @matmul_1024x2048x512 layout(#executable_layout)
     builtin.module {
       func.func @matmul_1024x2048x512() {
         %c0 = arith.constant 0 : index
@@ -43,7 +43,7 @@ hal.executable @matmul_1024x2048x512 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[8, 32], [4, 4], [0, 0, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @matmul_1024x2048x512
+//      CHECK: hal.executable.export public @matmul_1024x2048x512
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [8 : index, 2 : index, 1 : index]
 //      CHECK: func.func @matmul_1024x2048x512()
@@ -69,7 +69,7 @@ hal.executable @matmul_3136x24x96 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @matmul_3136x24x96 layout(#executable_layout)
+    hal.executable.export @matmul_3136x24x96 layout(#executable_layout)
     builtin.module {
       func.func @matmul_3136x24x96() {
         %c0 = arith.constant 0 : index
@@ -96,7 +96,7 @@ hal.executable @matmul_3136x24x96 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 8], [4, 4], [0, 0, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @matmul_3136x24x96
+//      CHECK: hal.executable.export public @matmul_3136x24x96
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [2 : index, 8 : index, 1 : index]
 //      CHECK: func.func @matmul_3136x24x96()
@@ -122,7 +122,7 @@ hal.executable @matmul_196x64x192 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @matmul_196x64x192 layout(#executable_layout)
+    hal.executable.export @matmul_196x64x192 layout(#executable_layout)
     builtin.module {
       func.func @matmul_196x64x192() {
         %c0 = arith.constant 0 : index
@@ -150,7 +150,7 @@ hal.executable @matmul_196x64x192 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[4, 32], [2, 4], [0, 0, 8]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @matmul_196x64x192
+//      CHECK: hal.executable.export public @matmul_196x64x192
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [8 : index, 2 : index, 1 : index]
 //      CHECK: func.func @matmul_196x64x192()
@@ -176,7 +176,7 @@ hal.executable @matmul_12544x96x16 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @matmul_12544x96x16 layout(#executable_layout)
+    hal.executable.export @matmul_12544x96x16 layout(#executable_layout)
     builtin.module {
       func.func @matmul_12544x96x16() {
         %c0 = arith.constant 0 : index
@@ -197,7 +197,7 @@ hal.executable @matmul_12544x96x16 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[8, 32], [4, 4], [0, 0, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @matmul_12544x96x16
+//      CHECK: hal.executable.export public @matmul_12544x96x16
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [8 : index, 2 : index, 1 : index]
 //      CHECK: func.func @matmul_12544x96x16()
@@ -223,7 +223,7 @@ hal.executable @matmul_49x160x576 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @matmul_49x160x576 layout(#executable_layout)
+    hal.executable.export @matmul_49x160x576 layout(#executable_layout)
     builtin.module {
       func.func @matmul_49x160x576() {
         %c0 = arith.constant 0 : index
@@ -251,7 +251,7 @@ hal.executable @matmul_49x160x576 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 32], [1, 4], [0, 0, 8]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @matmul_49x160x576
+//      CHECK: hal.executable.export public @matmul_49x160x576
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [8 : index, 1 : index, 1 : index]
 //      CHECK: func.func @matmul_49x160x576()
@@ -278,7 +278,7 @@ hal.executable @matmul_1x1024x576 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @matmul_1x1024x576 layout(#executable_layout)
+    hal.executable.export @matmul_1x1024x576 layout(#executable_layout)
     builtin.module {
       func.func @matmul_1x1024x576() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -308,7 +308,7 @@ hal.executable @matmul_1x1024x576 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 256], [1, 4], [0, 0, 8]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @matmul_1x1024x576
+//      CHECK: hal.executable.export public @matmul_1x1024x576
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [64 : index, 1 : index, 1 : index]
 //      CHECK: func.func @matmul_1x1024x576()
@@ -334,7 +334,7 @@ hal.executable @batch_matmul_4x384x384 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @batch_matmul_4x384x384 layout(#executable_layout)
+    hal.executable.export @batch_matmul_4x384x384 layout(#executable_layout)
     builtin.module {
       func.func @batch_matmul_4x384x384() {
         %c0 = arith.constant 0 : index
@@ -363,7 +363,7 @@ hal.executable @batch_matmul_4x384x384 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 12, 32], [1, 6, 4], [0, 0, 0, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @batch_matmul_4x384x384
+//      CHECK: hal.executable.export public @batch_matmul_4x384x384
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [8 : index, 2 : index, 1 : index]
 //      CHECK: func.func @batch_matmul_4x384x384()
@@ -389,7 +389,7 @@ hal.executable @batch_matmul_4x2x8 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @batch_matmul_4x2x8 layout(#executable_layout)
+    hal.executable.export @batch_matmul_4x2x8 layout(#executable_layout)
     builtin.module {
       func.func @batch_matmul_4x2x8() {
         %c0 = arith.constant 0 : index
@@ -418,7 +418,7 @@ hal.executable @batch_matmul_4x2x8 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 2, 8], [1, 1, 4], [0, 0, 0, 8]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
-//      CHECK: hal.executable.entry_point public @batch_matmul_4x2x8
+//      CHECK: hal.executable.export public @batch_matmul_4x2x8
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [2 : index, 2 : index, 1 : index]
 //      CHECK: func.func @batch_matmul_4x2x8()

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_nvidia_matmul_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_nvidia_matmul_cooperative_ops.mlir
@@ -34,7 +34,7 @@ hal.executable public @matmul_256x1024x128_div_sub {
            max_compute_workgroup_invocations = 1024 : i32,
            max_compute_workgroup_size = dense<[2147483647, 65535, 65535]> : vector<3xi32>,
            subgroup_size = 32 : i32}>}> {
-    hal.executable.entry_point public @matmul_256x1024x128_div_sub layout(#executable_layout)
+    hal.executable.export public @matmul_256x1024x128_div_sub layout(#executable_layout)
     builtin.module {
       func.func @matmul_256x1024x128_div_sub() {
         %c0 = arith.constant 0 : index
@@ -78,7 +78,7 @@ hal.executable public @matmul_256x1024x128_div_sub {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[16, 16, 16], [16, 16, 16]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorizeToCooperativeOps>
-//      CHECK: hal.executable.entry_point public @matmul_256x1024x128_div_sub
+//      CHECK: hal.executable.export public @matmul_256x1024x128_div_sub
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [32 : index, 1 : index, 1 : index]
 //      CHECK: func.func @matmul_256x1024x128_div_sub()
@@ -120,7 +120,7 @@ hal.executable public @matmul_256x1024x8 {
            max_compute_workgroup_invocations = 1024 : i32,
            max_compute_workgroup_size = dense<[2147483647, 65535, 65535]> : vector<3xi32>,
            subgroup_size = 32 : i32}>}> {
-    hal.executable.entry_point public @matmul_256x1024x8 layout(#executable_layout)
+    hal.executable.export public @matmul_256x1024x8 layout(#executable_layout)
     builtin.module {
       func.func @matmul_256x1024x8() {
         %c0 = arith.constant 0 : index
@@ -145,5 +145,5 @@ hal.executable public @matmul_256x1024x8 {
 }
 
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize
-//       CHECK: hal.executable.entry_point public @matmul_256x1024x8
+//       CHECK: hal.executable.export public @matmul_256x1024x8
 //  CHECK-SAME:   translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/convert_to_spirv.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/convert_to_spirv.mlir
@@ -9,7 +9,7 @@
 hal.executable private @push_constant {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>}> {
-    hal.executable.entry_point @push_constant layout(#executable_layout) {
+    hal.executable.export @push_constant layout(#executable_layout) {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module {
@@ -43,7 +43,7 @@ hal.executable private @push_constant {
 hal.executable private @resource_bindings_in_same_func {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>}> {
-    hal.executable.entry_point @resource_bindings_in_same_func layout(#executable_layout) {
+    hal.executable.export @resource_bindings_in_same_func layout(#executable_layout) {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module {
@@ -98,10 +98,10 @@ hal.executable private @resource_bindings_in_same_func {
 hal.executable private @resource_bindings_in_multi_entry_func {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>}> {
-    hal.executable.entry_point @resource_bindings_in_entry_func1 layout(#executable_layout) {
+    hal.executable.export @resource_bindings_in_entry_func1 layout(#executable_layout) {
       workgroup_size = [32: index, 1: index, 1: index]
     }
-    hal.executable.entry_point @resource_bindings_in_entry_func2 layout(#executable_layout) {
+    hal.executable.export @resource_bindings_in_entry_func2 layout(#executable_layout) {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module {
@@ -154,7 +154,7 @@ hal.executable private @resource_bindings_in_multi_entry_func {
 hal.executable private @interface_binding {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>}> {
-    hal.executable.entry_point @interface_binding layout(#executable_layout) {
+    hal.executable.export @interface_binding layout(#executable_layout) {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module {
@@ -197,7 +197,7 @@ hal.executable private @interface_binding {
 hal.executable private @interface_wg_id {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>}> {
-    hal.executable.entry_point @interface_wg_id layout(#executable_layout) {
+    hal.executable.export @interface_wg_id layout(#executable_layout) {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module {
@@ -232,7 +232,7 @@ hal.executable private @interface_wg_id {
 hal.executable private @interface_wg_count {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>}> {
-    hal.executable.entry_point @interface_wg_count layout(#executable_layout) {
+    hal.executable.export @interface_wg_count layout(#executable_layout) {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
@@ -29,7 +29,7 @@ hal.executable public @matmul_256x1024x128_div_sub {
           max_compute_workgroup_invocations = 1024 : i32,
           max_compute_workgroup_size = dense<[2147483647, 65535, 65535]> : vector<3xi32>,
           subgroup_size = 32 : i32}>}> {
-    hal.executable.entry_point public @matmul_256x1024x128_div_sub layout(#executable_layout)
+    hal.executable.export public @matmul_256x1024x128_div_sub layout(#executable_layout)
     builtin.module  {
       func.func @matmul_256x1024x128_div_sub() {
         %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_promotion.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_promotion.mlir
@@ -17,7 +17,7 @@ hal.executable @matmul_128x256x64 {
        max_compute_workgroup_invocations = 1024 : i32,
        max_compute_workgroup_size = dense<[65535, 65535, 65535]> : vector<3xi32>,
        subgroup_size = 32 : i32}>}> {
-    hal.executable.entry_point public @matmul_128x256x64 ordinal(0) layout(#executable_layout)
+    hal.executable.export public @matmul_128x256x64 ordinal(0) layout(#executable_layout)
     builtin.module {
       func.func @matmul_128x256x64() {
         %cst = arith.constant 0.000000e+00 : f32

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
@@ -15,7 +15,7 @@ hal.executable private @fuse_and_vectorize_fill_matmul {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @fuse_and_vectorize_fill_matmul layout(#executable_layout)
+    hal.executable.export @fuse_and_vectorize_fill_matmul layout(#executable_layout)
     builtin.module {
       func.func @fuse_and_vectorize_fill_matmul() {
         %c0 = arith.constant 0 : index
@@ -62,7 +62,7 @@ hal.executable private @fuse_and_vectorize_matmul_add {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @fuse_and_vectorize_matmul_add layout(#executable_layout)
+    hal.executable.export @fuse_and_vectorize_matmul_add layout(#executable_layout)
     builtin.module {
       func.func @fuse_and_vectorize_matmul_add() {
         %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute.mlir
@@ -19,7 +19,7 @@
 ]>
 hal.executable private @matmul {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @matmul layout(#executable_layout) {
+    hal.executable.export @matmul layout(#executable_layout) {
       workgroup_size = [16: index, 8: index, 1: index],
       translation_info = #translation
     }
@@ -89,7 +89,7 @@ hal.executable private @matmul {
 ]>
 hal.executable private @conv_1d {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @conv_1d layout(#executable_layout) {
+    hal.executable.export @conv_1d layout(#executable_layout) {
       workgroup_size = [32: index, 4: index, 1: index],
       translation_info = #translation
     }
@@ -169,7 +169,7 @@ hal.executable private @conv_1d {
 ]>
 hal.executable private @conv_2d {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @conv_2d layout(#executable_layout) {
+    hal.executable.export @conv_2d layout(#executable_layout) {
       workgroup_size = [32: index, 4: index, 1: index],
       translation_info = #translation
     }
@@ -284,7 +284,7 @@ hal.executable private @conv_2d {
 ]>
 hal.executable private @conv_3d {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @conv_3d layout(#executable_layout) {
+    hal.executable.export @conv_3d layout(#executable_layout) {
       workgroup_size = [32: index, 4: index, 1: index],
       translation_info = #translation
     }
@@ -355,7 +355,7 @@ hal.executable private @conv_3d {
 module  {
   hal.executable private @pooling_nhwc_max {
     hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-      hal.executable.entry_point @pooling_nhwc_max layout(#executable_layout) {
+      hal.executable.export @pooling_nhwc_max layout(#executable_layout) {
         workgroup_size = [32: index, 4: index, 1: index],
         translation_info = #translation
       }
@@ -422,7 +422,7 @@ module  {
 
 hal.executable @matvec {
   hal.executable.variant public @vulkan_spirv_fb, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point public @matvec ordinal(0) layout(#executable_layout) {
+    hal.executable.export public @matvec ordinal(0) layout(#executable_layout) {
       workgroup_size = [32: index, 1: index, 1: index],
       translation_info = #translation
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
@@ -11,7 +11,7 @@
 ]>
 hal.executable private @static_scatter_update_slice  {
   hal.executable.variant @vulkan_spirv_fb, target = <"vulkan", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @static_scatter_update_slice layout(#executable_layout) {
+    hal.executable.export @static_scatter_update_slice layout(#executable_layout) {
       translation_info = #translation,
       workgroup_size = [16 : index, 1 : index, 1 : index]
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_sort.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_sort.mlir
@@ -10,7 +10,7 @@
 ]>
 hal.executable private @static_3d_sort  {
   hal.executable.variant @vulkan_spirv_fb, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @static_3d_sort layout(#executable_layout) {
+    hal.executable.export @static_3d_sort layout(#executable_layout) {
       translation_info = #translation,
       workgroup_size = [16 : index, 1 : index, 1 : index]
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_promote_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_promote_matmul.mlir
@@ -17,7 +17,7 @@ hal.executable @matmul_256x1024x128 {
        max_compute_workgroup_invocations = 1024 : i32,
        max_compute_workgroup_size = dense<[2147483647, 65535, 65535]> : vector<3xi32>,
        subgroup_size = 32 : i32}>}> {
-    hal.executable.entry_point public @matmul_256x1024x128 ordinal(0) layout(#executable_layout) {
+    hal.executable.export public @matmul_256x1024x128 ordinal(0) layout(#executable_layout) {
       translation_info = #iree_codegen.translation_info<SPIRVVectorizeWithWorkgroupMemory workload_per_wg = [128, 128]>,
       workgroup_size = [32 : index, 8 : index, 1 : index]
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_batch_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_batch_matmul.mlir
@@ -11,7 +11,7 @@
 ]>
 hal.executable private @fused_fill_batch_matmul {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @fused_fill_batch_matmul layout(#executable_layout) {
+    hal.executable.export @fused_fill_batch_matmul layout(#executable_layout) {
       workgroup_size = [16: index, 1: index, 1: index],
       translation_info = #translation
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
@@ -11,7 +11,7 @@
 ]>
 hal.executable private @conv_static_shape_f32 {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @conv_static_shape_f32 layout(#executable_layout) {
+    hal.executable.export @conv_static_shape_f32 layout(#executable_layout) {
       workgroup_size = [4: index, 4: index, 1: index],
       translation_info = #translation
     }
@@ -102,7 +102,7 @@ hal.executable private @conv_static_shape_f32 {
 ]>
 hal.executable private @depthwise_conv_static_shape_f32 {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @depthwise_conv_static_shape_f32 layout(#executable_layout) {
+    hal.executable.export @depthwise_conv_static_shape_f32 layout(#executable_layout) {
       workgroup_size = [4: index, 4: index, 4: index],
       translation_info = #translation
     }
@@ -193,7 +193,7 @@ hal.executable private @depthwise_conv_static_shape_f32 {
 
 hal.executable private @low_padded_conv {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @low_padded_conv layout(#executable_layout) {
+    hal.executable.export @low_padded_conv layout(#executable_layout) {
       workgroup_size = [8: index, 2: index, 1: index],
       translation_info = #translation
     }
@@ -314,7 +314,7 @@ hal.executable private @low_padded_conv {
 
 hal.executable private @low_high_padded_depthwise_conv {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @low_high_padded_depthwise_conv layout(#executable_layout) {
+    hal.executable.export @low_high_padded_depthwise_conv layout(#executable_layout) {
       workgroup_size = [8: index, 2: index, 1: index],
       translation_info = #translation
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_matmul.mlir
@@ -11,7 +11,7 @@
 ]>
 hal.executable private @matmul_static_shape_f16 {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @matmul_static_shape_f16 layout(#executable_layout) {
+    hal.executable.export @matmul_static_shape_f16 layout(#executable_layout) {
       workgroup_size = [16: index, 1: index, 1: index],
       translation_info = #translation
     }
@@ -75,7 +75,7 @@ hal.executable private @matmul_static_shape_f16 {
 ]>
 hal.executable private @matmul_static_shape_f32 {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @matmul_static_shape_f32 layout(#executable_layout) {
+    hal.executable.export @matmul_static_shape_f32 layout(#executable_layout) {
       workgroup_size = [16: index, 1: index, 1: index],
       translation_info = #translation
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_to_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_to_cooperative_ops.mlir
@@ -30,7 +30,7 @@ hal.executable public @matmul_256x1024x128_div_sub {
            max_compute_workgroup_invocations = 1024 : i32,
            max_compute_workgroup_size = dense<[2147483647, 65535, 65535]> : vector<3xi32>,
            subgroup_size = 32 : i32}>}> {
-    hal.executable.entry_point public @matmul_256x1024x128_div_sub layout(#executable_layout) {
+    hal.executable.export public @matmul_256x1024x128_div_sub layout(#executable_layout) {
       translation_info = #translation,
       workgroup_size = [32 : index, 1 : index, 1 : index]
     } {

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -54,10 +54,9 @@ FailureOr<IREE::HAL::ExecutableEntryPointOp> defineWorkgroupCountRegion(
   Block *entryBlock = builder.createBlock(&region);
   // Add 3 index arguments for the workload.
   auto indexType = builder.getIndexType();
-  assert(IREE::HAL::ExecutableEntryPointOp::getNumWorkgroupDims() == 3 &&
-         "expected 3 dims");
   auto device =
       entryBlock->addArgument(builder.getType<IREE::HAL::DeviceType>(), loc);
+  // NOTE: this code currently assumes workloads are always defined as 3D.
   std::array<Value, 3> workload = {entryBlock->addArgument(indexType, loc),
                                    entryBlock->addArgument(indexType, loc),
                                    entryBlock->addArgument(indexType, loc)};

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -27,26 +27,26 @@ namespace iree_compiler {
 
 namespace {}  // namespace
 
-FailureOr<IREE::HAL::ExecutableEntryPointOp> defineWorkgroupCountRegion(
-    OpBuilder &builder, IREE::HAL::ExecutableEntryPointOp entryPointOp,
+FailureOr<IREE::HAL::ExecutableExportOp> defineWorkgroupCountRegion(
+    OpBuilder &builder, IREE::HAL::ExecutableExportOp exportOp,
     WorkgroupCountRegionBuilder regionBuilder) {
-  Location loc = entryPointOp.getLoc();
+  Location loc = exportOp.getLoc();
 
   OpBuilder::InsertionGuard guard(builder);
   // Create the cloned operation but with a single region.
-  builder.setInsertionPoint(entryPointOp);
+  builder.setInsertionPoint(exportOp);
 
-  auto clonedOp = builder.create<IREE::HAL::ExecutableEntryPointOp>(
-      loc, entryPointOp.sym_nameAttr(), entryPointOp.ordinalAttr(),
-      entryPointOp.layoutAttr(), entryPointOp.workgroup_sizeAttr(),
-      entryPointOp.workgroup_local_memoryAttr());
+  auto clonedOp = builder.create<IREE::HAL::ExecutableExportOp>(
+      loc, exportOp.sym_nameAttr(), exportOp.ordinalAttr(),
+      exportOp.layoutAttr(), exportOp.workgroup_sizeAttr(),
+      exportOp.workgroup_local_memoryAttr());
   // Copy over all attributes
-  for (auto attr : entryPointOp->getAttrs()) {
-    if (attr.getName() != entryPointOp.sym_nameAttrName() &&
-        attr.getName() != entryPointOp.ordinalAttrName() &&
-        attr.getName() != entryPointOp.layoutAttr() &&
-        attr.getName() != entryPointOp.workgroup_sizeAttrName() &&
-        attr.getName() != entryPointOp.workgroup_local_memoryAttrName()) {
+  for (auto attr : exportOp->getAttrs()) {
+    if (attr.getName() != exportOp.sym_nameAttrName() &&
+        attr.getName() != exportOp.ordinalAttrName() &&
+        attr.getName() != exportOp.layoutAttr() &&
+        attr.getName() != exportOp.workgroup_sizeAttrName() &&
+        attr.getName() != exportOp.workgroup_local_memoryAttrName()) {
       clonedOp->setAttr(attr.getName(), attr.getValue());
     }
   }
@@ -63,7 +63,7 @@ FailureOr<IREE::HAL::ExecutableEntryPointOp> defineWorkgroupCountRegion(
   std::array<Value, 3> workgroupCount =
       regionBuilder(builder, loc, device, workload);
   builder.create<IREE::HAL::ReturnOp>(loc, workgroupCount);
-  entryPointOp.erase();
+  exportOp.erase();
   return clonedOp;
 }
 

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -50,7 +50,7 @@ FailureOr<IREE::HAL::ExecutableExportOp> defineWorkgroupCountRegion(
       clonedOp->setAttr(attr.getName(), attr.getValue());
     }
   }
-  Region &region = clonedOp.workgroup_count_region();
+  Region &region = clonedOp.workgroup_count();
   Block *entryBlock = builder.createBlock(&region);
   // Add 3 index arguments for the workload.
   auto indexType = builder.getIndexType();

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
@@ -25,15 +25,15 @@ namespace iree_compiler {
 
 /// Specifies the number of workgroups to use for a particular entry point
 /// function, by updating the `worgroup_count` region in the
-/// `hal.executable.entry_point` op for this operation. The method takes a
+/// `hal.executable.export` op for this operation. The method takes a
 /// callback function, which computes the workgroup count (x,y,z) given the
 /// workload along (x,y,z).
-/// Returns a new `hal.executable.entry_point` op. MLIR semantics requires
+/// Returns a new `hal.executable.export` op. MLIR semantics requires
 /// creation of new ops when a region is added.
 using WorkgroupCountRegionBuilder = std::function<std::array<Value, 3>(
     OpBuilder &b, Location loc, Value device, std::array<Value, 3> workload)>;
-FailureOr<IREE::HAL::ExecutableEntryPointOp> defineWorkgroupCountRegion(
-    OpBuilder &builder, IREE::HAL::ExecutableEntryPointOp entryPointOp,
+FailureOr<IREE::HAL::ExecutableExportOp> defineWorkgroupCountRegion(
+    OpBuilder &builder, IREE::HAL::ExecutableExportOp exportOp,
     WorkgroupCountRegionBuilder regionBuilder);
 
 /// Insert patterns to perform folding of AffineMinOp by matching the pattern

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -59,10 +59,10 @@ llvm::SmallVector<mlir::linalg::ProcInfo, 2> getSubgroupIdsAndCounts(
 
 std::array<int64_t, 3> getWorkgroupSize(mlir::func::FuncOp funcOp) {
   std::array<int64_t, 3> workgroupSize;
-  FailureOr<IREE::HAL::ExecutableEntryPointOp> entryPointOp =
+  FailureOr<IREE::HAL::ExecutableExportOp> exportOp =
       mlir::iree_compiler::getEntryPoint(funcOp);
   llvm::Optional<mlir::ArrayAttr> workgroupSizeAttr =
-      entryPointOp->workgroup_size();
+      exportOp->workgroup_size();
   assert(workgroupSizeAttr.hasValue());
   for (auto it : llvm::enumerate(workgroupSizeAttr.getValue())) {
     workgroupSize[it.index()] =

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -33,12 +33,11 @@ namespace iree_compiler {
 // Utility functions to get entry points
 //===----------------------------------------------------------------------===//
 
-FailureOr<IREE::HAL::ExecutableEntryPointOp> getEntryPoint(
-    func::FuncOp funcOp) {
+FailureOr<IREE::HAL::ExecutableExportOp> getEntryPoint(func::FuncOp funcOp) {
   auto variantOp = funcOp->getParentOfType<IREE::HAL::ExecutableVariantOp>();
   if (!variantOp) return failure();
 
-  for (auto op : variantOp.getOps<IREE::HAL::ExecutableEntryPointOp>()) {
+  for (auto op : variantOp.getOps<IREE::HAL::ExecutableExportOp>()) {
     if (op.sym_name() == funcOp.getName()) {
       return op;
     }
@@ -50,14 +49,14 @@ bool isEntryPoint(func::FuncOp func) {
   return func.isPublic() && succeeded(getEntryPoint(func));
 }
 
-llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> getAllEntryPoints(
+llvm::StringMap<IREE::HAL::ExecutableExportOp> getAllEntryPoints(
     ModuleOp module) {
   auto variantOp = module->getParentOfType<IREE::HAL::ExecutableVariantOp>();
-  llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> entryPointOps;
-  for (auto op : variantOp.getOps<IREE::HAL::ExecutableEntryPointOp>()) {
-    entryPointOps[op.sym_name()] = op;
+  llvm::StringMap<IREE::HAL::ExecutableExportOp> exportOps;
+  for (auto op : variantOp.getOps<IREE::HAL::ExecutableExportOp>()) {
+    exportOps[op.sym_name()] = op;
   }
-  return entryPointOps;
+  return exportOps;
 }
 
 /// Returns the StringAttr with the name `stringAttr` in the configuration of

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -33,11 +33,11 @@ static constexpr unsigned kNumMaxParallelDims = 3;
 bool isEntryPoint(func::FuncOp func);
 
 /// Returns a map from function symbol name to corresponding entry point op.
-llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> getAllEntryPoints(
+llvm::StringMap<IREE::HAL::ExecutableExportOp> getAllEntryPoints(
     ModuleOp module);
 
 /// Returns the entry point op for the `funcOp`. Returns `nullptr` on failure.
-FailureOr<IREE::HAL::ExecutableEntryPointOp> getEntryPoint(func::FuncOp funcOp);
+FailureOr<IREE::HAL::ExecutableExportOp> getEntryPoint(func::FuncOp funcOp);
 
 /// Methods to get backend information.
 bool isX86(IREE::HAL::ExecutableVariantOp variantOp);

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -405,18 +405,6 @@ void DispatchTensorStoreOp::getCanonicalizationPatterns(
 }
 
 //===----------------------------------------------------------------------===//
-// flow.dispatch.workgroup.*
-//===----------------------------------------------------------------------===//
-
-OpFoldResult DispatchWorkgroupRankOp::fold(ArrayRef<Attribute> operands) {
-  if (auto dispatchOp = (*this)->getParentOfType<DispatchWorkgroupsOp>()) {
-    return IntegerAttr::get(IndexType::get(getContext()),
-                            APInt(64, dispatchOp.workgroup_count().size()));
-  }
-  return {};
-}
-
-//===----------------------------------------------------------------------===//
 // Tensor ops
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -34,12 +34,12 @@ def FLOW_DispatchWorkgroupsOp : FLOW_PureOp<"dispatch.workgroups", [
   ]>,
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{a dispatch of workgroups across an n-dimension grid}];
+  let summary = [{a dispatch of workgroups across a 3-dimensional grid}];
   let description = [{
-    Dispatches some number of workgroups across an n-dimensional grid. The
+    Dispatches some number of workgroups across a 3-dimensional grid. The
     body region will be invoked for each workgroup with a unique
     `flow.dispatch.workgroup.id` in the range of
-    `[0, flow.dispatch.workgroup.count)` (along each dimension).
+    `[0, flow.dispatch.workgroup.count)` (along each dimension XYZ).
 
     From the outside the dispatch operation has value semantics: some tensors
     (and optionally other primitive types) are consumed and one or more new
@@ -61,17 +61,16 @@ def FLOW_DispatchWorkgroupsOp : FLOW_PureOp<"dispatch.workgroups", [
     and even several different variants for a particular target device
     (differing workgroup sizes, etc).
 
-    Because of the general nature of the op in this dialect the workgroup count
-    provided to the `flow.dispatch.workgroups` op is in an abstract untiled
-    domain. Unlike when lowering to the HAL dialect the number of dimensions is
-    unbounded and does not yet have the workgroup size factored into it. As the
-    dispatch is lowered the workgroup count range will be converted into a 3D
-    XYZ grid space and divided up by the workgroup size chosen for particular
-    target devices.
+    Because at this point in the layering devices have not yet been selected the
+    workgroup count cannot be fully evaluated. Instead workload parameters are
+    captured that are then passed to a function that when later evaluated
+    computes the actual workgroup count based on target information. The
+    workload is not limited to the 3D XYZ grid dispatch of the workgroup count
+    and can contain any number of parameters used to compute it.
   }];
 
   let arguments = (ins
-    Variadic<FLOW_Dim>:$workgroup_count,
+    Variadic<FLOW_Dim>:$workload,
     Variadic<AnyType>:$operands,
     FLOW_ShapeDynamicDims:$operand_dims,
     FLOW_ShapeDynamicDims:$result_dims,
@@ -81,10 +80,10 @@ def FLOW_DispatchWorkgroupsOp : FLOW_PureOp<"dispatch.workgroups", [
     Variadic<AnyType>:$results
   );
 
-  let regions = (region AnyRegion:$body);
+  let regions = (region AnyRegion:$workgroup_body);
 
   let assemblyFormat = [{
-    `[` $workgroup_count `]` ``
+    (`[` $workload^ `]`)? ``
     `(` $operands `)` `:`
     custom<ShapedFunctionType>(ref($operands),
                                type($operands), $operand_dims,
@@ -94,13 +93,13 @@ def FLOW_DispatchWorkgroupsOp : FLOW_PureOp<"dispatch.workgroups", [
     `=` `\n` ` ` ` ` ` `
     custom<DispatchWorkgroupBody>(ref(type($operands)),
                                   ref(type($results)),
-                                  $body)
+                                  $workgroup_body)
   }];
 
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<(ins
-      "ValueRange":$workgroupCount,
+      "ValueRange":$workload,
       "TypeRange":$resultTypes, "ValueRange":$resultDims,
       "ValueRange":$operands, "ValueRange":$operandDims,
       "ArrayRef<int64_t>":$tiedOperands,
@@ -108,8 +107,6 @@ def FLOW_DispatchWorkgroupsOp : FLOW_PureOp<"dispatch.workgroups", [
   ];
 
   let extraClassDeclaration = [{
-    size_t getWorkgroupRank() { return workgroup_count().size(); }
-
     FunctionType getDispatchType() {
       return FunctionType::get(
           getContext(),
@@ -119,10 +116,10 @@ def FLOW_DispatchWorkgroupsOp : FLOW_PureOp<"dispatch.workgroups", [
     }
 
     /// Returns the index of the args() operand in the Operation operands list.
-    unsigned mapArgOperandToOpOperand(unsigned i) { return i + workgroup_count().size(); };
+    unsigned mapArgOperandToOpOperand(unsigned i) { return i + workload().size(); };
 
     ValueRange getOperandDynamicDims(unsigned idx) {
-      return IREE::Util::findVariadicDynamicDims(idx - workgroup_count().size(), operands(), operand_dims());
+      return IREE::Util::findVariadicDynamicDims(idx - workload().size(), operands(), operand_dims());
     }
     ValueRange getResultDynamicDims(unsigned idx) {
       return IREE::Util::findVariadicDynamicDims(idx, results(), result_dims());
@@ -133,27 +130,6 @@ def FLOW_DispatchWorkgroupsOp : FLOW_PureOp<"dispatch.workgroups", [
   let hasCanonicalizer = 1;
 }
 
-def FLOW_DispatchWorkgroupRankOp : FLOW_PureOp<"dispatch.workgroup.rank", [
-  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-]> {
-  let summary = [{returns the rank of the workgroup dimensions}];
-  let description = [{
-    The number of workgroup dimensions used during dispatch, bounding the
-    `flow.dispatch.workgroup.*` query functions.
-
-    ```mlir
-    %rank = flow.dispatch.workgroup.rank : index
-    ```
-  }];
-
-  let arguments = (ins);
-  let results = (outs FLOW_Dim:$result);
-
-  let assemblyFormat = "attr-dict `:` type($result)";
-
-  let hasFolder = 1;
-}
-
 def FLOW_DispatchWorkgroupIDOp : FLOW_PureOp<"dispatch.workgroup.id", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
@@ -162,13 +138,14 @@ def FLOW_DispatchWorkgroupIDOp : FLOW_PureOp<"dispatch.workgroup.id", [
     The global workgroup ID of the current workgroup in the range of
     `[0, flow.dispatch.workgroup.count)` along each dimension.
 
+    Represented as a 3D grid classically written as XYZ.
     Corresponds to the `WorkgroupId` SPIR-V built-in and the `blockIdx` CUDA
-    built-in variable, only in the flow dialect the number of dimensions is not
-    restricted to 3 (XYZ).
+    built-in variable.
 
     ```mlir
     %x = flow.dispatch.workgroup.id[0] : index
     %y = flow.dispatch.workgroup.id[1] : index
+    %z = flow.dispatch.workgroup.id[2] : index
     ```
   }];
 
@@ -197,13 +174,14 @@ def FLOW_DispatchWorkgroupCountOp : FLOW_PureOp<"dispatch.workgroup.count", [
   let description = [{
     The total number of workgroups along each dimension in the dispatch grid.
 
+    Represented as a 3D grid classically written as XYZ.
     Corresponds to the `NumWorkgroups` SPIR-V built-in and the `gridDim` CUDA
-    built-in variable, only in the flow dialect the number of dimensions is not
-    restricted to 3 (XYZ).
+    built-in variable.
 
     ```mlir
     %x = flow.dispatch.workgroup.count[0] : index
     %y = flow.dispatch.workgroup.count[1] : index
+    %z = flow.dispatch.workgroup.count[2] : index
     ```
   }];
 
@@ -239,13 +217,14 @@ def FLOW_DispatchWorkgroupSizeOp : FLOW_PureOp<"dispatch.workgroup.size", [
     still possible to use the symbolic workgroup size inside of dispatch
     executables as a placeholder for the resolved value once in the HAL.
 
+    Represented as a 3D grid classically written as XYZ.
     Corresponds to the `WorkgroupSize` SPIR-V built-in and the `blockDim` CUDA
-    built-in variable, only in the flow dialect the number of dimensions is not
-    restricted to 3 (XYZ).
+    built-in variable.
 
     ```mlir
     %x = flow.dispatch.workgroup.size[0] : index
     %y = flow.dispatch.workgroup.size[1] : index
+    %z = flow.dispatch.workgroup.size[2] : index
     ```
   }];
 
@@ -579,15 +558,13 @@ def FLOW_DispatchEntryOp : FLOW_Op<"dispatch.entry", [
   let arguments = (ins
     OptionalAttr<StrAttr>:$sym_visibility,
     SymbolNameAttr:$sym_name,
-    FlatSymbolRefAttr:$function_ref,
-    OptionalAttr<IndexAttr>:$workgroup_rank
+    FlatSymbolRefAttr:$function_ref
   );
 
   let builders = [
     OpBuilder<(ins
       "StringRef":$sym_name,
-      "FlatSymbolRefAttr":$function_ref,
-      "IntegerAttr":$workgroup_rank)>,
+      "FlatSymbolRefAttr":$function_ref)>,
   ];
 }
 
@@ -598,20 +575,23 @@ def FLOW_DispatchEntryOp : FLOW_Op<"dispatch.entry", [
 def FLOW_DispatchOp : FLOW_PureOp<"dispatch", [
   AttrSizedOperandSegments,
   FLOW_StreamableOp,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
   DeclareOpInterfaceMethods<Util_TiedOpInterface, [
     "getTiedOperandsIndexAndLength",
   ]>,
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{a dispatch of workgroups across an n-dimension grid}];
+  let summary = [{a dispatch of workgroups across a grid}];
   let description = [{
-    Dispatches workgroups across an n-dimensional grid defined by the specified
-    workgroup count. The workgroup count may be dynamic and any dimension may be
-    set to 0 to neuter the dispatch (no workgroup will execute).
+    Dispatches workgroups across an grid defined by the captured workload
+    parameters carrying the information required to compute the workgroup count
+    at runtime. The function for converting the workload into a 3D workgroup
+    count is attached to the dispatch entry point and may contain
+    arbitrary host logic.
   }];
 
   let arguments = (ins
-    Variadic<FLOW_Dim>:$workgroup_count,
+    Variadic<FLOW_Dim>:$workload,
     SymbolRefAttr:$entry_point,
     Variadic<AnyType>:$operands,
     FLOW_ShapeDynamicDims:$operand_dims,
@@ -625,19 +605,19 @@ def FLOW_DispatchOp : FLOW_PureOp<"dispatch", [
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<(ins
-      "DispatchEntryOp":$entryPoint, "ValueRange":$workgroupCount,
+      "DispatchEntryOp":$entryPoint, "ValueRange":$workload,
       "TypeRange":$resultTypes, "ValueRange":$resultDims,
       "ValueRange":$operands, "ValueRange":$operandDims,
       "ArrayAttr":$tiedOperands,
       CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes)>,
     OpBuilder<(ins
-      "DispatchEntryOp":$entryPoint, "ValueRange":$workgroupCount,
+      "DispatchEntryOp":$entryPoint, "ValueRange":$workload,
       "TypeRange":$resultTypes, "ValueRange":$resultDims,
       "ValueRange":$operands, "ValueRange":$operandDims,
       "ArrayRef<int64_t>":$tiedOperands,
       CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes),
       [{
-        build($_builder, $_state, entryPoint, workgroupCount,
+        build($_builder, $_state, entryPoint, workload,
               resultTypes, resultDims, operands, operandDims,
               $_builder.getIndexArrayAttr(tiedOperands),
               attributes);
@@ -652,7 +632,7 @@ def FLOW_DispatchOp : FLOW_PureOp<"dispatch", [
     bool isTransfer() { return false; }
 
     ValueRange getOperandDynamicDims(unsigned idx) {
-      return IREE::Util::findVariadicDynamicDims(idx - workgroup_count().size(), operands(), operand_dims());
+      return IREE::Util::findVariadicDynamicDims(idx - workload().size(), operands(), operand_dims());
     }
     ValueRange getResultDynamicDims(unsigned idx) {
       return IREE::Util::findVariadicDynamicDims(idx, results(), result_dims());
@@ -660,7 +640,8 @@ def FLOW_DispatchOp : FLOW_PureOp<"dispatch", [
   }];
 
   let assemblyFormat = [{
-    $entry_point `[` $workgroup_count `]` ``
+    $entry_point
+    (`[` $workload^ `]`)? ``
     `(` $operands `)` attr-dict `:`
     custom<ShapedFunctionType>(ref($operands),
                                type($operands), $operand_dims,
@@ -708,7 +689,7 @@ def FLOW_TensorTieShapeOp : FLOW_PureOp<"tensor.tie_shape", [
   let description = [{
     Metadata op used to tie tensors with their runtime-computed dynamic
     dimensions. This only exists transiently in the IR as a witness to shape
-    calculations and is removed during lowering. 
+    calculations and is removed during lowering.
   }];
 
   let arguments = (ins

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -553,6 +553,10 @@ def FLOW_ExecutableExportOp : FLOW_Op<"executable.export", [
   let description = [{
     Specifies an exported function with an externally-visible alias. Multiple
     exports can reference the same internal function.
+
+    Each entry point can have a unique workgroup count calculation region.
+    This region takes the workload parameters passed to each flow.dispatch and
+    produces an XYZ workgroup count for the 3D grid dispatch.
   }];
 
   let arguments = (ins
@@ -561,11 +565,22 @@ def FLOW_ExecutableExportOp : FLOW_Op<"executable.export", [
     FlatSymbolRefAttr:$function_ref
   );
 
+  let regions = (region AnyRegion:$workgroup_count);
+
+  let assemblyFormat = [{
+    custom<SymbolVisibility>($sym_visibility)
+    custom<SymbolAlias>($sym_name, $function_ref)
+    custom<WorkgroupCountRegion>($workgroup_count)
+    attr-dict-with-keyword
+  }];
+
   let builders = [
     OpBuilder<(ins
       "StringRef":$sym_name,
       "FlatSymbolRefAttr":$function_ref)>,
   ];
+
+  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -545,7 +545,7 @@ def FLOW_ExecutableEndOp : FLOW_Op<"executable_end", [
   let assemblyFormat = "attr-dict";
 }
 
-def FLOW_DispatchEntryOp : FLOW_Op<"dispatch.entry", [
+def FLOW_ExecutableExportOp : FLOW_Op<"executable.export", [
   HasParent<"IREE::Flow::ExecutableOp">,
   Symbol,
 ]> {
@@ -605,13 +605,13 @@ def FLOW_DispatchOp : FLOW_PureOp<"dispatch", [
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<(ins
-      "DispatchEntryOp":$entryPoint, "ValueRange":$workload,
+      "ExecutableExportOp":$entryPoint, "ValueRange":$workload,
       "TypeRange":$resultTypes, "ValueRange":$resultDims,
       "ValueRange":$operands, "ValueRange":$operandDims,
       "ArrayAttr":$tiedOperands,
       CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes)>,
     OpBuilder<(ins
-      "DispatchEntryOp":$entryPoint, "ValueRange":$workload,
+      "ExecutableExportOp":$entryPoint, "ValueRange":$workload,
       "TypeRange":$resultTypes, "ValueRange":$resultDims,
       "ValueRange":$operands, "ValueRange":$operandDims,
       "ArrayRef<int64_t>":$tiedOperands,

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/dispatch_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/dispatch_ops.mlir
@@ -20,6 +20,17 @@ func.func @dispatch(%arg0 : tensor<4xf32>) -> tensor<4xf32> {
 
 // -----
 
+// CHECK-LABEL: @dispatchNoWorkload
+func.func @dispatchNoWorkload(%arg0 : tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: %[[CST:.+]] = arith.constant
+  %cst = arith.constant 4 : index
+  // CHECK: %0 = flow.dispatch @ex0::@dispatch_fn(%[[CST]], %arg0) : (index, tensor<4xf32>) -> tensor<4xf32>
+  %0 = flow.dispatch @ex0::@dispatch_fn(%cst, %arg0) : (index, tensor<4xf32>) -> tensor<4xf32>
+  return %0 : tensor<4xf32>
+}
+
+// -----
+
 // CHECK-LABEL: @inplaceDispatch
 func.func @inplaceDispatch(%arg0 : tensor<4xf32>, %arg1 : tensor<8xf32>) -> (tensor<4xf32>, tensor<8xf32>) {
   // CHECK: %[[CST:.+]] = arith.constant

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/dispatch_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/dispatch_ops.mlir
@@ -6,7 +6,7 @@ flow.executable @ex0 {
       return %arg0 : tensor<4xf32>
     }
   }
-  flow.dispatch.entry @dispatch_fn
+  flow.executable.export @dispatch_fn
 }
 
 // CHECK-LABEL: @dispatch

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/dispatch_workgroups.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/dispatch_workgroups.mlir
@@ -25,9 +25,6 @@ func.func @complexWorkgroupsUsage(
 
     // Query symbolic workgroup info:
 
-    // CHECK: flow.dispatch.workgroup.rank : index
-    %workgroup_rank = flow.dispatch.workgroup.rank : index
-
     // CHECK-DAG: flow.dispatch.workgroup.id[0] : index
     // CHECK-DAG: flow.dispatch.workgroup.id[1] : index
     // CHECK-DAG: flow.dispatch.workgroup.count[0] : index

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/dispatch_workgroups_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/dispatch_workgroups_folding.mlir
@@ -1,26 +1,5 @@
 // RUN: iree-opt --allow-unregistered-dialect --split-input-file --canonicalize %s | iree-opt --allow-unregistered-dialect --split-input-file | FileCheck %s
 
-// CHECK-LABEL: @workgroupRankFolding
-func.func @workgroupRankFolding(%arg0 : tensor<?x4xf32>) -> tensor<4x?xf32> {
-  %c128 = arith.constant 128 : index
-  %x = arith.constant 100 : index
-  %y = arith.constant 50 : index
-  // CHECK: flow.dispatch.workgroups
-  %0 = flow.dispatch.workgroups[%x, %y](%arg0) : (tensor<?x4xf32>{%c128}) -> (tensor<4x?xf32>{%c128}) = (
-    %arg0_capture: !flow.dispatch.tensor<readonly:?x4xf32>,
-    %ret0: !flow.dispatch.tensor<writeonly:4x?xf32>
-  ) {
-    // CHECK: %[[RANK:.+]] = arith.constant 2 : index
-    %workgroup_rank = flow.dispatch.workgroup.rank : index
-    // CHECK-NEXT: "test.sink"(%[[RANK]])
-    "test.sink"(%workgroup_rank) : (index) -> ()
-    flow.return
-  }
-  return %0 : tensor<4x?xf32>
-}
-
-// -----
-
 // CHECK-LABEL: @inlineWithTiedResults1
 // CHECK-SAME: (%[[ARG0:.+]]: tensor<1x4xf32>)
 func.func @inlineWithTiedResults1(%arg0: tensor<1x4xf32>) -> tensor<1x4xf32> {

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/executable_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/executable_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: @dispatch_ex
 flow.executable @dispatch_ex {

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/executable_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/executable_ops.mlir
@@ -9,8 +9,8 @@ flow.executable @dispatch_ex {
       return
     }
   }
-  // CHECK: flow.dispatch.entry public @dispatch0
-  flow.dispatch.entry @dispatch0
-  // CHECK: flow.dispatch.entry public @dispatch0 as("dispatch0_alias")
-  flow.dispatch.entry @dispatch0 as("dispatch0_alias")
+  // CHECK: flow.executable.export public @dispatch0
+  flow.executable.export @dispatch0
+  // CHECK: flow.executable.export public @dispatch0 as("dispatch0_alias")
+  flow.executable.export @dispatch0 as("dispatch0_alias")
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DeduplicateExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DeduplicateExecutables.cpp
@@ -198,9 +198,9 @@ bool areExecutablesEquivalent(ExecutableOp lhs, ExecutableOp rhs) {
   // Must have the same number of entry point ops, with the same attributes.
   // Entry point op symbol names are expected to differ, that won't affect
   // equivalence.
-  if (!compare_ranges(lhsModule.getOps<DispatchEntryOp>(),
-                      rhsModule.getOps<DispatchEntryOp>(),
-                      [](DispatchEntryOp lhs, DispatchEntryOp rhs) {
+  if (!compare_ranges(lhsModule.getOps<ExecutableExportOp>(),
+                      rhsModule.getOps<ExecutableExportOp>(),
+                      [](ExecutableExportOp lhs, ExecutableExportOp rhs) {
                         return lhs->getAttrs() == rhs->getAttrs();
                       })) {
     return false;  // dispatch entry mismatch
@@ -269,17 +269,18 @@ class DeduplicateExecutablesPass
         duplicateExecutableOps.push_back(duplicateExecutableOp);
 
         // Record entry point reference replacements.
-        for (auto entryOpPair : llvm::zip(
-                 duplicateExecutableOp.getBlock().getOps<DispatchEntryOp>(),
-                 referenceExecutableOp.getBlock().getOps<DispatchEntryOp>())) {
+        for (auto exportOpPair : llvm::zip(
+                 duplicateExecutableOp.getBlock().getOps<ExecutableExportOp>(),
+                 referenceExecutableOp.getBlock()
+                     .getOps<ExecutableExportOp>())) {
           auto oldSymbolRefAttr = SymbolRefAttr::get(
               builder.getContext(), duplicateExecutableOp.getName(),
               {SymbolRefAttr::get(builder.getContext(),
-                                  std::get<0>(entryOpPair).sym_name())});
+                                  std::get<0>(exportOpPair).sym_name())});
           auto newSymbolRefAttr = SymbolRefAttr::get(
               builder.getContext(), referenceExecutableOp.getName(),
               {SymbolRefAttr::get(builder.getContext(),
-                                  std::get<1>(entryOpPair).sym_name())});
+                                  std::get<1>(exportOpPair).sym_name())});
           entryPointRefReplacements[oldSymbolRefAttr] = newSymbolRefAttr;
         }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -365,7 +365,7 @@ buildOperandLessFlowDispatchWorkgroupOp(PatternRewriter &rewriter, Location loc,
       loc, workload, resultTypes, resultDynamicDims,
       /*operands=*/ArrayRef<Value>{}, /*operandDims=*/ArrayRef<Value>{},
       /*tiedOperands=*/ArrayRef<int64_t>{});
-  Region &region = dispatchOp.body();
+  Region &region = dispatchOp.workgroup_body();
   Block *block = &region.front();
   OpBuilder::InsertionGuard g(rewriter);
   rewriter.setInsertionPointToEnd(block);
@@ -722,7 +722,7 @@ static void tryToTieOperandsAndResults(
 static LogicalResult legalizeDispatchWorkgroupOperands(
     IREE::Flow::DispatchWorkgroupsOp dispatchOp) {
   Location loc = dispatchOp.getLoc();
-  Region &region = dispatchOp.body();
+  Region &region = dispatchOp.workgroup_body();
   Block &block = region.front();
   OpBuilder b = OpBuilder::atBlockBegin(&block);
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DumpDispatchGraph.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DumpDispatchGraph.cpp
@@ -30,6 +30,8 @@ namespace iree_compiler {
 namespace IREE {
 namespace Flow {
 
+namespace {
+
 static const StringRef kLineStyleControlFlow = "dashed";
 static const StringRef kLineStyleDataFlow = "solid";
 static const StringRef kShapeNode = "box";
@@ -72,8 +74,6 @@ static std::string quoteString(const std::string &str) {
 
 using AttributeMap = llvm::StringMap<std::string>;
 
-namespace {
-
 /// This struct represents a node in the DOT language. Each node has an
 /// identifier and an optional identifier for the cluster (subgraph) that
 /// contains the node.
@@ -93,10 +93,12 @@ struct Node {
 /// This pass generates a Graphviz dataflow visualization of an MLIR operation.
 /// Note: See https://www.graphviz.org/doc/info/lang.html for more information
 /// about the Graphviz DOT language.
-class PrintOpPass : public DumpDispatchGraphBase<PrintOpPass> {
+class DumpDispatchGraphPass
+    : public DumpDispatchGraphBase<DumpDispatchGraphPass> {
  public:
-  PrintOpPass(raw_ostream &os) : os(os) {}
-  PrintOpPass(const PrintOpPass &o) : PrintOpPass(o.os.getOStream()) {}
+  DumpDispatchGraphPass(raw_ostream &os) : os(os) {}
+  DumpDispatchGraphPass(const DumpDispatchGraphPass &o)
+      : DumpDispatchGraphPass(o.os.getOStream()) {}
 
   void runOnOperation() override {
     auto modOp = dyn_cast<ModuleOp>(getOperation());
@@ -283,9 +285,9 @@ class PrintOpPass : public DumpDispatchGraphBase<PrintOpPass> {
         os << " = " << op->getName();
 
         if (auto dispatch = dyn_cast<DispatchOp>(op)) {
-          // print workgroup count
+          // print workload
           os << "[";
-          printOperands(os, dispatch.workgroup_count(), state);
+          printOperands(os, dispatch.workload(), state);
           os << "]\n";
 
           // print entry function name
@@ -413,7 +415,7 @@ class PrintOpPass : public DumpDispatchGraphBase<PrintOpPass> {
 }  // namespace
 
 std::unique_ptr<Pass> createDumpDispatchGraphPass(raw_ostream &os) {
-  return std::make_unique<PrintOpPass>(os);
+  return std::make_unique<DumpDispatchGraphPass>(os);
 }
 
 }  // namespace Flow

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
@@ -62,7 +62,7 @@ static ExecutableOp createExecutable(Location loc, StringRef executableName,
 // Converts a dispatch region op into a dispatch op to the outlined region.
 static LogicalResult convertToDispatchOp(DispatchWorkgroupsOp regionOp,
                                          ExecutableOp executableOp,
-                                         DispatchEntryOp entryPointOp) {
+                                         ExecutableExportOp exportOp) {
   // Insert at the same place as the original region.
   OpBuilder builder(regionOp);
 
@@ -70,7 +70,7 @@ static LogicalResult convertToDispatchOp(DispatchWorkgroupsOp regionOp,
   // Note that we copy the tied operand indices from the workgroups op - it
   // lines up 1:1 with the dispatch once we've outlined things.
   auto dispatchOp = builder.create<DispatchOp>(
-      regionOp.getLoc(), entryPointOp, regionOp.workload(),
+      regionOp.getLoc(), exportOp, regionOp.workload(),
       regionOp.getResultTypes(), regionOp.result_dims(), regionOp.operands(),
       regionOp.operand_dims(), regionOp.tied_operandsAttr());
 
@@ -133,12 +133,12 @@ static LogicalResult outlineDispatchWorkgroupsOp(
 
   // Add executable entry point pointing at the function.
   OpBuilder builder(executableOp.body());
-  auto entryPointOp = builder.create<DispatchEntryOp>(
+  auto exportOp = builder.create<ExecutableExportOp>(
       regionOp.getLoc(), workgroupFuncOp.getName(),
       SymbolRefAttr::get(workgroupFuncOp));
 
   // Finally convert the dispatch region into a dispatch to the outlined func.
-  return convertToDispatchOp(regionOp, executableOp, entryPointOp);
+  return convertToDispatchOp(regionOp, executableOp, exportOp);
 }
 
 }  // namespace

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
@@ -131,7 +131,7 @@ static LogicalResult outlineDispatchWorkgroupsOp(
   executableOp.getOperation()->moveBefore(parentFuncOp);
   executableOp.setPrivate();
 
-  // Add executable entry point pointing at the function.
+  // Add an export pointing at the entry point function.
   OpBuilder builder(executableOp.body());
   auto exportOp = builder.create<ExecutableExportOp>(
       regionOp.getLoc(), workgroupFuncOp.getName(),

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/deduplicate_executables.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/deduplicate_executables.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: flow.executable public @single_executable_ex_0
 flow.executable @single_executable_ex_0 {
-  flow.dispatch.entry @single_executable_entry_0
+  flow.executable.export @single_executable_entry_0
   builtin.module {
     func.func @single_executable_entry_0(%arg0: tensor<4xf32>) -> tensor<4xf32> {
       %0 = mhlo.add %arg0, %arg0 : tensor<4xf32>
@@ -22,7 +22,7 @@ func.func @single_executable(%arg0: tensor<4xf32>) -> tensor<4xf32> {
 
 // CHECK-LABEL: flow.executable public @duplicate_executables_ex_0
 flow.executable @duplicate_executables_ex_0 {
-  flow.dispatch.entry @duplicate_executables_entry_0
+  flow.executable.export @duplicate_executables_entry_0
   builtin.module {
     func.func @duplicate_executables_entry_0(%arg0: tensor<4xf32>) -> tensor<4xf32> {
       %0 = mhlo.add %arg0, %arg0 : tensor<4xf32>
@@ -32,7 +32,7 @@ flow.executable @duplicate_executables_ex_0 {
 }
 // CHECK-NOT: flow.executable public @duplicate_executables_ex_1
 flow.executable @duplicate_executables_ex_1 {
-  flow.dispatch.entry @duplicate_executables_entry_1
+  flow.executable.export @duplicate_executables_entry_1
   builtin.module {
     func.func @duplicate_executables_entry_1(%arg0: tensor<4xf32>) -> tensor<4xf32> {
       %0 = mhlo.add %arg0, %arg0 : tensor<4xf32>
@@ -42,7 +42,7 @@ flow.executable @duplicate_executables_ex_1 {
 }
 // CHECK-LABEL: flow.executable public @duplicate_executables_ex_2
 flow.executable @duplicate_executables_ex_2 {
-  flow.dispatch.entry @duplicate_executables_entry_2
+  flow.executable.export @duplicate_executables_entry_2
   builtin.module {
     func.func @duplicate_executables_entry_2(%arg0: tensor<4xf32>) -> tensor<4xf32> {
       %0 = mhlo.subtract %arg0, %arg0 : tensor<4xf32>
@@ -66,7 +66,7 @@ func.func @duplicate_executables(%arg0: tensor<4xf32>) -> tensor<4xf32> {
 
 // CHECK: flow.executable public @same_ops_diff_operands_ex_0
 flow.executable @same_ops_diff_operands_ex_0 {
-  flow.dispatch.entry @entry_0
+  flow.executable.export @entry_0
   builtin.module {
     func.func @entry_0(%arg0: tensor<2xi32>, %arg1: tensor<2xi32>) -> tensor<2xi32> {
       %0 = mhlo.multiply %arg0, %arg1 : tensor<2xi32>
@@ -76,7 +76,7 @@ flow.executable @same_ops_diff_operands_ex_0 {
 }
 // CHECK: flow.executable public @same_ops_diff_operands_ex_1
 flow.executable @same_ops_diff_operands_ex_1 {
-  flow.dispatch.entry @entry_1
+  flow.executable.export @entry_1
   builtin.module {
     func.func @entry_1(%arg0: tensor<2xi32>) -> tensor<2xi32> {
       %0 = mhlo.multiply %arg0, %arg0 : tensor<2xi32>
@@ -98,8 +98,8 @@ func.func @same_ops_diff_operands(%arg0: tensor<2xi32>, %arg1: tensor<2xi32>) ->
 
 // CHECK-LABEL: flow.executable public @multiple_entry_points_ex_0
 flow.executable @multiple_entry_points_ex_0 {
-  flow.dispatch.entry @multiple_entry_points_0_entry_0
-  flow.dispatch.entry @multiple_entry_points_0_entry_1
+  flow.executable.export @multiple_entry_points_0_entry_0
+  flow.executable.export @multiple_entry_points_0_entry_1
   builtin.module {
     func.func @multiple_entry_points_0_entry_0(%arg0: tensor<4xf32>) -> tensor<4xf32> {
       %0 = mhlo.add %arg0, %arg0 : tensor<4xf32>
@@ -113,8 +113,8 @@ flow.executable @multiple_entry_points_ex_0 {
 }
 // CHECK-NOT: flow.executable public @multiple_entry_points_ex_1
 flow.executable @multiple_entry_points_ex_1 {
-  flow.dispatch.entry @multiple_entry_points_1_entry_0
-  flow.dispatch.entry @multiple_entry_points_1_entry_1
+  flow.executable.export @multiple_entry_points_1_entry_0
+  flow.executable.export @multiple_entry_points_1_entry_1
   builtin.module {
     func.func @multiple_entry_points_1_entry_0(%arg0: tensor<4xf32>) -> tensor<4xf32> {
       %0 = mhlo.add %arg0, %arg0 : tensor<4xf32>
@@ -159,7 +159,7 @@ util.initializer {
 
 // CHECK-LABEL: flow.executable public @different_types_float_ex
 flow.executable @different_types_float_ex {
-  flow.dispatch.entry @different_types_float_entry
+  flow.executable.export @different_types_float_entry
   builtin.module {
     func.func @different_types_float_entry(%arg0: tensor<4xf32>) -> tensor<4xi1> {
       %0 = "mhlo.compare"(%arg0, %arg0) {comparison_direction = #mhlo<"comparison_direction EQ">} : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xi1>
@@ -169,7 +169,7 @@ flow.executable @different_types_float_ex {
 }
 // CHECK-LABEL: flow.executable public @different_types_int_ex
 flow.executable @different_types_int_ex {
-  flow.dispatch.entry @different_types_int_entry
+  flow.executable.export @different_types_int_entry
   builtin.module {
     func.func @different_types_int_entry(%arg0: tensor<4xi32>) -> tensor<4xi1> {
       %0 = "mhlo.compare"(%arg0, %arg0) {comparison_direction = #mhlo<"comparison_direction EQ">} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
@@ -191,7 +191,7 @@ func.func @different_types(%arg0: tensor<4xf32>) -> tensor<4xi1> {
 
 // CHECK-LABEL: flow.executable public @nested_ops_ex_0
 flow.executable @nested_ops_ex_0 {
-  flow.dispatch.entry @nested_ops_entry_0
+  flow.executable.export @nested_ops_entry_0
   builtin.module {
     func.func @nested_ops_entry_0(%input: tensor<1x4xi32>) -> tensor<1xi32> {
       %0 = arith.constant dense<0> : tensor<i32>
@@ -206,7 +206,7 @@ flow.executable @nested_ops_ex_0 {
 }
 // CHECK-NOT: flow.executable public @nested_ops_ex_1
 flow.executable @nested_ops_ex_1 {
-  flow.dispatch.entry @nested_ops_entry_1
+  flow.executable.export @nested_ops_entry_1
   builtin.module {
     func.func @nested_ops_entry_1(%input: tensor<1x4xi32>) -> tensor<1xi32> {
       %0 = arith.constant dense<0> : tensor<i32>
@@ -221,7 +221,7 @@ flow.executable @nested_ops_ex_1 {
 }
 // CHECK-LABEL: flow.executable public @nested_ops_ex_2
 flow.executable @nested_ops_ex_2 {
-  flow.dispatch.entry @nested_ops_entry_2
+  flow.executable.export @nested_ops_entry_2
   builtin.module {
     func.func @nested_ops_entry_2(%input: tensor<1x4xi32>) -> tensor<1xi32> {
       %0 = arith.constant dense<0> : tensor<i32>
@@ -250,7 +250,7 @@ func.func @nested_ops(%arg0: tensor<1x4xi32>) -> tensor<1xi32> {
 
 // CHECK-LABEL: flow.executable public @attributes_ex_0
 flow.executable @attributes_ex_0 {
-  flow.dispatch.entry @attributes_entry_0
+  flow.executable.export @attributes_entry_0
   builtin.module {
     func.func @attributes_entry_0(%input: tensor<1x4xi32>) -> tensor<1xi32> {
       %0 = arith.constant dense<0> : tensor<i32>
@@ -266,7 +266,7 @@ flow.executable @attributes_ex_0 {
 
 // CHECK-LABEL: flow.executable public @attributes_ex_1
 flow.executable @attributes_ex_1 {
-  flow.dispatch.entry @attributes_entry_1
+  flow.executable.export @attributes_entry_1
   builtin.module {
     func.func @attributes_entry_1(%input: tensor<1x4xi32>) -> tensor<4xi32> {
       %0 = arith.constant dense<0> : tensor<i32>
@@ -283,7 +283,7 @@ flow.executable @attributes_ex_1 {
 // Duplicate of @attributes_ex_0
 // CHECK-NOT: flow.executable public @attributes_ex_2
 flow.executable @attributes_ex_2 {
-  flow.dispatch.entry @attributes_entry_2
+  flow.executable.export @attributes_entry_2
   builtin.module {
     func.func @attributes_entry_2(%input: tensor<1x4xi32>) -> tensor<1xi32> {
       %0 = arith.constant dense<0> : tensor<i32>
@@ -301,7 +301,7 @@ flow.executable @attributes_ex_2 {
 
 // CHECK-LABEL: flow.executable public @block_successors_ex_0
 flow.executable @block_successors_ex_0 {
-  flow.dispatch.entry @entry_0
+  flow.executable.export @entry_0
   builtin.module {
     func.func @entry_0(%arg0: i32, %arg1: i32) -> i32 {
       %c0 = arith.constant 0 : i32
@@ -317,7 +317,7 @@ flow.executable @block_successors_ex_0 {
 }
 // CHECK-LABEL: flow.executable public @block_successors_ex_with_swapped_cond_br
 flow.executable @block_successors_ex_with_swapped_cond_br {
-  flow.dispatch.entry @entry_1
+  flow.executable.export @entry_1
   builtin.module {
     func.func @entry_0(%arg0: i32, %arg1: i32) -> i32 {
       %c0 = arith.constant 0 : i32

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/deduplicate_executables.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/deduplicate_executables.mlir
@@ -263,7 +263,6 @@ flow.executable @attributes_ex_0 {
     }
   }
 }
-
 // CHECK-LABEL: flow.executable public @attributes_ex_1
 flow.executable @attributes_ex_1 {
   flow.executable.export @attributes_entry_1
@@ -293,6 +292,48 @@ flow.executable @attributes_ex_2 {
         "mhlo.return"(%3) : (tensor<i32>) -> ()
       }) {dimensions = dense<1> : tensor<1xi64>} : (tensor<1x4xi32>, tensor<i32>) -> tensor<1xi32>
       return %1 : tensor<1xi32>
+    }
+  }
+}
+
+// -----
+
+// Executable contents are the same but the workgroup count function of ex_1
+// differs and should prevent it from deduplicating.
+// Ideally we'd still deduplicate but add another export.
+
+// CHECK-LABEL: flow.executable public @workgroup_count_ex_0
+flow.executable @workgroup_count_ex_0 {
+  flow.executable.export @workgroup_count_entry_0 workgroups(%arg0: index) -> (index, index, index) {
+    flow.return %arg0, %arg0, %arg0 : index, index, index
+  }
+  builtin.module {
+    func.func @workgroup_count_entry_0(%input: tensor<1xi32>) -> tensor<1xi32> {
+      return %input : tensor<1xi32>
+    }
+  }
+}
+
+// CHECK-LABEL: flow.executable public @workgroup_count_ex_1
+flow.executable @workgroup_count_ex_1 {
+  flow.executable.export @workgroup_count_entry_1 workgroups(%arg0: index, %arg1: index, %arg2: index) -> (index, index, index) {
+    flow.return %arg0, %arg1, %arg2 : index, index, index
+  }
+  builtin.module {
+    func.func @workgroup_count_entry_1(%input: tensor<1xi32>) -> tensor<1xi32> {
+      return %input : tensor<1xi32>
+    }
+  }
+}
+// Duplicate of @workgroup_count_ex_0
+// CHECK-NOT: flow.executable public @workgroup_count_ex_2
+flow.executable @workgroup_count_ex_2 {
+  flow.executable.export @workgroup_count_entry_2 workgroups(%arg0: index) -> (index, index, index) {
+    flow.return %arg0, %arg0, %arg0 : index, index, index
+  }
+  builtin.module {
+    func.func @workgroup_count_entry_2(%input: tensor<1xi32>) -> tensor<1xi32> {
+      return %input : tensor<1xi32>
     }
   }
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/outline_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/outline_dispatch_regions.mlir
@@ -1,8 +1,7 @@
 // RUN: iree-opt --allow-unregistered-dialect --split-input-file --iree-flow-outline-dispatch-regions %s | FileCheck %s
 
 //      CHECK: flow.executable private @staticShapeDispatch_dispatch_0
-// CHECK-NEXT:   flow.dispatch.entry public @staticShapeDispatch_dispatch_0 attributes {
-// CHECK-SAME:       workgroup_rank = 2 : index}
+// CHECK-NEXT:   flow.dispatch.entry public @staticShapeDispatch_dispatch_0
 //      CHECK: func.func @staticShapeDispatch_dispatch_0(
 // CHECK-SAME:     %[[ARG:.+]]: !flow.dispatch.tensor<readonly:8x4xf32>,
 // CHECK-SAME:     %[[RET:.+]]: !flow.dispatch.tensor<writeonly:4x8xf32>) {
@@ -37,13 +36,11 @@ func.func @staticShapeDispatch(%arg0 : tensor<8x4xf32>) -> tensor<4x8xf32> {
 // -----
 
 //      CHECK: flow.executable private @dispatchFnMuli_dispatch_0
-// CHECK-NEXT:   flow.dispatch.entry public @dispatchFnMuli_dispatch_0 attributes {
-// CHECK-SAME:       workgroup_rank = 2 : index}
+// CHECK-NEXT:   flow.dispatch.entry public @dispatchFnMuli_dispatch_0
 //      CHECK: func.func @dispatchFnMuli_dispatch_0(
 
 //      CHECK: flow.executable private @dispatchFnMuli_dispatch_1
-// CHECK-NEXT:   flow.dispatch.entry public @dispatchFnMuli_dispatch_1 attributes {
-// CHECK-SAME:       workgroup_rank = 2 : index}
+// CHECK-NEXT:   flow.dispatch.entry public @dispatchFnMuli_dispatch_1
 //      CHECK: func.func @dispatchFnMuli_dispatch_1(
 
 // CHECK-LABEL: func.func @dispatchFnMuli(
@@ -114,8 +111,7 @@ func.func @dispatchFn2(%arg0 : tensor<8x4xf32>) -> tensor<4x8xf32> {
 // -----
 
 //      CHECK: flow.executable private @dynamicShapeDispatch_dispatch_0
-// CHECK-NEXT:   flow.dispatch.entry public @dynamicShapeDispatch_dispatch_0 attributes {
-// CHECK-SAME:       workgroup_rank = 2 : index}
+// CHECK-NEXT:   flow.dispatch.entry public @dynamicShapeDispatch_dispatch_0
 //      CHECK: func.func @dynamicShapeDispatch_dispatch_0(
 // CHECK-SAME:     %[[ARG_TENSOR:.+]]: !flow.dispatch.tensor<readonly:7x?x24x?xf32>,
 // CHECK-SAME:     %[[DIM1_CAPTURE:.+]]: index, %[[DIM3_CAPTURE:.+]]: index,

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/outline_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/outline_dispatch_regions.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt --allow-unregistered-dialect --split-input-file --iree-flow-outline-dispatch-regions %s | FileCheck %s
 
 //      CHECK: flow.executable private @staticShapeDispatch_dispatch_0
-// CHECK-NEXT:   flow.dispatch.entry public @staticShapeDispatch_dispatch_0
+// CHECK-NEXT:   flow.executable.export public @staticShapeDispatch_dispatch_0
 //      CHECK: func.func @staticShapeDispatch_dispatch_0(
 // CHECK-SAME:     %[[ARG:.+]]: !flow.dispatch.tensor<readonly:8x4xf32>,
 // CHECK-SAME:     %[[RET:.+]]: !flow.dispatch.tensor<writeonly:4x8xf32>) {
@@ -36,11 +36,11 @@ func.func @staticShapeDispatch(%arg0 : tensor<8x4xf32>) -> tensor<4x8xf32> {
 // -----
 
 //      CHECK: flow.executable private @dispatchFnMuli_dispatch_0
-// CHECK-NEXT:   flow.dispatch.entry public @dispatchFnMuli_dispatch_0
+// CHECK-NEXT:   flow.executable.export public @dispatchFnMuli_dispatch_0
 //      CHECK: func.func @dispatchFnMuli_dispatch_0(
 
 //      CHECK: flow.executable private @dispatchFnMuli_dispatch_1
-// CHECK-NEXT:   flow.dispatch.entry public @dispatchFnMuli_dispatch_1
+// CHECK-NEXT:   flow.executable.export public @dispatchFnMuli_dispatch_1
 //      CHECK: func.func @dispatchFnMuli_dispatch_1(
 
 // CHECK-LABEL: func.func @dispatchFnMuli(
@@ -111,7 +111,7 @@ func.func @dispatchFn2(%arg0 : tensor<8x4xf32>) -> tensor<4x8xf32> {
 // -----
 
 //      CHECK: flow.executable private @dynamicShapeDispatch_dispatch_0
-// CHECK-NEXT:   flow.dispatch.entry public @dynamicShapeDispatch_dispatch_0
+// CHECK-NEXT:   flow.executable.export public @dynamicShapeDispatch_dispatch_0
 //      CHECK: func.func @dynamicShapeDispatch_dispatch_0(
 // CHECK-SAME:     %[[ARG_TENSOR:.+]]: !flow.dispatch.tensor<readonly:7x?x24x?xf32>,
 // CHECK-SAME:     %[[DIM1_CAPTURE:.+]]: index, %[[DIM3_CAPTURE:.+]]: index,

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transformation.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transformation.mlir
@@ -16,7 +16,7 @@ func.func @hloElementwiseOps(%arg0 : tensor<4xf32>) -> tensor<4xf32> {
 }
 
 // CHECK-LABEL: flow.executable private @hloElementwiseOps_dispatch_0 {
-//  CHECK-NEXT:   flow.dispatch.entry public @hloElementwiseOps_dispatch_0
+//  CHECK-NEXT:   flow.executable.export public @hloElementwiseOps_dispatch_0
 //  CHECK-NEXT:   module {
 //  CHECK-NEXT:     func.func @hloElementwiseOps_dispatch_0(%arg0: !flow.dispatch.tensor<readonly:4xf32>, %arg1: !flow.dispatch.tensor<writeonly:4xf32>) {
 //       CHECK:       %{{.+}} = linalg.generic
@@ -40,13 +40,13 @@ func.func @interleavedDot(%arg0 : tensor<4x4xf32>) -> tensor<4x4xf32> {
 }
 
 // CHECK-LABEL: flow.executable private @interleavedDot_dispatch_0 {
-//  CHECK-NEXT:   flow.dispatch.entry public @interleavedDot_dispatch_0
+//  CHECK-NEXT:   flow.executable.export public @interleavedDot_dispatch_0
 //  CHECK-NEXT:   module {
 //  CHECK-NEXT:     func.func @interleavedDot_dispatch_0
 //       CHECK:       %{{.+}} = linalg.generic
 //       CHECK:         %{{.+}} = arith.addf %{{.+}}, %{{.+}} : f32
 //       CHECK: flow.executable private @interleavedDot_dispatch_1 {
-//  CHECK-NEXT:   flow.dispatch.entry public @interleavedDot_dispatch_1
+//  CHECK-NEXT:   flow.executable.export public @interleavedDot_dispatch_1
 //  CHECK-NEXT:   module {
 //  CHECK-NEXT:     func.func @interleavedDot_dispatch_1
 //       CHECK:       %{{.+}} = linalg.matmul
@@ -74,7 +74,7 @@ func.func @reduction(%arg0 : tensor<4x8xf32>) -> tensor<4xf32> {
 }
 
 // CHECK-LABEL: flow.executable private @reduction_dispatch_0 {
-//  CHECK-NEXT:   flow.dispatch.entry public @reduction_dispatch_0
+//  CHECK-NEXT:   flow.executable.export public @reduction_dispatch_0
 //  CHECK-NEXT:   module {
 //  CHECK-NEXT:     func.func @reduction_dispatch_0
 //       CHECK:       %{{.+}} = linalg.generic

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/ConvertStreamToHAL.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/ConvertStreamToHAL.cpp
@@ -700,7 +700,7 @@ struct CmdDispatchOpPattern
                              {SymbolRefAttr::get(entryPointOp->getParentOp()),
                               SymbolRefAttr::get(entryPointOp)});
       auto caseWorkgroupCount = entryPointOp.calculateWorkgroupCount(
-          loc, device, adaptor.workgroup_count(), caseBuilder);
+          loc, device, adaptor.workload(), caseBuilder);
       caseBuilder.create<IREE::HAL::CommandBufferDispatchSymbolOp>(
           loc, commandBuffer, entryPointSymRef, caseWorkgroupCount[0],
           caseWorkgroupCount[1], caseWorkgroupCount[2]);

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -716,9 +716,9 @@ void ExecutableExportOp::print(OpAsmPrinter &p) {
   p << ")";
   p.printOptionalAttrDict(op->getAttrs(),
                           /*elidedAttrs=*/{"sym_name", "layout", "ordinal"});
-  if (workgroup_count_region().empty()) return;
+  if (workgroup_count().empty()) return;
   p << " ";
-  p.printRegion(workgroup_count_region());
+  p.printRegion(workgroup_count());
 }
 
 LogicalResult ExecutableExportOp::verify() {
@@ -727,7 +727,7 @@ LogicalResult ExecutableExportOp::verify() {
   // When there is no body, nothing to verify.
   if (!body) return success();
 
-  if (!llvm::hasSingleElement(workgroup_count_region())) {
+  if (!llvm::hasSingleElement(workgroup_count())) {
     return op.emitOpError() << "expected a single region block";
   }
   bool validArguments = true;
@@ -824,6 +824,7 @@ static std::array<Value, 3> calculateWorkgroupCountFromRegion(
     builder.clone(op, bvm);
   }
   auto returnOp = cast<IREE::HAL::ReturnOp>(body->getTerminator());
+  assert(returnOp.getNumOperands() == 3 && "must return xyz");
   return {
       bvm.lookup(returnOp.operands()[0]),
       bvm.lookup(returnOp.operands()[1]),

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -656,11 +656,11 @@ LogicalResult ExecutableOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// hal.executable.entry_point
+// hal.executable.export
 //===----------------------------------------------------------------------===//
 
-ParseResult ExecutableEntryPointOp::parse(OpAsmParser &parser,
-                                          OperationState &result) {
+ParseResult ExecutableExportOp::parse(OpAsmParser &parser,
+                                      OperationState &result) {
   StringAttr visibilityAttr;
   if (failed(parseSymbolVisibility(parser, visibilityAttr))) {
     return failure();
@@ -700,7 +700,7 @@ ParseResult ExecutableEntryPointOp::parse(OpAsmParser &parser,
   return success();
 }
 
-void ExecutableEntryPointOp::print(OpAsmPrinter &p) {
+void ExecutableExportOp::print(OpAsmPrinter &p) {
   Operation *op = getOperation();
   p << ' ';
   printSymbolVisibility(p, op, op->getAttrOfType<StringAttr>("sym_visibility"));
@@ -721,8 +721,8 @@ void ExecutableEntryPointOp::print(OpAsmPrinter &p) {
   p.printRegion(workgroup_count_region());
 }
 
-LogicalResult ExecutableEntryPointOp::verify() {
-  ExecutableEntryPointOp op = *this;
+LogicalResult ExecutableExportOp::verify() {
+  ExecutableExportOp op = *this;
   Block *body = getWorkgroupCountBody();
   // When there is no body, nothing to verify.
   if (!body) return success();
@@ -835,7 +835,7 @@ static std::array<Value, 3> calculateWorkgroupCountFromRegion(
 // The provided N-dimensional |workload| is the total number of invocations
 // required as calculated by the generic workload logic (basically, number of
 // output elements in tensors).
-std::array<Value, 3> ExecutableEntryPointOp::calculateWorkgroupCount(
+std::array<Value, 3> ExecutableExportOp::calculateWorkgroupCount(
     Location loc, Value device, ValueRange workload, OpBuilder &builder) {
   Block *body = getWorkgroupCountBody();
   if (body) {
@@ -848,7 +848,7 @@ std::array<Value, 3> ExecutableEntryPointOp::calculateWorkgroupCount(
 
 // Calculates the workgroup size (x, y, z). These are the dimension numbers
 // for a single workgroup.
-std::array<Value, 3> ExecutableEntryPointOp::calculateWorkgroupSize(
+std::array<Value, 3> ExecutableExportOp::calculateWorkgroupSize(
     Location loc, Value device, ValueRange workload, OpBuilder &builder) {
   // When no workgroup size is specified we just assume [1,1,1].
   // This yields a workgroup count that models the extents of the workload.

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -1536,16 +1536,11 @@ def HAL_ExecutableEntryPointOp : HAL_Op<"executable.entry_point", [
     An entry point exported by the executable with statically-available
     information describing the IO interface it uses and other dispatch metadata.
 
-    The `workgroup_count_region` region represents the computation that returns
-    the number of workgroups to use.
-    The arguments to the region represents the workload along x, y and z.
+    The `calculate_workgroup_count` region represents the computation that
+    returns the number of workgroups to use in the 3D grid dispatch.
+    The arguments to the region represents the workload as captured by each
+    dispatch.
     It returns the number of workgroups along x, y, and z.
-
-    TODO(ravishankarm): In reality there is no need to define what the
-    arguments represent. They could be any values that are needed to
-    compute the number of workgroups. Its unclear what these are in
-    general and how to plumb them through. So for now just accepting
-    the workload along x, y, and z.
   }];
 
   let arguments = (ins

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -1523,7 +1523,7 @@ def HAL_ExecutableEndOp : HAL_Op<"executable_end", [
   let assemblyFormat = "attr-dict";
 }
 
-def HAL_ExecutableEntryPointOp : HAL_Op<"executable.entry_point", [
+def HAL_ExecutableExportOp : HAL_Op<"executable.export", [
     Symbol,
     ParentOneOf<[
       "IREE::HAL::ExecutableSourceOp",

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -1552,7 +1552,7 @@ def HAL_ExecutableExportOp : HAL_Op<"executable.export", [
     OptionalAttr<IndexAttr>:$workgroup_local_memory
   );
 
-  let regions = (region AnyRegion:$workgroup_count_region);
+  let regions = (region AnyRegion:$workgroup_count);
 
   let builders = [
     OpBuilder<(ins
@@ -1576,8 +1576,8 @@ def HAL_ExecutableExportOp : HAL_Op<"executable.export", [
     static int64_t getNumWorkgroupDims() { return 3; }
 
     Block* getWorkgroupCountBody() {
-      if (workgroup_count_region().empty()) return nullptr;
-      return &workgroup_count_region().front();
+      if (workgroup_count().empty()) return nullptr;
+      return &workgroup_count().front();
     }
 
     // Calculates an XYZ workgroup count based on the given |workload|.

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/command_buffer_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/command_buffer_ops.mlir
@@ -135,7 +135,7 @@ func.func @command_buffer_bind_descriptor_set(
 
 hal.executable @ex {
   hal.executable.variant @backend, target = <"backend", "format"> {
-    hal.executable.entry_point @entry0 ordinal(0) layout(#hal.executable.layout<push_constants = 0, sets = [
+    hal.executable.export @entry0 ordinal(0) layout(#hal.executable.layout<push_constants = 0, sets = [
       #hal.descriptor_set.layout<0, bindings = [
         #hal.descriptor_set.binding<0, storage_buffer>,
         #hal.descriptor_set.binding<1, storage_buffer>
@@ -166,7 +166,7 @@ func.func @command_buffer_dispatch(
 
 hal.executable @ex {
   hal.executable.variant @backend, target = <"backend", "format"> {
-    hal.executable.entry_point @entry0 ordinal(0) layout(#hal.executable.layout<push_constants = 0, sets = [
+    hal.executable.export @entry0 ordinal(0) layout(#hal.executable.layout<push_constants = 0, sets = [
       #hal.descriptor_set.layout<0, bindings = [
         #hal.descriptor_set.binding<0, storage_buffer>,
         #hal.descriptor_set.binding<1, storage_buffer>

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
@@ -6,9 +6,9 @@
 hal.executable @ex {
   // CHECK: hal.executable.variant public @backend, target = #executable_target_format
   hal.executable.variant @backend, target = #executable_target_format {
-    // CHECK-DAG: hal.executable.entry_point public @entry0 ordinal(0) layout(#executable_layout) {
+    // CHECK-DAG: hal.executable.export public @entry0 ordinal(0) layout(#executable_layout) {
     // CHECK-SAME:     workgroup_size = [4 : index, 1 : index, 1 : index]
-    hal.executable.entry_point @entry0 ordinal(0) layout(#hal.executable.layout<push_constants = 0, sets = [
+    hal.executable.export @entry0 ordinal(0) layout(#hal.executable.layout<push_constants = 0, sets = [
       #hal.descriptor_set.layout<0, bindings = [
         #hal.descriptor_set.binding<0, storage_buffer>,
         #hal.descriptor_set.binding<1, storage_buffer>
@@ -34,9 +34,9 @@ hal.executable @ex {
 hal.executable @ex_with_workgroup_count_region {
   // CHECK: hal.executable.variant public @backend, target = #executable_target_format
   hal.executable.variant @backend, target = #executable_target_format {
-    // CHECK-DAG: hal.executable.entry_point public @entry0 ordinal(0) layout(#executable_layout) {
+    // CHECK-DAG: hal.executable.export public @entry0 ordinal(0) layout(#executable_layout) {
     // CHECK-SAME:     workgroup_size = [4 : index, 1 : index, 1 : index]
-    hal.executable.entry_point @entry0 ordinal(0) layout(#hal.executable.layout<push_constants = 0, sets = [
+    hal.executable.export @entry0 ordinal(0) layout(#hal.executable.layout<push_constants = 0, sets = [
       #hal.descriptor_set.layout<0, bindings = [
         #hal.descriptor_set.binding<0, storage_buffer>,
         #hal.descriptor_set.binding<1, storage_buffer>

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
@@ -212,9 +212,9 @@ class CUDATargetBackend final : public TargetBackend {
     }
 
     // Collect all the entry point names.
-    llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> entryPointOps;
-    for (auto op : variantOp.getOps<IREE::HAL::ExecutableEntryPointOp>()) {
-      entryPointOps[op.sym_name()] = op;
+    llvm::StringMap<IREE::HAL::ExecutableExportOp> exportOps;
+    for (auto op : variantOp.getOps<IREE::HAL::ExecutableExportOp>()) {
+      exportOps[op.sym_name()] = op;
     }
     std::vector<std::array<int32_t, 3>> workgroupSizes;
     std::vector<std::string> entryPointNames;
@@ -228,14 +228,12 @@ class CUDATargetBackend final : public TargetBackend {
       entryPointNames.emplace_back(llvmFunc->getName());
       std::array<int32_t, 3> workgroup_size;
       uint32_t workgroupLocalMemory = 0;
-      auto entryPointOp = entryPointOps[func.getName()];
-      if (auto workgroupLocalMemoryAttr =
-              entryPointOp.workgroup_local_memory()) {
+      auto exportOp = exportOps[func.getName()];
+      if (auto workgroupLocalMemoryAttr = exportOp.workgroup_local_memory()) {
         workgroupLocalMemory =
             workgroupLocalMemoryAttr.getValue().getSExtValue();
       }
-      if (Optional<ArrayAttr> workgroupSizeAttr =
-              entryPointOp.workgroup_size()) {
+      if (Optional<ArrayAttr> workgroupSizeAttr = exportOp.workgroup_size()) {
         for (auto it : llvm::enumerate(workgroupSizeAttr.getValue())) {
           workgroup_size[it.index()] = it.value().cast<IntegerAttr>().getInt();
         }

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp
@@ -295,10 +295,9 @@ class LLVMAOTTargetBackend final : public TargetBackend {
       } break;
     }
     auto align16 = llvm::Attribute::getWithAlignment(context, llvm::Align(16));
-    for (auto entryPointOp :
-         variantOp.getBlock().getOps<ExecutableEntryPointOp>()) {
+    for (auto exportOp : variantOp.getBlock().getOps<ExecutableExportOp>()) {
       // Find the matching function in the LLVM module.
-      auto *llvmFunc = llvmModule->getFunction(entryPointOp.getName());
+      auto *llvmFunc = llvmModule->getFunction(exportOp.getName());
       llvmFunc->setLinkage(llvm::GlobalValue::LinkageTypes::InternalLinkage);
       llvmFunc->setDSOLocal(true);
 
@@ -318,11 +317,11 @@ class LLVMAOTTargetBackend final : public TargetBackend {
       // Optionally entry points may specify that they require workgroup local
       // memory. We fetch that value here and plumb it through so the runtime
       // knows how much memory to reserve and pass in.
-      int64_t localMemorySize = entryPointOp.workgroup_local_memory()
+      int64_t localMemorySize = exportOp.workgroup_local_memory()
                                     .getValueOr(APInt(64, 0))
                                     .getSExtValue();
 
-      libraryBuilder.addExport(entryPointOp.getName(), "",
+      libraryBuilder.addExport(exportOp.getName(), "",
                                LibraryBuilder::DispatchAttrs{localMemorySize},
                                llvmFunc);
     }

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/MetalSPIRV/MetalSPIRVTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/MetalSPIRV/MetalSPIRVTarget.cpp
@@ -76,8 +76,8 @@ class MetalSPIRVTargetBackend : public TargetBackend {
     // names for constructing pipeline states. Get an ordered list of the entry
     // point names.
     SmallVector<StringRef, 8> entryPointNames;
-    spvModuleOp.walk([&](spirv::EntryPointOp entryPointOp) {
-      entryPointNames.push_back(entryPointOp.fn());
+    spvModuleOp.walk([&](spirv::EntryPointOp exportOp) {
+      entryPointNames.push_back(exportOp.fn());
     });
 
     // 1. Serialize the spirv::ModuleOp into binary format.

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTarget.cpp
@@ -129,9 +129,9 @@ class ROCMTargetBackend final : public TargetBackend {
     }
 
     // Collect all the entry point names.
-    llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> entryPointOps;
-    for (auto op : variantOp.getOps<IREE::HAL::ExecutableEntryPointOp>()) {
-      entryPointOps[op.sym_name()] = op;
+    llvm::StringMap<IREE::HAL::ExecutableExportOp> exportOps;
+    for (auto op : variantOp.getOps<IREE::HAL::ExecutableExportOp>()) {
+      exportOps[op.sym_name()] = op;
     }
     std::vector<std::array<int32_t, 3>> workgroupSizes;
     for (auto func : innerModuleOp.getOps<LLVM::LLVMFuncOp>()) {
@@ -139,9 +139,8 @@ class ROCMTargetBackend final : public TargetBackend {
       auto *llvmFunc = llvmModule->getFunction(func.getName());
       if (llvmFunc->isDeclaration()) continue;
       std::array<int32_t, 3> workgroup_size;
-      auto entryPointOp = entryPointOps[func.getName()];
-      if (Optional<ArrayAttr> workgroupSizeAttr =
-              entryPointOp.workgroup_size()) {
+      auto exportOp = exportOps[func.getName()];
+      if (Optional<ArrayAttr> workgroupSizeAttr = exportOp.workgroup_size()) {
         for (auto it : llvm::enumerate(workgroupSizeAttr.getValue())) {
           workgroup_size[it.index()] = it.value().cast<IntegerAttr>().getInt();
           flatWgSize *= it.value().cast<IntegerAttr>().getInt();
@@ -203,7 +202,7 @@ class ROCMTargetBackend final : public TargetBackend {
 
     auto entryPointNames = llvm::to_vector<8>(llvm::map_range(
         variantOp.getBlock()
-            .getOps<iree_compiler::IREE::HAL::ExecutableEntryPointOp>(),
+            .getOps<iree_compiler::IREE::HAL::ExecutableExportOp>(),
         [&](auto op) { return op.getName(); }));
     auto entryPointsRef = builder.createStringVec(entryPointNames);
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
@@ -203,19 +203,18 @@ LogicalResult TargetBackend::linkExecutablesInto(
 
       // Clone entry point ops and queue remapping ordinals and updating
       // symbol refs.
-      for (auto entryPointOp :
-           variantOp.getOps<IREE::HAL::ExecutableEntryPointOp>()) {
+      for (auto exportOp : variantOp.getOps<IREE::HAL::ExecutableExportOp>()) {
         auto newEntryPointOp =
-            linkedTargetBuilder.create<IREE::HAL::ExecutableEntryPointOp>(
-                entryPointOp.getLoc(), entryPointOp.sym_nameAttr(),
+            linkedTargetBuilder.create<IREE::HAL::ExecutableExportOp>(
+                exportOp.getLoc(), exportOp.sym_nameAttr(),
                 builder.getIndexAttr(nextEntryPointOrdinal++),
-                entryPointOp.layout(), ArrayAttr{}, IntegerAttr{});
+                exportOp.layout(), ArrayAttr{}, IntegerAttr{});
 
         // Add to replacement table for fixing up dispatch calls referencing
         // this entry point.
         auto oldSymbolRefAttr = SymbolRefAttr::get(
             builder.getContext(), sourceExecutableOp.getName(),
-            {SymbolRefAttr::get(variantOp), SymbolRefAttr::get(entryPointOp)});
+            {SymbolRefAttr::get(variantOp), SymbolRefAttr::get(exportOp)});
         auto newSymbolRefAttr = SymbolRefAttr::get(
             builder.getContext(), linkedExecutableOp.getName(),
             {SymbolRefAttr::get(linkedTargetOp),
@@ -242,7 +241,7 @@ LogicalResult TargetBackend::linkExecutablesInto(
   replaceEntryPointUses(moduleOp, entryPointRefReplacements);
 
   // Remove if we didn't add anything.
-  if (linkedTargetOp.getOps<IREE::HAL::ExecutableEntryPointOp>().empty()) {
+  if (linkedTargetOp.getOps<IREE::HAL::ExecutableExportOp>().empty()) {
     linkedTargetOp.erase();
     linkedExecutableOp.erase();
   }

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.h
@@ -74,30 +74,30 @@ struct TargetOptions {
 //   [[-iree-hal-materialize-interfaces]]
 //   -> hal.executable @my_exe
 //      + hal.executable.variant @spirv-v1.1-mobile filter="spirv-v1.1-mobile*"
-//          hal.executable.entry_point @my_entry
+//          hal.executable.export @my_entry
 //          module { ... }
 //      + hal.executable.variant @spirv-v1.1-desktop
 //      filter="spirv-v1.1-desktop*"
-//          hal.executable.entry_point @my_entry
+//          hal.executable.export @my_entry
 //          module { ... }
 //      + hal.executable.variant @spirv-v1.2-desktop
 //      filter="spirv-v1.2-desktop*"
-//          hal.executable.entry_point @my_entry
+//          hal.executable.export @my_entry
 //          module { ... }
 //   [[-iree-hal-translate-executables]]
 //   -> hal.executable @my_exe
 //      + hal.executable.variant @spirv-v1.1-mobile filter="spirv-v1.1-mobile*"
-//          hal.executable.entry_point @my_entry_1
-//          hal.executable.entry_point @my_entry_2
-//          hal.executable.entry_point @my_entry_3
+//          hal.executable.export @my_entry_1
+//          hal.executable.export @my_entry_2
+//          hal.executable.export @my_entry_3
 //          module { spv.module { ... } }
 //      + hal.executable.variant @spirv-v1.1-desktop
 //      filter="spirv-v1.1-desktop*"
-//          hal.executable.entry_point @my_entry
+//          hal.executable.export @my_entry
 //          module { spv.module { ... } }
 //      + hal.executable.variant @spirv-v1.2-desktop
 //      filter="spirv-v1.2-desktop*"
-//          hal.executable.entry_point @my_entry
+//          hal.executable.export @my_entry
 //          module { spv.module { ... } }
 //   [[-iree-hal-link-executables]]
 //   -> TODO(benvanik): linkage rules.
@@ -148,7 +148,7 @@ class TargetBackend {
   //       hal.interface.binding @arg1, set=0, binding=1, ...
   //     }
   //     hal.executable.variant @target, target="target-backend" {
-  //       hal.executable.entry_point @main interface(@main_io) {
+  //       hal.executable.export @main interface(@main_io) {
   //         ordinal = 0 : index
   //       }
   //       module { ... }
@@ -159,7 +159,7 @@ class TargetBackend {
   //   hal.executable @some_executable {
   //     hal.interface @main_io ...
   //     hal.executable.variant @target, target="target-backend" {
-  //       hal.executable.entry_point @main ...
+  //       hal.executable.export @main ...
   //       module { spv.module { ... } }
   //     }
   //   }
@@ -185,9 +185,9 @@ class TargetBackend {
   //     hal.interface @io_0 { ... }
   //     hal.interface @io_1 { ... }
   //     hal.executable.variant @target, target="target-backend" {
-  //       hal.executable.entry_point @main_dispatch_0 attributes { ... }
-  //       hal.executable.entry_point @main_dispatch_1 attributes { ... }
-  //       hal.executable.entry_point @main_dispatch_2 attributes { ... }
+  //       hal.executable.export @main_dispatch_0 attributes { ... }
+  //       hal.executable.export @main_dispatch_1 attributes { ... }
+  //       hal.executable.export @main_dispatch_2 attributes { ... }
   //       module {
   //         func.func @main_0(...) { ... }
   //         func.func @main_1(...) { ... }
@@ -199,7 +199,7 @@ class TargetBackend {
   //   hal.executable @main_dispatch_0 {
   //     hal.interface @io { ... }
   //     hal.executable.variant @other, target="other" {
-  //       hal.executable.entry_point @main_dispatch_0 attributes { ... }
+  //       hal.executable.export @main_dispatch_0 attributes { ... }
   //       module { ... }
   //     }
   //   }

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/VMVXTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/VMVXTarget.cpp
@@ -108,15 +108,13 @@ class VMVXTargetBackend final : public TargetBackend {
                                     OpBuilder &executableBuilder) override {
     // Add reflection information used at runtime specific to the HAL interface.
     SymbolTable symbolTable(variantOp.getInnerModule());
-    for (auto entryPointOp :
-         variantOp.getBlock().getOps<ExecutableEntryPointOp>()) {
-      auto funcOp =
-          symbolTable.lookup<IREE::VM::FuncOp>(entryPointOp.getName());
+    for (auto exportOp : variantOp.getBlock().getOps<ExecutableExportOp>()) {
+      auto funcOp = symbolTable.lookup<IREE::VM::FuncOp>(exportOp.getName());
 
       // Optionally entry points may specify that they require workgroup local
       // memory. We fetch that value here and plumb it through so the runtime
       // knows how much memory to reserve and pass in.
-      auto localMemorySizeAttr = entryPointOp.workgroup_local_memoryAttr();
+      auto localMemorySizeAttr = exportOp.workgroup_local_memoryAttr();
       if (localMemorySizeAttr) {
         funcOp.setReflectionAttr("local_memory", localMemorySizeAttr);
       }

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/test/linking.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/test/linking.mlir
@@ -10,7 +10,7 @@
 
 hal.executable private @dispatch_0 {
   hal.executable.variant @vmvx, target = #vmvx_target {
-    hal.executable.entry_point @dispatch_0 ordinal(0) layout(#executable_layout)
+    hal.executable.export @dispatch_0 ordinal(0) layout(#executable_layout)
     builtin.module {
       vm.module @module {
         vm.func @dispatch_0() {
@@ -23,7 +23,7 @@ hal.executable private @dispatch_0 {
 }
 hal.executable private @dispatch_1 {
   hal.executable.variant @vmvx, target = #vmvx_target {
-    hal.executable.entry_point @dispatch_1 ordinal(0) layout(#executable_layout)
+    hal.executable.export @dispatch_1 ordinal(0) layout(#executable_layout)
     builtin.module {
       vm.module @module {
         vm.func @dispatch_1() {
@@ -36,7 +36,7 @@ hal.executable private @dispatch_1 {
 }
 hal.executable private @dispatch_2 {
   hal.executable.variant @vmvx, target = #vmvx_target {
-    hal.executable.entry_point @dispatch_2 ordinal(0) layout(#executable_layout)
+    hal.executable.export @dispatch_2 ordinal(0) layout(#executable_layout)
     builtin.module {
       vm.module @module {
         vm.func @dispatch_2() {
@@ -73,9 +73,9 @@ util.initializer {
 // CHECK-NOT: hal.executable private @dispatch_2
 // CHECK:       hal.executable private @vmvx_linked {
 // CHECK-NEXT:    hal.executable.variant public @vmvx_bytecode_fb, target = #executable_target_vmvx_bytecode_fb {
-// CHECK-NEXT:      hal.executable.entry_point public @dispatch_0 ordinal(0)
-// CHECK-NEXT:      hal.executable.entry_point public @dispatch_1 ordinal(1)
-// CHECK-NEXT:      hal.executable.entry_point public @dispatch_2 ordinal(2)
+// CHECK-NEXT:      hal.executable.export public @dispatch_0 ordinal(0)
+// CHECK-NEXT:      hal.executable.export public @dispatch_1 ordinal(1)
+// CHECK-NEXT:      hal.executable.export public @dispatch_2 ordinal(2)
 // CHECK-NEXT:      module {
 // CHECK-NEXT:        vm.module public @linked_module {
 // CHECK-NEXT:          vm.func @dispatch_0() {
@@ -121,7 +121,7 @@ util.initializer {
 
 hal.executable private @dispatch_0 {
   hal.executable.variant @vmvx, target = #vmvx_target {
-    hal.executable.entry_point @dispatch_0 ordinal(0) layout(#executable_layout)
+    hal.executable.export @dispatch_0 ordinal(0) layout(#executable_layout)
     builtin.module {
       vm.module @module {
         vm.rodata public @rodata_a dense<[0]> : tensor<1xi32>
@@ -143,7 +143,7 @@ hal.executable private @dispatch_0 {
 }
 hal.executable private @dispatch_1 {
   hal.executable.variant @vmvx, target = #vmvx_target {
-    hal.executable.entry_point @dispatch_1 ordinal(0) layout(#executable_layout)
+    hal.executable.export @dispatch_1 ordinal(0) layout(#executable_layout)
     builtin.module {
       vm.module @module {
         // Conflict with a public symbol, this should be renamed when linked.

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/test/smoketest.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/test/smoketest.mlir
@@ -36,7 +36,7 @@ stream.executable public @add_dispatch_0 {
 
 // CHECK-LABEL: hal.executable public @add_dispatch_0
 //  CHECK-NEXT:   hal.executable.variant public @vmvx_bytecode_fb, target = <"vmvx", "vmvx-bytecode-fb"> {
-//  CHECK-NEXT:     hal.executable.entry_point public @add_dispatch_0 ordinal(0)
+//  CHECK-NEXT:     hal.executable.export public @add_dispatch_0 ordinal(0)
 //  CHECK-SAME:       layout(#hal.executable.layout<push_constants = 0, sets = [
 //  CHECK-SAME:         #hal.descriptor_set.layout<0, bindings = [
 //  CHECK-SAME:           #hal.descriptor_set.binding<0, storage_buffer>,

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -280,8 +280,8 @@ class VulkanSPIRVTargetBackend : public TargetBackend {
     // list of entry point names here that are then passed in
     // VkShaderModuleCreateInfo.
     SmallVector<StringRef, 8> entryPointNames;
-    spvModuleOp.walk([&](spirv::EntryPointOp entryPointOp) {
-      entryPointNames.push_back(entryPointOp.fn());
+    spvModuleOp.walk([&](spirv::EntryPointOp exportOp) {
+      entryPointNames.push_back(exportOp.fn());
     });
     auto entryPointsRef = builder.createStringVec(entryPointNames);
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/linking.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/linking.mlir
@@ -22,7 +22,7 @@
 
 hal.executable private @call_dispatch_0  {
   hal.executable.variant @vulkan_spirv_fb, target = #executable_target_vulkan_spirv_fb {
-    hal.executable.entry_point @call_dispatch_0 ordinal(0) layout(#executable_layout_0)
+    hal.executable.export @call_dispatch_0 ordinal(0) layout(#executable_layout_0)
     builtin.module {
       spv.module Logical GLSL450 requires #spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]> {
         spv.func @call_dispatch_0() "None" {
@@ -36,7 +36,7 @@ hal.executable private @call_dispatch_0  {
 }
 hal.executable private @call_dispatch_1  {
   hal.executable.variant @vulkan_spirv_fb, target = #executable_target_vulkan_spirv_fb {
-    hal.executable.entry_point @call_dispatch_1 ordinal(0) layout(#executable_layout_1)
+    hal.executable.export @call_dispatch_1 ordinal(0) layout(#executable_layout_1)
     builtin.module {
       spv.module Logical GLSL450 requires #spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]> {
         spv.func @call_dispatch_1() "None" {
@@ -50,7 +50,7 @@ hal.executable private @call_dispatch_1  {
 }
 hal.executable private @call_dispatch_2  {
   hal.executable.variant @vulkan_spirv_fb, target = #executable_target_vulkan_spirv_fb {
-    hal.executable.entry_point @call_dispatch_2 ordinal(0) layout(#executable_layout_0)
+    hal.executable.export @call_dispatch_2 ordinal(0) layout(#executable_layout_0)
     builtin.module {
       spv.module Logical GLSL450 requires #spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]> {
         spv.func @call_dispatch_2() "None" {
@@ -64,7 +64,7 @@ hal.executable private @call_dispatch_2  {
 }
 hal.executable private @call_dispatch_3  {
   hal.executable.variant @vulkan_spirv_fb, target = #executable_target_vulkan_spirv_fb {
-    hal.executable.entry_point @call_dispatch_3 ordinal(0) layout(#executable_layout_1)
+    hal.executable.export @call_dispatch_3 ordinal(0) layout(#executable_layout_1)
     builtin.module {
       spv.module Logical GLSL450 requires #spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]> {
         spv.func @call_dispatch_3() "None" {
@@ -78,7 +78,7 @@ hal.executable private @call_dispatch_3  {
 }
 hal.executable private @call_dispatch_4  {
   hal.executable.variant @vulkan_spirv_fb, target = #executable_target_vulkan_spirv_fb {
-    hal.executable.entry_point @call_dispatch_4 ordinal(0) layout(#executable_layout_1)
+    hal.executable.export @call_dispatch_4 ordinal(0) layout(#executable_layout_1)
     builtin.module {
       spv.module Logical GLSL450 requires #spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]> {
         spv.func @call_dispatch_4() "None" {
@@ -95,9 +95,9 @@ hal.executable private @call_dispatch_4  {
 
 //      CHECK: hal.executable private @linking_linked_vulkan_0 {
 // CHECK-NEXT:   hal.executable.variant public @vulkan_spirv_fb, target = #executable_target_vulkan_spirv_fb {
-// CHECK-NEXT:     hal.executable.entry_point public @call_dispatch_1 ordinal(0) layout(#executable_layout_0)
-// CHECK-NEXT:     hal.executable.entry_point public @call_dispatch_3 ordinal(1) layout(#executable_layout_0)
-// CHECK-NEXT:     hal.executable.entry_point public @call_dispatch_4 ordinal(2) layout(#executable_layout_0)
+// CHECK-NEXT:     hal.executable.export public @call_dispatch_1 ordinal(0) layout(#executable_layout_0)
+// CHECK-NEXT:     hal.executable.export public @call_dispatch_3 ordinal(1) layout(#executable_layout_0)
+// CHECK-NEXT:     hal.executable.export public @call_dispatch_4 ordinal(2) layout(#executable_layout_0)
 // CHECK-NEXT:     module  {
 // CHECK-NEXT:       spv.module Logical GLSL450 requires #spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]> {
 // CHECK-NEXT:         spv.func @call_dispatch_1() "None" {
@@ -122,8 +122,8 @@ hal.executable private @call_dispatch_4  {
 
 //      CHECK: hal.executable private @linking_linked_vulkan {
 // CHECK-NEXT:   hal.executable.variant public @vulkan_spirv_fb, target = #executable_target_vulkan_spirv_fb {
-// CHECK-NEXT:     hal.executable.entry_point public @call_dispatch_0 ordinal(0) layout(#executable_layout_1)
-// CHECK-NEXT:     hal.executable.entry_point public @call_dispatch_2 ordinal(1) layout(#executable_layout_1)
+// CHECK-NEXT:     hal.executable.export public @call_dispatch_0 ordinal(0) layout(#executable_layout_1)
+// CHECK-NEXT:     hal.executable.export public @call_dispatch_2 ordinal(1) layout(#executable_layout_1)
 // CHECK-NEXT:     module  {
 // CHECK-NEXT:       spv.module Logical GLSL450 requires #spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]> {
 // CHECK-NEXT:         spv.func @call_dispatch_0() "None" {

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD
@@ -27,7 +27,7 @@ iree_compiler_cc_library(
         "MaterializeResourceCaches.cpp",
         "MemoizeDeviceQueries.cpp",
         "Passes.cpp",
-        "ResolveEntryPointOrdinals.cpp",
+        "ResolveExportOrdinals.cpp",
         "SerializeExecutables.cpp",
         "TranslateExecutables.cpp",
         "VerifyTargetEnvironment.cpp",

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
@@ -28,7 +28,7 @@ iree_cc_library(
     "MaterializeResourceCaches.cpp"
     "MemoizeDeviceQueries.cpp"
     "Passes.cpp"
-    "ResolveEntryPointOrdinals.cpp"
+    "ResolveExportOrdinals.cpp"
     "SerializeExecutables.cpp"
     "TranslateExecutables.cpp"
     "VerifyTargetEnvironment.cpp"

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/DumpExecutableBenchmarks.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/DumpExecutableBenchmarks.cpp
@@ -45,13 +45,13 @@ struct DispatchParams {
   // All locations that dispatch with these parameters.
   SmallVector<Location> locs;
   // Workload used as input to the workgroup count calculation function.
-  Vec3 workload;
+  SmallVector<unsigned> workload;
   // Analyzed minimum binding sizes.
   SmallVector<Binding> bindings;
 };
 
 using DispatchParamsMap =
-    llvm::DenseMap<SymbolRefAttr, llvm::MapVector<Vec3, DispatchParams>>;
+    llvm::DenseMap<SymbolRefAttr, llvm::SmallVector<DispatchParams>>;
 
 // Walk |moduleOp| and gather all of the dispatches to each executable.
 // Dispatch parameters are deduplicated by workload so that there's only ever
@@ -71,17 +71,17 @@ static DispatchParamsMap gatherDispatchParams(mlir::ModuleOp moduleOp) {
       assert(bindingAttrs &&
              "interface materialization must annotate dispatch sites");
 
-      auto workloadValues = dispatchOp.workgroup_count();
-      APInt workloadX, workloadY, workloadZ;
-      if (!matchPattern(workloadValues[0], m_ConstantInt(&workloadX)) ||
-          !matchPattern(workloadValues[1], m_ConstantInt(&workloadY)) ||
-          !matchPattern(workloadValues[2], m_ConstantInt(&workloadZ))) {
-        // Non-constant workload; skip this dispatch.
-        return;
+      auto workloadValues = dispatchOp.workload();
+      SmallVector<unsigned> workload;
+      workload.reserve(workloadValues.size());
+      for (auto workloadValue : workloadValues) {
+        APInt workloadConstValue;
+        if (!matchPattern(workloadValue, m_ConstantInt(&workloadConstValue))) {
+          // Non-constant workload; skip this dispatch.
+          return;
+        }
+        workload.push_back(workloadConstValue.getSExtValue());
       }
-      Vec3 workload =
-          std::make_tuple(workloadX.getSExtValue(), workloadY.getSExtValue(),
-                          workloadZ.getSExtValue());
 
       SmallVector<Binding> bindings;
       for (auto it : llvm::zip(bindingAttrs, dispatchOp.resource_lengths())) {
@@ -97,11 +97,22 @@ static DispatchParamsMap gatherDispatchParams(mlir::ModuleOp moduleOp) {
                             resourceLength.getSExtValue()});
       }
 
+      // Work around needing a mutable key for the set; C++ was a mistake.
       auto &dispatchParamsSet = map[dispatchOp.entry_point()];
-      auto &dispatchParams = dispatchParamsSet[workload];
-      dispatchParams.locs.push_back(dispatchOp.getLoc());
-      dispatchParams.workload = workload;
-      dispatchParams.bindings = bindings;
+      DispatchParams *dispatchParams = nullptr;
+      for (auto &it : dispatchParamsSet) {
+        if (it.workload == workload) {
+          dispatchParams = &it;
+          break;
+        }
+      }
+      if (!dispatchParams) {
+        dispatchParamsSet.push_back({});
+        dispatchParams = &dispatchParamsSet.back();
+      }
+      dispatchParams->locs.push_back(dispatchOp.getLoc());
+      dispatchParams->workload = workload;
+      dispatchParams->bindings = bindings;
     });
   }
 
@@ -163,13 +174,15 @@ static void appendDispatchBenchmark(
     DispatchParams dispatchParams, OpBuilder &moduleBuilder) {
   auto loc = FusedLoc::get(executableOp.getContext(), dispatchParams.locs);
 
-  std::string baseName =
-      (executableOp.getName() + "_" + variantOp.getName() + "_" +
-       entryPointOp.getName() + "_" +
-       std::to_string(std::get<0>(dispatchParams.workload)) + "x" +
-       std::to_string(std::get<1>(dispatchParams.workload)) + "x" +
-       std::to_string(std::get<2>(dispatchParams.workload)))
-          .str();
+  std::string baseName = (executableOp.getName() + "_" + variantOp.getName() +
+                          "_" + entryPointOp.getName())
+                             .str();
+  if (!dispatchParams.workload.empty()) {
+    baseName += "_" + std::to_string(dispatchParams.workload[0]);
+    for (size_t i = 1; i < dispatchParams.workload.size(); ++i) {
+      baseName += "x" + std::to_string(dispatchParams.workload[i]);
+    }
+  }
 
   // Add a global variable holding an initialized buffer for the dispatch IO.
   auto bufferGlobalOp =
@@ -264,14 +277,11 @@ static void appendDispatchBenchmark(
   if (currentSet != -1) flushSet();
 
   // Compute the workgroup parameters.
-  auto workgroupCount = entryPointOp.calculateWorkgroupCount(
-      loc, device,
-      {
-          indexSet.get(std::get<0>(dispatchParams.workload)),
-          indexSet.get(std::get<1>(dispatchParams.workload)),
-          indexSet.get(std::get<2>(dispatchParams.workload)),
-      },
-      funcBuilder);
+  auto workload = llvm::to_vector(
+      llvm::map_range(dispatchParams.workload,
+                      [&](unsigned dim) { return indexSet.get(dim); }));
+  auto workgroupCount =
+      entryPointOp.calculateWorkgroupCount(loc, device, workload, funcBuilder);
 
   // Loop around dispatches based on batch size.
   // Note that we insert a barrier between each dispatch - we could make this
@@ -346,9 +356,9 @@ static mlir::OwningOpRef<mlir::ModuleOp> buildBenchmarkModule(
         {FlatSymbolRefAttr::get(entryPointOp.getNameAttr())});
     auto dispatchParamsSet = dispatchParamsMap.find(symbolRefAttr);
     if (dispatchParamsSet != dispatchParamsMap.end()) {
-      for (auto dispatchParams : dispatchParamsSet->second) {
+      for (auto &dispatchParams : dispatchParamsSet->second) {
         appendDispatchBenchmark(executableOp, variantOp, entryPointOp,
-                                dispatchParams.second, moduleBuilder);
+                                dispatchParams, moduleBuilder);
         hasAnyBenchmarks = true;
       }
     }

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
@@ -49,8 +49,7 @@ static LogicalResult materializeExecutableFromSourceOp(
 
   // With this hand-authored path all variants have the same layout and entry
   // points and we can just clone them.
-  auto sourceEntryPointOps =
-      sourceOp.getOps<IREE::HAL::ExecutableEntryPointOp>();
+  auto sourceEntryPointOps = sourceOp.getOps<IREE::HAL::ExecutableExportOp>();
   auto sourceModuleOp = sourceOp.getInnerModule();
 
   // Materialize all of the hal.executable.variant ops for all backends we are
@@ -219,7 +218,8 @@ static void annotateDispatchSite(IREE::Stream::CmdDispatchOp dispatchOp,
 }
 
 // Adds the entry point ops with assigned ordinals for each entry function.
-// The entry points will all use the provided |interfaceOp|.
+// The entry points will all use the provided |interfaceOp| and be exported with
+// hal.executable.export ops.
 static LogicalResult declareEntryPointOps(
     IREE::Stream::ExecutableOp sourceExecutableOp,
     IREE::HAL::ExecutableOp targetExecutableOp,
@@ -228,7 +228,7 @@ static LogicalResult declareEntryPointOps(
       targetExecutableOp.getBlock().getOps<IREE::HAL::ExecutableVariantOp>();
   OpBuilder executableBuilder(&targetExecutableOp.getBlock().front());
 
-  // For each exported function create a HAL entry point and dispatch thunk.
+  // For each exported function create a HAL export decl and dispatch thunk.
   int nextOrdinal = 0;
   for (auto exportOp :
        sourceExecutableOp.body().getOps<IREE::Stream::ExecutableExportOp>()) {
@@ -253,11 +253,18 @@ static LogicalResult declareEntryPointOps(
     for (auto variantOp : variantOps) {
       // Declare the entry point on the target.
       OpBuilder targetBuilder(&variantOp.getBlock().front());
-      targetBuilder.create<IREE::HAL::ExecutableEntryPointOp>(
+      auto newExportOp = targetBuilder.create<IREE::HAL::ExecutableExportOp>(
           exportOp.getLoc(),
           targetBuilder.getStringAttr(exportOp.function_ref()),
           targetBuilder.getIndexAttr(ordinal), layoutAttr, ArrayAttr{},
           IntegerAttr{});
+
+      // Clone the workgroup count calculation function.
+      if (!exportOp.workgroup_count().empty()) {
+        mlir::BlockAndValueMapping mapper;
+        exportOp.workgroup_count().front().cloneInto(
+            &newExportOp.workgroup_count(), mapper);
+      }
 
       // Clone the updated interface-based function into the target.
       auto targetFuncOp = baseFuncOp.clone();
@@ -301,11 +308,11 @@ struct InlineConstantWorkgroupSizePattern
     // Lookup the entry point matching the parent.
     auto funcOp = sizeOp->getParentOfType<mlir::func::FuncOp>();
     auto variantOp = funcOp->getParentOfType<IREE::HAL::ExecutableVariantOp>();
-    auto entryPointOp = dyn_cast<IREE::HAL::ExecutableEntryPointOp>(
+    auto exportOp = dyn_cast<IREE::HAL::ExecutableExportOp>(
         SymbolTable::lookupSymbolIn(variantOp, funcOp.getName()));
-    assert(entryPointOp &&
+    assert(exportOp &&
            "must have an entry point corresponding to the parent func");
-    auto workgroupSizeAttr = entryPointOp.workgroup_sizeAttr();
+    auto workgroupSizeAttr = exportOp.workgroup_sizeAttr();
     if (!workgroupSizeAttr) return failure();
 
     uint64_t dimIdx = sizeOp.dimension().getZExtValue();

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeResourceCaches.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeResourceCaches.cpp
@@ -53,10 +53,9 @@ class MaterializeResourceCachesPass
     for (auto executableOp : executableOps) {
       for (auto variantOp :
            executableOp.getOps<IREE::HAL::ExecutableVariantOp>()) {
-        for (auto entryPointOp :
-             variantOp.getOps<IREE::HAL::ExecutableEntryPointOp>()) {
-          defineExecutableLayoutOp(entryPointOp.getLoc(),
-                                   entryPointOp.layout());
+        for (auto exportOp :
+             variantOp.getOps<IREE::HAL::ExecutableExportOp>()) {
+          defineExecutableLayoutOp(exportOp.getLoc(), exportOp.layout());
         }
       }
     }
@@ -206,10 +205,10 @@ class MaterializeResourceCachesPass
       // Gather each of the executable layouts needed for each entry point in
       // the executable.
       SmallVector<Value, 8> executableLayoutValues;
-      for (auto entryPointOp :
-           executableVariantOp.getOps<IREE::HAL::ExecutableEntryPointOp>()) {
-        auto executableLayoutGlobalOp = defineExecutableLayoutOp(
-            executableOp.getLoc(), entryPointOp.layout());
+      for (auto exportOp :
+           executableVariantOp.getOps<IREE::HAL::ExecutableExportOp>()) {
+        auto executableLayoutGlobalOp =
+            defineExecutableLayoutOp(executableOp.getLoc(), exportOp.layout());
         executableLayoutValues.push_back(
             caseBuilder.createOrFold<IREE::Util::GlobalLoadOp>(
                 loc, ExecutableLayoutType::get(loc.getContext()),

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -142,7 +142,7 @@ void buildHALTransformPassPipeline(OpPassManager &passManager,
 
   // TODO(benvanik): move translation down to here.
 
-  // After all executables are translated and before resolving entry point
+  // After all executables are translated and before resolving export
   // ordinals, we allow the backends to link executables together. For example,
   // the LLVM AOT backend may combine all executable targets for the same
   // architecture into a single executable and link it as a shared library.
@@ -150,10 +150,10 @@ void buildHALTransformPassPipeline(OpPassManager &passManager,
     passManager.addPass(createLinkExecutablesPass());
   }
 
-  // Resolve entry point ordinals from nested symbol references prior to
+  // Resolve export ordinals from nested symbol references prior to
   // serialization. As this pass creates lookup ops it should run before
   // MaterializeResourceCachesPass.
-  passManager.addPass(createResolveEntryPointOrdinalsPass());
+  passManager.addPass(createResolveExportOrdinalsPass());
 
   // Gather cachable resources such as executables and descriptor sets and
   // cache them at initialization-time.

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.h
@@ -103,9 +103,9 @@ std::unique_ptr<OperationPass<mlir::ModuleOp>> createLinkExecutablesPass();
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createLinkTargetExecutablesPass(
     StringRef target);
 
-// Resolves hal.executable.entry_point references to ordinals.
+// Resolves hal.executable.export references to ordinals.
 std::unique_ptr<OperationPass<mlir::ModuleOp>>
-createResolveEntryPointOrdinalsPass();
+createResolveExportOrdinalsPass();
 
 // Converts hal.executable.variants to one or more hal.executable.binary ops.
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableOp>>
@@ -161,7 +161,7 @@ inline void registerHALPasses() {
   createMaterializeInterfacesPass();
   createMaterializeResourceCachesPass(targetOptions);
   createMemoizeDeviceQueriesPass();
-  createResolveEntryPointOrdinalsPass();
+  createResolveExportOrdinalsPass();
   createSerializeExecutablesPass();
   createSerializeTargetExecutablesPass("");
   createTranslateExecutablesPass();

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/BUILD
@@ -27,7 +27,7 @@ iree_lit_test_suite(
             "materialize_interfaces.mlir",
             "materialize_resource_caches.mlir",
             "memoize_device_queries.mlir",
-            "resolve_entry_point_ordinals.mlir",
+            "resolve_export_ordinals.mlir",
             "verify_target_environment.mlir",
         ],
         include = ["*.mlir"],

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/CMakeLists.txt
@@ -24,7 +24,7 @@ iree_lit_test_suite(
     "materialize_interfaces.mlir"
     "materialize_resource_caches.mlir"
     "memoize_device_queries.mlir"
-    "resolve_entry_point_ordinals.mlir"
+    "resolve_export_ordinals.mlir"
     "verify_target_environment.mlir"
   TOOLS
     FileCheck

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/convert_to_hal.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/convert_to_hal.mlir
@@ -20,7 +20,7 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
   // CHECK: hal.executable private @ex
   hal.executable private @ex {
     hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-      hal.executable.entry_point public @dispatch ordinal(0) layout(#executable_layout) {
+      hal.executable.export public @dispatch ordinal(0) layout(#executable_layout) {
         translation_info = #iree_codegen.translation_info<CPUDefault workload_per_wg = [4]>
       } {
       ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):  // no predecessors

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_benchmarks.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_benchmarks.mlir
@@ -27,7 +27,7 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
   // CHECK: hal.executable private @ex0
   hal.executable private @ex0 {
     hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-      hal.executable.entry_point public @dispatch0 ordinal(0) layout(#executable_layout_0) {
+      hal.executable.export public @dispatch0 ordinal(0) layout(#executable_layout_0) {
         translation_info = #iree_codegen.translation_info<CPUDefault workload_per_wg = [4]>
       } {
       ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):
@@ -41,7 +41,7 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
         }
       }
 
-      hal.executable.entry_point public @dispatch1 ordinal(1) layout(#executable_layout_1) {
+      hal.executable.export public @dispatch1 ordinal(1) layout(#executable_layout_1) {
         translation_info = #iree_codegen.translation_info<CPUDefault workload_per_wg = [4]>
       } {
       ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_sources.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_sources.mlir
@@ -22,7 +22,7 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
     // We expect local outputs with attributes inlined:
     // CHECK-NEXT: hal.executable.variant {{.+}}, target = <"llvm"
     hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-      hal.executable.entry_point public @dispatch0 ordinal(0) layout(#executable_layout) {
+      hal.executable.export public @dispatch0 ordinal(0) layout(#executable_layout) {
         translation_info = #iree_codegen.translation_info<CPUDefault workload_per_wg = [4]>
       } {
       ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):  // no predecessors
@@ -41,7 +41,7 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
   // CHECK: hal.executable private @ex1
   hal.executable private @ex1 {
     hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-      hal.executable.entry_point public @dispatch1 ordinal(0) layout(#executable_layout) {
+      hal.executable.export public @dispatch1 ordinal(0) layout(#executable_layout) {
         translation_info = #iree_codegen.translation_info<CPUDefault workload_per_wg = [4]>
       } {
       ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):  // no predecessors

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
@@ -15,7 +15,7 @@ module attributes {hal.device.targets = [
 ]} {
 
 hal.executable.source public @ex {
-  hal.executable.entry_point public @entry layout(#hal.executable.layout<push_constants = 1, sets = [
+  hal.executable.export public @entry layout(#hal.executable.layout<push_constants = 1, sets = [
     #hal.descriptor_set.layout<0, bindings = [
       #hal.descriptor_set.binding<0, storage_buffer>
     ]>,
@@ -41,11 +41,11 @@ hal.executable.source public @ex {
 
 // CHECK: hal.executable public @ex
 // CHECK:   hal.executable.variant public @embedded_elf_arm_64, target = #executable_target_embedded_elf_arm_64
-// CHECK:     hal.executable.entry_point public @entry layout(#executable_layout)
+// CHECK:     hal.executable.export public @entry layout(#executable_layout)
 // CHECK:     builtin.module
 // CHECK-NEXT:  func.func @entry()
 // CHECK:   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64
-// CHECK:     hal.executable.entry_point public @entry layout(#executable_layout)
+// CHECK:     hal.executable.export public @entry layout(#executable_layout)
 // CHECK:     builtin.module
 // CHECK-NEXT:  func.func @entry()
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
@@ -1,5 +1,56 @@
 // RUN: iree-opt --split-input-file --iree-hal-materialize-interfaces %s | FileCheck %s
 
+// Tests an executable with a workgroup count region specified.
+
+module attributes {hal.device.targets = [
+  #hal.device.target<"cpu", {
+    executable_targets = [
+      #hal.executable.target<"llvm", "embedded-elf-arm_64">,
+      #hal.executable.target<"llvm", "embedded-elf-x86_64">
+    ]
+  }>
+]} {
+
+// CHECK: hal.executable private @ex_workgroups
+// CHECK:   hal.executable.variant public @embedded_elf_arm_64, target = #executable_target_embedded_elf_arm_64
+// CHECK:     hal.executable.export public @entry ordinal(0) layout(#executable_layout) {
+// CHECK-NEXT: ^bb0(%[[DEVICE:.+]]: !hal.device, %[[ARG0:.+]]: index, %[[ARG1:.+]]: index):
+// CHECK-NEXT:   hal.return %[[ARG0]], %[[ARG1]], %[[ARG0]] : index, index, index
+// CHECK-NEXT: }
+// CHECK:     builtin.module
+// CHECK-NEXT:  func.func @entry()
+// CHECK:   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64
+// CHECK:     hal.executable.export public @entry ordinal(0) layout(#executable_layout) {
+// CHECK-NEXT: ^bb0(%[[DEVICE:.+]]: !hal.device, %[[ARG0:.+]]: index, %[[ARG1:.+]]: index):
+// CHECK-NEXT:   hal.return %[[ARG0]], %[[ARG1]], %[[ARG0]] : index, index, index
+// CHECK-NEXT: }
+// CHECK:     builtin.module
+// CHECK-NEXT:  func.func @entry()
+
+stream.executable private @ex_workgroups {
+  stream.executable.export public @entry workgroups(%arg0: index, %arg1: index) -> (index, index, index) {
+    stream.return %arg0, %arg1, %arg0 : index, index, index
+  }
+  builtin.module {
+    func.func @entry() {
+      return
+    }
+  }
+}
+
+// CHECK-LABEL: @main
+func.func @main(%arg0: !stream.resource<external>, %arg1: index) -> !stream.resource<external> {
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c4 = arith.constant 4 : index
+  %0 = stream.async.dispatch @ex_workgroups::@entry[%c1, %c2](%arg0, %c4) : (!stream.resource<external>{%arg1}, index) -> %arg0{%arg1}
+  return %0 : !stream.resource<external>
+}
+
+}
+
+// -----
+
 // Tests an already-specified executable source op is expanded into the variants
 // specified by the target configuration. These source executables may come from
 // hand-authored code or other dialects that perform interface assignment

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_resource_caches.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_resource_caches.mlir
@@ -122,13 +122,13 @@ module attributes {hal.device.targets = [#hal.device.target<"cpu">]} {
 //   - If there is no matching hal.executable.variant then the executable will not be cached
 hal.executable @exe {
   hal.executable.variant @vmvx, target = <"vmvx", "vmvx-bytecode-fb"> {
-    hal.executable.entry_point @entry0 ordinal(0) layout(#executable_layout_0) {
+    hal.executable.export @entry0 ordinal(0) layout(#executable_layout_0) {
       workgroup_size = [32 : index, 1 : index, 1 : index]
     }
-    hal.executable.entry_point @entry0_alias ordinal(0) layout(#executable_layout_0) {
+    hal.executable.export @entry0_alias ordinal(0) layout(#executable_layout_0) {
       workgroup_size = [32 : index, 1 : index, 1 : index]
     }
-    hal.executable.entry_point @entry1 ordinal(1) layout(#executable_layout_1) {
+    hal.executable.export @entry1 ordinal(1) layout(#executable_layout_1) {
       workgroup_size = [32 : index, 1 : index, 1 : index]
     }
   }

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/resolve_export_ordinals.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/resolve_export_ordinals.mlir
@@ -1,8 +1,8 @@
-// RUN: iree-opt --split-input-file --iree-hal-resolve-entry-point-ordinals %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-hal-resolve-export-ordinals %s | FileCheck %s
 
 hal.executable @exe {
   hal.executable.variant @target, target = <"vmvx", "vmvx-bytecode-fb"> {
-    hal.executable.entry_point @entry ordinal(0) layout(#hal.executable.layout<push_constants = 0, sets = [
+    hal.executable.export @entry ordinal(0) layout(#hal.executable.layout<push_constants = 0, sets = [
       #hal.descriptor_set.layout<0, bindings = [
         #hal.descriptor_set.binding<0, storage_buffer>,
         #hal.descriptor_set.binding<1, storage_buffer>
@@ -57,7 +57,7 @@ func.func @dispatch_already_using_ordinals(
 
 hal.executable @exe {
   hal.executable.variant @target, target = <"vmvx", "vmvx-bytecode-fb"> {
-    hal.executable.entry_point @entry ordinal(0) layout(#hal.executable.layout<push_constants = 0, sets = [
+    hal.executable.export @entry ordinal(0) layout(#hal.executable.layout<push_constants = 0, sets = [
       #hal.descriptor_set.layout<0, bindings = [
         #hal.descriptor_set.binding<0, storage_buffer>,
         #hal.descriptor_set.binding<1, storage_buffer>

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/ConvertFlowToStream.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/ConvertFlowToStream.cpp
@@ -377,7 +377,7 @@ struct ConvertExecutableOp
     streamOp->setDialectAttrs(flowOp->getDialectAttrs());
     rewriter.setInsertionPointToStart(&streamOp.body().front());
 
-    // flow.executable.export -> stream.executable.entry_point
+    // flow.executable.export -> stream.executable.export
     for (auto exportOp : flowOp.getOps<IREE::Flow::ExecutableExportOp>()) {
       auto newOp = rewriter.create<IREE::Stream::ExecutableExportOp>(
           entryOp.getLoc(), entryOp.sym_name(), entryOp.function_refAttr());

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/ConvertFlowToStream.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/ConvertFlowToStream.cpp
@@ -377,8 +377,8 @@ struct ConvertExecutableOp
     streamOp->setDialectAttrs(flowOp->getDialectAttrs());
     rewriter.setInsertionPointToStart(&streamOp.body().front());
 
-    // flow.dispatch.entry -> stream.executable.entry_point
-    for (auto entryOp : flowOp.getOps<IREE::Flow::DispatchEntryOp>()) {
+    // flow.executable.export -> stream.executable.entry_point
+    for (auto exportOp : flowOp.getOps<IREE::Flow::ExecutableExportOp>()) {
       auto newOp = rewriter.create<IREE::Stream::ExecutableExportOp>(
           entryOp.getLoc(), entryOp.sym_name(), entryOp.function_refAttr());
       newOp->setDialectAttrs(entryOp->getDialectAttrs());

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/ConvertFlowToStream.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/ConvertFlowToStream.cpp
@@ -296,7 +296,7 @@ struct ConvertDispatchOp : public OpConversionPattern<IREE::Flow::DispatchOp> {
     }
 
     rewriter.replaceOpWithNewOp<IREE::Stream::AsyncDispatchOp>(
-        op, resultTypes, adaptor.workgroup_count(), adaptor.entry_point(),
+        op, resultTypes, adaptor.workload(), adaptor.entry_point(),
         dispatchOperands, dispatchOperandSizes, resultSizes,
         adaptor.tied_operandsAttr(),
         /*affinity=*/nullptr);

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/dispatch_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/dispatch_ops.mlir
@@ -1,5 +1,18 @@
 // RUN: iree-opt --split-input-file --iree-stream-conversion --canonicalize %s | FileCheck %s
 
+// CHECK-LABEL: @dispatchNoWorkload
+//  CHECK-SAME: (%[[INPUT:.+]]: !stream.resource<*>, %[[INPUT_SIZE:.+]]: index, %[[DIM1:.+]]: index, %[[DIM3:.+]]: index)
+func.func @dispatchNoWorkload(%input: tensor<7x?x24x?xf32>, %dim1: index, %dim3: index) -> tensor<?x?x1024xf32> {
+  //      CHECK: %[[RESULT_SIZE:.+]] = stream.tensor.sizeof tensor<?x?x1024xf32>{%[[DIM1]], %[[DIM3]]}
+  //      CHECK: %[[RESULT:.+]] = stream.async.dispatch @ex::@entry(%[[INPUT]]) :
+  // CHECK-SAME:     (!stream.resource<*>{%[[INPUT_SIZE]]}) -> !stream.resource<*>{%[[RESULT_SIZE]]}
+  %0 = flow.dispatch @ex::@entry(%input) : (tensor<7x?x24x?xf32>{%dim1, %dim3}) -> tensor<?x?x1024xf32>{%dim1, %dim3}
+  // return %[[RESULT]], %[[RESULT_SIZE]] : !stream.resource<*>, index
+  return %0 : tensor<?x?x1024xf32>
+}
+
+// -----
+
 // CHECK-LABEL: @dispatch
 //  CHECK-SAME: (%[[INPUT:.+]]: !stream.resource<*>, %[[INPUT_SIZE:.+]]: index, %[[DIM1:.+]]: index, %[[DIM3:.+]]: index)
 func.func @dispatch(%input: tensor<7x?x24x?xf32>, %dim1: index, %dim3: index) -> tensor<?x?x1024xf32> {

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/executable_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/executable_ops.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: @rank_0_binding
 flow.executable private @rank_0_binding {
-  flow.dispatch.entry public @dispatch
+  flow.executable.export public @dispatch
   builtin.module {
     // CHECK: func.func @dispatch(%[[INPUT:.+]]: !stream.binding)
     func.func @dispatch(%input: !flow.dispatch.tensor<readonly:i64>) {
@@ -19,7 +19,7 @@ flow.executable private @rank_0_binding {
 
 // CHECK-LABEL: @static_bindings
 flow.executable private @static_bindings {
-  flow.dispatch.entry public @dispatch
+  flow.executable.export public @dispatch
   builtin.module {
     // CHECK: func.func @dispatch(%[[INPUT:.+]]: !stream.binding, %[[OUTPUT:.+]]: !stream.binding)
     func.func @dispatch(%input: !flow.dispatch.tensor<readonly:1x4xf32>, %output: !flow.dispatch.tensor<writeonly:4xf32>) {
@@ -41,7 +41,7 @@ flow.executable private @static_bindings {
 
 // CHECK-LABEL: @dynamic_bindings
 flow.executable private @dynamic_bindings {
-  flow.dispatch.entry public @dispatch
+  flow.executable.export public @dispatch
   builtin.module {
     // CHECK: func.func @dispatch(%[[DIM:.+]]: index, %[[INPUT:.+]]: !stream.binding, %[[OUTPUT:.+]]: !stream.binding)
     func.func @dispatch(%dim: index, %input: !flow.dispatch.tensor<readonly:1x?xf32>, %output: !flow.dispatch.tensor<writeonly:?xf32>) {
@@ -63,7 +63,7 @@ flow.executable private @dynamic_bindings {
 
 // CHECK-LABEL: @indirect_dynamic_bindings
 flow.executable private @indirect_dynamic_bindings {
-  flow.dispatch.entry public @dispatch
+  flow.executable.export public @dispatch
   builtin.module {
     // CHECK: func.func @dispatch(%[[DIM_TENSOR:.+]]: !stream.binding, %[[INPUT:.+]]: !stream.binding, %[[OUTPUT:.+]]: !stream.binding)
     func.func @dispatch(%dim_tensor: !flow.dispatch.tensor<readonly:i64>, %input: !flow.dispatch.tensor<readonly:1x?xf32>, %output: !flow.dispatch.tensor<writeonly:?xf32>) {
@@ -93,7 +93,7 @@ flow.executable private @indirect_dynamic_bindings {
 
 // CHECK-LABEL: @nested_bindings
 flow.executable private @nested_bindings {
-  flow.dispatch.entry public @dispatch
+  flow.executable.export public @dispatch
   builtin.module {
     // CHECK: func.func @dispatch(%[[DIM:.+]]: index, %[[INPUT:.+]]: !stream.binding, %[[OUTPUT:.+]]: !stream.binding)
     func.func @dispatch(%dim: index, %input: !flow.dispatch.tensor<readonly:1x?xf32>, %output: !flow.dispatch.tensor<writeonly:?xf32>) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/executable_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/executable_ops.mlir
@@ -1,5 +1,24 @@
 // RUN: iree-opt --split-input-file --iree-stream-conversion --canonicalize %s | FileCheck %s
 
+// CHECK-LABEL: @workgroup_count_region
+flow.executable private @workgroup_count_region {
+  // CHECK-NEXT: stream.executable.export public @dispatch
+  flow.executable.export public @dispatch
+      // CHECK-SAME: workgroups(%[[ARG0:.+]]: index) -> (index, index, index) {
+      workgroups(%arg0: index) -> (index, index, index) {
+        // CHECK-NEXT: stream.return %[[ARG0]], %[[ARG0]], %[[ARG0]] : index, index, index
+        flow.return %arg0, %arg0, %arg0 : index, index, index
+      }
+  builtin.module {
+    // CHECK: func.func @dispatch()
+    func.func @dispatch() {
+      return
+    }
+  }
+}
+
+// -----
+
 // CHECK-LABEL: @rank_0_binding
 flow.executable private @rank_0_binding {
   flow.executable.export public @dispatch

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -2036,7 +2036,7 @@ LogicalResult ExecutableOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// stream.executable.entry
+// stream.executable.export
 //===----------------------------------------------------------------------===//
 
 void ExecutableExportOp::build(OpBuilder &builder, OperationState &state,

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -1049,7 +1049,7 @@ LogicalResult BuiltinSplatI64Op::convertBuiltinOp(OpBuilder &builder) {
   auto count =
       builder.createOrFold<arith::DivUIOp>(getLoc(), result_size(), c8);
   auto one = builder.create<arith::ConstantIndexOp>(getLoc(), 1);
-  Value workgroupCount[3] = {
+  Value workload[3] = {
       count,
       one,
       one,
@@ -1069,7 +1069,7 @@ LogicalResult BuiltinSplatI64Op::convertBuiltinOp(OpBuilder &builder) {
       result().getType(),
   };
   auto dispatchOp = builder.create<IREE::Stream::AsyncDispatchOp>(
-      getLoc(), resultTypes, workgroupCount,
+      getLoc(), resultTypes, workload,
       SymbolRefAttr::get(
           builder.getStringAttr("__builtin_splat_i64"),
           FlatSymbolRefAttr::get(builder.getContext(), "__builtin_splat_i64")),
@@ -1115,7 +1115,7 @@ LogicalResult BuiltinFillI64Op::convertBuiltinOp(OpBuilder &builder) {
   auto count =
       builder.createOrFold<arith::DivUIOp>(getLoc(), target_length(), c8);
   auto one = builder.create<arith::ConstantIndexOp>(getLoc(), 1);
-  Value workgroupCount[3] = {
+  Value workload[3] = {
       count,
       one,
       one,
@@ -1139,7 +1139,7 @@ LogicalResult BuiltinFillI64Op::convertBuiltinOp(OpBuilder &builder) {
       result().getType(),
   };
   auto dispatchOp = builder.create<IREE::Stream::AsyncDispatchOp>(
-      getLoc(), resultTypes, workgroupCount,
+      getLoc(), resultTypes, workload,
       SymbolRefAttr::get(
           builder.getStringAttr("__builtin_fill_i64"),
           FlatSymbolRefAttr::get(builder.getContext(), "__builtin_fill_i64")),

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -50,6 +50,34 @@ static void createArgs(ArrayRef<OpAsmParser::UnresolvedOperand> operands,
   }
 }
 
+// Verifies that a dispatch |op|'s |workload| matches that of the |exportOp|.
+static LogicalResult verifyDispatchWorkload(
+    Operation *op, IREE::Stream::ExecutableExportOp exportOp,
+    ValueRange workload) {
+  // If the target has a workgroup count computation function we can verify that
+  // the workload here matches what is expected.
+  if (!exportOp.workgroup_count().empty()) {
+    auto &workgroupCount = exportOp.workgroup_count();
+    if (workgroupCount.getNumArguments() != workload.size()) {
+      return op->emitOpError()
+             << "workload mismatch; entry point expects "
+             << workgroupCount.getNumArguments()
+             << " arguments but dispatch provides " << workload.size();
+    }
+    for (auto it : llvm::enumerate(llvm::zip(workgroupCount.getArgumentTypes(),
+                                             workload.getTypes()))) {
+      auto expectedType = std::get<0>(it.value());
+      auto actualType = std::get<1>(it.value());
+      if (expectedType != actualType) {
+        return op->emitOpError() << "workload operand " << it.index()
+                                 << " type mismatch; expected " << expectedType
+                                 << " but passed " << actualType;
+      }
+    }
+  }
+  return success();
+}
+
 // Verifies that |dynamicDims| contains the appropriate number of dims for all
 // of the dynamic dimensions in |values|.
 static LogicalResult verifyOpDynamicDims(Operation *op, ValueRange values,
@@ -509,36 +537,67 @@ static void printConstantValueList(OpAsmPrinter &p, Operation *op,
 }
 
 //===----------------------------------------------------------------------===//
-// custom<SymbolAlias>($sym_name, $alias)
+// custom<WorkgroupCountRegion>($body)
 //===----------------------------------------------------------------------===//
-//  @foo            sym_name: @foo, alias: @foo
-//  @foo as @bar    sym_name: @bar, alias: @foo
 
-static ParseResult parseSymbolAlias(OpAsmParser &parser, StringAttr &sym_name,
-                                    FlatSymbolRefAttr &alias) {
-  if (failed(parser.parseAttribute(alias))) {
+static ParseResult parseWorkgroupCountRegion(OpAsmParser &parser,
+                                             Region &body) {
+  if (failed(parser.parseOptionalKeyword("workgroups"))) {
+    // Omitted.
+    return success();
+  }
+
+  SmallVector<OpAsmParser::Argument> args;
+  if (failed(parser.parseArgumentList(args, AsmParser::Delimiter::Paren,
+                                      /*allowType=*/true,
+                                      /*allowAttrs=*/true))) {
     return failure();
   }
-  if (succeeded(parser.parseOptionalKeyword("as"))) {
-    if (failed(parser.parseLParen()) ||
-        failed(parser.parseAttribute(sym_name)) ||
-        failed(parser.parseRParen())) {
-      return failure();
-    }
-  } else {
-    sym_name = StringAttr::get(parser.getContext(), alias.getValue());
+
+  // Return types must be 3 dimensions (workgroup count XYZ).
+  SmallVector<Type> returnTypes;
+  if (failed(parser.parseArrowTypeList(returnTypes))) {
+    return failure();
   }
+  if (returnTypes.size() != 3 ||
+      !llvm::all_of(returnTypes, [](Type type) { return type.isIndex(); })) {
+    return parser.emitError(parser.getCurrentLocation())
+           << "workgroup count region must return the XYZ dimension counts";
+  }
+
+  // Parse region contents.
+  if (failed(parser.parseRegion(body, args, /*enableNameShadowing=*/false))) {
+    return failure();
+  }
+
+  // Verify the return types match.
+  for (auto returnOp : body.getOps<IREE::Stream::ReturnOp>()) {
+    for (auto it : llvm::zip(returnTypes, returnOp.getOperandTypes())) {
+      if (std::get<0>(it) != std::get<1>(it)) {
+        return returnOp.emitOpError()
+               << "operands do not match expected region return types";
+      }
+    }
+  }
+
   return success();
 }
 
-static void printSymbolAlias(OpAsmPrinter &p, Operation *op,
-                             StringAttr sym_name, FlatSymbolRefAttr alias) {
-  p.printAttributeWithoutType(alias);
-  if (sym_name.getValue() != alias.getValue()) {
-    p << " as(\"";
-    p.printSymbolName(sym_name.getValue());
-    p << "\")";
+static void printWorkgroupCountRegion(OpAsmPrinter &p, Operation *op,
+                                      Region &body) {
+  if (body.empty()) return;
+  p << "workgroups(";
+  auto args = body.getArguments();
+  for (unsigned i = 0; i < args.size(); ++i) {
+    if (i > 0) p << ", ";
+    p.printRegionArgument(args[i]);
   }
+  p << ")";
+  Type indexType = IndexType::get(body.getContext());
+  p.printArrowTypeList(TypeRange{indexType, indexType, indexType});
+  p << " ";
+  p.printRegion(body, /*printEntryBlockArgs=*/false,
+                /*printBlockTerminators=*/true);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1368,6 +1427,32 @@ LogicalResult AsyncDispatchOp::verify() {
   return success();
 }
 
+LogicalResult AsyncDispatchOp::verifySymbolUses(
+    SymbolTableCollection &symbolTable) {
+  Operation *op = getOperation();
+  auto exportOp =
+      symbolTable.lookupNearestSymbolFrom<IREE::Stream::ExecutableExportOp>(
+          op, entry_point());
+  if (!exportOp) {
+    // TODO(benvanik): there are a lot of tests that are assuming this is not
+    // verified. We'll need to go add dummy executables for all of them. Today
+    // we just bail on the verifier if the symbol isn't found.
+    //
+    // Should be:
+    //   return op->emitOpError() << "undefined entry point: " << entry_point();
+    return success();
+  }
+
+  // Verify that the workload parameters captured match the target export.
+  if (failed(verifyDispatchWorkload(op, exportOp, workload()))) {
+    return failure();
+  }
+
+  // TODO(benvanik): verify that the target function has matching operands.
+
+  return success();
+}
+
 std::pair<unsigned, unsigned> AsyncDispatchOp::getTiedOperandsIndexAndLength() {
   return getODSOperandIndexAndLength(1);  // $operands
 }
@@ -1676,6 +1761,32 @@ LogicalResult CmdDispatchOp::verify() {
     return op->emitOpError() << "dispatch with " << resourceCount
                              << " resources has mismatched associated ranges";
   }
+  return success();
+}
+
+LogicalResult CmdDispatchOp::verifySymbolUses(
+    SymbolTableCollection &symbolTable) {
+  Operation *op = getOperation();
+  auto exportOp =
+      symbolTable.lookupNearestSymbolFrom<IREE::Stream::ExecutableExportOp>(
+          op, entry_point());
+  if (!exportOp) {
+    // TODO(benvanik): there are a lot of tests that are assuming this is not
+    // verified. We'll need to go add dummy executables for all of them. Today
+    // we just bail on the verifier if the symbol isn't found.
+    //
+    // Should be:
+    //   return op->emitOpError() << "undefined entry point: " << entry_point();
+    return success();
+  }
+
+  // Verify that the workload parameters captured match the target export.
+  if (failed(verifyDispatchWorkload(op, exportOp, workload()))) {
+    return failure();
+  }
+
+  // TODO(benvanik): verify that the target function has matching operands.
+
   return success();
 }
 
@@ -2046,6 +2157,22 @@ void ExecutableExportOp::build(OpBuilder &builder, OperationState &state,
         builder.getStringAttr(sym_name), function_ref);
 }
 
+LogicalResult ExecutableExportOp::verify() {
+  // Workgroup count region is optional.
+  if (!workgroup_count().empty()) {
+    // Verify the return ops all provide XYZ values.
+    for (auto returnOp : workgroup_count().getOps<IREE::Stream::ReturnOp>()) {
+      if (returnOp.getNumOperands() != 3 ||
+          !llvm::all_of(returnOp.getOperandTypes(),
+                        [](Type type) { return type.isIndex(); })) {
+        return returnOp.emitOpError()
+               << "workgroup count region must return the XYZ dimension counts";
+      }
+    }
+  }
+  return success();
+}
+
 ::mlir::func::FuncOp ExecutableExportOp::getFunctionRef() {
   auto executableOp =
       this->getOperation()->getParentOfType<IREE::Stream::ExecutableOp>();
@@ -2067,6 +2194,15 @@ LogicalResult BindingSubspanOp::verify() {
   }
 
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// stream.return
+//===----------------------------------------------------------------------===//
+
+MutableOperandRange ReturnOp::getMutableSuccessorOperands(
+    Optional<unsigned> index) {
+  return operandsMutable();
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -1841,7 +1841,7 @@ def Stream_AsyncDispatchOp : Stream_Op<"async.dispatch", [
   }];
 
   let arguments = (ins
-    Variadic<Index>:$workgroup_count,
+    Variadic<Index>:$workload,
     SymbolRefAttr:$entry_point,
     Variadic<AnyTypeOf<[
       Stream_AnyStreamResource,
@@ -1858,7 +1858,8 @@ def Stream_AsyncDispatchOp : Stream_Op<"async.dispatch", [
 
   let assemblyFormat = [{
     (`on` `(` $affinity^ `)`)?
-    $entry_point `[` $workgroup_count `]` ``
+    $entry_point
+    (`[` $workload^ `]`)? ``
     `(` $operands `)` attr-dict `:`
     custom<ShapedFunctionType>(ref($operands),
                                type($operands), $operand_sizes,
@@ -2298,7 +2299,7 @@ def Stream_CmdDispatchOp : Stream_Op<"cmd.dispatch", [
   }];
 
   let arguments = (ins
-    Variadic<Index>:$workgroup_count,
+    Variadic<Index>:$workload,
     SymbolRefAttr:$entry_point,
     Variadic<Stream_PrimitiveType>:$operands,
     Variadic<Stream_AnyStreamResource>:$resources,
@@ -2310,7 +2311,8 @@ def Stream_CmdDispatchOp : Stream_Op<"cmd.dispatch", [
   let results = (outs);
 
   let assemblyFormat = [{
-    $entry_point `[` $workgroup_count `]` ``
+    $entry_point
+    (`[` $workload^ `]`)? ``
     (`(` $operands^ `:` type($operands) `)`)? `{`
     custom<DispatchResources>($resources, type($resources), $resource_sizes,
                               $resource_offsets, $resource_lengths,

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -1825,6 +1825,7 @@ def Stream_AsyncStoreOp : Stream_PureOp<"async.store", [
 
 def Stream_AsyncDispatchOp : Stream_Op<"async.dispatch", [
   AttrSizedOperandSegments,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
   Stream_AffinityOp,
   Stream_AsyncPhaseOp,
   Stream_StreamableOp,
@@ -2286,6 +2287,7 @@ def Stream_CmdCopyOp : Stream_Op<"cmd.copy", [
 
 def Stream_CmdDispatchOp : Stream_Op<"cmd.dispatch", [
   AttrSizedOperandSegments,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
   Stream_CmdPhaseOp,
   Stream_StreamableOp,
   Stream_SubviewEffectOp,
@@ -2785,6 +2787,10 @@ def Stream_ExecutableExportOp : Stream_Op<"executable.export", [
   let description = [{
     Specifies an exported function with an externally-visible alias. Multiple
     exports can reference the same internal function.
+
+    Each entry point can have a unique workgroup count calculation region.
+    This region takes the workload parameters passed to each flow.dispatch and
+    produces an XYZ workgroup count for the 3D grid dispatch.
   }];
 
   let arguments = (ins
@@ -2793,9 +2799,12 @@ def Stream_ExecutableExportOp : Stream_Op<"executable.export", [
     FlatSymbolRefAttr:$function_ref
   );
 
+  let regions = (region AnyRegion:$workgroup_count);
+
   let assemblyFormat = [{
     custom<SymbolVisibility>($sym_visibility)
     custom<SymbolAlias>($sym_name, $function_ref)
+    custom<WorkgroupCountRegion>($workgroup_count)
     attr-dict-with-keyword
   }];
 
@@ -2809,6 +2818,8 @@ def Stream_ExecutableExportOp : Stream_Op<"executable.export", [
   let extraClassDeclaration = [{
     ::mlir::func::FuncOp getFunctionRef();
   }];
+
+  let hasVerifier = 1;
 }
 
 def Stream_BindingSubspanOp : Stream_PureOp<"binding.subspan", [
@@ -2846,6 +2857,32 @@ def Stream_BindingSubspanOp : Stream_PureOp<"binding.subspan", [
 // Misc
 //===----------------------------------------------------------------------===//
 
+def Stream_ReturnOp : Stream_Op<"return", [
+  ParentOneOf<[
+    "IREE::Stream::ExecutableExportOp",
+  ]>,
+  NoSideEffect,
+  DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface, [
+    "getMutableSuccessorOperands",
+  ]>,
+  ReturnLike,
+  Terminator,
+]> {
+  let summary = [{returns results from a region}];
+  let description = [{
+    The values returned are copied by-value.
+  }];
+
+  let arguments = (ins
+    Variadic<AnyType>:$operands
+  );
+
+  let assemblyFormat = [{
+    attr-dict
+    $operands `:` type($operands)
+  }];
+}
+
 def Stream_YieldOp : Stream_Op<"yield", [
   ParentOneOf<[
     "IREE::Stream::AsyncExecuteOp",
@@ -2858,6 +2895,7 @@ def Stream_YieldOp : Stream_Op<"yield", [
   DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface, [
     "getMutableSuccessorOperands",
   ]>,
+  ReturnLike,
   Terminator,
   SameVariadicOperandSize,
   Util_SizeAwareOp,

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/async_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/async_ops.mlir
@@ -122,6 +122,16 @@ func.func @asyncDispatch(%arg0: !stream.resource<*>, %arg1: index) -> !stream.re
 
 // -----
 
+// CHECK-LABEL: @asyncDispatchNoWorkload
+func.func @asyncDispatchNoWorkload(%arg0: !stream.resource<*>, %arg1: index) -> !stream.resource<*> {
+  %c4 = arith.constant 4 : index
+  // CHECK: = stream.async.dispatch @executable::@dispatch(%arg0, %c4) : (!stream.resource<*>{%arg1}, index) -> %arg0{%arg1}
+  %0 = stream.async.dispatch @executable::@dispatch(%arg0, %c4) : (!stream.resource<*>{%arg1}, index) -> %arg0{%arg1}
+  return %0 : !stream.resource<*>
+}
+
+// -----
+
 // CHECK-LABEL: @asyncExecute
 func.func @asyncExecute(%arg0: !stream.resource<*>, %arg1: index, %arg2: !stream.timepoint) -> (!stream.resource<*>, !stream.timepoint) {
   // CHECK: = stream.async.execute await(%arg2) => with(%arg0 as %arg3: !stream.resource<*>{%arg1}) -> %arg0{%arg1} {

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/async_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/async_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file %s --verify-diagnostics | FileCheck %s
 
 // CHECK-LABEL: @asyncAlloca
 func.func @asyncAlloca(%arg0: index) -> !stream.resource<transient> {
@@ -117,6 +117,51 @@ func.func @asyncDispatch(%arg0: !stream.resource<*>, %arg1: index) -> !stream.re
   %c4 = arith.constant 4 : index
   // CHECK: = stream.async.dispatch @executable::@dispatch[%c1, %c2, %c3](%arg0, %c4) : (!stream.resource<*>{%arg1}, index) -> %arg0{%arg1}
   %0 = stream.async.dispatch @executable::@dispatch[%c1, %c2, %c3](%arg0, %c4) : (!stream.resource<*>{%arg1}, index) -> %arg0{%arg1}
+  return %0 : !stream.resource<*>
+}
+
+// -----
+
+stream.executable private @executable {
+  stream.executable.export public @dispatch workgroups(%arg0: index, %arg1: index) -> (index, index, index) {
+    stream.return %arg0, %arg1, %arg0 : index, index, index
+  }
+  builtin.module {
+    func.func @dispatch() {
+      return
+    }
+  }
+}
+
+// CHECK-LABEL: @asyncDispatchWithWorkgroupCount
+func.func @asyncDispatchWithWorkgroupCount(%arg0: !stream.resource<*>, %arg1: index) -> !stream.resource<*> {
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c4 = arith.constant 4 : index
+  // CHECK: = stream.async.dispatch @executable::@dispatch[%c1, %c2](%arg0, %c4) : (!stream.resource<*>{%arg1}, index) -> %arg0{%arg1}
+  %0 = stream.async.dispatch @executable::@dispatch[%c1, %c2](%arg0, %c4) : (!stream.resource<*>{%arg1}, index) -> %arg0{%arg1}
+  return %0 : !stream.resource<*>
+}
+
+// -----
+
+stream.executable private @executable {
+  stream.executable.export public @dispatch workgroups(%arg0: index) -> (index, index, index) {
+    stream.return %arg0, %arg0, %arg0 : index, index, index
+  }
+  builtin.module {
+    func.func @dispatch() {
+      return
+    }
+  }
+}
+
+func.func @asyncDispatchWithInvalidWorkload(%arg0: !stream.resource<*>, %arg1: index) -> !stream.resource<*> {
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c4 = arith.constant 4 : index
+  // expected-error @+1 {{op workload mismatch; entry point expects 1 arguments but dispatch provides 2}}
+  %0 = stream.async.dispatch @executable::@dispatch[%c1, %c2](%arg0, %c4) : (!stream.resource<*>{%arg1}, index) -> %arg0{%arg1}
   return %0 : !stream.resource<*>
 }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/executable_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/executable_ops.mlir
@@ -1,11 +1,11 @@
-// RUN: iree-opt --split-input-file %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file %s --verify-diagnostics | FileCheck %s
 
 // CHECK-LABEL: stream.executable private @executable
 stream.executable private @executable {
   // CHECK-NEXT: stream.executable.export public @dispatch
   stream.executable.export public @dispatch
   // CHECK-NEXT: builtin.module
-  builtin.module  {
+  builtin.module {
     // CHECK-NEXT: func.func @dispatch(%arg0: !stream.binding, %arg1: !stream.binding, %arg2: index) {
     func.func @dispatch(%arg0: !stream.binding, %arg1: !stream.binding, %arg2: index) {
       %c0 = arith.constant 0 : index
@@ -14,6 +14,55 @@ stream.executable private @executable {
       // CHECK-DAG: = stream.binding.subspan %arg1[%c0] : !stream.binding -> !flow.dispatch.tensor<readonly:?x5x4xf32>{%arg2}
       %1 = stream.binding.subspan %arg1[%c0] : !stream.binding -> !flow.dispatch.tensor<readonly:?x5x4xf32>{%arg2}
       // CHECK: return
+      return
+    }
+  }
+}
+
+// -----
+
+// CHECK-LABEL: stream.executable private @executable_with_workgroup_count
+stream.executable private @executable_with_workgroup_count {
+  // CHECK-NEXT: stream.executable.export public @dispatch
+  stream.executable.export public @dispatch
+      // CHECK-SAME: workgroups(%arg0: index, %arg1: index, %arg2: index) -> (index, index, index) {
+      workgroups(%arg0: index, %arg1: index, %arg2: index) -> (index, index, index) {
+        // CHECK-NEXT: stream.return %arg0, %arg1, %arg2 : index, index, index
+        stream.return %arg0, %arg1, %arg2 : index, index, index
+      }
+  // CHECK: builtin.module
+  builtin.module {
+    // CHECK-NEXT: func.func @dispatch
+    func.func @dispatch() {
+      // CHECK: return
+      return
+    }
+  }
+}
+
+// -----
+
+stream.executable private @bad_workgroup_result_count {
+  // expected-error @+1 {{workgroup count region must return the XYZ dimension counts}}
+  stream.executable.export public @dispatch workgroups(%arg0: index, %arg1: index) -> (index, index) {
+    stream.return %arg0, %arg1 : index, index
+  }
+  builtin.module  {
+    func.func @dispatch() {
+      return
+    }
+  }
+}
+
+// -----
+
+stream.executable private @bad_workgroup_result_types {
+  // expected-error @+1 {{workgroup count region must return the XYZ dimension counts}}
+  stream.executable.export public @dispatch workgroups(%arg0: index, %arg1: f32) -> (index, f32, index) {
+    stream.return %arg0, %arg1, %arg0 : index, f32, index
+  }
+  builtin.module  {
+    func.func @dispatch() {
       return
     }
   }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/FuseDispatchBindings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/FuseDispatchBindings.cpp
@@ -296,9 +296,9 @@ static void updateDispatchSite(IREE::Stream::CmdDispatchOp dispatchOp,
   // Replace the old dispatch op with a new one.
   OpBuilder builder(dispatchOp);
   auto newOp = builder.create<IREE::Stream::CmdDispatchOp>(
-      dispatchOp.getLoc(), dispatchOp.workgroup_count(),
-      dispatchOp.entry_pointAttr(), newOperands, newResources, newResourceSizes,
-      newOffsets, newLengths, builder.getArrayAttr(newAccesses));
+      dispatchOp.getLoc(), dispatchOp.workload(), dispatchOp.entry_pointAttr(),
+      newOperands, newResources, newResourceSizes, newOffsets, newLengths,
+      builder.getArrayAttr(newAccesses));
   (void)newOp;
   LLVM_DEBUG({
     llvm::dbgs() << "updated dispatch:\n";

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
@@ -609,9 +609,9 @@ static LogicalResult applyAsyncDispatchOp(IREE::Stream::AsyncDispatchOp asyncOp,
   }
 
   builder.create<IREE::Stream::CmdDispatchOp>(
-      asyncOp.getLoc(), asyncOp.workgroup_count(), asyncOp.entry_point(),
-      newOperands, newResources, newResourceSizes, newResourceOffsets,
-      newResourceLengths, builder.getArrayAttr(newResourceAccesses));
+      asyncOp.getLoc(), asyncOp.workload(), asyncOp.entry_point(), newOperands,
+      newResources, newResourceSizes, newResourceOffsets, newResourceLengths,
+      builder.getArrayAttr(newResourceAccesses));
   asyncOp.erase();
   return success();
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/convert_to_stream.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/convert_to_stream.mlir
@@ -3,7 +3,7 @@
 // CHECK: stream.executable private @executable
 flow.executable private @executable {
   // CHECK: stream.executable.export public @dispatch
-  flow.dispatch.entry public @dispatch attributes {workgroup_rank = 3 : index}
+  flow.dispatch.entry public @dispatch
   builtin.module {
     // CHECK: func.func @dispatch(%arg0: !stream.binding, %arg1: !stream.binding, %[[ARG0_DIM0:.+]]: index, %[[ARG1_DIM1:.+]]: index)
     func.func @dispatch(%arg0: !flow.dispatch.tensor<readonly:?x4xf32>, %arg1: !flow.dispatch.tensor<writeonly:4x?xf32>,
@@ -74,7 +74,7 @@ func.func @custom_ops(%arg0: tensor<4x8xf32>) -> tensor<8x4xf32> {
 // CHECK: stream.executable private @while_test_dispatch_0
 flow.executable private @while_test_dispatch_0 {
   // CHECK: stream.executable.export public @dispatch
-  flow.dispatch.entry public @dispatch attributes {workgroup_rank = 3 : index}
+  flow.dispatch.entry public @dispatch
   // CHECK: builtin.module
   builtin.module {
     // CHECK: func.func @dispatch(%[[BINDING0:.+]]: !stream.binding, %[[BINDING1:.+]]: !stream.binding)
@@ -100,7 +100,7 @@ flow.executable private @while_test_dispatch_0 {
 
 // CHECK: stream.executable private @while_test_dispatch_1
 flow.executable private @while_test_dispatch_1 {
-  flow.dispatch.entry public @dispatch attributes {workgroup_rank = 3 : index}
+  flow.dispatch.entry public @dispatch
   builtin.module  {
     func.func @dispatch(%arg0: !flow.dispatch.tensor<readonly:i32>, %arg1: !flow.dispatch.tensor<writeonly:i32>) {
       %c2_i32 = arith.constant 2 : i32

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/convert_to_stream.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/convert_to_stream.mlir
@@ -3,7 +3,7 @@
 // CHECK: stream.executable private @executable
 flow.executable private @executable {
   // CHECK: stream.executable.export public @dispatch
-  flow.dispatch.entry public @dispatch
+  flow.executable.export public @dispatch
   builtin.module {
     // CHECK: func.func @dispatch(%arg0: !stream.binding, %arg1: !stream.binding, %[[ARG0_DIM0:.+]]: index, %[[ARG1_DIM1:.+]]: index)
     func.func @dispatch(%arg0: !flow.dispatch.tensor<readonly:?x4xf32>, %arg1: !flow.dispatch.tensor<writeonly:4x?xf32>,
@@ -74,7 +74,7 @@ func.func @custom_ops(%arg0: tensor<4x8xf32>) -> tensor<8x4xf32> {
 // CHECK: stream.executable private @while_test_dispatch_0
 flow.executable private @while_test_dispatch_0 {
   // CHECK: stream.executable.export public @dispatch
-  flow.dispatch.entry public @dispatch
+  flow.executable.export public @dispatch
   // CHECK: builtin.module
   builtin.module {
     // CHECK: func.func @dispatch(%[[BINDING0:.+]]: !stream.binding, %[[BINDING1:.+]]: !stream.binding)
@@ -100,7 +100,7 @@ flow.executable private @while_test_dispatch_0 {
 
 // CHECK: stream.executable private @while_test_dispatch_1
 flow.executable private @while_test_dispatch_1 {
-  flow.dispatch.entry public @dispatch
+  flow.executable.export public @dispatch
   builtin.module  {
     func.func @dispatch(%arg0: !flow.dispatch.tensor<readonly:i32>, %arg1: !flow.dispatch.tensor<writeonly:i32>) {
       %c2_i32 = arith.constant 2 : i32

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/dump_statistics.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/dump_statistics.mlir
@@ -14,6 +14,10 @@
 // CHECK-CSV: ; Aggregate Statistics
 // CHECK-CSV: "Constants","Constant Size","Variables","Variable Size","Awaits","Submissions","Transient Size","Fills","Copies","Dispatches","Executables"
 // CHECK-CSV: 1,0,0,0,2,3,0,0,2,3,2
+// CHECK-CSV: ; Execution
+// CHECK-CSV: "Depth","Command","Symbol","Length","Invocations","Workload","Operands","Resources"
+// CHECK-CSV: 0,"copy",,192,,,,
+// CHECK-CSV: 0,"dispatch","@func_a_ex_0::@dispatch_0",,4,"4;1;1",0,3
 
 util.global private mutable @_constant__timepoint = #stream.timepoint<immediate>
 util.global private @_constant : !stream.resource<constant>

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.h
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.h
@@ -63,6 +63,17 @@ void printTypeOrAttr(OpAsmPrinter &p, Operation *op, TypeAttr type,
                      Attribute attr);
 
 //===----------------------------------------------------------------------===//
+// custom<SymbolAlias>($sym_name, $alias)
+//===----------------------------------------------------------------------===//
+//  @foo            sym_name: @foo, alias: @foo
+//  @foo as("bar")  sym_name: @bar, alias: @foo
+
+ParseResult parseSymbolAlias(OpAsmParser &parser, StringAttr &sym_name,
+                             FlatSymbolRefAttr &alias);
+void printSymbolAlias(OpAsmPrinter &p, Operation *op, StringAttr sym_name,
+                      FlatSymbolRefAttr alias);
+
+//===----------------------------------------------------------------------===//
 // custom<TypeAlias>($encoding_type, $storage_type)
 //===----------------------------------------------------------------------===//
 // some.op custom<TypeAlias>($encoding_type, $storage_type)

--- a/integrations/tensorflow/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
+++ b/integrations/tensorflow/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
@@ -551,21 +551,6 @@ def IREEInput_TensorTraceOp : IREEInput_Op<"tensor.trace", []> {
 
 // TODO: Define dispatch.workgroup op.
 
-def IREEInput_DispatchWorkgroupRankOp : IREEInput_PureOp<"dispatch.workgroup.rank"> {
-  let summary = [{returns the rank of the workgroup dimensions}];
-  let description = [{
-    The number of workgroup dimensions used during dispatch, bounding the
-    `iree_input.dispatch.workgroup.*` query functions.
-
-    ```mlir
-    %rank = iree_input.dispatch.workgroup.rank : index
-    ```
-  }];
-  let arguments = (ins);
-  let results = (outs IREEInput_Dim:$result);
-  let assemblyFormat = "attr-dict `:` type($result)";
-}
-
 def IREEInput_DispatchWorkgroupIDOp : IREEInput_PureOp<"dispatch.workgroup.id"> {
   let summary = [{returns the index of the current workgroup in the grid}];
   let description = [{

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
@@ -551,21 +551,6 @@ def IREEInput_TensorTraceOp : IREEInput_Op<"tensor.trace", []> {
 
 // TODO: Define dispatch.workgroup op.
 
-def IREEInput_DispatchWorkgroupRankOp : IREEInput_PureOp<"dispatch.workgroup.rank"> {
-  let summary = [{returns the rank of the workgroup dimensions}];
-  let description = [{
-    The number of workgroup dimensions used during dispatch, bounding the
-    `iree_input.dispatch.workgroup.*` query functions.
-
-    ```mlir
-    %rank = iree_input.dispatch.workgroup.rank : index
-    ```
-  }];
-  let arguments = (ins);
-  let results = (outs IREEInput_Dim:$result);
-  let assemblyFormat = "attr-dict `:` type($result)";
-}
-
 def IREEInput_DispatchWorkgroupIDOp : IREEInput_PureOp<"dispatch.workgroup.id"> {
   let summary = [{returns the index of the current workgroup in the grid}];
   let description = [{

--- a/runtime/src/iree/hal/cts/testdata/command_buffer_dispatch_test.mlir
+++ b/runtime/src/iree/hal/cts/testdata/command_buffer_dispatch_test.mlir
@@ -13,7 +13,7 @@
 ]>
 
 hal.executable.source public @executable {
-  hal.executable.entry_point public @abs layout(#executable_layout)
+  hal.executable.export public @abs layout(#executable_layout)
 
   builtin.module {
     func.func @abs() {

--- a/runtime/src/iree/hal/cts/testdata/executable_cache_test.mlir
+++ b/runtime/src/iree/hal/cts/testdata/executable_cache_test.mlir
@@ -13,7 +13,7 @@
 ]>
 
 hal.executable.source public @executable {
-  hal.executable.entry_point public @abs layout(#executable_layout)
+  hal.executable.export public @abs layout(#executable_layout)
 
   builtin.module {
     func.func @abs() {

--- a/runtime/src/iree/hal/local/elf/testdata/elementwise_mul.mlir
+++ b/runtime/src/iree/hal/local/elf/testdata/elementwise_mul.mlir
@@ -36,7 +36,7 @@ hal.executable.source public @ex {
   //
   // The ordinal is used to specify the entry point on command line tools and
   // must be unique across all entry points within the same executable.
-  hal.executable.entry_point public @elementwise_mul ordinal(0) layout(#executable_layout)
+  hal.executable.export public @elementwise_mul ordinal(0) layout(#executable_layout)
 
   // The inner module defining the executable. This may have any number of
   // private functions and only those with declared entry points will be

--- a/runtime/src/iree/hal/local/executable_library_benchmark.md
+++ b/runtime/src/iree/hal/local/executable_library_benchmark.md
@@ -140,7 +140,7 @@ This (today) results in a single extracted file you pass to the tool:
 --executable_file=_simple_mul_dispatch_0_llvm_binary_ex_elf.so
 ```
 
-3. Find `ResolveEntryPointOrdinalsPass` and look for the dispatch:
+3. Find `ResolveExportOrdinalsPass` and look for the dispatch:
 
 ```mlir
   hal.command_buffer.dispatch<%cmd : !hal.command_buffer>

--- a/tests/compiler_driver/hal_executable.mlir
+++ b/tests/compiler_driver/hal_executable.mlir
@@ -21,7 +21,7 @@ hal.executable.source public @executable {
   // Exported functions are declared with the layout they use and may optionally
   // contain other information - though when hand-authoring that's usually
   // omitted.
-  hal.executable.entry_point public @mul layout(#executable_layout)
+  hal.executable.export public @mul layout(#executable_layout)
 
   // The inner module defining the executable. This may have any number of
   // private functions and only those with declared entry points will be


### PR DESCRIPTION
This changes the flow/stream-level dispatch ops back to using workloads (parameters defining the workload of a dispatch) and adds support for defining a region on `flow/stream.executable.export` ops that computes the workgroup count from that workload. This region is optional and if omitted the existing codegen pass that inserts the workgroup count region on the HAL exports will be used. The intent is still that only device-agnostic decisions are made at the flow level and that the ops that end up in the region are eventually substituted in device-specific ways in particular HAL codegen backends.

This initial work is meant to incrementally break some of the existing assumptions around workload being 3D and entirely defined by the backends. These changes preserve the current behavior where the workload must be index values but in the future it will be extended to arbitrary host types. Further out it'll also be able to take in tensor types for data-dependent calculations that'll end up as indirect dispatches in the HAL (probably with things like flow.dispatch.tensor.load being allowed in the workgroup count functions).

After this has had some time to soak and the explorations into different dispatch region formation approaches make progress we can evaluate making the workgroup count region required. Even if doing the current synthesizing of the logic deeper down in codegen we could have a placeholder op (`flow.dispatch.calculate_workgroup_count` etc) that would be placed in the region and then converted by the backends instead of relying on empty regions.

The last missing piece to wire this up end-to-end is the reworking of the `flow.dispatch.workgroups` op to support defining the region and the outline dispatch regions pass being updated to copy it along.