### PR TITLE
Add `--no-tests=error` to ctest invocations in CI scripts.

### DIFF
--- a/build_tools/buildkite/cmake/android/arm64-v8a/pipeline.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/pipeline.yml
@@ -25,7 +25,7 @@ steps:
       - "buildkite-agent artifact download --step build build-artifacts.tgz ./"
       - "tar xzf build-artifacts.tgz"
       - "find build-android/ -name '*.cmake' -exec sed -i \"s!\\$IREE_DOCKER_WORKDIR/!\\$PWD/!g\" {} \\;"
-      - "ctest --test-dir build-android/ --timeout 900 --output-on-failure"
+      - "ctest --test-dir build-android/ --timeout 900 --output-on-failure --no-tests=error"
     agents:
       - "android-soc=google-tensor"
       - "queue=test-android"
@@ -42,7 +42,7 @@ steps:
       - "find build-android/ -name '*.cmake' -exec sed -i \"s!\\$IREE_DOCKER_WORKDIR/!\\$PWD/!g\" {} \\;"
       # Pixel 4 ships an old Adreno GPU driver. There are quite a few bugs triggered by our tests.
       # Disable running tests entirely on Pixel 4. Moto Edge X30 gets us covered on Adreno GPU.
-      - "ctest --test-dir build-android/ --timeout 900 --output-on-failure --label-exclude \"vulkan\""
+      - "ctest --test-dir build-android/ --timeout 900 --output-on-failure --no-tests=error --label-exclude \"vulkan\""
     agents:
       - "android-soc=snapdragon-855"
       - "queue=test-android"
@@ -57,7 +57,7 @@ steps:
       - "buildkite-agent artifact download --step build build-artifacts.tgz ./"
       - "tar xzf build-artifacts.tgz"
       - "find build-android/ -name '*.cmake' -exec sed -i \"s!\\$IREE_DOCKER_WORKDIR/!\\$PWD/!g\" {} \\;"
-      - "ctest --test-dir build-android/ --timeout 900 --output-on-failure"
+      - "ctest --test-dir build-android/ --timeout 900 --output-on-failure --no-tests=error"
     agents:
       - "android-soc=snapdragon-8gen1"
       - "queue=test-android"

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -62,8 +62,9 @@ fi
 label_exclude_regex="($(IFS="|" ; echo "${label_exclude_args[*]}"))"
 
 echo "******************** Running main project ctests ************************"
-ctest\
+ctest \
   --test-dir "${BUILD_DIR}" \
   --timeout 900 \
   --output-on-failure \
+  --no-tests=error \
   --label-exclude "${label_exclude_regex}"

--- a/build_tools/cmake/test.sh
+++ b/build_tools/cmake/test.sh
@@ -62,7 +62,11 @@ label_exclude_regex="($(IFS="|" ; echo "${label_exclude_args[*]?}"))"
 
 cd "$BUILD_DIR"
 echo "******************** Running main project ctests ************************"
-ctest --timeout 900 --output-on-failure --label-exclude "${label_exclude_regex?}"
+ctest \
+  --timeout 900 \
+  --output-on-failure \
+  --no-tests=error \
+  --label-exclude "${label_exclude_regex?}"
 
 echo "******************** llvm-external-projects tests ***********************"
 cmake --build . --target check-iree-dialects -- -k 0

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build.sh
@@ -74,7 +74,10 @@ export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-$(nproc)}
 tests_passed=true
 
 echo "***** Testing with CTest *****"
-if ! ctest --timeout 900 --output-on-failure \
+if ! ctest \
+   --timeout 900 \
+   --output-on-failure \
+   --no-tests=error \
    --tests-regex "^integrations/tensorflow/|^runtime/bindings/python/" \
    --label-exclude "^nokokoro$|^vulkan_uses_vk_khr_shader_float16_int8$"
 then

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
@@ -81,7 +81,10 @@ tests_passed=true
 # Only test drivers that use the GPU, since we run all tests on non-GPU machines
 # as well.
 echo "***** Testing with CTest *****"
-if ! ctest --timeout 900 --output-on-failure \
+if ! ctest \
+   --timeout 900 \
+   --output-on-failure \
+   --no-tests=error \
    --tests-regex "^integrations/tensorflow/|^runtime/bindings/python/" \
    --label-regex "^driver=vulkan$|^driver=cuda$" \
    --label-exclude "^nokokoro$"

--- a/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader-asan/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader-asan/build.sh
@@ -134,7 +134,10 @@ excluded_tests_regex="($(IFS="|" ; echo "${excluded_tests[*]?}"))"
 cd ${CMAKE_BUILD_DIR?}
 
 echo "******************** Running main project ctests ************************"
-ctest --timeout 900 --output-on-failure \
+ctest \
+  --timeout 900 \
+  --output-on-failure \
+  --no-tests=error \
   --label-exclude "${label_exclude_regex}" \
   --exclude-regex "${excluded_tests_regex?}"
 


### PR DESCRIPTION
Follow-up to https://github.com/google/iree/pull/9373. This should actually cause our pipelines to fail if we've misconfigured testing (pfffff, who would ever do _that_?).

Before:
```
Test project D:/dev/projects/iree-build
No tests were found!!!
```

After:
```
Test project D:/dev/projects/iree-build
No tests were found!!!
Errors while running CTest
Output from these tests are in: D:/dev/projects/iree-build/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
```