### PR TITLE
TSan CI

### DIFF
--- a/build_tools/buildkite/pipelines/trusted/postsubmit.yml
+++ b/build_tools/buildkite/pipelines/trusted/postsubmit.yml
@@ -22,3 +22,10 @@ steps:
       ./build_tools/buildkite/scripts/wait_for_pipeline_success.py \
         --annotate \
         build-runtime-cmake
+
+  - label: "Executing build-and-test-tsan"
+    key: "build-and-test-tsan"
+    commands: |
+      ./build_tools/buildkite/scripts/wait_for_pipeline_success.py \
+        --annotate \
+        build-and-test-tsan

--- a/build_tools/buildkite/pipelines/trusted/presubmit.yml
+++ b/build_tools/buildkite/pipelines/trusted/presubmit.yml
@@ -54,3 +54,16 @@ steps:
       ./build_tools/buildkite/scripts/wait_for_pipeline_success.py \
         --annotate \
         test-runtime-cmake
+
+  - label: "Executing build-and-test-tsan"
+    key: "build-and-test-tsan"
+    plugins:
+      - https://github.com/GMNGeoffrey/smooth-checkout-buildkite-plugin#24e54e7729:
+          repos:
+            - config:
+                - url: ${BUILDKITE_REPO}
+                  ref: ${CONFIG_FETCH_REF}
+    commands: |
+      ./build_tools/buildkite/scripts/wait_for_pipeline_success.py \
+        --annotate \
+        build-and-test-tsan

--- a/build_tools/buildkite/pipelines/untrusted/build-and-test-tsan.yml
+++ b/build_tools/buildkite/pipelines/untrusted/build-and-test-tsan.yml
@@ -1,0 +1,29 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+steps:
+  # A single step doing both the build and the testing removes the need to
+  # upload a large build artifact between separate build and test steps.
+  # We tried that, but the resulting artifact size exceeded the allowed max size
+  # (5.9G vs 5G).
+  - label: ":thread: Build and test with ThreadSanitizer"
+    agents:
+      queue: "cpu"
+      security: "untrusted"
+    env:
+      IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
+      BUILD_DIR: "build-tsan-${BUILDKITE_BUILD_ID}"
+    commands: |
+      git submodule sync
+      git submodule update --init --jobs 8 --depth 1
+
+      docker run --user="$(id -u):$(id -g)" \
+        --volume="$$PWD:$$IREE_DOCKER_WORKDIR" \
+        --workdir="$$IREE_DOCKER_WORKDIR" \
+        --rm \
+        gcr.io/iree-oss/base@sha256:32a501b23abeae69eb33e5e78295312f5df28bacabc799dffe218764a66ed28e \
+        ./build_tools/cmake/build_and_test_tsan.sh \
+        "$${BUILD_DIR}"

--- a/build_tools/cmake/build_and_test_tsan.sh
+++ b/build_tools/cmake/build_and_test_tsan.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Build and test, using CMake/CTest, with ThreadSanitizer instrumentation.
+#
+# The desired build directory can be passed as
+# the first argument. Otherwise, it uses the environment variable
+# IREE_TSAN_BUILD_DIR, defaulting to "build-tsan". Designed for CI, but
+# can be run manually. This reuses the build directory if it already exists.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname -- "$( readlink -f -- "$0"; )")";
+
+BUILD_DIR="${1:-}"
+
+if [[ -z "${BUILD_DIR}" ]]; then
+  BUILD_DIR="${IREE_TSAN_BUILD_DIR:-build-tsan}"
+fi
+
+source "${SCRIPT_DIR}/setup_build.sh"
+
+CMAKE_ARGS=(
+  "-G" "Ninja"
+
+  # The debug information will help get more helpful TSan reports (stacks).
+  "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+
+  # Let's make linking fast. Also, there's the off chance that TSan might be
+  # better supported with LLD.
+  "-DIREE_ENABLE_LLD=ON"
+
+  # Enable TSan in all C/C++ targets, including IREE runtime, compiler, tests.
+  "-DIREE_ENABLE_TSAN=ON"
+
+  # Enable TSan in iree_bytecode_module's. Otherwise, our TSan-enabled IREE
+  # runtime won't be able to call into these modules.
+  "-DIREE_BYTECODE_MODULE_ENABLE_TSAN=ON"
+
+  # Link iree_bytecode_module's with system linker, not embedded-ELF linker.
+  # Necessary with TSan.
+  "-DIREE_BYTECODE_MODULE_FORCE_SYSTEM_DYLIB_LINKER=ON"
+
+  # Don't build samples: they assume embedded-ELF so don't work with
+  # IREE_BYTECODE_MODULE_FORCE_SYSTEM_DYLIB_LINKER=ON.
+  "-DIREE_BUILD_SAMPLES=OFF"
+
+  # Enable CUDA compiler and runtime builds unconditionally. Our CI images all
+  # have enough deps to at least build CUDA support and compile CUDA binaries.
+  # We will skip running GPU tests below but this still yields a bit more TSan
+  # coverage, at least in the compiler, and regarding the runtime it's at least
+  # checking that it builds with TSan.
+  "-DIREE_HAL_DRIVER_CUDA=ON"
+  "-DIREE_TARGET_BACKEND_CUDA=ON"
+)
+
+"${CMAKE_BIN}" -B "${BUILD_DIR}" "${CMAKE_ARGS[@]?}"
+
+echo "Building all"
+echo "------------"
+"$CMAKE_BIN" --build "${BUILD_DIR}" -- -k 0
+
+echo "Building test deps"
+echo "------------------"
+"$CMAKE_BIN" --build "${BUILD_DIR}" --target iree-test-deps -- -k 0
+
+# Disable actually running GPU tests. This tends to yield TSan reports that are
+# specific to one's particular GPU driver and therefore hard to reproduce across
+# machines and often un-actionable anyway.
+# See e.g. https://github.com/google/iree/issues/9393
+export IREE_VULKAN_DISABLE=1
+export IREE_CUDA_DISABLE=1
+
+# Honor the "notsan" label on tests.
+export IREE_EXTRA_COMMA_SEPARATED_CTEST_LABELS_TO_EXCLUDE=notsan
+
+"${SCRIPT_DIR}/ctest_all.sh" "${BUILD_DIR}"

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -58,6 +58,9 @@ if [[ "${IREE_VULKAN_F16_DISABLE}" == 1 ]]; then
   label_exclude_args+=("^vulkan_uses_vk_khr_shader_float16_int8$")
 fi
 
+IFS=',' read -ra extra_label_exclude_args <<< "${IREE_EXTRA_COMMA_SEPARATED_CTEST_LABELS_TO_EXCLUDE:-}"
+label_exclude_args+=(${extra_label_exclude_args[@]})
+
 # Join on "|"
 label_exclude_regex="($(IFS="|" ; echo "${label_exclude_args[*]}"))"
 


### PR DESCRIPTION
This adds a TSan CI bot under `buildkite/presubmit` and postsubmit.

Example run: https://buildkite.com/iree/presubmit/builds/261 -> `Executing build-and-test-tsan` -> https://buildkite.com/iree/unregistered/builds/43