### PR TITLE
[Buildkite] Move the setting of environment variables to environment agent hook

### DIFF
--- a/build_tools/buildkite/agent/hooks/environment-trusted-agent.sh
+++ b/build_tools/buildkite/agent/hooks/environment-trusted-agent.sh
@@ -1,0 +1,9 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+export BUILDKITE_ANNOTATION_CONTEXT="$${BUILDKITE_STEP_ID}"
+export IREE_BUILDKITE_ACCESS_TOKEN="$(gcloud secrets versions access latest \
+          --secret=iree-buildkite-privileged)"

--- a/build_tools/buildkite/agent/hooks/environment-untrusted-agent.sh
+++ b/build_tools/buildkite/agent/hooks/environment-untrusted-agent.sh
@@ -1,0 +1,9 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+export BUILDKITE_ANNOTATION_CONTEXT="$${BUILDKITE_STEP_ID}"
+export IREE_BUILDKITE_ACCESS_TOKEN="$(gcloud secrets versions access latest \
+          --secret=iree-buildkite-presubmit-pipelines)"

--- a/build_tools/buildkite/pipelines/trusted/postsubmit.yml
+++ b/build_tools/buildkite/pipelines/trusted/postsubmit.yml
@@ -13,17 +13,12 @@ steps:
     concurrency: 1
     concurrency_group: "update-pipelines"
     commands: |
-      export BUILDKITE_ACCESS_TOKEN="$(gcloud secrets versions access latest \
-          --secret=iree-buildkite-privileged)"
       build_tools/buildkite/scripts/update_pipeline_configurations.py
 
   - wait
 
   - label: "Executing build-runtime-cmake"
     commands: |
-      export BUILDKITE_ANNOTATION_CONTEXT="$${BUILDKITE_STEP_ID}"
-      export BUILDKITE_ACCESS_TOKEN="$(gcloud secrets versions access latest \
-          --secret=iree-buildkite-presubmit-pipelines)"
       ./build_tools/buildkite/scripts/wait_for_pipeline_success.py \
         --annotate \
         build-runtime-cmake

--- a/build_tools/buildkite/pipelines/trusted/presubmit.yml
+++ b/build_tools/buildkite/pipelines/trusted/presubmit.yml
@@ -37,9 +37,6 @@ steps:
                 - url: ${BUILDKITE_REPO}
                   ref: ${CONFIG_FETCH_REF}
     commands: |
-      export BUILDKITE_ANNOTATION_CONTEXT="$${BUILDKITE_STEP_ID}"
-      export BUILDKITE_ACCESS_TOKEN="$(gcloud secrets versions access latest \
-          --secret=iree-buildkite-presubmit-pipelines)"
       ./build_tools/buildkite/scripts/wait_for_pipeline_success.py \
         --annotate \
         build-runtime-cmake
@@ -54,9 +51,6 @@ steps:
                 - url: ${BUILDKITE_REPO}
                   ref: ${CONFIG_FETCH_REF}
     commands: |
-      export BUILDKITE_ANNOTATION_CONTEXT="$${BUILDKITE_STEP_ID}"
-      export BUILDKITE_ACCESS_TOKEN="$(gcloud secrets versions access latest \
-          --secret=iree-buildkite-presubmit-pipelines)"
       ./build_tools/buildkite/scripts/wait_for_pipeline_success.py \
         --annotate \
         test-runtime-cmake

--- a/build_tools/buildkite/pipelines/untrusted/test-runtime-cmake.yml
+++ b/build_tools/buildkite/pipelines/untrusted/test-runtime-cmake.yml
@@ -11,8 +11,6 @@ steps:
       queue: "orchestration"
       security: "untrusted"
     commands: |
-      export BUILDKITE_ACCESS_TOKEN="$(gcloud secrets versions access latest \
-          --secret=iree-buildkite-presubmit-pipelines)"
       ./build_tools/buildkite/scripts/wait_for_pipeline_success.py \
         --output-build-json=build.json \
         build-runtime-cmake

--- a/build_tools/buildkite/scripts/common/buildkite_pipeline_manager.py
+++ b/build_tools/buildkite/scripts/common/buildkite_pipeline_manager.py
@@ -81,7 +81,7 @@ class BuildkitePipelineManager(object):
     # manager: https://cloud.google.com/secret-manager. Users can create a
     # personal token for running this script locally:
     # https://buildkite.com/docs/apis/managing-api-tokens
-    access_token = os.environ["BUILDKITE_ACCESS_TOKEN"]
+    access_token = os.environ["IREE_BUILDKITE_ACCESS_TOKEN"]
 
     # Buildkite sets these environment variables. See
     # https://buildkite.com/docs/pipelines/environment-variables. If running

--- a/build_tools/buildkite/scripts/update_pipeline_configurations.py
+++ b/build_tools/buildkite/scripts/update_pipeline_configurations.py
@@ -284,7 +284,7 @@ def main(args):
   # manager: https://cloud.google.com/secret-manager. Users can create a
   # personal token for running this script locally:
   # https://buildkite.com/docs/apis/managing-api-tokens
-  access_token = os.environ["BUILDKITE_ACCESS_TOKEN"]
+  access_token = os.environ["IREE_BUILDKITE_ACCESS_TOKEN"]
 
   # Buildkite sets these environment variables. See
   # https://buildkite.com/docs/pipelines/environment-variables. If running


### PR DESCRIPTION
This avoids needing to do this in every step. So the agents will always
have their tokens and annotations will be step-specific by default.