### PR TITLE
Add BUILD file for vm/test/emitc and samples/emitc_modules

### DIFF
--- a/build_tools/bazel/iree_c_module.bzl
+++ b/build_tools/bazel/iree_c_module.bzl
@@ -1,0 +1,70 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Rules for compiling IREEi C modules."""
+
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_library")
+
+def iree_c_module(
+        name,
+        src,
+        h_file_output,
+        flags = [
+          "--compile-mode=vm",
+          "--output-format=vm-c",
+        ],
+        deps = [
+          "//runtime/src/iree/vm",
+          "//runtime/src/iree/vm:ops",
+          "//runtime/src/iree/vm:ops_emitc",
+          "//runtime/src/iree/vm:shims_emitc",
+        ],
+        # TODO: Rename this to 'compile_tool'
+        translate_tool = "//tools:iree-compile",
+        **kwargs):
+    """Builds an IREE C module.
+
+    Args:
+        name: Name of the target
+        src: mlir source file to be compiled to an IREE module.
+        h_file_output: The H header file to output.
+        flags: additional flags to pass to the compiler. Bytecode
+            translation and backend flags are passed automatically.
+        deps: Optional. Dependencies to add to the generated library.
+        translate_tool: the compiler to use to generate the module.
+            Defaults to iree-compile.
+        **kwargs: any additional attributes to pass to the underlying rules.
+    """
+
+    native.genrule(
+        name = name + "_gen",
+        srcs = [src],
+        outs = [h_file_output],
+        cmd = " && ".join([
+            " ".join([
+                "$(location %s)" % (translate_tool),
+                " ".join(flags),
+                "-o $(location %s)" % (h_file_output),
+                "$(location %s)" % (src),
+            ]),
+        ]),
+        tools = [translate_tool],
+        message = "Generating C module  %s..." % (name),
+        output_to_bindir = 1,
+        **kwargs
+    )
+    iree_runtime_cc_library(
+      name = name,
+      hdrs = [h_file_output],
+      srcs = ["//runtime/src/iree/vm:module_impl_emitc.c", h_file_output],
+      copts = [
+        "-DEMITC_IMPLEMENTATION='\"$(location %s)\"'" % h_file_output,
+      ],
+      deps = deps,
+      **kwargs
+    )
+
+

--- a/build_tools/bazel/iree_c_module.bzl
+++ b/build_tools/bazel/iree_c_module.bzl
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-"""Rules for compiling IREEi C modules."""
+"""Rules for compiling IREE C modules."""
 
 load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_library")
 
@@ -12,18 +12,14 @@ def iree_c_module(
         name,
         src,
         h_file_output,
-        flags = [
-          "--compile-mode=vm",
-          "--output-format=vm-c",
-        ],
+        flags,
         deps = [
-          "//runtime/src/iree/vm",
-          "//runtime/src/iree/vm:ops",
-          "//runtime/src/iree/vm:ops_emitc",
-          "//runtime/src/iree/vm:shims_emitc",
+            "//runtime/src/iree/vm",
+            "//runtime/src/iree/vm:ops",
+            "//runtime/src/iree/vm:ops_emitc",
+            "//runtime/src/iree/vm:shims_emitc",
         ],
-        # TODO: Rename this to 'compile_tool'
-        translate_tool = "//tools:iree-compile",
+        compile_tool = "//tools:iree-compile",
         **kwargs):
     """Builds an IREE C module.
 
