### PR TITLE
Dont' add `vulkan_headers` submodule by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -573,7 +573,9 @@ endif()
 
 add_subdirectory(build_tools/third_party/flatcc EXCLUDE_FROM_ALL)
 
-add_subdirectory(third_party/vulkan_headers EXCLUDE_FROM_ALL)
+if(IREE_HAL_DRIVER_VULKAN)
+  add_subdirectory(third_party/vulkan_headers EXCLUDE_FROM_ALL)
+endif()
 
 # TODO(scotttodd): Iterate some more and find a better place for this.
 if(NOT CMAKE_CROSSCOMPILING)


### PR DESCRIPTION
Allows to clone fewer submodules if (cross-)compiling for a target that
doesn't involve the HAL Vulkan driver.