### PR TITLE
Anchor iree.natvis path on IREE_ROOT_DIR for downstream builds.

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -334,7 +334,7 @@ iree_select_compiler_opts(IREE_DEFAULT_LINKOPTS
     ${_IREE_PTHREADS_LINKOPTS}
     ${_IREE_LOGGING_LINKOPTS}
   MSVC
-    "-natvis:${CMAKE_SOURCE_DIR}/runtime/iree.natvis"
+    "-natvis:${IREE_ROOT_DIR}/runtime/iree.natvis"
 )
 
 # Add to LINKOPTS on a binary to configure it for X/Wayland/Windows/etc


### PR DESCRIPTION
CMAKE_SOURCE_DIR is the top level of the source tree, which is _not_ iree/CMakeLists.txt when IREE is included by another project. In my case, I'm trying to have https://github.com/google/iree-samples fetch the primary project as part of moving a C++ sample into that repo (https://github.com/google/iree/issues/8011).