### PR TITLE
Adding an optional workgroup count region to flow.dispatch.workgroups.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -80,7 +80,10 @@ def FLOW_DispatchWorkgroupsOp : FLOW_PureOp<"dispatch.workgroups", [
     Variadic<AnyType>:$results
   );
 
-  let regions = (region AnyRegion:$workgroup_body);
+  let regions = (region
+    AnyRegion:$workgroup_body,
+    AnyRegion:$workgroup_count
+  );
 
   let assemblyFormat = [{
     (`[` $workload^ `]`)? ``
@@ -94,6 +97,7 @@ def FLOW_DispatchWorkgroupsOp : FLOW_PureOp<"dispatch.workgroups", [
     custom<DispatchWorkgroupBody>(ref(type($operands)),
                                   ref(type($results)),
                                   $workgroup_body)
+    `` custom<DispatchWorkgroupsCountRegion>($workgroup_count)
   }];
 
   let skipDefaultBuilders = 1;

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
@@ -137,6 +137,11 @@ static LogicalResult outlineDispatchWorkgroupsOp(
       regionOp.getLoc(), workgroupFuncOp.getName(),
       SymbolRefAttr::get(workgroupFuncOp));
 
+  // Move over the workgroup count region, if present.
+  if (!regionOp.workgroup_count().empty()) {
+    exportOp.workgroup_count().takeBody(regionOp.workgroup_count());
+  }
+
   // Finally convert the dispatch region into a dispatch to the outlined func.
   return convertToDispatchOp(regionOp, executableOp, exportOp);
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/outline_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/outline_dispatch_regions.mlir
@@ -154,3 +154,19 @@ func.func @dynamicShapeDispatch(%arg0 : tensor<7x?x24x?xf32>) -> tensor<?x?x1024
   // CHECK-NEXT: return %[[RET0]]
   return %ret0 : tensor<?x?x1024xf32>
 }
+
+// -----
+
+// CHECK-LABEL: func.func @dispatchWithCountRegion
+func.func @dispatchWithCountRegion(%arg0: tensor<4xi32>) -> tensor<4xi32> {
+  %x = arith.constant 100 : index
+  %y = arith.constant 50 : index
+  %0 = flow.dispatch.workgroups[%x, %y](%arg0) : (tensor<4xi32>) -> %arg0 =
+      (%arg0_capture: !flow.dispatch.tensor<readwrite:4xi32>) {
+    flow.return
+  } count(%x_capture: index, %y_capture: index) -> (index, index, index) {
+    %z = arith.constant 1 : index
+    flow.return %x_capture, %y_capture, %z : index, index, index
+  }
+  return %0 : tensor<4xi32>
+}


### PR DESCRIPTION
This completes the plumbing as the region is already supported after
outlining.

I hate the syntax, but until we settle on where distribution happens
and potentially split the op into distributed/non-distributed variants
(like the old flow.dispatch.region we had) this will suffice.