### PR TITLE
[vulkan] Create command pools with CREATE_RESET_COMMAND_BUFFER_BIT

### DIFF
--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -411,7 +411,8 @@ static iree_status_t iree_hal_vulkan_create_transient_command_pool(
   VkCommandPoolCreateInfo create_info;
   create_info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
   create_info.pNext = NULL;
-  create_info.flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
+  create_info.flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT |
+                      VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
   create_info.queueFamilyIndex = queue_family_index;
   VkCommandPoolHandle* command_pool = new VkCommandPoolHandle(logical_device);
   iree_status_t status = VK_RESULT_TO_STATUS(


### PR DESCRIPTION
According to ARM Mali GPU doc
https://developer.arm.com/documentation/101897/0200/cpu-overheads/command-pools-for-vulkan:

> Command pools do not automatically recycle memory from deleted command
> buffers unless created with the RESET_COMMAND_BUFFER_BIT flag. Pools
> without this flag do not recycle their memory until the application
> resets the pool.

This helps to address a memory leaking issue in `iree-benchmark-module`
where we run many repetitions/iterations of the model with the same
Vulkan device. The command pool's lifetime is associated with the
device; so it ends up we never release the resources occupied by
previous command buffers until the whole program exit.

This is not an issue for other GPUs (e.g., Adreno). However,
we will need this flag eventually anyway, given that ML workloads
does not have a clearcut frame concept where we can
`vkResetCommandPool` at the frame boundary. So we need to track
individual command buffers and reset them separately.