### PR TITLE
[vulkan] Enable necessary portability features on Apple platforms

### DIFF
--- a/runtime/src/iree/hal/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/vulkan/vulkan_device.cc
@@ -67,7 +67,7 @@ IREE_API_EXPORT iree_status_t iree_hal_vulkan_query_extensibility_set(
   // here changes our minimum requirements and should be done carefully.
   // Optional extensions here are feature detected by the runtime.
 
-#ifdef IREE_PLATFORM_APPLE
+#if defined(IREE_PLATFORM_APPLE)
   // VK_KHR_portability_subset:
   // For Apple platforms, Vulkan is layered on top of Metal via MoltenVK.
   // It exposes this extension to allow a non-conformant Vulkan implementation
@@ -75,6 +75,14 @@ IREE_API_EXPORT iree_status_t iree_hal_vulkan_query_extensibility_set(
   // be enabled if exists.
   ADD_EXT(IREE_HAL_VULKAN_EXTENSIBILITY_DEVICE_EXTENSIONS_REQUIRED,
           VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+
+  // VK_KHR_portability_enumeration:
+  // Further, since devices which support the VK_KHR_portability_subset
+  // extension are not fully conformant Vulkan implementations, the Vulkan
+  // loader does not report those devices unless the application explicitly
+  // asks for them.
+  ADD_EXT(IREE_HAL_VULKAN_EXTENSIBILITY_INSTANCE_EXTENSIONS_REQUIRED,
+          VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
 #endif
 
   // VK_KHR_storage_buffer_storage_class:

--- a/runtime/src/iree/hal/vulkan/vulkan_driver.cc
+++ b/runtime/src/iree/hal/vulkan/vulkan_driver.cc
@@ -234,7 +234,14 @@ IREE_API_EXPORT iree_status_t iree_hal_vulkan_driver_create(
   VkInstanceCreateInfo create_info;
   create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
   create_info.pNext = NULL;
+#if defined(IREE_PLATFORM_APPLE)
+  // There are no native Vulkan implementations on Apple platforms. Including
+  // this bit allows the Vulkan loader to enumerate MoltenVK, which emulates
+  // Vulkan on top of Metal, as an implementation.
+  create_info.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+#else
   create_info.flags = 0;
+#endif
   create_info.pApplicationInfo = &app_info;
   create_info.enabledLayerCount = enabled_layers.count;
   create_info.ppEnabledLayerNames = enabled_layers.values;


### PR DESCRIPTION
These features are needed to suppress validation warnings of:

```
vkCreateDevice: Attempting to create a VkDevice from a VkPhysicalDevice
which is from a portability driver without the
VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR bit in the
VkInstanceCreateInfo flags being set and the
VK_KHR_portability_enumeration extension enabled. In future versions of
the loader this VkPhysicalDevice will not be enumerated.
```