### PR TITLE
Adding iree_hal_driver_create_device_by_path & co.

### DIFF
--- a/experimental/rocm/rocm_driver.c
+++ b/experimental/rocm/rocm_driver.c
@@ -172,8 +172,9 @@ static iree_status_t iree_hal_rocm_driver_select_default_device(
   return status;
 }
 
-static iree_status_t iree_hal_rocm_driver_create_device(
+static iree_status_t iree_hal_rocm_driver_create_device_by_id(
     iree_hal_driver_t* base_driver, iree_hal_device_id_t device_id,
+    iree_host_size_t param_count, const iree_string_pair_t* params,
     iree_allocator_t host_allocator, iree_hal_device_t** out_device) {
   iree_hal_rocm_driver_t* driver = iree_hal_rocm_driver_cast(base_driver);
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -201,8 +202,23 @@ static iree_status_t iree_hal_rocm_driver_create_device(
   return status;
 }
 
+static iree_status_t iree_hal_rocm_driver_create_device_by_path(
+    iree_hal_driver_t* base_driver, iree_string_view_t driver_name,
+    iree_string_view_t device_path, iree_host_size_t param_count,
+    const iree_string_pair_t* params, iree_allocator_t host_allocator,
+    iree_hal_device_t** out_device) {
+  if (!iree_string_view_is_empty(device_path)) {
+    return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                            "device paths not yet implemented");
+  }
+  return iree_hal_rocm_driver_create_device_by_id(
+      base_driver, IREE_HAL_DEVICE_ID_DEFAULT, param_count, params,
+      host_allocator, out_device);
+}
+
 static const iree_hal_driver_vtable_t iree_hal_rocm_driver_vtable = {
     .destroy = iree_hal_rocm_driver_destroy,
     .query_available_devices = iree_hal_rocm_driver_query_available_devices,
-    .create_device = iree_hal_rocm_driver_create_device,
+    .create_device_by_id = iree_hal_rocm_driver_create_device_by_id,
+    .create_device_by_path = iree_hal_rocm_driver_create_device_by_path,
 };

--- a/runtime/src/iree/hal/BUILD
+++ b/runtime/src/iree/hal/BUILD
@@ -72,6 +72,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/base:core_headers",
         "//runtime/src/iree/base:tracing",
         "//runtime/src/iree/base/internal",
+        "//runtime/src/iree/base/internal:path",
         "//runtime/src/iree/base/internal:synchronization",
     ],
 )

