### PR TITLE
Adding support for reading binary files in tool --function_input=.

### DIFF
--- a/runtime/src/iree/hal/string_util.h
+++ b/runtime/src/iree/hal/string_util.h
@@ -48,6 +48,14 @@ IREE_API_EXPORT iree_status_t iree_hal_format_element_type(
     iree_hal_element_type_t element_type, iree_host_size_t buffer_capacity,
     char* buffer, iree_host_size_t* out_buffer_length);
 
+// Parses a shape and type from a `[shape]x[type]` string |value|.
+// Behaves the same as calling iree_hal_parse_shape and
+// iree_hal_parse_element_type. Ignores any training `=`.
+IREE_API_EXPORT iree_status_t iree_hal_parse_shape_and_element_type(
+    iree_string_view_t value, iree_host_size_t shape_capacity,
+    iree_hal_dim_t* out_shape, iree_host_size_t* out_shape_rank,
+    iree_hal_element_type_t* out_element_type);
+
 // Parses a serialized element of |element_type| to its in-memory form.
 // |data_ptr| must be at least large enough to contain the bytes of the element.
 // For example, "1.2" of type IREE_HAL_ELEMENT_TYPE_FLOAT32 will write the 4

--- a/runtime/src/iree/tools/utils/vm_util.h
+++ b/runtime/src/iree/tools/utils/vm_util.h
@@ -29,10 +29,9 @@ namespace iree {
 // Buffers should be in the IREE standard shaped buffer format:
 //   [shape]xtype=[value]
 // described in iree/hal/api.h
-// Uses |allocator| to allocate the buffers.
-// Uses descriptors in |descs| for type information and validation.
+// Uses |device_allocator| to allocate the buffers.
 // The returned variant list must be freed by the caller.
-Status ParseToVariantList(iree_hal_allocator_t* allocator,
+Status ParseToVariantList(iree_hal_allocator_t* device_allocator,
                           iree::span<const std::string> input_strings,
                           iree_vm_list_t** out_list);
 
@@ -43,7 +42,6 @@ Status ParseToVariantList(iree_hal_allocator_t* allocator,
 //   [shape]xtype=[value]
 // described in
 // https://github.com/google/iree/tree/main/iree/hal/api.h
-// Uses descriptors in |descs| for type information and validation.
 Status PrintVariantList(iree_vm_list_t* variant_list, size_t max_element_count,
                         std::ostream* os);
 inline Status PrintVariantList(iree_vm_list_t* variant_list, std::ostream* os) {

--- a/tools/iree-benchmark-module-main.cc
+++ b/tools/iree-benchmark-module-main.cc
@@ -124,6 +124,8 @@ IREE_FLAG_CALLBACK(
     "  2x2xi32=1 2 3 4\n"
     "Optionally, brackets may be used to separate the element values:\n"
     "  2x2xi32=[[1 2][3 4]]\n"
+    "Raw binary files can be read to provide buffer contents:\n"
+    "  2x2xi32=@some/file.bin\n"
     "Each occurrence of the flag indicates an input in the order they were\n"
     "specified on the command line.");
 

--- a/tools/iree-run-module-main.cc
+++ b/tools/iree-run-module-main.cc
@@ -72,6 +72,8 @@ IREE_FLAG_CALLBACK(
     "  2x2xi32=1 2 3 4\n"
     "Optionally, brackets may be used to separate the element values:\n"
     "  2x2xi32=[[1 2][3 4]]\n"
+    "Raw binary files can be read to provide buffer contents:\n"
+    "  2x2xi32=@some/file.bin\n"
     "Each occurrence of the flag indicates an input in the order they were\n"
     "specified on the command line.");
 


### PR DESCRIPTION
Raw binary data read from a file can now be used to initialize buffer
view contents. No interpretation is done on the data. The shape and
element type information is still required. Works in all tools using the
VM utils (iree-run-module, iree-benchmark-module, iree-run-mlir).

Example:
```
iree-benchmark-module ... --function_input=4x2xi32=@some/file.bin
```