### PR TITLE
Account for rank-reduced version of `flow.dispatch.tensor.load` when resolving `tensor.dim` ops.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -339,15 +339,15 @@ LogicalResult DispatchTensorLoadOp::reifyResultShapes(
   SmallVector<Value> shape;
   if (!mixedSizes.empty()) {
     // Slicing out a tile; return the size sliced.
-    shape = llvm::to_vector<6>(llvm::map_range(
-        getMixedSizes(), [&](OpFoldResult valueOrAttr) -> Value {
-          if (auto attr = valueOrAttr.dyn_cast<Attribute>()) {
-            return b.create<arith::ConstantIndexOp>(
-                getLoc(), attr.cast<IntegerAttr>().getInt());
-          } else {
-            return valueOrAttr.dyn_cast<Value>();
-          }
-        }));
+    shape.reserve(mixedSizes.size());
+    auto droppedDims = getDroppedDims();
+    for (auto mixedSize : llvm::enumerate(mixedSizes)) {
+      if (droppedDims.test(mixedSize.index())) {
+        continue;
+      }
+      shape.push_back(
+          getValueOrCreateConstantIndexOp(b, getLoc(), mixedSize.value()));
+    }
   } else {
     // Result size matches the source size (no slicing).
     unsigned dynamicIdx = 0;

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/BUILD
@@ -22,6 +22,7 @@ iree_lit_test_suite(
             "dispatch_workgroups.mlir",
             "dispatch_workgroups_folding.mlir",
             "executable_ops.mlir",
+            "resolve_dim_ops.mlir",
             "tensor_folding.mlir",
             "tensor_ops.mlir",
             "types.mlir",

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     "dispatch_workgroups.mlir"
     "dispatch_workgroups_folding.mlir"
     "executable_ops.mlir"
+    "resolve_dim_ops.mlir"
     "tensor_folding.mlir"
     "tensor_ops.mlir"
     "types.mlir"

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/resolve_dim_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/resolve_dim_ops.mlir
@@ -1,0 +1,19 @@
+// RUN: iree-opt -resolve-ranked-shaped-type-result-dims -split-input-file %s | FileCheck %s
+
+func.func @tensor_load_op() -> (index, index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %0 = hal.interface.constant.load[0] : index
+  %1 = hal.interface.constant.load[1] : index
+  %2 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
+      : !flow.dispatch.tensor<readonly:?x1x1x?xf32>{%0, %1}
+  %3 = flow.dispatch.tensor.load %2, offsets = [0, 0, 0, 0], sizes = [%0, 1, 1, %1], strides = [1, 1, 1, 1]
+      : !flow.dispatch.tensor<readonly:?x1x1x?xf32>{%0, %1} -> tensor<?x?xf32>
+  %4 = tensor.dim %3, %c0 : tensor<?x?xf32>
+  %5 = tensor.dim %3, %c1 : tensor<?x?xf32>
+  return %4, %5 : index, index
+}
+// CHECK-LABEL: func @tensor_load_op()
+//   CHECK-DAG:   %[[D0:.+]] = hal.interface.constant.load[0]
+//   CHECK-DAG:   %[[D1:.+]] = hal.interface.constant.load[1]
+//       CHECK:   return %[[D0]], %[[D1]]


### PR DESCRIPTION
Issue #9322 