### PR TITLE
Using -fmacro-prefix-map to clean up __FILE__ macros.

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -72,10 +72,12 @@ set(IREE_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 iree_select_compiler_opts(IREE_DEFAULT_COPTS
   CLANG_OR_GCC
     "-fvisibility=hidden"
+
     # NOTE: The RTTI setting must match what LLVM was compiled with (defaults
     # to RTTI disabled).
     "$<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>"
     "$<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions>"
+
   MSVC_OR_CLANG_CL
     # Exclude a bunch of rarely-used APIs, such as crypto/DDE/shell.
     # https://docs.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers
@@ -278,6 +280,22 @@ if(IREE_DEV_MODE)
       "-Wno-error=unused-variable"
   )
 endif()
+
+# Debug information and __FILE__ macros get expanded with full paths by default.
+# This results in binaries that differ based on what directories they are built
+# from and that's annoying.
+#
+# For now in all configurations we make __FILE__ macros relative. We could also
+# make debug information relative using -fdebug-prefix-map but deterministic
+# builds are most interesting in release modes that have debug info stripped.
+get_filename_component(_IREE_ROOT_NAME ${IREE_ROOT_DIR} NAME)
+iree_select_compiler_opts(IREE_DEFAULT_COPTS
+  # TODO(benvanik): make this CLANG_OR_GCC once clang-9 is no longer supported.
+  CLANG_GTE_10
+    "-fmacro-prefix-map=${IREE_ROOT_DIR}=${_IREE_ROOT_NAME}"
+  GCC
+    "-fmacro-prefix-map=${IREE_ROOT_DIR}=${_IREE_ROOT_NAME}"
+)
 
 # On MSVC, CMake sets /GR by default (enabling RTTI), but we set /GR-
 # (disabling it) above. To avoid Command line warning D9025 which warns about

--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -182,7 +182,7 @@ function(iree_select_compiler_opts OPTS)
     _IREE_SELECTS
     ""
     ""
-    "ALL;CLANG;CLANG_CL;MSVC;GCC;CLANG_OR_GCC;MSVC_OR_CLANG_CL"
+    "ALL;CLANG;CLANG_GTE_10;CLANG_CL;MSVC;GCC;CLANG_OR_GCC;MSVC_OR_CLANG_CL"
   )
   # OPTS is a variable containing the *name* of the variable being populated, so
   # we need to dereference it twice.
@@ -197,6 +197,9 @@ function(iree_select_compiler_opts OPTS)
       list(APPEND _OPTS ${_IREE_SELECTS_MSVC_OR_CLANG_CL})
     else()
       list(APPEND _OPTS ${_IREE_SELECTS_CLANG})
+      if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+        list(APPEND _OPTS ${_IREE_SELECTS_CLANG_GTE_10})
+      endif()
       list(APPEND _OPTS ${_IREE_SELECTS_CLANG_OR_GCC})
     endif()
   elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")

--- a/runtime/src/iree/base/internal/flags.c
+++ b/runtime/src/iree/base/internal/flags.c
@@ -538,7 +538,9 @@ IREE_FLAG_CALLBACK(iree_flags_parse_flagfile, iree_flags_print_flagfile, NULL,
                    "Parses a newline-separated list of flags from a file.\n"
                    "Flags are parsed at the point where the flagfile is "
                    "specified\nand following flags may override the parsed "
-                   "values.");
+                   "values.\nNOTE: this --help output is a flagfile! Pipe "
+                   "this to a file, tweak the\noptions from their defaults, "
+                   "and pass it back in using --flagfile=.");
 
 #endif  // IREE_FLAGS_ENABLE_FLAG_FILE
 


### PR DESCRIPTION
The full file path is substituted for just the basename of the checkout.

Before:
```
# Flags in /mnt/d/Dev/iree/tools/iree-run-module-main.cc
```
Now:
```
# Flags in iree/tools/iree-run-module-main.cc:30
```

(if my repo was in iree-foo, that'd be iree-foo/tools/...)

This helps to make the build more deterministic when iree_status_t,
flags, or logging are used.