### PR TITLE
check if the def op is null

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DumpDispatchGraph.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DumpDispatchGraph.cpp
@@ -399,7 +399,7 @@ class DumpDispatchGraphPass
       auto operand = it.value();
       auto op = operand.getDefiningOp();
 
-      if (isScalarConstantOp(op)) {
+      if (op && isScalarConstantOp(op)) {
         auto ty = operand.getType();
         if (ty.isa<IntegerType>()) {
           os << cast<arith::ConstantIntOp>(op).value();


### PR DESCRIPTION
It is possible that there is no defining operation for an Op.