### PR TITLE
Demo running on self-hosted runners

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -24,37 +24,37 @@ on:
 
 jobs:
   build_core:
-    name: "${{ matrix.os }} :: Build ${{ matrix.build_package }} Package"
-    runs-on: ${{ matrix.os }}
+    name: "${{ matrix.build_family }} :: Build ${{ matrix.build_package }} Package"
+    runs-on: ${{ matrix.runner }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         include:
           # Ubuntu packages.
-          - os: ubuntu-20.04
+          - runner: [self-hosted, cpu]
             build_family: linux
             build_package: main-dist-linux
             experimental: false
-          - os: ubuntu-20.04
+          - runner: [self-hosted, cpu]
             build_family: linux
             build_package: py-compiler-pkg
             experimental: false
-          - os: ubuntu-20.04
+          - runner: [self-hosted, cpu]
             build_family: linux
             build_package: py-runtime-pkg
             experimental: false
-          - os: ubuntu-20.04
+          - runner: [self-hosted, cpu]
             build_family: linux
             build_package: py-tf-compiler-tools-pkg
             experimental: false
 
           # Macos packages.
-          - os: macos-latest
+          - runner: macos-11
             build_family: macos
             build_package: py-compiler-pkg
             experimental: true
-          - os: macos-latest
+          - runner: macos-11
             build_family: macos
             build_package: py-runtime-pkg
             experimental: true
@@ -196,6 +196,7 @@ jobs:
     name: "Invoke workflow to validate and publish release"
     needs: build_core
     runs-on: ubuntu-20.04
+    if: github.event.inputs.release_id != ''
     steps:
       - name: "Invoke workflow :: Validate and Publish Release"
         uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7  # v1


### PR DESCRIPTION
We have a single manually-constructed runner with all the CPU.

I expect this won't work the first time. I think I can test it with a
workflow dispatch running it on this PR without a release ID (now that
I've made the publish step conditional on there being a release ID),
but would like to double check first.