### PR TITLE
Apply code upgrades for python >= 3.7 

### DIFF
--- a/build_tools/benchmarks/run_benchmarks_on_android.py
+++ b/build_tools/benchmarks/run_benchmarks_on_android.py
@@ -165,7 +165,7 @@ def adb_start_cmd(cmd_args: Sequence[str],
   if verbose:
     cmd_str = " ".join(cmd)
     print(f"cmd: {cmd_str}")
-  return subprocess.Popen(cmd, stdout=subprocess.PIPE, universal_newlines=True)
+  return subprocess.Popen(cmd, stdout=subprocess.PIPE, text=True)
 
 
 def get_vmfb_full_path_for_benchmark_case(benchmark_case_dir: str) -> str:

--- a/build_tools/benchmarks/run_benchmarks_on_linux.py
+++ b/build_tools/benchmarks/run_benchmarks_on_linux.py
@@ -79,7 +79,7 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
                                env={"TRACY_NO_EXIT": "1"},
                                cwd=case_dir,
                                stdout=subprocess.PIPE,
-                               universal_newlines=True)
+                               text=True)
 
     wait_for_iree_benchmark_module_start(process, self.verbose)
 

--- a/build_tools/docker/utils.py
+++ b/build_tools/docker/utils.py
@@ -25,15 +25,10 @@ def run_command(command: Sequence[str],
     # Dummy CompletedProess with successful returncode.
     return subprocess.CompletedProcess(command, returncode=0)
 
-  if capture_output:
-    # TODO(#4131) python>=3.7: Use capture_output=True.
-    run_kwargs["stdout"] = subprocess.PIPE
-    run_kwargs["stderr"] = subprocess.PIPE
-
-  # TODO(#4131) python>=3.7: Replace 'universal_newlines' with 'text'.
   completed_process = subprocess.run(command,
-                                     universal_newlines=text,
+                                     text=text,
                                      check=check,
+                                     capture_output=capture_output,
                                      **run_kwargs)
   return completed_process
 

--- a/build_tools/scripts/utils.py
+++ b/build_tools/scripts/utils.py
@@ -24,21 +24,8 @@ def check_and_get_output_lines(command: Sequence[str],
   print(f'Running: `{" ".join(command)}`')
   if dry_run:
     return None, None
-  process = subprocess.run(
-      command,
-      # TODO(#4131) python>=3.7: Use capture_output=True.
-      stderr=subprocess.PIPE,
-      stdout=subprocess.PIPE,
-      # TODO(#4131) python>=3.7: Replace 'universal_newlines' with 'text'.
-      universal_newlines=True)
-
-  if log_stderr:
-    for line in process.stderr.splitlines():
-      print(line)
-
-  process.check_returncode()
-
-  return process.stdout.splitlines()
+  return subprocess.run(command, stdout=subprocess.PIPE, text=true,
+                        check=True).stdout.splitlines()
 
 
 def get_test_targets(test_suite_path: str):

--- a/compiler/src/iree/compiler/API/python/iree/compiler/tools/binaries.py
+++ b/compiler/src/iree/compiler/API/python/iree/compiler/tools/binaries.py
@@ -191,11 +191,7 @@ def invoke_immediate(command_line: List[str],
     elif immediate_input is not None:
       run_args["input"] = immediate_input
 
-    # Capture output.
-    # TODO(#4131) python>=3.7: Use capture_output=True.
-    run_args["stdout"] = subprocess.PIPE
-    run_args["stderr"] = subprocess.PIPE
-    process = subprocess.run(command_line, **run_args)
+    process = subprocess.run(command_line, capture_output=True, **run_args)
     if process.returncode != 0:
       raise CompilerToolError(process)
     # Emit stderr contents.

--- a/compiler/src/iree/compiler/API/python/iree/compiler/tools/core.py
+++ b/compiler/src/iree/compiler/API/python/iree/compiler/tools/core.py
@@ -7,8 +7,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# TODO(#4131) python>=3.7: Use postponed type annotations.
-
+from __future__ import annotations
+from dataclasses import dataclass
 from enum import Enum
 import logging
 import subprocess
@@ -46,7 +46,7 @@ class InputType(Enum):
   XLA = "xla"
 
   @staticmethod
-  def parse(spec: Union[str, "InputType"]) -> "InputType":
+  def parse(spec: Union[str, InputType]) -> InputType:
     """Parses or returns an InputType.
 
     Args:
@@ -71,7 +71,7 @@ class OutputFormat(Enum):
   MLIR_TEXT = "mlir-text"
 
   @staticmethod
-  def parse(spec: Union[str, "OutputFormat"]) -> "OutputFormat":
+  def parse(spec: Union[str, OutputFormat]) -> OutputFormat:
     """Parses or returns an OutputFormat.
 
     Args:
@@ -89,7 +89,7 @@ class OutputFormat(Enum):
     return OutputFormat[spec]
 
 
-# TODO(#4131) python>=3.7: Consider using a dataclass.
+@dataclass
 class CompilerOptions:
   """Options to the compiler backend.
 
@@ -128,37 +128,24 @@ class CompilerOptions:
       for benchmarking.
   """
 
-  def __init__(self,
-               *,
-               output_file: Optional[str] = None,
-               target_backends: Sequence[str] = (),
-               input_type: Union[InputType, str] = InputType.NONE,
-               output_format: Union[OutputFormat,
-                                    str] = OutputFormat.FLATBUFFER_BINARY,
-               extra_args: Sequence[str] = (),
-               optimize: bool = True,
-               output_mlir_debuginfo: bool = True,
-               output_generic_mlir: bool = False,
-               extended_diagnostics: bool = False,
-               strip_debug_ops: bool = False,
-               strip_source_map: bool = False,
-               crash_reproducer_path: Optional[str] = None,
-               enable_tflite_bindings: bool = False,
-               enable_benchmark: bool = False):
-    self.output_file = output_file
-    self.target_backends = target_backends
-    self.input_type = InputType.parse(input_type)
-    self.output_format = OutputFormat.parse(output_format)
-    self.extra_args = extra_args
-    self.optimize = optimize
-    self.output_mlir_debuginfo = output_mlir_debuginfo
-    self.output_generic_mlir = output_generic_mlir
-    self.extended_diagnostics = extended_diagnostics
-    self.strip_debug_ops = strip_debug_ops
-    self.strip_source_map = strip_source_map
-    self.crash_reproducer_path = crash_reproducer_path
-    self.enable_tflite_bindings = enable_tflite_bindings
-    self.enable_benchmark = enable_benchmark
+  output_file: Optional[str] = None
+  target_backends: Sequence[str] = ()
+  input_type: Union[InputType, str] = InputType.NONE
+  output_format: Union[OutputFormat, str] = OutputFormat.FLATBUFFER_BINARY
+  extra_args: Sequence[str] = ()
+  optimize: bool = True
+  output_mlir_debuginfo: bool = True
+  output_generic_mlir: bool = False
+  extended_diagnostics: bool = False
+  strip_debug_ops: bool = False
+  strip_source_map: bool = False
+  crash_reproducer_path: Optional[str] = None
+  enable_tflite_bindings: bool = False
+  enable_benchmark: bool = False
+
+  def __post_init__(self):
+    self.input_type = InputType.parse(self.input_type)
+    self.output_format = OutputFormat.parse(self.output_format)
 
 
 def build_compile_command_line(input_file: str, tfs: TempFileSaver,

--- a/compiler/src/iree/compiler/API/python/iree/compiler/tools/tflite.py
+++ b/compiler/src/iree/compiler/API/python/iree/compiler/tools/tflite.py
@@ -5,8 +5,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Imports TFLite binaries via the `iree-import-tflite` tool."""
-# TODO(#4131) python>=3.7: Use postponed type annotations.
 
+from dataclasses import dataclass
 from enum import Enum
 import logging
 import tempfile
@@ -37,45 +37,35 @@ def is_available():
   return True
 
 
-# TODO(#4131) python>=3.7: Consider using a dataclass.
+@dataclass
 class ImportOptions(CompilerOptions):
-  """Import options layer on top of the backend compiler options."""
+  """Import options layer on top of the backend compiler options.
 
-  def __init__(self,
-               input_arrays: Sequence[str] = (),
-               output_arrays: Sequence[str] = (),
-               import_only: bool = False,
-               import_extra_args: Sequence[str] = (),
-               save_temp_tfl_input: Optional[str] = None,
-               save_temp_iree_input: Optional[str] = None,
-               input_type: Optional[str] = "tosa",
-               **kwargs):
-    """Initialize options from keywords.
+  Args:
+    input_arrays: Sequence of input array node names (if different from
+      default).
+    output_arrays: Sequence of output array node names (if different from
+      default).
+    import_only: Only import the module. If True, the result will be textual
+      MLIR that can be further fed to the IREE compiler. If False (default),
+      the result will be the fully compiled IREE binary. In both cases,
+      bytes-like output is returned. Note that if the output_file= is
+      specified and import_only=True, then the MLIR form will be written to
+      the output file.
+    import_extra_args: Extra arguments to pass to the iree-import-tf tool.
+    save_temp_tfl_input: Optionally save the IR that results from importing
+      the flatbuffer (prior to any further transformations).
+    save_temp_iree_input: Optionally save the IR that is the result of the
+      import (ready to be passed to IREE).
+  """
 
-    Args:
-      input_arrays: Sequence of input array node names (if different from
-        default).
-      output_arrays: Sequence of output array node names (if different from
-        default).
-      import_only: Only import the module. If True, the result will be textual
-        MLIR that can be further fed to the IREE compiler. If False (default),
-        the result will be the fully compiled IREE binary. In both cases,
-        bytes-like output is returned. Note that if the output_file= is
-        specified and import_only=True, then the MLIR form will be written to
-        the output file.
-      import_extra_args: Extra arguments to pass to the iree-import-tf tool.
-      save_temp_tfl_input: Optionally save the IR that results from importing
-        the flatbuffer (prior to any further transformations).
-      save_temp_iree_input: Optionally save the IR that is the result of the
-        import (ready to be passed to IREE).
-    """
-    super().__init__(input_type=input_type, **kwargs)
-    self.input_arrays = input_arrays
-    self.output_arrays = output_arrays
-    self.import_only = import_only
-    self.import_extra_args = import_extra_args
-    self.save_temp_tfl_input = save_temp_tfl_input
-    self.save_temp_iree_input = save_temp_iree_input
+  input_arrays: Sequence[str] = ()
+  output_arrays: Sequence[str] = ()
+  import_only: bool = False
+  import_extra_args: Sequence[str] = ()
+  save_temp_tfl_input: Optional[str] = None
+  save_temp_iree_input: Optional[str] = None
+  input_type: Optional[str] = "tosa"
 
 
 def build_import_command_line(input_path: str, tfs: TempFileSaver,

--- a/compiler/src/iree/compiler/API/python/iree/compiler/tools/xla.py
+++ b/compiler/src/iree/compiler/API/python/iree/compiler/tools/xla.py
@@ -6,8 +6,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Imports XLA artifacts via the `iree-import-xla` tool."""
 
-# TODO(#4131) python>=3.7: Use postponed type annotations.
-
+from __future__ import annotations
+from dataclasses import dataclass
 from enum import Enum
 import logging
 import tempfile
@@ -47,7 +47,7 @@ class ImportFormat(Enum):
   MLIR_TEXT = "mlir_text"
 
   @staticmethod
-  def parse(spec: Union[str, "ImportFormat"]) -> "ImportFormat":
+  def parse(spec: Union[str, ImportFormat]) -> ImportFormat:
     """Parses or returns an ImportFormat.
 
     Args:
@@ -65,31 +65,24 @@ class ImportFormat(Enum):
     return ImportFormat[spec]
 
 
-# TODO(#4131) python>=3.7: Consider using a dataclass.
+@dataclass
 class ImportOptions(CompilerOptions):
-  """Import options layer on top of the backend compiler options."""
+  """Import options layer on top of the backend compiler options.
 
-  def __init__(self,
-               import_only: bool = False,
-               import_format: Union[ImportFormat,
-                                    str] = ImportFormat.BINARY_PROTO,
-               import_extra_args: Sequence[str] = (),
-               save_temp_mhlo_input: Optional[str] = None,
-               save_temp_iree_input: Optional[str] = None,
-               **kwargs):
-    """Initialize options from keywords.
+  Args:
+    import_format: Format of the proto (text or binary).
+    save_temp_iree_input: Optionally save the IR that is the result of the
+      import (ready to be passed to IREE).
+  """
 
-    Args:
-      import_format: Format of the proto (text or binary).
-      save_temp_iree_input: Optionally save the IR that is the result of the
-        import (ready to be passed to IREE).
-    """
-    super().__init__(**kwargs)
-    self.import_only = import_only
-    self.import_format = ImportFormat.parse(import_format)
-    self.import_extra_args = import_extra_args
-    self.save_temp_mhlo_input = save_temp_mhlo_input
-    self.save_temp_iree_input = save_temp_iree_input
+  import_only: bool = False
+  import_format: Union[ImportFormat, str] = ImportFormat.BINARY_PROTO
+  import_extra_args: Sequence[str] = ()
+  save_temp_mhlo_input: Optional[str] = None
+  save_temp_iree_input: Optional[str] = None
+
+  def __post_init__(self):
+    self.import_format = ImportFormat.parse(self.import_format)
 
 
 def build_import_command_line(input_path: str, tfs: TempFileSaver,

--- a/integrations/tensorflow/iree-dialects/python/iree/compiler/dialects/iree_pydm/importer/util.py
+++ b/integrations/tensorflow/iree-dialects/python/iree/compiler/dialects/iree_pydm/importer/util.py
@@ -4,6 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from __future__ import annotations
 from types import ModuleType
 from typing import Any, Mapping, Optional, Sequence, Union
 
@@ -190,7 +191,7 @@ class ImportStage:
       "hooks",
   ]
 
-  def __init__(self, ic: ImportContext, hooks: "ImportHooks"):
+  def __init__(self, ic: ImportContext, hooks: ImportHooks):
     self.ic = ic
     self.hooks = hooks
 
@@ -221,7 +222,7 @@ class Intrinsic:
   UNBOUND_VALUE = _UnboundValue()
 
   def resolve_static_getattr(self, stage: ImportStage,
-                             attr_name: str) -> "ResolveOutcome":
+                             attr_name: str) -> ResolveOutcome:
     return Intrinsic.UNBOUND_VALUE
 
   def emit_call(self, stage: ImportStage, args: Sequence[ir.Value],
@@ -237,7 +238,7 @@ class Intrinsic:
         f"the compiler intrinsic {self} can not be serialized as a value")
 
   @staticmethod
-  def make_singleton(cls) -> "Intrinsic":
+  def make_singleton(cls) -> Intrinsic:
     """Class decorator to instantiate a singleton intrinsic class."""
     assert issubclass(cls, Intrinsic)
     return cls()

--- a/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/module_utils.py
+++ b/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/module_utils.py
@@ -5,8 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Utilities for compiling 'tf.Module's"""
 
-# TODO(#4131) python>=3.7: Use postponed type annotations.
-
+from __future__ import annotations
 import collections
 import os
 import tempfile
@@ -79,7 +78,7 @@ def _get_tf_import_output_kwargs(artifacts_dir: str,
 
 def _incrementally_compile_tf_module(
     module: Type[tf.Module],
-    backend_info: "BackendInfo",
+    backend_info: BackendInfo,
     exported_names: Sequence[str] = (),
     artifacts_dir: Optional[str] = None,
 ) -> Tuple[bytes, Optional[str]]:
@@ -130,8 +129,8 @@ def _incrementally_compile_tf_module(
 
 
 def _incrementally_compile_tf_signature_def_saved_model(
-    saved_model_dir: str, saved_model_tags: Set[str],
-    backend_info: "BackendInfo", exported_name: str, artifacts_dir: str):
+    saved_model_dir: str, saved_model_tags: Set[str], backend_info: BackendInfo,
+    exported_name: str, artifacts_dir: str):
   """Compile a SignatureDef SavedModel and optionally save compilation artifacts.
 
   The module blob this creates is not callable. See IreeCompiledModule for an
@@ -184,7 +183,7 @@ class CompiledModule(object):
   def __init__(
       self,
       module_name: str,
-      backend_info: "BackendInfo",
+      backend_info: BackendInfo,
       compiled_paths: Union[Dict[str, str], None],
   ):
     """Shared base constructor – not useful on its own.
@@ -207,7 +206,7 @@ class CompiledModule(object):
   @classmethod
   def create_from_class(cls,
                         module_class: Type[tf.Module],
-                        backend_info: "BackendInfo",
+                        backend_info: BackendInfo,
                         exported_names: Sequence[str] = (),
                         artifacts_dir: Optional[str] = None):
     """Compile a tf.Module subclass to the target backend in backend_info.
@@ -225,7 +224,7 @@ class CompiledModule(object):
   @classmethod
   def create_from_instance(cls,
                            module_instance: tf.Module,
-                           backend_info: "BackendInfo",
+                           backend_info: BackendInfo,
                            exported_names: Sequence[str] = (),
                            artifacts_dir: Optional[str] = None):
     """Compile a tf.Module instance to the target backend in backend_info.
@@ -248,7 +247,7 @@ class CompiledModule(object):
       saved_model_dir: str,
       saved_model_tags: Set[str],
       module_name: str,
-      backend_info: "BackendInfo",
+      backend_info: BackendInfo,
       exported_name: str,
       input_names: Sequence[str],
       output_names: Sequence[str],
@@ -307,7 +306,7 @@ class IreeCompiledModule(CompiledModule):
   def __init__(
       self,
       module_name: str,
-      backend_info: "BackendInfo",
+      backend_info: BackendInfo,
       compiled_paths: Dict[str, str],
       vm_module: iree.runtime.VmModule,
       config: iree.runtime.Config,
@@ -331,7 +330,7 @@ class IreeCompiledModule(CompiledModule):
   @classmethod
   def create_from_class(cls,
                         module_class: Type[tf.Module],
-                        backend_info: "BackendInfo",
+                        backend_info: BackendInfo,
                         exported_names: Sequence[str] = (),
                         artifacts_dir: Optional[str] = None):
     """Compile a tf.Module subclass to the target backend in backend_info.
@@ -352,7 +351,7 @@ class IreeCompiledModule(CompiledModule):
   @classmethod
   def create_from_instance(cls,
                            module_instance: tf.Module,
-                           backend_info: "BackendInfo",
+                           backend_info: BackendInfo,
                            exported_names: Sequence[str] = (),
                            artifacts_dir: Optional[str] = None):
     """Compile a tf.Module instance to the target backend in backend_info.
@@ -388,7 +387,7 @@ class IreeCompiledModule(CompiledModule):
       saved_model_dir: str,
       saved_model_tags: Set[str],
       module_name: str,
-      backend_info: "BackendInfo",
+      backend_info: BackendInfo,
       exported_name: str,
       input_names: Sequence[str],
       output_names: Sequence[str],
@@ -484,7 +483,7 @@ class TfCompiledModule(CompiledModule):
   def __init__(
       self,
       module_name: str,
-      backend_info: "BackendInfo",
+      backend_info: BackendInfo,
       constructor: Callable[[], tf.Module],
       exported_names: Sequence[str],
   ):
@@ -508,7 +507,7 @@ class TfCompiledModule(CompiledModule):
   @classmethod
   def create_from_class(cls,
                         module_class: Type[tf.Module],
-                        backend_info: "BackendInfo",
+                        backend_info: BackendInfo,
                         exported_names: Sequence[str] = (),
                         artifacts_dir: Optional[str] = None):
     """Compile a tf.Module subclass to the target backend in backend_info.
@@ -531,7 +530,7 @@ class TfCompiledModule(CompiledModule):
       saved_model_dir: str,
       saved_model_tags: Set[str],
       module_name: str,
-      backend_info: "BackendInfo",
+      backend_info: BackendInfo,
       exported_name: str,
       input_names: Sequence[str],
       output_names: Sequence[str],
@@ -781,7 +780,7 @@ class TfLiteCompiledModule(CompiledModule):
   def __init__(
       self,
       module_name: str,
-      backend_info: "BackendInfo",
+      backend_info: BackendInfo,
       compiled_paths: Dict[str, str],
       interpreters: Dict[str, tf.lite.Interpreter],
       output_names: Optional[Sequence[str]] = None,
@@ -803,7 +802,7 @@ class TfLiteCompiledModule(CompiledModule):
   @classmethod
   def create_from_class(cls,
                         module_class: Type[tf.Module],
-                        backend_info: "BackendInfo",
+                        backend_info: BackendInfo,
                         exported_names: Sequence[str] = (),
                         artifacts_dir: Optional[str] = None):
     """Compile a tf.Module subclass to the target backend in backend_info.
@@ -830,7 +829,7 @@ class TfLiteCompiledModule(CompiledModule):
       saved_model_dir: str,
       saved_model_tags: Set[str],
       module_name: str,
-      backend_info: "BackendInfo",
+      backend_info: BackendInfo,
       exported_name: str,
       input_names: Sequence[str],
       output_names: Sequence[str],
@@ -957,6 +956,6 @@ class BackendInfo:
         input_names, output_names, artifacts_dir)
 
   @classmethod
-  def get_all_backends(cls) -> Sequence["BackendInfo"]:
+  def get_all_backends(cls) -> Sequence[BackendInfo]:
     """Returns a list of all BackendInfo configurations."""
     return [BackendInfo(backend_name) for backend_name in cls._name_to_info]

--- a/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/tf_test_utils.py
@@ -13,8 +13,8 @@
 #   ref: reference – for the reference CompiledModule
 #   tar: target - for one of the target CompiledModules
 
-# TODO(#4131) python>=3.7: Use postponed type annotations.
-
+from __future__ import annotations
+from dataclasses import dataclass
 import collections
 import copy
 import itertools
@@ -105,9 +105,20 @@ def get_target_backends() -> Sequence[module_utils.BackendInfo]:
   return backends
 
 
-# TODO(#4131) python>=3.7: Consider using a (frozen) dataclass.
-Modules = collections.namedtuple("Modules",
-                                 ["ref_module", "tar_modules", "artifacts_dir"])
+@dataclass(frozen=True)
+class Modules:
+  """Compiled modules.
+
+  Args:
+    ref_module: Module compiled with the reference backend.
+    tar_modules: Sequence of modules compiled with the different target 
+      backends.
+    artifacts_dir: String pointing to where compilation artifacts were saved.
+  """
+  ref_module: module_utils.CompiledModule
+  tar_modules: Sequence[module_utils.CompiledModule]
+  artifacts_dir: str
+
 
 # We have to use a global variable to store the compiled modules so that we can
 # avoid recompilation. This is because the TestCase class resets it's entire
@@ -134,7 +145,7 @@ def compile_tf_module(module_class: Type[tf.Module],
       module_class.__name__ will be used.
 
   Returns:
-    A 'Modules' namedtuple containing the reference module, target modules and
+    A 'Modules' dataclass containing the reference module, target modules and
     artifacts directory.
   """
   global _global_modules
@@ -179,7 +190,7 @@ def compile_tf_signature_def_saved_model(
     output_names: A sequence of named outputs to extract from the saved model.
 
   Returns:
-    A 'Modules' namedtuple containing the reference module, target modules and
+    A 'Modules' dataclass containing the reference module, target modules and
     artifacts directory.
   """
   global _global_modules
@@ -231,7 +242,7 @@ class UnitTestSpec:
     self.kwargs = dict() if kwargs is None else kwargs
     self.input_generator = input_generator
 
-  def with_name(self, new_name: str) -> "UnitTestSpec":
+  def with_name(self, new_name: str) -> UnitTestSpec:
     return UnitTestSpec(new_name, self.input_signature, self.input_generator,
                         self.input_args, self.kwargs)
 

--- a/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/trace_utils.py
+++ b/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/trace_utils.py
@@ -9,8 +9,7 @@
 #   ref: reference – for the reference CompiledModule
 #   tar: target - for one of the target CompiledModules
 
-# TODO(#4131) python>=3.7: Use postponed type annotations.
-
+from __future__ import annotations
 import copy
 import glob
 import inspect
@@ -34,7 +33,7 @@ def _zfill_width(length: int) -> Union[int, None]:
   return int(np.ceil(np.log10(length))) if length else None
 
 
-def get_trace_dir(artifacts_dir: str, trace: "Trace") -> str:
+def get_trace_dir(artifacts_dir: str, trace: Trace) -> str:
   trace_dir = os.path.join(artifacts_dir, trace.backend_id, "traces",
                            trace.function_name)
   os.makedirs(trace_dir, exist_ok=True)
@@ -135,7 +134,7 @@ class ModuleCall:
         pickle.dump(value, f)
 
   @staticmethod
-  def load(call_dir: str) -> "ModuleCall":
+  def load(call_dir: str) -> ModuleCall:
     """Loads and returns a trace serialized with ModuleCall.serialize."""
     with open(os.path.join(call_dir, "metadata.pkl"), "rb") as f:
       kwargs = pickle.load(f)
@@ -160,7 +159,7 @@ class Trace:
 
   def __init__(self,
                module: Union[module_utils.CompiledModule, None],
-               function: Union[Callable[["TracedModule"], None], None],
+               function: Union[Callable[[TracedModule], None], None],
                _load_dict: Optional[Dict[str, Any]] = None):
     """Extracts metadata from module and function and initializes.
 
@@ -295,7 +294,7 @@ class Trace:
           f.writelines(compiled_path + "\n")
 
   @staticmethod
-  def load(trace_dir: str) -> "Trace":
+  def load(trace_dir: str) -> Trace:
     """Loads and returns a trace serialized with Trace.serialize.
 
     Args:

--- a/llvm-external-projects/iree-dialects/python/iree/compiler/dialects/iree_pydm/importer/util.py
+++ b/llvm-external-projects/iree-dialects/python/iree/compiler/dialects/iree_pydm/importer/util.py
@@ -4,6 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from __future__ import annotations
 from types import ModuleType
 from typing import Any, Mapping, Optional, Sequence, Union
 
@@ -190,7 +191,7 @@ class ImportStage:
       "hooks",
   ]
 
-  def __init__(self, ic: ImportContext, hooks: "ImportHooks"):
+  def __init__(self, ic: ImportContext, hooks: ImportHooks):
     self.ic = ic
     self.hooks = hooks
 
@@ -221,7 +222,7 @@ class Intrinsic:
   UNBOUND_VALUE = _UnboundValue()
 
   def resolve_static_getattr(self, stage: ImportStage,
-                             attr_name: str) -> "ResolveOutcome":
+                             attr_name: str) -> ResolveOutcome:
     return Intrinsic.UNBOUND_VALUE
 
   def emit_call(self, stage: ImportStage, args: Sequence[ir.Value],
@@ -237,7 +238,7 @@ class Intrinsic:
         f"the compiler intrinsic {self} can not be serialized as a value")
 
   @staticmethod
-  def make_singleton(cls) -> "Intrinsic":
+  def make_singleton(cls) -> Intrinsic:
     """Class decorator to instantiate a singleton intrinsic class."""
     assert issubclass(cls, Intrinsic)
     return cls()

--- a/runtime/bindings/python/iree/runtime/system_api.py
+++ b/runtime/bindings/python/iree/runtime/system_api.py
@@ -14,7 +14,7 @@ and functions.
 # pylint: disable=unused-argument
 # pylint: disable=g-explicit-length-test
 
-# TODO(#4131) python>=3.7: Use postponed type annotations.
+from __future__ import annotations
 
 __all__ = [
     "load_vm_flatbuffer",
@@ -186,7 +186,7 @@ class BoundModule:
   Resolves item access (["foo"]) as function resolution.
   """
 
-  def __init__(self, context: "SystemContext", vm_module: _binding.VmModule):
+  def __init__(self, context: SystemContext, vm_module: _binding.VmModule):
     self._context = context
     self._tracer = self._context._config.tracer
     self._vm_module = vm_module


### PR DESCRIPTION
This commit upgrades the python scripts to use the following features
supported since python 3.7:

- postponed type annotations
- `dataclass`
- `capture_output=` and `text=` in some `subprocess` functions

This closes https://github.com/google/iree/issues/4131