### PR TITLE
Define module target in iree_bytecode_module

### DIFF
--- a/build_tools/cmake/iree_benchmark_suite.cmake
+++ b/build_tools/cmake/iree_benchmark_suite.cmake
@@ -80,7 +80,7 @@ function(iree_benchmark_suite)
     "BENCHMARK_MODES;BENCHMARK_TOOL;MODULES"
   )
 
-  iree_package_name(PACKAGE_NAME)
+  iree_package_name(_PACKAGE_NAME)
 
   # Add the benchmark suite target.
   set(SUITE_SUB_TARGET "iree-benchmark-suites-${_RULE_GROUP_NAME}")
@@ -118,7 +118,7 @@ function(iree_benchmark_suite)
       # Update the source file to the downloaded-to place.
       string(REPLACE "/" ";" _SOURCE_URL_SEGMENTS "${_SOURCE_URL}")
       list(POP_BACK _SOURCE_URL_SEGMENTS _LAST_URL_SEGMENT)
-      set(_DOWNLOAD_TARGET "${PACKAGE_NAME}_iree-download-benchmark-source-${_LAST_URL_SEGMENT}")
+      set(_DOWNLOAD_TARGET "${_PACKAGE_NAME}_iree-download-benchmark-source-${_LAST_URL_SEGMENT}")
 
       # Strip off gzip suffix if present (downloader unzips if necessary)
       string(REGEX REPLACE "\.gz$" "" _SOURCE_FILE_BASENAME "${_LAST_URL_SEGMENT}")
@@ -150,7 +150,7 @@ function(iree_benchmark_suite)
       set(_TFLITE_FILE "${_MODULE_SOURCE}")
       set(_MODULE_SOURCE "${_TFLITE_FILE}.mlir")
       get_filename_component(_TFLITE_FILE_BASENAME "${_TFLITE_FILE}" NAME)
