### PR TITLE
Removing iree_hal_driver_id_t in favor of just string names.

### DIFF
--- a/build_tools/cmake/iree_hal_cts_test_suite.cmake
+++ b/build_tools/cmake/iree_hal_cts_test_suite.cmake
@@ -13,7 +13,7 @@ include(CMakeParseArguments)
 #
 # Parameters:
 #   DRIVER_NAME: The name of the driver to test. Used for both target names and
-#       for `iree_hal_driver_registry_try_create_by_name()` within test code.
+#       for `iree_hal_driver_registry_try_create()` within test code.
 #   VARIANT_SUFFIX: Suffix to add to the test names, separate from the driver
 #       name. Useful when specifying multiple configurations using `ARGS` or
 #       other parameters.

--- a/compiler/src/iree/compiler/ConstEval/Runtime.cpp
+++ b/compiler/src/iree/compiler/ConstEval/Runtime.cpp
@@ -264,7 +264,7 @@ void CompiledBinary::initialize(void* data, size_t length) {
 
   // Create driver and device.
   iree_hal_driver_t* driver = nullptr;
-  IREE_CHECK_OK(iree_hal_driver_registry_try_create_by_name(
+  IREE_CHECK_OK(iree_hal_driver_registry_try_create(
       runtime.registry, iree_make_cstring_view("local-task"),
       iree_allocator_system(), &driver));
   IREE_CHECK_OK(iree_hal_driver_create_default_device(

--- a/docs/website/docs/bindings/c-api.md
+++ b/docs/website/docs/bindings/c-api.md
@@ -112,7 +112,7 @@ IREE_CHECK_OK(iree_vm_instance_create(iree_allocator_system(), &instance));
 // driver like the GPU "vulkan" driver. The driver(s) used should match with
 // the target(s) specified during compilation.
 iree_hal_driver_t* driver = NULL;
-IREE_CHECK_OK(iree_hal_driver_registry_try_create_by_name(
+IREE_CHECK_OK(iree_hal_driver_registry_try_create(
     iree_hal_driver_registry_default(),
     iree_string_view_literal("local-task"),
     iree_allocator_system(), &driver));

--- a/experimental/rocm/registration/driver_module.c
+++ b/experimental/rocm/registration/driver_module.c
@@ -13,14 +13,11 @@
 #include "iree/base/api.h"
 #include "iree/base/tracing.h"
 
-#define IREE_HAL_ROCM_DRIVER_ID 0x524f434d0au  // ROCM
-
 static iree_status_t iree_hal_rocm_driver_factory_enumerate(
     void *self, const iree_hal_driver_info_t **out_driver_infos,
     iree_host_size_t *out_driver_info_count) {
   // NOTE: we could query supported ROCM versions or featuresets here.
   static const iree_hal_driver_info_t driver_infos[1] = {{
-      .driver_id = IREE_HAL_ROCM_DRIVER_ID,
       .driver_name = iree_string_view_literal("rocm"),
       .full_name = iree_string_view_literal("ROCM (dynamic)"),
   }};
@@ -30,25 +27,20 @@ static iree_status_t iree_hal_rocm_driver_factory_enumerate(
 }
 
 static iree_status_t iree_hal_rocm_driver_factory_try_create(
-    void *self, iree_hal_driver_id_t driver_id, iree_allocator_t host_allocator,
+    void *self, iree_string_view_t driver_name, iree_allocator_t host_allocator,
     iree_hal_driver_t **out_driver) {
   IREE_ASSERT_ARGUMENT(out_driver);
   *out_driver = NULL;
-  if (driver_id != IREE_HAL_ROCM_DRIVER_ID) {
+  if (!iree_string_view_equal(driver_name, IREE_SV("rocm"))) {
     return iree_make_status(IREE_STATUS_UNAVAILABLE,
-                            "no driver with ID %016" PRIu64
-                            " is provided by this factory",
-                            driver_id);
+                            "no driver '%.*s' is provided by this factory",
+                            (int)driver_name.size, driver_name.data);
   }
   IREE_TRACE_ZONE_BEGIN(z0);
-  // When we expose more than one driver (different rocm versions, etc) we
-  // can name them here:
-  iree_string_view_t identifier = iree_make_cstring_view("rocm");
-
   iree_hal_rocm_driver_options_t driver_options;
   iree_hal_rocm_driver_options_initialize(&driver_options);
   iree_status_t status = iree_hal_rocm_driver_create(
-      identifier, &driver_options, host_allocator, out_driver);
+      driver_name, &driver_options, host_allocator, out_driver);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/runtime/bindings/python/hal.cc
+++ b/runtime/bindings/python/hal.cc
@@ -228,7 +228,7 @@ std::vector<std::string> HalDriver::Query() {
 
 HalDriver HalDriver::Create(const std::string& driver_name) {
   iree_hal_driver_t* driver;
-  CheckApiStatus(iree_hal_driver_registry_try_create_by_name(
+  CheckApiStatus(iree_hal_driver_registry_try_create(
                      iree_hal_driver_registry_default(),
                      {driver_name.data(), driver_name.size()},
                      iree_allocator_system(), &driver),

--- a/runtime/bindings/tflite/interpreter.c
+++ b/runtime/bindings/tflite/interpreter.c
@@ -48,7 +48,7 @@ static iree_status_t _TfLiteInterpreterPrepareHAL(
 
   // TODO(benvanik): switch to iree_hal_driver_registry_try_create when
   // implemented.
-  iree_status_t status = iree_hal_driver_registry_try_create_by_name(
+  iree_status_t status = iree_hal_driver_registry_try_create(
       driver_registry, driver_name, interpreter->allocator,
       &interpreter->driver);
   iree_allocator_free(interpreter->allocator, driver_infos);

--- a/runtime/src/iree/hal/cts/cts_test_base.h
+++ b/runtime/src/iree/hal/cts/cts_test_base.h
@@ -148,7 +148,7 @@ class CtsTestBase : public ::testing::TestWithParam<std::string> {
 
     // No existing driver, attempt to create.
     iree_hal_driver_t* driver = NULL;
-    iree_status_t status = iree_hal_driver_registry_try_create_by_name(
+    iree_status_t status = iree_hal_driver_registry_try_create(
         iree_hal_driver_registry_default(),
         iree_make_string_view(driver_name.data(), driver_name.size()),
         iree_allocator_system(), &driver);

--- a/runtime/src/iree/hal/driver.c
+++ b/runtime/src/iree/hal/driver.c
@@ -53,7 +53,7 @@ IREE_API_EXPORT iree_status_t iree_hal_driver_create_default_device(
   *out_device = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
   iree_status_t status = _VTABLE_DISPATCH(driver, create_device)(
-      driver, IREE_HAL_DRIVER_ID_INVALID, host_allocator, out_device);
+      driver, IREE_HAL_DEVICE_ID_INVALID, host_allocator, out_device);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/runtime/src/iree/hal/driver.h
+++ b/runtime/src/iree/hal/driver.h
@@ -22,11 +22,6 @@ extern "C" {
 // Types and Enums
 //===----------------------------------------------------------------------===//
 
-// An opaque factory-specific handle to identify different drivers.
-typedef uint64_t iree_hal_driver_id_t;
-
-#define IREE_HAL_DRIVER_ID_INVALID 0ull
-
 // Describes a driver providing device enumeration and creation.
 // The lifetime of memory referenced by this structure (such as strings) is
 // dependent on where it originated.
@@ -39,9 +34,6 @@ typedef uint64_t iree_hal_driver_id_t;
 //   driver registry lock is held.
 typedef struct iree_hal_driver_info_t {
   IREE_API_UNSTABLE
-
-  // Opaque handle used by factories. Unique across all factories.
-  iree_hal_driver_id_t driver_id;
 
   // Canonical name of the driver as used in command lines, documentation, etc.
   // Examples: 'metal', 'vulkan'

--- a/runtime/src/iree/hal/driver_registry.h
+++ b/runtime/src/iree/hal/driver_registry.h
@@ -68,7 +68,7 @@ typedef struct iree_hal_driver_factory_t {
   //
   // Called with the driver registry lock held; may be called from any thread.
   iree_status_t(IREE_API_PTR* try_create)(void* self,
-                                          iree_hal_driver_id_t driver_id,
+                                          iree_string_view_t driver_name,
                                           iree_allocator_t host_allocator,
                                           iree_hal_driver_t** out_driver);
 } iree_hal_driver_factory_t;
@@ -138,17 +138,6 @@ IREE_API_EXPORT iree_status_t iree_hal_driver_registry_enumerate(
     iree_hal_driver_info_t** out_driver_infos,
     iree_host_size_t* out_driver_info_count);
 
-// Attempts to create a driver registered with the driver registry by a specific
-// ID as returned during enumeration in iree_hal_driver_info_t::driver_id.
-// This can be used to specify the exact driver to create in cases where there
-// may be multiple factories providing drivers with the same name.
-//
-// Thread-safe. May block the caller if the driver is delay-loaded and needs to
-// perform additional loading/verification/etc before returning.
-IREE_API_EXPORT iree_status_t iree_hal_driver_registry_try_create(
-    iree_hal_driver_registry_t* registry, iree_hal_driver_id_t driver_id,
-    iree_allocator_t host_allocator, iree_hal_driver_t** out_driver);
-
 // Attempts to create a driver registered with the given canonical driver name.
 // Effectively enumerate + find by name + try_create if found. Factories are
 // searched in most-recently-added order such that it's possible to override
@@ -157,7 +146,7 @@ IREE_API_EXPORT iree_status_t iree_hal_driver_registry_try_create(
 //
 // Thread-safe. May block the caller if the driver is delay-loaded and needs to
 // perform additional loading/verification/etc before returning.
-IREE_API_EXPORT iree_status_t iree_hal_driver_registry_try_create_by_name(
+IREE_API_EXPORT iree_status_t iree_hal_driver_registry_try_create(
     iree_hal_driver_registry_t* registry, iree_string_view_t driver_name,
     iree_allocator_t host_allocator, iree_hal_driver_t** out_driver);
 

--- a/runtime/src/iree/modules/check/check_test.cc
+++ b/runtime/src/iree/modules/check/check_test.cc
@@ -35,7 +35,7 @@ class CheckTest : public ::testing::Test {
     IREE_ASSERT_OK(iree_hal_module_register_types());
 
     iree_hal_driver_t* hal_driver = nullptr;
-    IREE_ASSERT_OK(iree_hal_driver_registry_try_create_by_name(
+    IREE_ASSERT_OK(iree_hal_driver_registry_try_create(
         iree_hal_driver_registry_default(),
         iree_make_cstring_view("local-task"), iree_allocator_system(),
         &hal_driver));

--- a/runtime/src/iree/runtime/instance.c
+++ b/runtime/src/iree/runtime/instance.c
@@ -153,8 +153,8 @@ IREE_API_EXPORT iree_status_t iree_runtime_instance_try_create_default_device(
       iree_runtime_instance_host_allocator(instance);
   iree_hal_driver_t* driver = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_hal_driver_registry_try_create_by_name(
-              driver_registry, driver_name, host_allocator, &driver));
+      z0, iree_hal_driver_registry_try_create(driver_registry, driver_name,
+                                              host_allocator, &driver));
 
   // Create the default device on that driver.
   iree_status_t status =

--- a/runtime/src/iree/tools/utils/trace_replay.c
+++ b/runtime/src/iree/tools/utils/trace_replay.c
@@ -79,7 +79,7 @@ static iree_status_t iree_trace_replay_create_device(
 
   // Try to create a device from the driver.
   iree_hal_driver_t* driver = NULL;
-  IREE_RETURN_IF_ERROR(iree_hal_driver_registry_try_create_by_name(
+  IREE_RETURN_IF_ERROR(iree_hal_driver_registry_try_create(
       iree_hal_driver_registry_default(), driver_name, host_allocator,
       &driver));
   iree_status_t status =

--- a/runtime/src/iree/tools/utils/vm_util.cc
+++ b/runtime/src/iree/tools/utils/vm_util.cc
@@ -240,11 +240,11 @@ Status PrintVariantList(iree_vm_list_t* variant_list, size_t max_element_count,
 Status CreateDevice(const char* driver_name, iree_hal_device_t** out_device) {
   IREE_LOG(INFO) << "Creating driver and device for '" << driver_name << "'...";
   iree_hal_driver_t* driver = nullptr;
-  IREE_RETURN_IF_ERROR(iree_hal_driver_registry_try_create_by_name(
-                           iree_hal_driver_registry_default(),
-                           iree_make_cstring_view(driver_name),
-                           iree_allocator_system(), &driver),
-                       "creating driver '%s'", driver_name);
+  IREE_RETURN_IF_ERROR(
+      iree_hal_driver_registry_try_create(iree_hal_driver_registry_default(),
+                                          iree_make_cstring_view(driver_name),
+                                          iree_allocator_system(), &driver),
+      "creating driver '%s'", driver_name);
   IREE_RETURN_IF_ERROR(iree_hal_driver_create_default_device(
                            driver, iree_allocator_system(), out_device),
                        "creating default device for driver '%s'", driver_name);

--- a/samples/simple_embedding/device_cuda.c
+++ b/samples/simple_embedding/device_cuda.c
@@ -24,7 +24,7 @@ iree_status_t create_sample_device(iree_allocator_t host_allocator,
   // Create the HAL driver from the name.
   iree_hal_driver_t* driver = NULL;
   iree_string_view_t identifier = iree_make_cstring_view("cuda");
-  iree_status_t status = iree_hal_driver_registry_try_create_by_name(
+  iree_status_t status = iree_hal_driver_registry_try_create(
       iree_hal_driver_registry_default(), identifier, host_allocator, &driver);
 
   // Create the default device (primary GPU).

--- a/samples/simple_embedding/device_vulkan.c
+++ b/samples/simple_embedding/device_vulkan.c
@@ -24,7 +24,7 @@ iree_status_t create_sample_device(iree_allocator_t host_allocator,
   // Create the HAL driver from the name.
   iree_hal_driver_t* driver = NULL;
   iree_string_view_t identifier = iree_make_cstring_view("vulkan");
-  iree_status_t status = iree_hal_driver_registry_try_create_by_name(
+  iree_status_t status = iree_hal_driver_registry_try_create(
       iree_hal_driver_registry_default(), identifier, host_allocator, &driver);
 
   // Create the default device (primary GPU).


### PR DESCRIPTION
Progress on #9343 (URI schemas => driver names).