### PR TITLE
Fix case where there are no test temp directories to create

### DIFF
--- a/build_tools/cmake/iree_configure_testing.cmake
+++ b/build_tools/cmake/iree_configure_testing.cmake
@@ -22,7 +22,7 @@ set(IREE_TEST_TMPDIR_ROOT "${IREE_BINARY_DIR}/test_tmpdir")
 #   TEST_NAME: the test name, e.g. iree/base/math_test
 function(iree_configure_test TEST_NAME)
   set(_TEST_TMPDIR "${IREE_TEST_TMPDIR_ROOT}/${TEST_NAME}_test_tmpdir")
-  set_property(GLOBAL APPEND PROPERTY IREE_TEST_TMPDIRS ${_TEST_TMPDIR})
+  # set_property(GLOBAL APPEND PROPERTY IREE_TEST_TMPDIRS ${_TEST_TMPDIR})
   set_property(TEST ${TEST_NAME} APPEND PROPERTY ENVIRONMENT "TEST_TMPDIR=${_TEST_TMPDIR}")
 
   # IREE_*_DISABLE environment variables may used to skip test cases which
@@ -72,8 +72,10 @@ function(iree_create_ctest_customization)
       string(APPEND _CUR_CMD " ${_DIR}")
     endif()
   endforeach()
-  string(APPEND _CUR_CMD "\"\n")
-  string(APPEND IREE_CREATE_TEST_TMPDIRS_COMMANDS "${_CUR_CMD}")
+  if(NOT _CUR_CMD STREQUAL _CMD_PREFIX)
+    string(APPEND _CUR_CMD "\"\n")
+    string(APPEND IREE_CREATE_TEST_TMPDIRS_COMMANDS "${_CUR_CMD}")
+  endif()
 
   configure_file("build_tools/cmake/CTestCustom.cmake.in" "${IREE_BINARY_DIR}/CTestCustom.cmake" @ONLY)
 endfunction()

--- a/build_tools/cmake/iree_configure_testing.cmake
+++ b/build_tools/cmake/iree_configure_testing.cmake
@@ -22,7 +22,7 @@ set(IREE_TEST_TMPDIR_ROOT "${IREE_BINARY_DIR}/test_tmpdir")
 #   TEST_NAME: the test name, e.g. iree/base/math_test
 function(iree_configure_test TEST_NAME)
   set(_TEST_TMPDIR "${IREE_TEST_TMPDIR_ROOT}/${TEST_NAME}_test_tmpdir")
-  # set_property(GLOBAL APPEND PROPERTY IREE_TEST_TMPDIRS ${_TEST_TMPDIR})
+  set_property(GLOBAL APPEND PROPERTY IREE_TEST_TMPDIRS ${_TEST_TMPDIR})
   set_property(TEST ${TEST_NAME} APPEND PROPERTY ENVIRONMENT "TEST_TMPDIR=${_TEST_TMPDIR}")
 
   # IREE_*_DISABLE environment variables may used to skip test cases which


### PR DESCRIPTION
This behavior, introduced in https://github.com/google/iree/pull/9405,
is broken on Android, where we don't do this temp directory
registration:
https://buildkite.com/iree/iree-test-android/builds/6452

Triggered a run of the android test pipeline on this PR:
https://buildkite.com/iree/iree-test-android/builds/6458