### PR TITLE
Revert ctest --test-dir change from Android pipeline.

### DIFF
--- a/build_tools/buildkite/cmake/android/arm64-v8a/pipeline.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/pipeline.yml
@@ -25,7 +25,8 @@ steps:
       - "buildkite-agent artifact download --step build build-artifacts.tgz ./"
       - "tar xzf build-artifacts.tgz"
       - "find build-android/ -name '*.cmake' -exec sed -i \"s!\\$IREE_DOCKER_WORKDIR/!\\$PWD/!g\" {} \\;"
-      - "ctest --test-dir build-android/ --timeout 900 --output-on-failure"
+      - "cd build-android/"
+      - "ctest --timeout 900 --output-on-failure"
     agents:
       - "android-soc=google-tensor"
       - "queue=test-android"
@@ -40,9 +41,10 @@ steps:
       - "buildkite-agent artifact download --step build build-artifacts.tgz ./"
       - "tar xzf build-artifacts.tgz"
       - "find build-android/ -name '*.cmake' -exec sed -i \"s!\\$IREE_DOCKER_WORKDIR/!\\$PWD/!g\" {} \\;"
+      - "cd build-android/"
       # Pixel 4 ships an old Adreno GPU driver. There are quite a few bugs triggered by our tests.
       # Disable running tests entirely on Pixel 4. Moto Edge X30 gets us covered on Adreno GPU.
-      - "ctest --test-dir build-android/ --timeout 900 --output-on-failure --label-exclude \"vulkan\""
+      - "ctest --timeout 900 --output-on-failure --label-exclude \"vulkan\""
     agents:
       - "android-soc=snapdragon-855"
       - "queue=test-android"
@@ -57,7 +59,8 @@ steps:
       - "buildkite-agent artifact download --step build build-artifacts.tgz ./"
       - "tar xzf build-artifacts.tgz"
       - "find build-android/ -name '*.cmake' -exec sed -i \"s!\\$IREE_DOCKER_WORKDIR/!\\$PWD/!g\" {} \\;"
-      - "ctest --test-dir build-android/ --timeout 900 --output-on-failure"
+      - "cd build-android/"
+      - "ctest --timeout 900 --output-on-failure"
     agents:
       - "android-soc=snapdragon-8gen1"
       - "queue=test-android"


### PR DESCRIPTION
These are running on devices that we have not yet updated CMake on, so the `--test-dir` flag is ignored, resulting in
```
Test project /var/lib/buildkite-agent/builds/IREE-LAB-RPI4-Pixel6Pro-1-ray-1008524145-1/iree/iree-test-android
No tests were found!!!
```
(full logs: https://buildkite.com/iree/iree-test-android/builds/6350)

Partial revert of https://github.com/google/iree/pull/9253, noticed at https://github.com/google/iree/pull/9372#discussion_r891685626. It's a shame that `No tests were found!!!` does not come with a failure exit code :/