-      set(_TFLITE_IMPORT_TARGET "${PACKAGE_NAME}_iree-import-tflite-${_TFLITE_FILE_BASENAME}")
+      set(_TFLITE_IMPORT_TARGET "${_PACKAGE_NAME}_iree-import-tflite-${_TFLITE_FILE_BASENAME}")
       if(NOT TARGET "${_TFLITE_IMPORT_TARGET}")
         add_custom_command(
           OUTPUT "${_MODULE_SOURCE}"
@@ -214,14 +214,14 @@ function(iree_benchmark_suite)
 
       # Register the target once and share across all benchmarks having the same
       # MLIR source and translation flags.
-      set(
-        _TRANSLATION_TARGET_NAME
-        "${PACKAGE_NAME}_iree-generate-benchmark-artifact-${_MODULE_SOURCE_BASENAME_WITH_HASH}"
+      set(_MODULE_NAME
+        "iree-generate-benchmark-artifact-${_MODULE_SOURCE_BASENAME_WITH_HASH}"
       )
-      if(NOT TARGET "${_TRANSLATION_TARGET_NAME}")
+      set(_MODULE_TARGET_NAME "${_PACKAGE_NAME}_${_MODULE_NAME}")
+      if(NOT TARGET "${_MODULE_TARGET_NAME}")
         iree_bytecode_module(
           NAME
-            "${_TRANSLATION_TARGET_NAME}"
+            "${_MODULE_NAME}"
           MODULE_FILE_NAME
             "${_VMFB_FILE}"
           SRC
@@ -234,27 +234,24 @@ function(iree_benchmark_suite)
             "${_FRIENDLY_TARGET_NAME}"
         )
 
-        # TODO(#9254): that add_custom_target should be done by
-        # iree_bytecode_module.
-        add_custom_target("${_TRANSLATION_TARGET_NAME}"
-          DEPENDS "${_VMFB_FILE}"
-        )
-
         # Mark dependency so that we have one target to drive them all.
-        add_dependencies(iree-benchmark-suites "${_TRANSLATION_TARGET_NAME}")
-        add_dependencies("${SUITE_SUB_TARGET}" "${_TRANSLATION_TARGET_NAME}")
-      endif(NOT TARGET "${_TRANSLATION_TARGET_NAME}")
+        add_dependencies(iree-benchmark-suites "${_MODULE_TARGET_NAME}")
+        add_dependencies("${SUITE_SUB_TARGET}" "${_MODULE_TARGET_NAME}")
+      endif()
 
-      set(_COMPILE_STATS_TRANSLATION_TARGET_NAME
-        "${_TRANSLATION_TARGET_NAME}-compile-stats"
+      set(_COMPILE_STATS_MODULE_NAME
+        "${_MODULE_NAME}-compile-stats"
+      )
+      set(_COMPILE_STATS_MODULE_TARGET_NAME
+        "${_PACKAGE_NAME}_${_COMPILE_STATS_MODULE_NAME}"
       )
       set(_COMPILE_STATS_VMFB_FILE
         "${_VMFB_ARTIFACTS_DIR}/${_MODULE_SOURCE_BASENAME_WITH_HASH}-compile-stats.vmfb"
       )
-      if(IREE_ENABLE_COMPILATION_BENCHMARKS AND NOT TARGET "${_COMPILE_STATS_TRANSLATION_TARGET_NAME}")
+      if(IREE_ENABLE_COMPILATION_BENCHMARKS AND NOT TARGET "${_COMPILE_STATS_MODULE_TARGET_NAME}")
         iree_bytecode_module(
           NAME
-            "${_COMPILE_STATS_TRANSLATION_TARGET_NAME}"
+            "${_COMPILE_STATS_MODULE_NAME}"
           MODULE_FILE_NAME
             "${_COMPILE_STATS_VMFB_FILE}"
           SRC
@@ -271,28 +268,22 @@ function(iree_benchmark_suite)
             "${_FRIENDLY_TARGET_NAME}"
         )
 
-        # TODO(#9254): that add_custom_target should be done by
-        # iree_bytecode_module.
-        add_custom_target("${_COMPILE_STATS_TRANSLATION_TARGET_NAME}"
-          DEPENDS "${_COMPILE_STATS_VMFB_FILE}"
-        )
-
         # Mark dependency so that we have one target to drive them all.
         add_dependencies(iree-benchmark-suites
-          "${_COMPILE_STATS_TRANSLATION_TARGET_NAME}"
+          "${_COMPILE_STATS_MODULE_TARGET_NAME}"
         )
         add_dependencies("${SUITE_SUB_TARGET}"
-          "${_COMPILE_STATS_TRANSLATION_TARGET_NAME}"
+          "${_COMPILE_STATS_MODULE_TARGET_NAME}"
         )
       endif()
 
       if(NOT TARGET "${_FRIENDLY_TARGET_NAME}")
         add_custom_target("${_FRIENDLY_TARGET_NAME}")
       endif()
-      add_dependencies("${_FRIENDLY_TARGET_NAME}" "${_TRANSLATION_TARGET_NAME}")
+      add_dependencies("${_FRIENDLY_TARGET_NAME}" "${_MODULE_TARGET_NAME}")
       if(IREE_ENABLE_COMPILATION_BENCHMARKS)
         add_dependencies("${_FRIENDLY_TARGET_NAME}"
-          "${_COMPILE_STATS_TRANSLATION_TARGET_NAME}")
+          "${_COMPILE_STATS_MODULE_TARGET_NAME}")
       endif()
 
       set(_RUN_SPEC_DIR "${_ROOT_ARTIFACTS_DIR}/${_MODULE_DIR_NAME}/${_BENCHMARK_DIR_NAME}")
@@ -320,7 +311,7 @@ function(iree_benchmark_suite)
       )
 
       set(_FLAGFILE_GEN_TARGET_NAME
-        "${PACKAGE_NAME}_iree-generate-benchmark-flagfile__${_RUN_SPEC_TARGET_SUFFIX}")
+        "${_PACKAGE_NAME}_iree-generate-benchmark-flagfile__${_RUN_SPEC_TARGET_SUFFIX}")
       add_custom_target("${_FLAGFILE_GEN_TARGET_NAME}"
         DEPENDS "${_FLAG_FILE}"
       )
@@ -336,7 +327,7 @@ function(iree_benchmark_suite)
       )
 
       set(_TOOLFILE_GEN_TARGET_NAME
-        "${PACKAGE_NAME}_iree-generate-benchmark-toolfile__${_RUN_SPEC_TARGET_SUFFIX}")
+        "${_PACKAGE_NAME}_iree-generate-benchmark-toolfile__${_RUN_SPEC_TARGET_SUFFIX}")
       add_custom_target("${_TOOLFILE_GEN_TARGET_NAME}"
         DEPENDS "${_TOOL_FILE}"
       )
@@ -358,7 +349,8 @@ function(iree_benchmark_suite)
       )
 
       set(_COMPILATION_FLAGFILE_GEN_TARGET_NAME
-        "${PACKAGE_NAME}_iree-generate-benchmark-compilation-flagfile__${_RUN_SPEC_TARGET_SUFFIX}")
+        "${_PACKAGE_NAME}_iree-generate-benchmark-compilation-flagfile__${_RUN_SPEC_TARGET_SUFFIX}")
+      message("${_COMPILATION_FLAGFILE_GEN_TARGET_NAME}")
       add_custom_target("${_COMPILATION_FLAGFILE_GEN_TARGET_NAME}"
         DEPENDS "${_COMPILATION_FLAGFILE}"
       )