@@ -31,10 +27,9 @@ def iree_c_module(
         name: Name of the target
         src: mlir source file to be compiled to an IREE module.
         h_file_output: The H header file to output.
-        flags: additional flags to pass to the compiler. Bytecode
-            translation and backend flags are passed automatically.
+        flags: flags to pass to the compile tool.
         deps: Optional. Dependencies to add to the generated library.
-        translate_tool: the compiler to use to generate the module.
+        compile_tool: the compiler to use to generate the module.
             Defaults to iree-compile.
         **kwargs: any additional attributes to pass to the underlying rules.
     """
@@ -45,26 +40,24 @@ def iree_c_module(
         outs = [h_file_output],
         cmd = " && ".join([
             " ".join([
-                "$(location %s)" % (translate_tool),
+                "$(location %s)" % (compile_tool),
                 " ".join(flags),
                 "-o $(location %s)" % (h_file_output),
                 "$(location %s)" % (src),
             ]),
         ]),
-        tools = [translate_tool],
+        tools = [compile_tool],
         message = "Generating C module  %s..." % (name),
         output_to_bindir = 1,
         **kwargs
     )
     iree_runtime_cc_library(
-      name = name,
-      hdrs = [h_file_output],
-      srcs = ["//runtime/src/iree/vm:module_impl_emitc.c", h_file_output],
-      copts = [
-        "-DEMITC_IMPLEMENTATION='\"$(location %s)\"'" % h_file_output,
-      ],
-      deps = deps,
-      **kwargs
+        name = name,
+        hdrs = [h_file_output],
+        srcs = ["//runtime/src/iree/vm:module_impl_emitc.c", h_file_output],
+        copts = [
+            "-DEMITC_IMPLEMENTATION='\"$(location %s)\"'" % h_file_output,
+        ],
+        deps = deps,
+        **kwargs
     )
-
-

--- a/runtime/src/iree/vm/BUILD
+++ b/runtime/src/iree/vm/BUILD
@@ -334,3 +334,5 @@ iree_runtime_cc_library(
         "//runtime/src/iree/base:core_headers",
     ],
 )
+
+exports_files(["module_impl_emitc.c"])

--- a/runtime/src/iree/vm/test/emitc/BUILD
+++ b/runtime/src/iree/vm/test/emitc/BUILD
@@ -1,0 +1,198 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_cmake_extra_content", "iree_runtime_cc_library", "iree_runtime_cc_test")
+load("//build_tools/bazel:iree_c_module.bzl", "iree_c_module")
+
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+iree_cmake_extra_content(
+    content = """
+if(NOT IREE_BUILD_COMPILER OR NOT IREE_BUILD_TESTS OR NOT IREE_ENABLE_EMITC)
+  return()
+endif()
+""",
+    inline = True,
+)
+
+iree_runtime_cc_test(
+  name = "module_test",
+  srcs = ["module_test.cc"],
+  deps = [
+    "//runtime/src/iree/base:cc",
+    "//runtime/src/iree/base:logging",
+    "//runtime/src/iree/testing:gtest",
+    "//runtime/src/iree/testing:gtest_main",
+    "//runtime/src/iree/vm",
+    "//runtime/src/iree/vm:ops",
+    "//runtime/src/iree/vm:ops_emitc",
+    "//runtime/src/iree/vm:shims_emitc",
+    ":arithmetic_ops",
+    ":arithmetic_ops_f32",
+    ":arithmetic_ops_i64",
+    ":assignment_ops",
+    ":assignment_ops_f32",
+    ":assignment_ops_i64",
+    ":buffer_ops",
+    ":call_ops",
+    ":comparison_ops",
+    ":comparison_ops_f32",
+    ":comparison_ops_i64",
+    ":control_flow_ops",
+    ":conversion_ops",
+    ":conversion_ops_f32",
+    ":conversion_ops_i64",
+    ":global_ops",
+    ":global_ops_f32",
+    ":global_ops_i64",
+    ":list_ops",
+    ":list_variant_ops",
+    ":ref_ops",
+    ":shift_ops",
+    ":shift_ops_i64",
+  ],
+)
+
+iree_c_module(
+  name = "arithmetic_ops",
+  src = "//runtime/src/iree/vm/test:arithmetic_ops.mlir",
+  h_file_output = "arithmetic_ops.h",
+)
+
+iree_c_module(
+  name = "arithmetic_ops_f32",
+  src = "//runtime/src/iree/vm/test:arithmetic_ops_f32.mlir",
+  h_file_output = "arithmetic_ops_f32.h",
+)
+
+iree_c_module(
+  name = "arithmetic_ops_i64",
+  src = "//runtime/src/iree/vm/test:arithmetic_ops_i64.mlir",
+  h_file_output = "arithmetic_ops_i64.h",
+)
+
+iree_c_module(
+  name = "assignment_ops",
+  src = "//runtime/src/iree/vm/test:assignment_ops.mlir",
+  h_file_output = "assignment_ops.h",
+)
+
+iree_c_module(
+  name = "assignment_ops_f32",
+  src = "//runtime/src/iree/vm/test:assignment_ops_f32.mlir",
+  h_file_output = "assignment_ops_f32.h",
+)
+
+iree_c_module(
+  name = "assignment_ops_i64",
+  src = "//runtime/src/iree/vm/test:assignment_ops_i64.mlir",
+  h_file_output = "assignment_ops_i64.h",
+)
+iree_c_module(
+  name = "buffer_ops",
+  src = "//runtime/src/iree/vm/test:buffer_ops.mlir",
+  h_file_output = "buffer_ops.h",
+)
+
+iree_c_module(
+  name = "call_ops",
+  src = "//runtime/src/iree/vm/test:call_ops.mlir",
+  h_file_output = "call_ops.h",
+)
+
+iree_c_module(
+  name = "comparison_ops",
+  src = "//runtime/src/iree/vm/test:comparison_ops.mlir",
+  h_file_output = "comparison_ops.h",
+)
+
+iree_c_module(
+  name = "comparison_ops_f32",
+  src = "//runtime/src/iree/vm/test:comparison_ops_f32.mlir",
+  h_file_output = "comparison_ops_f32.h",
+)
+
+iree_c_module(
+  name = "comparison_ops_i64",
+  src = "//runtime/src/iree/vm/test:comparison_ops_i64.mlir",
+  h_file_output = "comparison_ops_i64.h",
+)
+
+iree_c_module(
+  name = "control_flow_ops",
+  src = "//runtime/src/iree/vm/test:control_flow_ops.mlir",
+  h_file_output = "control_flow_ops.h",
+)
+
+iree_c_module(
+  name = "conversion_ops",
+  src = "//runtime/src/iree/vm/test:conversion_ops.mlir",
+  h_file_output = "conversion_ops.h",
+)
+
+iree_c_module(
+  name = "conversion_ops_f32",
+  src = "//runtime/src/iree/vm/test:conversion_ops_f32.mlir",
+  h_file_output = "conversion_ops_f32.h",
+)
+
+iree_c_module(
+  name = "conversion_ops_i64",
+  src = "//runtime/src/iree/vm/test:conversion_ops_i64.mlir",
+  h_file_output = "conversion_ops_i64.h",
+)
+
+iree_c_module(
+  name = "global_ops",
+  src = "//runtime/src/iree/vm/test:global_ops.mlir",
+  h_file_output = "global_ops.h",
+)
+
+iree_c_module(
+  name = "global_ops_f32",
+  src = "//runtime/src/iree/vm/test:global_ops_f32.mlir",
+  h_file_output = "global_ops_f32.h",
+)
+
+iree_c_module(
+  name = "global_ops_i64",
+  src = "//runtime/src/iree/vm/test:global_ops_i64.mlir",
+  h_file_output = "global_ops_i64.h",
+)
+
+iree_c_module(
+  name = "list_ops",
+  src = "//runtime/src/iree/vm/test:list_ops.mlir",
+  h_file_output = "list_ops.h",
+)
+
+iree_c_module(
+  name = "list_variant_ops",
+  src = "//runtime/src/iree/vm/test:list_variant_ops.mlir",
+  h_file_output = "list_variant_ops.h",
+)
+
+iree_c_module(
+  name = "ref_ops",
+  src = "//runtime/src/iree/vm/test:ref_ops.mlir",
+  h_file_output = "ref_ops.h",
+)
+
+iree_c_module(
+  name = "shift_ops",
+  src = "//runtime/src/iree/vm/test:shift_ops.mlir",
+  h_file_output = "shift_ops.h",
+)
+
+iree_c_module(
+  name = "shift_ops_i64",
+  src = "//runtime/src/iree/vm/test:shift_ops_i64.mlir",
+  h_file_output = "shift_ops_i64.h",
+)

--- a/runtime/src/iree/vm/test/emitc/BUILD
+++ b/runtime/src/iree/vm/test/emitc/BUILD
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("//build_tools/bazel:build_defs.oss.bzl", "iree_cmake_extra_content", "iree_runtime_cc_library", "iree_runtime_cc_test")
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_library", "iree_runtime_cc_test")
 load("//build_tools/bazel:iree_c_module.bzl", "iree_c_module")
 
 package(
@@ -13,186 +13,270 @@ package(
     licenses = ["notice"],  # Apache 2.0
 )
 
-iree_cmake_extra_content(
-    content = """
-if(NOT IREE_BUILD_COMPILER OR NOT IREE_BUILD_TESTS OR NOT IREE_ENABLE_EMITC)
-  return()
-endif()
-""",
-    inline = True,
-)
-
 iree_runtime_cc_test(
-  name = "module_test",
-  srcs = ["module_test.cc"],
-  deps = [
-    "//runtime/src/iree/base:cc",
-    "//runtime/src/iree/base:logging",
-    "//runtime/src/iree/testing:gtest",
-    "//runtime/src/iree/testing:gtest_main",
-    "//runtime/src/iree/vm",
-    "//runtime/src/iree/vm:ops",
-    "//runtime/src/iree/vm:ops_emitc",
-    "//runtime/src/iree/vm:shims_emitc",
-    ":arithmetic_ops",
-    ":arithmetic_ops_f32",
-    ":arithmetic_ops_i64",
-    ":assignment_ops",
-    ":assignment_ops_f32",
-    ":assignment_ops_i64",
-    ":buffer_ops",
-    ":call_ops",
-    ":comparison_ops",
-    ":comparison_ops_f32",
-    ":comparison_ops_i64",
-    ":control_flow_ops",
-    ":conversion_ops",
-    ":conversion_ops_f32",
-    ":conversion_ops_i64",
-    ":global_ops",
-    ":global_ops_f32",
-    ":global_ops_i64",
-    ":list_ops",
-    ":list_variant_ops",
-    ":ref_ops",
-    ":shift_ops",
-    ":shift_ops_i64",
-  ],
+    name = "module_test",
+    srcs = ["module_test.cc"],
+    deps = [
+        ":arithmetic_ops",
+        ":arithmetic_ops_f32",
+        ":arithmetic_ops_i64",
+        ":assignment_ops",
+        ":assignment_ops_f32",
+        ":assignment_ops_i64",
+        ":buffer_ops",
+        ":call_ops",
+        ":comparison_ops",
+        ":comparison_ops_f32",
+        ":comparison_ops_i64",
+        ":control_flow_ops",
+        ":conversion_ops",
+        ":conversion_ops_f32",
+        ":conversion_ops_i64",
+        ":global_ops",
+        ":global_ops_f32",
+        ":global_ops_i64",
+        ":list_ops",
+        ":list_variant_ops",
+        ":ref_ops",
+        ":shift_ops",
+        ":shift_ops_i64",
+        "//runtime/src/iree/base:cc",
+        "//runtime/src/iree/base:logging",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+        "//runtime/src/iree/vm",
+        "//runtime/src/iree/vm:ops",
+        "//runtime/src/iree/vm:ops_emitc",
+        "//runtime/src/iree/vm:shims_emitc",
+    ],
 )
 
 iree_c_module(
-  name = "arithmetic_ops",
-  src = "//runtime/src/iree/vm/test:arithmetic_ops.mlir",
-  h_file_output = "arithmetic_ops.h",
+    name = "arithmetic_ops",
+    src = "//runtime/src/iree/vm/test:arithmetic_ops.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "arithmetic_ops.h",
 )
 
 iree_c_module(
-  name = "arithmetic_ops_f32",
-  src = "//runtime/src/iree/vm/test:arithmetic_ops_f32.mlir",
-  h_file_output = "arithmetic_ops_f32.h",
+    name = "arithmetic_ops_f32",
+    src = "//runtime/src/iree/vm/test:arithmetic_ops_f32.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "arithmetic_ops_f32.h",
 )
 
 iree_c_module(
-  name = "arithmetic_ops_i64",
-  src = "//runtime/src/iree/vm/test:arithmetic_ops_i64.mlir",
-  h_file_output = "arithmetic_ops_i64.h",
+    name = "arithmetic_ops_i64",
+    src = "//runtime/src/iree/vm/test:arithmetic_ops_i64.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "arithmetic_ops_i64.h",
 )
 
 iree_c_module(
-  name = "assignment_ops",
-  src = "//runtime/src/iree/vm/test:assignment_ops.mlir",
-  h_file_output = "assignment_ops.h",
+    name = "assignment_ops",
+    src = "//runtime/src/iree/vm/test:assignment_ops.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "assignment_ops.h",
 )
 
 iree_c_module(
-  name = "assignment_ops_f32",
-  src = "//runtime/src/iree/vm/test:assignment_ops_f32.mlir",
-  h_file_output = "assignment_ops_f32.h",
+    name = "assignment_ops_f32",
+    src = "//runtime/src/iree/vm/test:assignment_ops_f32.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "assignment_ops_f32.h",
 )
 
 iree_c_module(
-  name = "assignment_ops_i64",
-  src = "//runtime/src/iree/vm/test:assignment_ops_i64.mlir",
-  h_file_output = "assignment_ops_i64.h",
-)
-iree_c_module(
-  name = "buffer_ops",
-  src = "//runtime/src/iree/vm/test:buffer_ops.mlir",
-  h_file_output = "buffer_ops.h",
-)
-
-iree_c_module(
-  name = "call_ops",
-  src = "//runtime/src/iree/vm/test:call_ops.mlir",
-  h_file_output = "call_ops.h",
+    name = "assignment_ops_i64",
+    src = "//runtime/src/iree/vm/test:assignment_ops_i64.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "assignment_ops_i64.h",
 )
 
 iree_c_module(
-  name = "comparison_ops",
-  src = "//runtime/src/iree/vm/test:comparison_ops.mlir",
-  h_file_output = "comparison_ops.h",
+    name = "buffer_ops",
+    src = "//runtime/src/iree/vm/test:buffer_ops.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "buffer_ops.h",
 )
 
 iree_c_module(
-  name = "comparison_ops_f32",
-  src = "//runtime/src/iree/vm/test:comparison_ops_f32.mlir",
-  h_file_output = "comparison_ops_f32.h",
+    name = "call_ops",
+    src = "//runtime/src/iree/vm/test:call_ops.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "call_ops.h",
 )
 
 iree_c_module(
-  name = "comparison_ops_i64",
-  src = "//runtime/src/iree/vm/test:comparison_ops_i64.mlir",
-  h_file_output = "comparison_ops_i64.h",
+    name = "comparison_ops",
+    src = "//runtime/src/iree/vm/test:comparison_ops.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "comparison_ops.h",
 )
 
 iree_c_module(
-  name = "control_flow_ops",
-  src = "//runtime/src/iree/vm/test:control_flow_ops.mlir",
-  h_file_output = "control_flow_ops.h",
+    name = "comparison_ops_f32",
+    src = "//runtime/src/iree/vm/test:comparison_ops_f32.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "comparison_ops_f32.h",
 )
 
 iree_c_module(
-  name = "conversion_ops",
-  src = "//runtime/src/iree/vm/test:conversion_ops.mlir",
-  h_file_output = "conversion_ops.h",
+    name = "comparison_ops_i64",
+    src = "//runtime/src/iree/vm/test:comparison_ops_i64.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "comparison_ops_i64.h",
 )
 
 iree_c_module(
-  name = "conversion_ops_f32",
-  src = "//runtime/src/iree/vm/test:conversion_ops_f32.mlir",
-  h_file_output = "conversion_ops_f32.h",
+    name = "control_flow_ops",
+    src = "//runtime/src/iree/vm/test:control_flow_ops.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "control_flow_ops.h",
 )
 
 iree_c_module(
-  name = "conversion_ops_i64",
-  src = "//runtime/src/iree/vm/test:conversion_ops_i64.mlir",
-  h_file_output = "conversion_ops_i64.h",
+    name = "conversion_ops",
+    src = "//runtime/src/iree/vm/test:conversion_ops.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "conversion_ops.h",
 )
 
 iree_c_module(
-  name = "global_ops",
-  src = "//runtime/src/iree/vm/test:global_ops.mlir",
-  h_file_output = "global_ops.h",
+    name = "conversion_ops_f32",
+    src = "//runtime/src/iree/vm/test:conversion_ops_f32.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "conversion_ops_f32.h",
 )
 
 iree_c_module(
-  name = "global_ops_f32",
-  src = "//runtime/src/iree/vm/test:global_ops_f32.mlir",
-  h_file_output = "global_ops_f32.h",
+    name = "conversion_ops_i64",
+    src = "//runtime/src/iree/vm/test:conversion_ops_i64.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "conversion_ops_i64.h",
 )
 
 iree_c_module(
-  name = "global_ops_i64",
-  src = "//runtime/src/iree/vm/test:global_ops_i64.mlir",
-  h_file_output = "global_ops_i64.h",
+    name = "global_ops",
+    src = "//runtime/src/iree/vm/test:global_ops.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "global_ops.h",
 )
 
 iree_c_module(
-  name = "list_ops",
-  src = "//runtime/src/iree/vm/test:list_ops.mlir",
-  h_file_output = "list_ops.h",
+    name = "global_ops_f32",
+    src = "//runtime/src/iree/vm/test:global_ops_f32.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "global_ops_f32.h",
 )
 
 iree_c_module(
-  name = "list_variant_ops",
-  src = "//runtime/src/iree/vm/test:list_variant_ops.mlir",
-  h_file_output = "list_variant_ops.h",
+    name = "global_ops_i64",
+    src = "//runtime/src/iree/vm/test:global_ops_i64.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "global_ops_i64.h",
 )
 
 iree_c_module(
-  name = "ref_ops",
-  src = "//runtime/src/iree/vm/test:ref_ops.mlir",
-  h_file_output = "ref_ops.h",
+    name = "list_ops",
+    src = "//runtime/src/iree/vm/test:list_ops.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "list_ops.h",
 )
 
 iree_c_module(
-  name = "shift_ops",
-  src = "//runtime/src/iree/vm/test:shift_ops.mlir",
-  h_file_output = "shift_ops.h",
+    name = "list_variant_ops",
+    src = "//runtime/src/iree/vm/test:list_variant_ops.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "list_variant_ops.h",
 )
 
 iree_c_module(
-  name = "shift_ops_i64",
-  src = "//runtime/src/iree/vm/test:shift_ops_i64.mlir",
-  h_file_output = "shift_ops_i64.h",
+    name = "ref_ops",
+    src = "//runtime/src/iree/vm/test:ref_ops.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "ref_ops.h",
+)
+
+iree_c_module(
+    name = "shift_ops",
+    src = "//runtime/src/iree/vm/test:shift_ops.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "shift_ops.h",
+)
+
+iree_c_module(
+    name = "shift_ops_i64",
+    src = "//runtime/src/iree/vm/test:shift_ops_i64.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "shift_ops_i64.h",
 )

--- a/runtime/src/iree/vm/test/emitc/BUILD
+++ b/runtime/src/iree/vm/test/emitc/BUILD
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_library", "iree_runtime_cc_test")
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_test")
 load("//build_tools/bazel:iree_c_module.bzl", "iree_c_module")
 
 package(

--- a/samples/emitc_modules/BUILD
+++ b/samples/emitc_modules/BUILD
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("//build_tools/bazel:build_defs.oss.bzl", "iree_cmake_extra_content", "iree_runtime_cc_library", "iree_runtime_cc_test")
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_library", "iree_runtime_cc_test")
 load("//build_tools/bazel:iree_c_module.bzl", "iree_c_module")
 
 package(
@@ -13,22 +13,13 @@ package(
     licenses = ["notice"],  # Apache 2.0
 )
 
-iree_cmake_extra_content(
-    content = """
-if(NOT IREE_ENABLE_EMITC)
-  return()
-endif()
-""",
-    inline = True,
-)
-
 iree_c_module(
   name = "add_module",
   src = "add.mlir",
   h_file_output = "add_module.h",
   flags = [
-    "--iree-mlir-to-vm-c-module",
-    "--iree-hal-target-backends=vmvx"
+    "--compile-mode=vm",
+    "--output-format=vm-c"
   ],
 )
 
@@ -51,8 +42,8 @@ iree_c_module(
   src = "import_module_a.mlir",
   h_file_output = "import_module_a.h",
   flags = [
-    "--iree-mlir-to-vm-c-module",
-    "--iree-hal-target-backends=vmvx"
+    "--compile-mode=vm",
+    "--output-format=vm-c"
   ],
 )
 
@@ -61,8 +52,8 @@ iree_c_module(
   src = "import_module_b.mlir",
   h_file_output = "import_module_b.h",
   flags = [
-    "--iree-mlir-to-vm-c-module",
-    "--iree-hal-target-backends=vmvx"
+    "--compile-mode=vm",
+    "--output-format=vm-c"
   ],
 )
 

--- a/samples/emitc_modules/BUILD
+++ b/samples/emitc_modules/BUILD
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_library", "iree_runtime_cc_test")
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_test")
 load("//build_tools/bazel:iree_c_module.bzl", "iree_c_module")
 
 package(
@@ -14,61 +14,60 @@ package(
 )
 
 iree_c_module(
-  name = "add_module",
-  src = "add.mlir",
-  h_file_output = "add_module.h",
-  flags = [
-    "--compile-mode=vm",
-    "--output-format=vm-c"
-  ],
+    name = "add_module",
+    src = "add.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "add_module.h",
 )
 
 iree_runtime_cc_test(
-  name = "add_module_test",
-  srcs = ["add_module_test.cc"],
-  deps = [
-    ":add_module",
-    "//runtime/src/iree/base",
-    "//runtime/src/iree/base:cc",
-    "//runtime/src/iree/testing:gtest",
-    "//runtime/src/iree/testing:gtest_main",
-    "//runtime/src/iree/vm:vm",
-    "//runtime/src/iree/vm:cc",
-  ]
+    name = "add_module_test",
+    srcs = ["add_module_test.cc"],
+    deps = [
+        ":add_module",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base:cc",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+        "//runtime/src/iree/vm",
+        "//runtime/src/iree/vm:cc",
+    ],
 )
 
 iree_c_module(
-  name = "import_module_a",
-  src = "import_module_a.mlir",
-  h_file_output = "import_module_a.h",
-  flags = [
-    "--compile-mode=vm",
-    "--output-format=vm-c"
-  ],
+    name = "import_module_a",
+    src = "import_module_a.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "import_module_a.h",
 )
 
 iree_c_module(
-  name = "import_module_b",
-  src = "import_module_b.mlir",
-  h_file_output = "import_module_b.h",
-  flags = [
-    "--compile-mode=vm",
-    "--output-format=vm-c"
-  ],
+    name = "import_module_b",
+    src = "import_module_b.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--output-format=vm-c",
+    ],
+    h_file_output = "import_module_b.h",
 )
 
 iree_runtime_cc_test(
-  name = "import_module_test",
-  srcs = ["import_module_test.cc"],
-  deps = [
-    ":import_module_a",
-    ":import_module_b",
-    "//runtime/src/iree/base",
-    "//runtime/src/iree/base:cc",
-    "//runtime/src/iree/testing:gtest",
-    "//runtime/src/iree/testing:gtest_main",
-    "//runtime/src/iree/vm:vm",
-    "//runtime/src/iree/vm:cc",
-  ]
+    name = "import_module_test",
+    srcs = ["import_module_test.cc"],
+    deps = [
+        ":import_module_a",
+        ":import_module_b",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base:cc",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+        "//runtime/src/iree/vm",
+        "//runtime/src/iree/vm:cc",
+    ],
 )
-

--- a/samples/emitc_modules/BUILD
+++ b/samples/emitc_modules/BUILD
@@ -1,0 +1,83 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_cmake_extra_content", "iree_runtime_cc_library", "iree_runtime_cc_test")
+load("//build_tools/bazel:iree_c_module.bzl", "iree_c_module")
+
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+iree_cmake_extra_content(
+    content = """
+if(NOT IREE_ENABLE_EMITC)
+  return()
+endif()
+""",
+    inline = True,
+)
+
+iree_c_module(
+  name = "add_module",
+  src = "add.mlir",
+  h_file_output = "add_module.h",
+  flags = [
+    "--iree-mlir-to-vm-c-module",
+    "--iree-hal-target-backends=vmvx"
+  ],
+)
+
+iree_runtime_cc_test(
+  name = "add_module_test",
+  srcs = ["add_module_test.cc"],
+  deps = [
+    ":add_module",
+    "//runtime/src/iree/base",
+    "//runtime/src/iree/base:cc",
+    "//runtime/src/iree/testing:gtest",
+    "//runtime/src/iree/testing:gtest_main",
+    "//runtime/src/iree/vm:vm",
+    "//runtime/src/iree/vm:cc",
+  ]
+)
+
+iree_c_module(
+  name = "import_module_a",
+  src = "import_module_a.mlir",
+  h_file_output = "import_module_a.h",
+  flags = [
+    "--iree-mlir-to-vm-c-module",
+    "--iree-hal-target-backends=vmvx"
+  ],
+)
+
+iree_c_module(
+  name = "import_module_b",
+  src = "import_module_b.mlir",
+  h_file_output = "import_module_b.h",
+  flags = [
+    "--iree-mlir-to-vm-c-module",
+    "--iree-hal-target-backends=vmvx"
+  ],
+)
+
+iree_runtime_cc_test(
+  name = "import_module_test",
+  srcs = ["import_module_test.cc"],
+  deps = [
+    ":import_module_a",
+    ":import_module_b",
+    "//runtime/src/iree/base",
+    "//runtime/src/iree/base:cc",
+    "//runtime/src/iree/testing:gtest",
+    "//runtime/src/iree/testing:gtest_main",
+    "//runtime/src/iree/vm:vm",
+    "//runtime/src/iree/vm:cc",
+  ]
+)
+


### PR DESCRIPTION
Also adds iree_c_module bazel rule mirroring CMake side. This does not
add the automatic generation to bazel_to_cmake.

Fixes #7345
