### PR TITLE
Create pre-command repository hook

### DIFF
--- a/.buildkite/hooks
+++ b/.buildkite/hooks
@@ -1,0 +1,1 @@
+../build_tools/buildkite/repository_hooks/

--- a/build_tools/buildkite/agent/hooks/README.md
+++ b/build_tools/buildkite/agent/hooks/README.md
@@ -1,3 +1,9 @@
-Hooks for the buildkite agents. See https://buildkite.com/docs/agent/v3/hooks.
-Each hook file is prefixed with the name of the hook. It should be deployed on
-agents under that name rather than its full name.
+# Buildkite Agent Hooks
+
+Agent hooks to be installed on the buildkite agents. See
+https://buildkite.com/docs/agent/v3/hooks. Each hook file is prefixed with the
+name of the hook. Note that It should be deployed on agents under that name
+rather than its full name.
+
+Note that "repository" or "local" hooks are located at
+"build_tools/buildkite/repository_hooks".

--- a/build_tools/buildkite/pipelines/trusted/presubmit.yml
+++ b/build_tools/buildkite/pipelines/trusted/presubmit.yml
@@ -22,6 +22,7 @@ steps:
                 - url: ${BUILDKITE_REPO}
                   ref: ${CONFIG_FETCH_REF}
     commands: |
+      echo "$${NOT_SET}"
       ./build_tools/buildkite/scripts/check_cla.py ${BUILDKITE_COMMIT} \
           || buildkite-agent pipeline upload \
               build_tools/buildkite/pipelines/fragment/cla-failure.yml

--- a/build_tools/buildkite/pipelines/trusted/presubmit.yml
+++ b/build_tools/buildkite/pipelines/trusted/presubmit.yml
@@ -22,6 +22,7 @@ steps:
                 - url: ${BUILDKITE_REPO}
                   ref: ${CONFIG_FETCH_REF}
     commands: |
+      set -u
       echo "$${NOT_SET}"
       ./build_tools/buildkite/scripts/check_cla.py ${BUILDKITE_COMMIT} \
           || buildkite-agent pipeline upload \

--- a/build_tools/buildkite/repository_hooks/README.md
+++ b/build_tools/buildkite/repository_hooks/README.md
@@ -1,0 +1,7 @@
+# Buildkite Repository Hooks
+
+Repository hooks to be run during the job lifecycle of every Buildkite job.
+These are symlinked from `.buildkite/hooks` because the hooks are required to be
+at that path by Buildkite
+([feature request to make this customizable](https://forum.buildkite.community/t/custom-repository-hook-location/2081)). These hooks are *sourced*, so must be
+bash.

--- a/build_tools/buildkite/repository_hooks/pre-command
+++ b/build_tools/buildkite/repository_hooks/pre-command
@@ -16,5 +16,3 @@ set -o errexit
 set -o nounset
 # Fail if any command in a pipe fails (not just the last one)
 set -o pipefail
-
-echo "${NOT_SET}"

--- a/build_tools/buildkite/repository_hooks/pre-command
+++ b/build_tools/buildkite/repository_hooks/pre-command
@@ -1,0 +1,14 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Some configuration for *all* buildkite jobs that check out this repository.
+
+# Exit if any command fails
+set -e
+# Error if an undefined variable is used
+set -u
+# Fail if any command in a pipe fails (not just the last one)
+set -o pipefail

--- a/build_tools/buildkite/repository_hooks/pre-command
+++ b/build_tools/buildkite/repository_hooks/pre-command
@@ -6,9 +6,15 @@
 
 # Some configuration for *all* buildkite jobs that check out this repository.
 
+set -x
+
+echo "${BASH_SOURCE?}"
+
 # Exit if any command fails
 set -o errexit
 # Error if an undefined variable is used
 set -o nounset
 # Fail if any command in a pipe fails (not just the last one)
 set -o pipefail
+
+echo "${NOT_SET}"

--- a/build_tools/buildkite/repository_hooks/pre-command
+++ b/build_tools/buildkite/repository_hooks/pre-command
@@ -7,8 +7,8 @@
 # Some configuration for *all* buildkite jobs that check out this repository.
 
 # Exit if any command fails
-set -e
+set -o errexit
 # Error if an undefined variable is used
-set -u
+set -o nounset
 # Fail if any command in a pipe fails (not just the last one)
 set -o pipefail

--- a/build_tools/scripts/check_tabs.sh
+++ b/build_tools/scripts/check_tabs.sh
@@ -33,7 +33,16 @@ if (( ${#files[@]} == 0 )); then
   exit 0
 fi;
 
-diff="$(grep --with-filename --line-number --perl-regexp --binary-files=without-match '\t' "${files[@]}")"
+# find is necessary to filter out symlinks
+diff="$(\
+  find ${files[@]} -type f | \
+  grep \
+  --with-filename \
+  --line-number \
+  --perl-regexp \
+  --binary-files=without-match \
+  '\t' \
+)"
 
 grep_exit="$?"
 

--- a/build_tools/scripts/lint.sh
+++ b/build_tools/scripts/lint.sh
@@ -120,9 +120,14 @@ else
   echo "'yamllint' not found. Skipping check"
 fi
 
+# Just a newline
+echo ""
+
 if (( "${FINAL_RET}" != 0 )); then
   echo "Encountered failures. Check error messages and changes to the working" \
        "directory and git index (which may contain fixes) and try again."
+else
+  echo "Lint checks were successful."
 fi
 
 exit "${FINAL_RET}"


### PR DESCRIPTION
These are hooks that will run on every buildkite job that checks out
this repository. Here I'm just setting some strict-error defaults. I
think Buildkite already sets `-e` and maybe `-o pipefail`, but based on
the error in https://buildkite.com/iree/unregistered/builds/26, does
not set `-u`. This will avoid needing to write `?` after every variable
expansion. It's still probably a good idea to include these options at
the top of scripts, since those will frequently be run locally.