### PR TITLE
Outline workgroup count computing IR in a new DispatchWorkgroupsOp::workgroup_count region.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -552,6 +552,7 @@ def FLOW_ExecutableEndOp : FLOW_Op<"executable_end", [
 def FLOW_ExecutableExportOp : FLOW_Op<"executable.export", [
   HasParent<"IREE::Flow::ExecutableOp">,
   Symbol,
+  IsolatedFromAbove,
 ]> {
   let summary = [{defines an executable entry point for dispatch operations}];
   let description = [{

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
@@ -136,6 +136,8 @@ static LogicalResult outlineDispatchWorkgroupsOp(
   auto exportOp = builder.create<ExecutableExportOp>(
       regionOp.getLoc(), workgroupFuncOp.getName(),
       SymbolRefAttr::get(workgroupFuncOp));
+  if (!regionOp.workgroup_count().empty())
+    exportOp.workgroup_count().takeBody(regionOp.workgroup_count());
 
   // Move over the workgroup count region, if present.
   if (!regionOp.workgroup_count().empty()) {

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -2782,6 +2782,7 @@ def Stream_ExecutableEndOp : Stream_Op<"executable.end", [
 def Stream_ExecutableExportOp : Stream_Op<"executable.export", [
   HasParent<"IREE::Stream::ExecutableOp">,
   Symbol,
+  IsolatedFromAbove,
 ]> {
   let summary = [{defines an executable entry point for dispatch operations}];
   let description = [{

--- a/tests/e2e/linalg_transform/transform_dialect_dispatch_spec.mlir
+++ b/tests/e2e/linalg_transform/transform_dialect_dispatch_spec.mlir
@@ -13,8 +13,7 @@ transform.with_pdl_patterns {
   transform.structured.canonicalized_sequence %arg0 {
   ^bb1(%arg1: !pdl.operation):
     %0 = pdl_match @pdl_matmul_target in %arg1
-    // TODO: atm we can only use 1 thread as the plumbing through HAL is not done yet.
-    %tiling_1_result:2 = tile_to_foreach_thread_op %0 {num_threads = [1, 1]}
+    %tiling_1_result:2 = tile_to_foreach_thread_op %0 {num_threads = [13, 33]}
     transform.iree.foreach_thread_to_flow
   }
 }


### PR DESCRIPTION
This revision introduces a helper function that populates the `workgroup_count`region by starting from a `scf::ForeachThreadOp::getNumThreads` and iteratively pulls in the "last" operation from a worklist of ops that it maintains.
The algorithm stops at any op that tries to pull in any op with non-index operands.
At this time, this is only tested for constant ops.
    
This allows proper parallel semantics, when previously only single-threaded execution was legal.

In the process, the Flow/Stream::ExecutableExport ops had to be made IsolatedFromAbove to avoid spurious hoistings that create verification errors.