--- a/build_tools/cmake/iree_benchmark_suite.cmake
+++ b/build_tools/cmake/iree_benchmark_suite.cmake
@@ -214,14 +214,14 @@ function(iree_benchmark_suite)
 
       # Register the target once and share across all benchmarks having the same
       # MLIR source and translation flags.
-      set(_MODULE_NAME
+      set(_TRANSLATION_NAME
         "iree-generate-benchmark-artifact-${_MODULE_SOURCE_BASENAME_WITH_HASH}"
       )
-      set(_MODULE_TARGET_NAME "${_PACKAGE_NAME}_${_MODULE_NAME}")
-      if(NOT TARGET "${_MODULE_TARGET_NAME}")
+      set(_TRANSLATION_TARGET_NAME "${_PACKAGE_NAME}_${_TRANSLATION_NAME}")
+      if(NOT TARGET "${_TRANSLATION_TARGET_NAME}")
         iree_bytecode_module(
           NAME
-            "${_MODULE_NAME}"
+            "${_TRANSLATION_NAME}"
           MODULE_FILE_NAME
             "${_VMFB_FILE}"
           SRC
@@ -235,23 +235,23 @@ function(iree_benchmark_suite)
         )
 
         # Mark dependency so that we have one target to drive them all.
-        add_dependencies(iree-benchmark-suites "${_MODULE_TARGET_NAME}")
-        add_dependencies("${SUITE_SUB_TARGET}" "${_MODULE_TARGET_NAME}")
+        add_dependencies(iree-benchmark-suites "${_TRANSLATION_TARGET_NAME}")
+        add_dependencies("${SUITE_SUB_TARGET}" "${_TRANSLATION_TARGET_NAME}")
       endif()
 
-      set(_COMPILE_STATS_MODULE_NAME
-        "${_MODULE_NAME}-compile-stats"
+      set(_COMPILE_STATS_TRANSLATION_NAME
+        "${_TRANSLATION_NAME}-compile-stats"
       )
-      set(_COMPILE_STATS_MODULE_TARGET_NAME
-        "${_PACKAGE_NAME}_${_COMPILE_STATS_MODULE_NAME}"
+      set(_COMPILE_STATS_TRANSLATION_TARGET_NAME
+        "${_PACKAGE_NAME}_${_COMPILE_STATS_TRANSLATION_NAME}"
       )
       set(_COMPILE_STATS_VMFB_FILE
         "${_VMFB_ARTIFACTS_DIR}/${_MODULE_SOURCE_BASENAME_WITH_HASH}-compile-stats.vmfb"
       )
-      if(IREE_ENABLE_COMPILATION_BENCHMARKS AND NOT TARGET "${_COMPILE_STATS_MODULE_TARGET_NAME}")
+      if(IREE_ENABLE_COMPILATION_BENCHMARKS AND NOT TARGET "${_COMPILE_STATS_TRANSLATION_TARGET_NAME}")
         iree_bytecode_module(
           NAME
-            "${_COMPILE_STATS_MODULE_NAME}"
+            "${_COMPILE_STATS_TRANSLATION_NAME}"
           MODULE_FILE_NAME
             "${_COMPILE_STATS_VMFB_FILE}"
           SRC
@@ -270,20 +270,20 @@ function(iree_benchmark_suite)
 
         # Mark dependency so that we have one target to drive them all.
         add_dependencies(iree-benchmark-suites
-          "${_COMPILE_STATS_MODULE_TARGET_NAME}"
+          "${_COMPILE_STATS_TRANSLATION_TARGET_NAME}"
         )
         add_dependencies("${SUITE_SUB_TARGET}"
-          "${_COMPILE_STATS_MODULE_TARGET_NAME}"
+          "${_COMPILE_STATS_TRANSLATION_TARGET_NAME}"
         )
       endif()
 
       if(NOT TARGET "${_FRIENDLY_TARGET_NAME}")
         add_custom_target("${_FRIENDLY_TARGET_NAME}")
       endif()
-      add_dependencies("${_FRIENDLY_TARGET_NAME}" "${_MODULE_TARGET_NAME}")
+      add_dependencies("${_FRIENDLY_TARGET_NAME}" "${_TRANSLATION_TARGET_NAME}")
       if(IREE_ENABLE_COMPILATION_BENCHMARKS)
         add_dependencies("${_FRIENDLY_TARGET_NAME}"
-          "${_COMPILE_STATS_MODULE_TARGET_NAME}")
+          "${_COMPILE_STATS_TRANSLATION_TARGET_NAME}")
       endif()
 
       set(_RUN_SPEC_DIR "${_ROOT_ARTIFACTS_DIR}/${_MODULE_DIR_NAME}/${_BENCHMARK_DIR_NAME}")
@@ -350,7 +350,6 @@ function(iree_benchmark_suite)
 
       set(_COMPILATION_FLAGFILE_GEN_TARGET_NAME
         "${_PACKAGE_NAME}_iree-generate-benchmark-compilation-flagfile__${_RUN_SPEC_TARGET_SUFFIX}")
-      message("${_COMPILATION_FLAGFILE_GEN_TARGET_NAME}")
       add_custom_target("${_COMPILATION_FLAGFILE_GEN_TARGET_NAME}"
         DEPENDS "${_COMPILATION_FLAGFILE}"
       )

--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -30,9 +30,10 @@ include(CMakeParseArguments)
 # FRIENDLY_NAME: Optional. Name to use to display build progress info.
 #
 # Note:
-# By default, iree_bytecode_module will create a library named ${NAME}_c,
-# and alias target iree::${NAME}_c. The iree:: form should always be used.
-# This is to reduce namespace pollution.
+# By default, iree_bytecode_module will create a module target named ${NAME} and
+# a library named ${NAME}_c. The library has an alias target iree::${NAME}_c.
+# The module doesn't have an alias due to a lack of support on custom target.
+# The iree:: form should always be used to reduce namespace pollution.
 function(iree_bytecode_module)
   cmake_parse_arguments(
     _RULE
@@ -111,6 +112,13 @@ function(iree_bytecode_module)
     COMMENT
       "Generating ${_MODULE_FILE_NAME} from ${_FRIENDLY_NAME}"
     VERBATIM
+  )
+
+  # Only add iree_${NAME} as custom target doesn't support aliasing to
+  # iree::${NAME}.
+  iree_package_name(_PACKAGE_NAME)
+  add_custom_target("${_PACKAGE_NAME}_${_RULE_NAME}"
+    DEPENDS "${_MODULE_FILE_NAME}"
   )
 
   if(_RULE_TESTONLY)

--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -149,18 +149,6 @@ function(iree_check_test)
       ${_RULE_TARGET_CPU_FEATURES}
   )
 
-  # iree_bytecode_module does not define a target, only a custom command.
-  # We need to create a target that depends on the command to ensure the
-  # module gets built.
-  # TODO(b/146898896): Do this in iree_bytecode_module and avoid having to
-  # reach into the internals.
-  set(_MODULE_TARGET_NAME "${_NAME}_module")
-  add_custom_target(
-    "${_MODULE_TARGET_NAME}"
-     DEPENDS
-       "${_MODULE_FILE_NAME}"
-  )
-
   set(_RUNNER_TARGET "iree-check-module")
 
   # A target specifically for the test. We could combine this with the above,
@@ -168,7 +156,7 @@ function(iree_check_test)
   add_custom_target("${_NAME}" ALL)
   add_dependencies(
     "${_NAME}"
-    "${_MODULE_TARGET_NAME}"
+    "${_NAME}_module"
     "${_RUNNER_TARGET}"
   )
 

--- a/build_tools/cmake/iree_hal_cts_test_suite.cmake
+++ b/build_tools/cmake/iree_hal_cts_test_suite.cmake
@@ -109,7 +109,7 @@ function(iree_hal_cts_test_suite)
         # We should add a new function like `iree_hal_executable()`.
         iree_bytecode_module(
           NAME
-            ${_RULE_COMPILER_TARGET_BACKEND}_${_FILE_NAME}
+            ${_RULE_COMPILER_TARGET_BACKEND}_${_FILE_NAME}_module
           MODULE_FILE_NAME
             "${_RULE_COMPILER_TARGET_BACKEND}_${_FILE_NAME}.bin"
           SRC

--- a/build_tools/cmake/iree_trace_runner_test.cmake
+++ b/build_tools/cmake/iree_trace_runner_test.cmake
@@ -67,24 +67,12 @@ function(iree_trace_runner_test)
       ${_RULE_TARGET_CPU_FEATURES}
   )
 
-  # iree_bytecode_module does not define a target, only a custom command.
-  # We need to create a target that depends on the command to ensure the
-  # module gets built.
-  # TODO(b/146898896): Do this in iree_bytecode_module and avoid having to
-  # reach into the internals.
-  set(_MODULE_TARGET_NAME "${_NAME}_module")
-  add_custom_target(
-    "${_MODULE_TARGET_NAME}"
-     DEPENDS
-       "${_RULE_MODULE_FILE_NAME}"
-  )
-
   # A target specifically for the test. We could combine this with the above,
   # but we want that one to get pulled into iree_bytecode_module.
   add_custom_target("${_NAME}" ALL)
   add_dependencies(
     "${_NAME}"
-    "${_MODULE_TARGET_NAME}"
+    "${_NAME}_module"
     "${_RULE_TRACE_RUNNER}"
   )
 


### PR DESCRIPTION
Define a custom target `${PACKAGE_NAME}_${NAME}` for the VMFB module in `iree_bytecode_module`.

Fix #9254.