--- a/runtime/src/iree/hal/CMakeLists.txt
+++ b/runtime/src/iree/hal/CMakeLists.txt
@@ -59,6 +59,7 @@ iree_cc_library(
     iree::base
     iree::base::core_headers
     iree::base::internal
+    iree::base::internal::path
     iree::base::internal::synchronization
     iree::base::tracing
   PUBLIC

--- a/runtime/src/iree/hal/cts/driver_test.h
+++ b/runtime/src/iree/hal/cts/driver_test.h
@@ -35,8 +35,9 @@ TEST_P(driver_test, QueryAndCreateAvailableDevices) {
                              device_infos[i].name.size)
               << "'";
     iree_hal_device_t* device = NULL;
-    IREE_ASSERT_OK(iree_hal_driver_create_device(
-        driver_, device_infos[i].device_id, iree_allocator_system(), &device));
+    IREE_ASSERT_OK(iree_hal_driver_create_device_by_id(
+        driver_, device_infos[i].device_id, /*param_count=*/0, /*params=*/NULL,
+        iree_allocator_system(), &device));
     iree_string_view_t device_id = iree_hal_device_id(device);
     std::cout << "  Created device with id: '"
               << std::string(device_id.data, device_id.size) << "'";

--- a/runtime/src/iree/hal/device.h
+++ b/runtime/src/iree/hal/device.h
@@ -32,7 +32,7 @@ extern "C" {
 // An opaque driver-specific handle to identify different devices.
 typedef uintptr_t iree_hal_device_id_t;
 
-#define IREE_HAL_DEVICE_ID_INVALID 0ull
+#define IREE_HAL_DEVICE_ID_DEFAULT 0ull
 
 // Describes features supported by a device.
 // These flags indicate the availability of features that may be enabled at the

--- a/runtime/src/iree/hal/driver_registry.h
+++ b/runtime/src/iree/hal/driver_registry.h
@@ -150,6 +150,31 @@ IREE_API_EXPORT iree_status_t iree_hal_driver_registry_try_create(
     iree_hal_driver_registry_t* registry, iree_string_view_t driver_name,
     iree_allocator_t host_allocator, iree_hal_driver_t** out_driver);
 
+// Attempts to create a device with the given `driver://path?params` URI.
+// Factories are searched in most-recently-added order such that it's possible
+// to override drivers with newer registrations when multiple factories provide
+// for the same driver name.
+//
+// The driver specifier is required in the URI but the path and params are
+// optional. The path is a driver-dependent string that identifies a particular
+// device or type of device. If the path is omitted the driver will select a
+// device based on heuristics, flags, the environment, or a die roll.
+//
+// !!!! WARNING !!!!
+// Each call to this function may create a new driver. Drivers are generally
+// very expensive to create and often taint the process for its lifetime by
+// loading shared libraries, connecting to system resources, etc. Some drivers
+// may only be able to have one instance live at a time or will fail in
+// spectacularly nasty ways if multiple instances are used simultaneously.
+// If creating multiple devices then instead create a driver once and use
+// iree_hal_driver_create_device_by_uri to create the devices.
+//
+// Thread-safe. May block the caller if the driver is delay-loaded and needs to
+// perform additional loading/verification/etc before returning.
+IREE_API_EXPORT iree_status_t iree_hal_create_device(
+    iree_hal_driver_registry_t* registry, iree_string_view_t device_uri,
+    iree_allocator_t host_allocator, iree_hal_device_t** out_device);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/runtime/src/iree/hal/drivers/cuda/cuda_driver.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_driver.c
@@ -192,8 +192,9 @@ static iree_status_t iree_hal_cuda_driver_select_default_device(
   return status;
 }
 
-static iree_status_t iree_hal_cuda_driver_create_device(
+static iree_status_t iree_hal_cuda_driver_create_device_by_id(
     iree_hal_driver_t* base_driver, iree_hal_device_id_t device_id,
+    iree_host_size_t param_count, const iree_string_pair_t* params,
     iree_allocator_t host_allocator, iree_hal_device_t** out_device) {
   iree_hal_cuda_driver_t* driver = iree_hal_cuda_driver_cast(base_driver);
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -221,8 +222,23 @@ static iree_status_t iree_hal_cuda_driver_create_device(
   return status;
 }
 
+static iree_status_t iree_hal_cuda_driver_create_device_by_path(
+    iree_hal_driver_t* base_driver, iree_string_view_t driver_name,
+    iree_string_view_t device_path, iree_host_size_t param_count,
+    const iree_string_pair_t* params, iree_allocator_t host_allocator,
+    iree_hal_device_t** out_device) {
+  if (!iree_string_view_is_empty(device_path)) {
+    return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                            "device paths not yet implemented");
+  }
+  return iree_hal_cuda_driver_create_device_by_id(
+      base_driver, IREE_HAL_DEVICE_ID_DEFAULT, param_count, params,
+      host_allocator, out_device);
+}
+
 static const iree_hal_driver_vtable_t iree_hal_cuda_driver_vtable = {
     .destroy = iree_hal_cuda_driver_destroy,
     .query_available_devices = iree_hal_cuda_driver_query_available_devices,
-    .create_device = iree_hal_cuda_driver_create_device,
+    .create_device_by_id = iree_hal_cuda_driver_create_device_by_id,
+    .create_device_by_path = iree_hal_cuda_driver_create_device_by_path,
 };

--- a/runtime/src/iree/hal/drivers/local_sync/sync_driver.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_driver.c
@@ -112,8 +112,9 @@ static iree_status_t iree_hal_sync_driver_query_available_devices(
       (void**)out_device_infos);
 }
 
-static iree_status_t iree_hal_sync_driver_create_device(
+static iree_status_t iree_hal_sync_driver_create_device_by_id(
     iree_hal_driver_t* base_driver, iree_hal_device_id_t device_id,
+    iree_host_size_t param_count, const iree_string_pair_t* params,
     iree_allocator_t host_allocator, iree_hal_device_t** out_device) {
   iree_hal_sync_driver_t* driver = iree_hal_sync_driver_cast(base_driver);
   return iree_hal_sync_device_create(
@@ -121,8 +122,23 @@ static iree_status_t iree_hal_sync_driver_create_device(
       driver->loaders, driver->device_allocator, host_allocator, out_device);
 }
 
+static iree_status_t iree_hal_sync_driver_create_device_by_path(
+    iree_hal_driver_t* base_driver, iree_string_view_t driver_name,
+    iree_string_view_t device_path, iree_host_size_t param_count,
+    const iree_string_pair_t* params, iree_allocator_t host_allocator,
+    iree_hal_device_t** out_device) {
+  if (!iree_string_view_is_empty(device_path)) {
+    return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                            "device paths not yet implemented");
+  }
+  return iree_hal_sync_driver_create_device_by_id(
+      base_driver, IREE_HAL_DEVICE_ID_DEFAULT, param_count, params,
+      host_allocator, out_device);
+}
+
 static const iree_hal_driver_vtable_t iree_hal_sync_driver_vtable = {
     .destroy = iree_hal_sync_driver_destroy,
     .query_available_devices = iree_hal_sync_driver_query_available_devices,
-    .create_device = iree_hal_sync_driver_create_device,
+    .create_device_by_id = iree_hal_sync_driver_create_device_by_id,
+    .create_device_by_path = iree_hal_sync_driver_create_device_by_path,
 };

--- a/runtime/src/iree/hal/drivers/local_task/task_driver.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_driver.c
@@ -118,8 +118,9 @@ static iree_status_t iree_hal_task_driver_query_available_devices(
       (void**)out_device_infos);
 }
 
-static iree_status_t iree_hal_task_driver_create_device(
+static iree_status_t iree_hal_task_driver_create_device_by_id(
     iree_hal_driver_t* base_driver, iree_hal_device_id_t device_id,
+    iree_host_size_t param_count, const iree_string_pair_t* params,
     iree_allocator_t host_allocator, iree_hal_device_t** out_device) {
   iree_hal_task_driver_t* driver = iree_hal_task_driver_cast(base_driver);
   return iree_hal_task_device_create(
@@ -128,8 +129,23 @@ static iree_status_t iree_hal_task_driver_create_device(
       host_allocator, out_device);
 }
 
+static iree_status_t iree_hal_task_driver_create_device_by_path(
+    iree_hal_driver_t* base_driver, iree_string_view_t driver_name,
+    iree_string_view_t device_path, iree_host_size_t param_count,
+    const iree_string_pair_t* params, iree_allocator_t host_allocator,
+    iree_hal_device_t** out_device) {
+  if (!iree_string_view_is_empty(device_path)) {
+    return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                            "device paths not yet implemented");
+  }
+  return iree_hal_task_driver_create_device_by_id(
+      base_driver, IREE_HAL_DEVICE_ID_DEFAULT, param_count, params,
+      host_allocator, out_device);
+}
+
 static const iree_hal_driver_vtable_t iree_hal_task_driver_vtable = {
     .destroy = iree_hal_task_driver_destroy,
     .query_available_devices = iree_hal_task_driver_query_available_devices,
-    .create_device = iree_hal_task_driver_create_device,
+    .create_device_by_id = iree_hal_task_driver_create_device_by_id,
+    .create_device_by_path = iree_hal_task_driver_create_device_by_path,
 };

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_driver.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_driver.cc
@@ -437,8 +437,9 @@ static iree_status_t iree_hal_vulkan_driver_select_default_device(
   return status;
 }
 
-static iree_status_t iree_hal_vulkan_driver_create_device(
+static iree_status_t iree_hal_vulkan_driver_create_device_by_id(
     iree_hal_driver_t* base_driver, iree_hal_device_id_t device_id,
+    iree_host_size_t param_count, const iree_string_pair_t* params,
     iree_allocator_t host_allocator, iree_hal_device_t** out_device) {
   iree_hal_vulkan_driver_t* driver = iree_hal_vulkan_driver_cast(base_driver);
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -478,11 +479,26 @@ static iree_status_t iree_hal_vulkan_driver_create_device(
   return status;
 }
 
+static iree_status_t iree_hal_vulkan_driver_create_device_by_path(
+    iree_hal_driver_t* base_driver, iree_string_view_t driver_name,
+    iree_string_view_t device_path, iree_host_size_t param_count,
+    const iree_string_pair_t* params, iree_allocator_t host_allocator,
+    iree_hal_device_t** out_device) {
+  if (!iree_string_view_is_empty(device_path)) {
+    return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                            "device paths not yet implemented");
+  }
+  return iree_hal_vulkan_driver_create_device_by_id(
+      base_driver, IREE_HAL_DEVICE_ID_DEFAULT, param_count, params,
+      host_allocator, out_device);
+}
+
 namespace {
 const iree_hal_driver_vtable_t iree_hal_vulkan_driver_vtable = {
     /*.destroy=*/iree_hal_vulkan_driver_destroy,
     /*.query_available_devices=*/
     iree_hal_vulkan_driver_query_available_devices,
-    /*.create_device=*/iree_hal_vulkan_driver_create_device,
+    /*.create_device_by_id=*/iree_hal_vulkan_driver_create_device_by_id,
+    /*.create_device_by_path=*/iree_hal_vulkan_driver_create_device_by_path,
 };
 }  // namespace

--- a/runtime/src/iree/tools/utils/vm_util.cc
+++ b/runtime/src/iree/tools/utils/vm_util.cc
@@ -237,19 +237,4 @@ Status PrintVariantList(iree_vm_list_t* variant_list, size_t max_element_count,
   return OkStatus();
 }
 
-Status CreateDevice(const char* driver_name, iree_hal_device_t** out_device) {
-  IREE_LOG(INFO) << "Creating driver and device for '" << driver_name << "'...";
-  iree_hal_driver_t* driver = nullptr;
-  IREE_RETURN_IF_ERROR(
-      iree_hal_driver_registry_try_create(iree_hal_driver_registry_default(),
-                                          iree_make_cstring_view(driver_name),
-                                          iree_allocator_system(), &driver),
-      "creating driver '%s'", driver_name);
-  IREE_RETURN_IF_ERROR(iree_hal_driver_create_default_device(
-                           driver, iree_allocator_system(), out_device),
-                       "creating default device for driver '%s'", driver_name);
-  iree_hal_driver_release(driver);
-  return OkStatus();
-}
-
 }  // namespace iree

--- a/runtime/src/iree/tools/utils/vm_util.h
+++ b/runtime/src/iree/tools/utils/vm_util.h
@@ -52,10 +52,6 @@ inline Status PrintVariantList(iree_vm_list_t* variant_list,
   return PrintVariantList(variant_list, max_element_count, &std::cout);
 }
 
-// Creates the default device for |driver| in |out_device|.
-// The returned |out_device| must be released by the caller.
-Status CreateDevice(const char* driver_name, iree_hal_device_t** out_device);
-
 }  // namespace iree
 
 #endif  // IREE_TOOLS_UTILS_VM_UTIL_H_

--- a/runtime/src/iree/tools/utils/vm_util_test.cc
+++ b/runtime/src/iree/tools/utils/vm_util_test.cc
@@ -27,7 +27,9 @@ class VmUtilTest : public ::testing::Test {
 
   virtual void SetUp() {
     IREE_ASSERT_OK(iree_hal_module_register_types());
-    IREE_ASSERT_OK(CreateDevice("local-sync", &device_));
+    IREE_ASSERT_OK(iree_hal_create_device(iree_hal_driver_registry_default(),
+                                          IREE_SV("local-sync"),
+                                          iree_allocator_system(), &device_));
     allocator_ = iree_hal_device_allocator(device_);
   }
 

--- a/tools/android/run_module_app/src/main.cc
+++ b/tools/android/run_module_app/src/main.cc
@@ -102,7 +102,10 @@ Status RunModule(const IreeModuleInvocation& invocation) {
       iree_allocator_null(), iree_allocator_system(), &input_module));
 
   iree_hal_device_t* device = nullptr;
-  IREE_RETURN_IF_ERROR(CreateDevice(invocation.driver.c_str(), &device));
+  IREE_RETURN_IF_ERROR(iree_hal_create_device(
+      iree_hal_driver_registry_default(),
+      iree_make_string_view(invocation.driver.data(), invocation.driver.size()),
+      iree_allocator_system(), &device));
   iree_vm_module_t* hal_module = nullptr;
   IREE_RETURN_IF_ERROR(
       iree_hal_module_create(device, iree_allocator_system(), &hal_module));

--- a/tools/iree-benchmark-module-main.cc
+++ b/tools/iree-benchmark-module-main.cc
@@ -315,7 +315,9 @@ class IREEBenchmark {
         iree_vm_instance_create(iree_allocator_system(), &instance_));
 
     // Create IREE's device and module.
-    IREE_RETURN_IF_ERROR(iree::CreateDevice(FLAG_driver, &device_));
+    IREE_RETURN_IF_ERROR(iree_hal_create_device(
+        iree_hal_driver_registry_default(), IREE_SV(FLAG_driver),
+        iree_allocator_system(), &device_));
     IREE_RETURN_IF_ERROR(
         iree_hal_module_create(device_, iree_allocator_system(), &hal_module_));
     IREE_RETURN_IF_ERROR(iree_vm_bytecode_module_create(

--- a/tools/iree-check-module-main.cc
+++ b/tools/iree-check-module-main.cc
@@ -113,7 +113,9 @@ iree_status_t Run(std::string module_file_path, int* out_exit_code) {
       iree_allocator_system(), &input_module));
 
   iree_hal_device_t* device = nullptr;
-  IREE_RETURN_IF_ERROR(CreateDevice(FLAG_driver, &device));
+  IREE_RETURN_IF_ERROR(iree_hal_create_device(
+      iree_hal_driver_registry_default(), IREE_SV(FLAG_driver),
+      iree_allocator_system(), &device));
   iree_vm_module_t* hal_module = nullptr;
   IREE_RETURN_IF_ERROR(
       iree_hal_module_create(device, iree_allocator_system(), &hal_module));

--- a/tools/iree-run-mlir-main.cc
+++ b/tools/iree-run-mlir-main.cc
@@ -349,7 +349,10 @@ Status EvaluateFunctions(iree_vm_instance_t* instance,
   }
 
   iree_hal_device_t* device = nullptr;
-  IREE_RETURN_IF_ERROR(CreateDevice(driver_name.c_str(), &device));
+  IREE_RETURN_IF_ERROR(iree_hal_create_device(
+      iree_hal_driver_registry_default(),
+      iree_make_string_view(driver_name.data(), driver_name.size()),
+      iree_allocator_system(), &device));
   iree_vm_module_t* hal_module = nullptr;
   IREE_RETURN_IF_ERROR(
       iree_hal_module_create(device, iree_allocator_system(), &hal_module));

--- a/tools/iree-run-module-main.cc
+++ b/tools/iree-run-module-main.cc
@@ -111,7 +111,9 @@ iree_status_t Run() {
       iree_allocator_system(), &input_module));
 
   iree_hal_device_t* device = nullptr;
-  IREE_RETURN_IF_ERROR(CreateDevice(FLAG_driver, &device));
+  IREE_RETURN_IF_ERROR(iree_hal_create_device(
+      iree_hal_driver_registry_default(), IREE_SV(FLAG_driver),
+      iree_allocator_system(), &device));
   iree_vm_module_t* hal_module = nullptr;
   IREE_RETURN_IF_ERROR(
       iree_hal_module_create(device, iree_allocator_system(), &hal_module));


### PR DESCRIPTION
This adds the plumbing for creating devices by path specs in addition
to creating them by driver-specific IDs. A helper was also added to
create by ordinal to simplify tools that want to expose devices in a
canonical form with other driver-specific tools.

The creation methods also gain the ability to pass in key-value pair
parameters. Drivers can now use these parameters to refine device
selection and configure the devices during creation. The entire driver
layer is optional so the extra string handling here is only in cases that
desire it, and for devices that have no properties (like local-sync) it
doesn't add a cost.

A helper that parses a canonical device URI into the components for
create_device_by_path was added as iree_hal_driver_create_device_by_uri
and should be used by most hosting applications. For tooling and other
one-shot situations an even more convienient iree_hal_create_device is
added as an easy way to create devices with a massive footgun attached.
This may explode when using multiple devices or recreating devices; the
solution there is for the hosting application to create and cache the
drivers it wants to ensure remain around.

Progress on #9343.