### PR TITLE
Update docs in samples/vision_inference.

### DIFF
--- a/samples/vision_inference/README.md
+++ b/samples/vision_inference/README.md
@@ -3,6 +3,15 @@
 This sample demonstrates how to run a MNIST handwritten digit detection vision
 model on an image using IREE's command line tools.
 
+A similar sample is implemented in C code over in the iree-samples repository
+at https://github.com/google/iree-samples/tree/main/cpp/vision_inference
+
+* This version of the sample uses a Python script to convert an image into the
+  expected format then runs the compiled MNIST program through IREE's command
+  line tools
+* The other version uses a C library to decode and pre-process an image then
+  uses IREE's C API to load the compiled program and run it on the image
+
 ## Instructions
 
 From this directory:
@@ -16,11 +25,12 @@ iree-compile \
     -o /tmp/mnist_cpu.vmfb
 
 # Convert the test image to the 1x28x28x1xf32 buffer format the program expects.
-cat mnist_test.png | python3 convert_to_float_grayscale.py > /tmp/mnist_test.bin
+cat mnist_test.png | python3 convert_image.py > /tmp/mnist_test.bin
 
 # Run the program, passing the path to the binary file as a function input.
 iree-run-module \
-  /tmp/mnist_test.bin \
+  --module_file=/tmp/mnist_cpu.bin \
+  --entry_point=predict \
   --function_input=1x28x28x1xf32=@/tmp/mnist_test.bin
 
 # Observe the results - a list of prediction confidence scores for each digit.

--- a/samples/vision_inference/convert_image.py
+++ b/samples/vision_inference/convert_image.py
@@ -6,14 +6,20 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+# This script converts an image into a 28x28 grayscale f32 buffer.
+# Usage:
+#   cat image.png | python3 convert_image.py > converted_image.bin
+
 import sys
 from PIL import Image
 import numpy as np
 
 # Read image from stdin (in any format supported by PIL).
 with Image.open(sys.stdin.buffer) as color_img:
+  # Resize to 28x28, matching what the program expects.
+  resized_color_img = color_img.resize((28, 28))
   # Convert to grayscale.
-  grayscale_img = color_img.convert('L')
+  grayscale_img = resized_color_img.convert('L')
   # Rescale to a float32 in range [0.0, 1.0].
   grayscale_arr = np.array(grayscale_img)
   grayscale_arr_f32 = grayscale_arr.astype(np.float32) / 255.0


### PR DESCRIPTION
* Mention the C sample in the iree-samples repo
* Fix test commands :P
* Resize to 28x28 in python script, rename to just `convert_image.py`

Part of https://github.com/google/iree/issues/9374