### PR TITLE
Rename "translate" to "compile" across build systems.

### DIFF
--- a/benchmarks/TFLite/android-adreno.cmake
+++ b/benchmarks/TFLite/android-adreno.cmake
@@ -10,13 +10,13 @@
 #                                                                              #
 # Each suite benchmarks a list of modules with configurations specifying a     #
 # target architecture and runtime characteristics (e.g. threads/cores). These  #
-# benchmarks only configure IREE translation and runtime flags for the target  #
+# benchmarks only configure IREE compilation and runtime flags for the target  #
 # architecture and do *not* include any non-default flags. No non-default      #
 # flags should be added here.                                                  #
 #                                                                              #
 ################################################################################
 
-set(ANDROID_ADRENO_GPU_TRANSLATION_FLAGS
+set(ANDROID_ADRENO_GPU_COMPILATION_FLAGS
   "--iree-input-type=tosa"
   "--iree-vulkan-target-triple=adreno-unknown-android11"
 )
@@ -40,8 +40,8 @@ iree_benchmark_suite(
     "vulkan-spirv"
   TARGET_ARCHITECTURE
     "GPU-Adreno"
-  TRANSLATION_FLAGS
-    ${ANDROID_ADRENO_GPU_TRANSLATION_FLAGS}
+  COMPILATION_FLAGS
+    ${ANDROID_ADRENO_GPU_COMPILATION_FLAGS}
   BENCHMARK_TOOL
     iree-benchmark-module
   CONFIG
@@ -85,8 +85,8 @@ iree_benchmark_suite(
     "vulkan-spirv"
   TARGET_ARCHITECTURE
     "GPU-Adreno"
-  TRANSLATION_FLAGS
-    ${ANDROID_ADRENO_GPU_TRANSLATION_FLAGS}
+  COMPILATION_FLAGS
+    ${ANDROID_ADRENO_GPU_COMPILATION_FLAGS}
     "--iree-flow-enable-fuse-padding-into-consumer-ops"
   BENCHMARK_TOOL
     iree-benchmark-module
@@ -127,8 +127,8 @@ iree_benchmark_suite(
     "vulkan-spirv"
   TARGET_ARCHITECTURE
     "GPU-Adreno"
-  TRANSLATION_FLAGS
-    ${ANDROID_ADRENO_GPU_TRANSLATION_FLAGS}
+  COMPILATION_FLAGS
+    ${ANDROID_ADRENO_GPU_COMPILATION_FLAGS}
     "--iree-flow-enable-fuse-padding-into-consumer-ops"
     "--iree-hal-benchmark-dispatch-repeat-count=16"
   BENCHMARK_TOOL

--- a/benchmarks/TFLite/android-arm64-v8a.cmake
+++ b/benchmarks/TFLite/android-arm64-v8a.cmake
@@ -10,13 +10,13 @@
 #                                                                              #
 # Each suite benchmarks a list of modules with configurations specifying a     #
 # target architecture and runtime characteristics (e.g. threads/cores). These  #
-# benchmarks only configure IREE translation and runtime flags for the target  #
+# benchmarks only configure IREE compilation and runtime flags for the target  #
 # architecture and do *not* include any non-default flags. No non-default      #
 # flags should be added here.                                                  #
 #                                                                              #
 ################################################################################
 
-set(ANDROID_CPU_TRANSLATION_FLAGS
+set(ANDROID_CPU_COMPILATION_FLAGS
   "--iree-input-type=tosa"
   "--iree-llvm-target-triple=aarch64-none-linux-android29")
 
@@ -41,8 +41,8 @@ iree_benchmark_suite(
     "dylib-llvm-aot"
   TARGET_ARCHITECTURE
     "CPU-ARM64-v8A"
-  TRANSLATION_FLAGS
-    ${ANDROID_CPU_TRANSLATION_FLAGS}
+  COMPILATION_FLAGS
+    ${ANDROID_CPU_COMPILATION_FLAGS}
   BENCHMARK_TOOL
     iree-benchmark-module
   CONFIG
@@ -72,8 +72,8 @@ iree_benchmark_suite(
     "dylib-llvm-aot"
   TARGET_ARCHITECTURE
     "CPU-ARM64-v8A"
-  TRANSLATION_FLAGS
-    ${ANDROID_CPU_TRANSLATION_FLAGS}
+  COMPILATION_FLAGS
+    ${ANDROID_CPU_COMPILATION_FLAGS}
   BENCHMARK_TOOL
     iree-benchmark-module
   CONFIG
@@ -105,8 +105,8 @@ iree_benchmark_suite(
 #     "dylib-llvm-aot"
 #   TARGET_ARCHITECTURE
 #     "CPU-ARM64-v8A"
-#   TRANSLATION_FLAGS
-#     ${ANDROID_CPU_TRANSLATION_FLAGS}
+#   COMPILATION_FLAGS
+#     ${ANDROID_CPU_COMPILATION_FLAGS}
 #   BENCHMARK_TOOL
 #     iree-benchmark-module
 #   CONFIG
@@ -136,8 +136,8 @@ iree_benchmark_suite(
 #     "dylib-llvm-aot"
 #   TARGET_ARCHITECTURE
 #     "CPU-ARM64-v8A"
-#   TRANSLATION_FLAGS
-#     ${ANDROID_CPU_TRANSLATION_FLAGS}
+#   COMPILATION_FLAGS
+#     ${ANDROID_CPU_COMPILATION_FLAGS}
 #   BENCHMARK_TOOL
 #     iree-benchmark-module
 #   CONFIG
@@ -168,8 +168,8 @@ iree_benchmark_suite(
     "dylib-llvm-aot"
   TARGET_ARCHITECTURE
     "CPU-ARM64-v8A"
-  TRANSLATION_FLAGS
-    ${ANDROID_CPU_TRANSLATION_FLAGS}
+  COMPILATION_FLAGS
+    ${ANDROID_CPU_COMPILATION_FLAGS}
   BENCHMARK_TOOL
     iree-benchmark-module
   CONFIG
@@ -219,8 +219,8 @@ iree_benchmark_suite(
     "dylib-llvm-aot"
   TARGET_ARCHITECTURE
     "CPU-ARM64-v8A"
-  TRANSLATION_FLAGS
-    ${ANDROID_CPU_TRANSLATION_FLAGS}
+  COMPILATION_FLAGS
+    ${ANDROID_CPU_COMPILATION_FLAGS}
     "--iree-flow-mmt4d-target-options=arch=aarch64"
   BENCHMARK_TOOL
     iree-benchmark-module
@@ -248,8 +248,8 @@ iree_benchmark_suite(
     "dylib-llvm-aot"
   TARGET_ARCHITECTURE
     "CPU-ARM64-v8A"
-  TRANSLATION_FLAGS
-    ${ANDROID_CPU_TRANSLATION_FLAGS}
+  COMPILATION_FLAGS
+    ${ANDROID_CPU_COMPILATION_FLAGS}
     "--iree-flow-mmt4d-target-options=arch=aarch64 features=+dotprod"
     "--iree-llvm-target-cpu-features=+dotprod"
   BENCHMARK_TOOL
@@ -286,8 +286,8 @@ iree_benchmark_suite(
     "dylib-llvm-aot"
   TARGET_ARCHITECTURE
     "CPU-ARM64-v8A"
-  TRANSLATION_FLAGS
-    ${ANDROID_CPU_TRANSLATION_FLAGS}
+  COMPILATION_FLAGS
+    ${ANDROID_CPU_COMPILATION_FLAGS}
     "--iree-flow-mmt4d-target-options=arch=aarch64"
   BENCHMARK_TOOL
     iree-benchmark-module
@@ -317,8 +317,8 @@ iree_benchmark_suite(
     "dylib-llvm-aot"
   TARGET_ARCHITECTURE
     "CPU-ARM64-v8A"
-  TRANSLATION_FLAGS
-    ${ANDROID_CPU_TRANSLATION_FLAGS}
+  COMPILATION_FLAGS
+    ${ANDROID_CPU_COMPILATION_FLAGS}
     "--iree-flow-mmt4d-target-options=arch=aarch64 features=+dotprod"
     "--iree-llvm-target-cpu-features=+dotprod"
   BENCHMARK_TOOL
@@ -352,8 +352,8 @@ iree_benchmark_suite(
 #     "dylib-llvm-aot"
 #   TARGET_ARCHITECTURE
 #     "CPU-ARM64-v8A"
-#   TRANSLATION_FLAGS
-#     ${ANDROID_CPU_TRANSLATION_FLAGS}
+#   COMPILATION_FLAGS
+#     ${ANDROID_CPU_COMPILATION_FLAGS}
 #     "--iree-flow-mmt4d-target-options=arch=aarch64"
 #   BENCHMARK_TOOL
 #     iree-benchmark-module
@@ -384,8 +384,8 @@ iree_benchmark_suite(
 #     "dylib-llvm-aot"
 #   TARGET_ARCHITECTURE
 #     "CPU-ARM64-v8A"
-#   TRANSLATION_FLAGS
-#     ${ANDROID_CPU_TRANSLATION_FLAGS}
+#   COMPILATION_FLAGS
+#     ${ANDROID_CPU_COMPILATION_FLAGS}
 #     "--iree-flow-mmt4d-target-options=arch=aarch64"
 #   BENCHMARK_TOOL
 #     iree-benchmark-module
@@ -420,8 +420,8 @@ iree_benchmark_suite(
     "dylib-llvm-aot"
   TARGET_ARCHITECTURE
     "CPU-ARM64-v8A"
-  TRANSLATION_FLAGS
-    ${ANDROID_CPU_TRANSLATION_FLAGS}
+  COMPILATION_FLAGS
+    ${ANDROID_CPU_COMPILATION_FLAGS}
     "--iree-flow-mmt4d-target-options=arch=aarch64"
 
   BENCHMARK_TOOL
@@ -452,8 +452,8 @@ iree_benchmark_suite(
     "dylib-llvm-aot"
   TARGET_ARCHITECTURE
     "CPU-ARM64-v8A"
-  TRANSLATION_FLAGS
-    ${ANDROID_CPU_TRANSLATION_FLAGS}
+  COMPILATION_FLAGS
+    ${ANDROID_CPU_COMPILATION_FLAGS}
     "--iree-flow-mmt4d-target-options=arch=aarch64 features=+dotprod"
     "--iree-llvm-target-cpu-features=+dotprod"
 
@@ -486,7 +486,7 @@ iree_benchmark_suite(
     "vmvx"
   TARGET_ARCHITECTURE
     "CPU-ARM64-v8A"
-  TRANSLATION_FLAGS
+  COMPILATION_FLAGS
     "--iree-input-type=tosa"
   BENCHMARK_TOOL
     iree-benchmark-module

--- a/benchmarks/TFLite/android-mali.cmake
+++ b/benchmarks/TFLite/android-mali.cmake
@@ -10,13 +10,13 @@
 #                                                                              #
 # Each suite benchmarks a list of modules with configurations specifying a     #
 # target architecture and runtime characteristics (e.g. threads/cores). These  #
-# benchmarks only configure IREE translation and runtime flags for the target  #
+# benchmarks only configure IREE compilation and runtime flags for the target  #
 # architecture and do *not* include any non-default flags. No non-default      #
 # flags should be added here.                                                  #
 #                                                                              #
 ################################################################################
 
-set(ANDROID_MALI_GPU_TRANSLATION_FLAGS
+set(ANDROID_MALI_GPU_COMPILATION_FLAGS
   "--iree-input-type=tosa"
   "--iree-vulkan-target-triple=valhall-unknown-android11"
 )
@@ -40,8 +40,8 @@ iree_benchmark_suite(
     "vulkan-spirv"
   TARGET_ARCHITECTURE
     "GPU-Mali-Valhall"
-  TRANSLATION_FLAGS
-    ${ANDROID_MALI_GPU_TRANSLATION_FLAGS}
+  COMPILATION_FLAGS
+    ${ANDROID_MALI_GPU_COMPILATION_FLAGS}
   BENCHMARK_TOOL
     iree-benchmark-module
   CONFIG
@@ -64,8 +64,8 @@ iree_benchmark_suite(
     "vulkan-spirv"
   TARGET_ARCHITECTURE
     "GPU-Mali-Valhall"
-  TRANSLATION_FLAGS
-    ${ANDROID_MALI_GPU_TRANSLATION_FLAGS}
+  COMPILATION_FLAGS
+    ${ANDROID_MALI_GPU_COMPILATION_FLAGS}
     # This isn't a special optimization flag. It's so we can reuse the same f32
     # model file. See comments on MOBILEBERT_FP16_MODULE
     "--iree-flow-demote-f32-to-f16"
@@ -112,8 +112,8 @@ iree_benchmark_suite(
     "vulkan-spirv"
   TARGET_ARCHITECTURE
     "GPU-Mali-Valhall"
-  TRANSLATION_FLAGS
-    ${ANDROID_MALI_GPU_TRANSLATION_FLAGS}
+  COMPILATION_FLAGS
+    ${ANDROID_MALI_GPU_COMPILATION_FLAGS}
     "--iree-flow-enable-fuse-padding-into-consumer-ops"
   BENCHMARK_TOOL
     iree-benchmark-module
@@ -136,7 +136,7 @@ iree_benchmark_suite(
     "vulkan-spirv"
   TARGET_ARCHITECTURE
     "GPU-Mali-Valhall"
-  TRANSLATION_FLAGS
+  COMPILATION_FLAGS
     "--iree-input-type=tosa"
     "--iree-flow-demote-f32-to-f16"
     "--iree-vulkan-target-triple=valhall-unknown-android11"
@@ -178,8 +178,8 @@ iree_benchmark_suite(
     "vulkan-spirv"
   TARGET_ARCHITECTURE
     "GPU-Mali-Valhall"
-  TRANSLATION_FLAGS
-    ${ANDROID_MALI_GPU_TRANSLATION_FLAGS}
+  COMPILATION_FLAGS
+    ${ANDROID_MALI_GPU_COMPILATION_FLAGS}
     "--iree-flow-enable-fuse-padding-into-consumer-ops"
     "--iree-hal-benchmark-dispatch-repeat-count=32"
   BENCHMARK_TOOL
@@ -205,7 +205,7 @@ iree_benchmark_suite(
     "vulkan-spirv"
   TARGET_ARCHITECTURE
     "GPU-Mali-Valhall"
-  TRANSLATION_FLAGS
+  COMPILATION_FLAGS
     "--iree-input-type=tosa"
     "--iree-flow-demote-f32-to-f16"
     "--iree-vulkan-target-triple=valhall-unknown-android11"

--- a/benchmarks/TFLite/linux-riscv.cmake
+++ b/benchmarks/TFLite/linux-riscv.cmake
@@ -10,13 +10,13 @@
 #                                                                              #
 # Each suite benchmarks a list of modules with configurations specifying a     #
 # target architecture and runtime characteristics (e.g. threads/cores). These  #
-# benchmarks only configure IREE translation and runtime flags for the target  #
+# benchmarks only configure IREE compilation and runtime flags for the target  #
 # architecture and do *not* include any non-default flags. No non-default      #
 # flags should be added here.                                                  #
 #                                                                              #
 ################################################################################
 
-set(LINUX_RV64_GENERIC_CPU_TRANSLATION_FLAGS
+set(LINUX_RV64_GENERIC_CPU_COMPILATION_FLAGS
   "--iree-input-type=tosa"
   "--iree-llvm-target-triple=riscv64"
   "--iree-llvm-target-cpu=generic-rv64"
@@ -26,7 +26,7 @@ set(LINUX_RV64_GENERIC_CPU_TRANSLATION_FLAGS
   "--riscv-v-fixed-length-vector-lmul-max=8"
 )
 
-set(LINUX_RV32_GENERIC_CPU_TRANSLATION_FLAGS
+set(LINUX_RV32_GENERIC_CPU_COMPILATION_FLAGS
   "--iree-input-type=tosa"
   "--iree-llvm-target-triple=riscv32-pc-linux-elf"
   "--iree-llvm-target-cpu=generic-rv32"
@@ -52,8 +52,8 @@ iree_benchmark_suite(
     "dylib-llvm-aot"
   TARGET_ARCHITECTURE
     "CPU-RV64-Generic"
-  TRANSLATION_FLAGS
-    ${LINUX_RV64_GENERIC_CPU_TRANSLATION_FLAGS}
+  COMPILATION_FLAGS
+    ${LINUX_RV64_GENERIC_CPU_COMPILATION_FLAGS}
   BENCHMARK_TOOL
     iree-benchmark-module
   CONFIG
@@ -78,8 +78,8 @@ iree_benchmark_suite(
     "dylib-llvm-aot"
   TARGET_ARCHITECTURE
     "CPU-RV32-Generic"
-  TRANSLATION_FLAGS
-    ${LINUX_RV32_GENERIC_CPU_TRANSLATION_FLAGS}
+  COMPILATION_FLAGS
+    ${LINUX_RV32_GENERIC_CPU_COMPILATION_FLAGS}
   BENCHMARK_TOOL
     iree-benchmark-module
   CONFIG

--- a/benchmarks/TFLite/linux-x86_64.cmake
+++ b/benchmarks/TFLite/linux-x86_64.cmake
@@ -10,13 +10,13 @@
 #                                                                              #
 # Each suite benchmarks a list of modules with configurations specifying a     #
 # target architecture and runtime characteristics (e.g. threads/cores). These  #
-# benchmarks only configure IREE translation and runtime flags for the target  #
+# benchmarks only configure IREE compilation and runtime flags for the target  #
 # architecture and do *not* include any non-default flags. No non-default      #
 # flags should be added here.                                                  #
 #                                                                              #
 ################################################################################
 
-set(LINUX_X86_64_CASCADELAKE_CPU_TRANSLATION_FLAGS
+set(LINUX_X86_64_CASCADELAKE_CPU_COMPILATION_FLAGS
   "--iree-input-type=tosa"
   "--iree-llvm-target-cpu=cascadelake"
   "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
@@ -41,8 +41,8 @@ iree_benchmark_suite(
     "dylib-llvm-aot"
   TARGET_ARCHITECTURE
     "CPU-x86_64-CascadeLake"
-  TRANSLATION_FLAGS
-    ${LINUX_X86_64_CASCADELAKE_CPU_TRANSLATION_FLAGS}
+  COMPILATION_FLAGS
+    ${LINUX_X86_64_CASCADELAKE_CPU_COMPILATION_FLAGS}
   BENCHMARK_TOOL
     iree-benchmark-module
   CONFIG
@@ -70,8 +70,8 @@ iree_benchmark_suite(
     "dylib-llvm-aot"
   TARGET_ARCHITECTURE
     "CPU-x86_64-CascadeLake"
-  TRANSLATION_FLAGS
-    ${LINUX_X86_64_CASCADELAKE_CPU_TRANSLATION_FLAGS}
+  COMPILATION_FLAGS
+    ${LINUX_X86_64_CASCADELAKE_CPU_COMPILATION_FLAGS}
   BENCHMARK_TOOL
     iree-benchmark-module
   CONFIG
@@ -101,8 +101,8 @@ iree_benchmark_suite(
     "dylib-llvm-aot"
   TARGET_ARCHITECTURE
     "CPU-x86_64-CascadeLake"
-  TRANSLATION_FLAGS
-    ${LINUX_X86_64_CASCADELAKE_CPU_TRANSLATION_FLAGS}
+  COMPILATION_FLAGS
+    ${LINUX_X86_64_CASCADELAKE_CPU_COMPILATION_FLAGS}
   BENCHMARK_TOOL
     iree-benchmark-module
   CONFIG
@@ -132,8 +132,8 @@ iree_benchmark_suite(
     "dylib-llvm-aot"
   TARGET_ARCHITECTURE
     "CPU-x86_64-CascadeLake"
-  TRANSLATION_FLAGS
-    ${LINUX_X86_64_CASCADELAKE_CPU_TRANSLATION_FLAGS}
+  COMPILATION_FLAGS
+    ${LINUX_X86_64_CASCADELAKE_CPU_COMPILATION_FLAGS}
   BENCHMARK_TOOL
     iree-benchmark-module
   CONFIG

--- a/build_tools/bazel/iree_bytecode_module.bzl
+++ b/build_tools/bazel/iree_bytecode_module.bzl
@@ -15,8 +15,7 @@ def iree_bytecode_module(
         src,
         module = None,
         flags = ["--iree-mlir-to-vm-bytecode-module"],
-        # TODO: Rename this to 'compile_tool'
-        translate_tool = "//tools:iree-compile",
+        compile_tool = "//tools:iree-compile",
         linker_tool = "@llvm-project//lld:lld",
         c_identifier = "",
         deps = [],
@@ -28,7 +27,7 @@ def iree_bytecode_module(
         src: mlir source file to be compiled to an IREE module.
         flags: additional flags to pass to the compiler. Bytecode
             translation and backend flags are passed automatically.
-        translate_tool: the compiler to use to generate the module.
+        compile_tool: the compiler to use to generate the module.
             Defaults to iree-compile.
         linker_tool: the linker to use.
             Defaults to the lld from the llvm-project directory.
@@ -49,7 +48,7 @@ def iree_bytecode_module(
         ],
         cmd = " && ".join([
             " ".join([
-                "$(location %s)" % (translate_tool),
+                "$(location %s)" % (compile_tool),
                 " ".join(flags),
                 "--iree-llvm-embedded-linker-path=$(location %s)" % (linker_tool),
                 "--iree-llvm-wasm-linker-path=$(location %s)" % (linker_tool),
@@ -58,7 +57,7 @@ def iree_bytecode_module(
                 "$(location %s)" % (src),
             ]),
         ]),
-        tools = [translate_tool, linker_tool],
+        tools = [compile_tool, linker_tool],
         message = "Compiling IREE module %s..." % (name),
         output_to_bindir = 1,
         **kwargs

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
@@ -441,15 +441,14 @@ class BuildFileFunctions(object):
                            name,
                            src,
                            flags=None,
-                           translate_tool=None,
+                           compile_tool=None,
                            c_identifier=None,
                            deps=None,
                            testonly=None):
     name_block = _convert_string_arg_block("NAME", name, quote=False)
     src_block = _convert_string_arg_block("SRC", src)
     c_identifier_block = _convert_string_arg_block("C_IDENTIFIER", c_identifier)
-    translate_tool_block = _convert_target_block("TRANSLATE_TOOL",
-                                                 translate_tool)
+    compile_tool_block = _convert_target_block("COMPILE_TOOL", compile_tool)
     flags_block = _convert_string_list_block("FLAGS", flags)
     deps_block = _convert_target_list_block("DEPS", deps)
     testonly_block = _convert_option_block("TESTONLY", testonly)
@@ -458,7 +457,7 @@ class BuildFileFunctions(object):
                             f"{name_block}"
                             f"{src_block}"
                             f"{c_identifier_block}"
-                            f"{translate_tool_block}"
+                            f"{compile_tool_block}"
                             f"{flags_block}"
                             f"{deps_block}"
                             f"{testonly_block}"

--- a/build_tools/cmake/iree_benchmark_suite.cmake
+++ b/build_tools/cmake/iree_benchmark_suite.cmake
@@ -36,7 +36,7 @@
 #   TARGET_BACKEND: The compiler target backend.
 #   TARGET_ARCHITECTURE: The detailed target backend's architecture.
 #   TRANSLATION_FLAGS: A list of command-line options and their values to
-#       pass to the IREE translation tool for artifact generation.
+#       pass to the IREE compiler tool for artifact generation.
 #   CONFIG: Benchmark runner configuration name.
 #   DRIVER: The runtime driver.
 #   RUNTIME_FLAGS: A list of command-line options and their values to pass

--- a/build_tools/cmake/iree_benchmark_suite.cmake
+++ b/build_tools/cmake/iree_benchmark_suite.cmake
@@ -35,7 +35,7 @@
 #       separated list of benchmark mode tags.
 #   TARGET_BACKEND: The compiler target backend.
 #   TARGET_ARCHITECTURE: The detailed target backend's architecture.
-#   TRANSLATION_FLAGS: A list of command-line options and their values to
+#   COMPILATION_FLAGS: A list of command-line options and their values to
 #       pass to the IREE compiler tool for artifact generation.
 #   CONFIG: Benchmark runner configuration name.
 #   DRIVER: The runtime driver.
@@ -43,7 +43,7 @@
 #       to the IREE runtime during benchmark exectuion.
 #
 # The above parameters largely fall into two categories: 1) for specifying
-# the MLIR input module and its metadata, 2) for specifying the translation/
+# the MLIR input module and its metadata, 2) for specifying the compilation/
 # runtime configuration.
 #
 # 1)
@@ -55,10 +55,10 @@
 #
 # 2)
 #
-# TARGET_BACKEND and TRANSLATION_FLAGS control how the input module will be
+# TARGET_BACKEND and COMPILATION_FLAGS control how the input module will be
 # converted into the final IREE deployable module format. DRIVER and
 # RUNTIME_FLAGS specify how the module will be executed. BENCHMARK_MODES
-# can be used to give descriptions of the translation/runtime configuration
+# can be used to give descriptions of the compilation/runtime configuration
 # (e.g., full-inference vs. kernel-execution) and specify more contextual
 # requirements (e.g., big-core vs. little-core).
 #
@@ -72,7 +72,7 @@ function(iree_benchmark_suite)
     _RULE
     ""
     "GROUP_NAME;CONFIG;DRIVER;TARGET_BACKEND;TARGET_ARCHITECTURE"
-    "BENCHMARK_MODES;BENCHMARK_TOOL;MODULES;TRANSLATION_FLAGS;RUNTIME_FLAGS"
+    "BENCHMARK_MODES;BENCHMARK_TOOL;MODULES;COMPILATION_FLAGS;RUNTIME_FLAGS"
   )
 
   iree_validate_required_arguments(
@@ -195,40 +195,40 @@ function(iree_benchmark_suite)
       list(APPEND _FRIENDLY_TARGET_NAME_LIST ${_COMMON_NAME_SEGMENTS})
       list(JOIN _FRIENDLY_TARGET_NAME_LIST "__" _FRIENDLY_TARGET_NAME)
 
-      # The full list of translation flags.
-      set(_TRANSLATION_ARGS "")
-      list(APPEND _TRANSLATION_ARGS "--iree-mlir-to-vm-bytecode-module")
-      list(APPEND _TRANSLATION_ARGS "--mlir-print-op-on-diagnostic=false")
-      list(APPEND _TRANSLATION_ARGS "--iree-hal-target-backends=${_RULE_TARGET_BACKEND}")
-      list(SORT _RULE_TRANSLATION_FLAGS)
-      list(APPEND _TRANSLATION_ARGS ${_RULE_TRANSLATION_FLAGS})
+      # The full list of compilation flags.
+      set(_COMPILATION_ARGS "")
+      list(APPEND _COMPILATION_ARGS "--iree-mlir-to-vm-bytecode-module")
+      list(APPEND _COMPILATION_ARGS "--mlir-print-op-on-diagnostic=false")
+      list(APPEND _COMPILATION_ARGS "--iree-hal-target-backends=${_RULE_TARGET_BACKEND}")
+      list(SORT _RULE_COMPILATION_FLAGS)
+      list(APPEND _COMPILATION_ARGS ${_RULE_COMPILATION_FLAGS})
 
       # Get a unique identifier for this IREE module file by hashing the command
       # line flags and input file. We will also use this for the CMake target.
       # Note that this is NOT A SECURE HASHING ALGORITHM. We just want
       # uniqueness and MD5 is fast. If that changes, switch to something much
       # better (like SHA256).
-      string(MD5 _VMFB_HASH "${_TRANSLATION_ARGS};${_MODULE_SOURCE}")
+      string(MD5 _VMFB_HASH "${_COMPILATION_ARGS};${_MODULE_SOURCE}")
       get_filename_component(_MODULE_SOURCE_BASENAME "${_MODULE_SOURCE}" NAME)
       set(_MODULE_SOURCE_BASENAME_WITH_HASH "${_MODULE_SOURCE_BASENAME}-${_VMFB_HASH}")
       set(_VMFB_FILE "${_VMFB_ARTIFACTS_DIR}/${_MODULE_SOURCE_BASENAME_WITH_HASH}.vmfb")
 
       # Register the target once and share across all benchmarks having the same
-      # MLIR source and translation flags.
-      set(_TRANSLATION_NAME
+      # MLIR source and compilation flags.
+      set(_COMPILATION_NAME
         "iree-generate-benchmark-artifact-${_MODULE_SOURCE_BASENAME_WITH_HASH}"
       )
-      set(_TRANSLATION_TARGET_NAME "${_PACKAGE_NAME}_${_TRANSLATION_NAME}")
-      if(NOT TARGET "${_TRANSLATION_TARGET_NAME}")
+      set(_COMPILATION_TARGET_NAME "${_PACKAGE_NAME}_${_COMPILATION_NAME}")
+      if(NOT TARGET "${_COMPILATION_TARGET_NAME}")
         iree_bytecode_module(
           NAME
-            "${_TRANSLATION_NAME}"
+            "${_COMPILATION_NAME}"
           MODULE_FILE_NAME
             "${_VMFB_FILE}"
           SRC
             "${_MODULE_SOURCE}"
           FLAGS
-            ${_TRANSLATION_ARGS}
+            ${_COMPILATION_ARGS}
           DEPENDS
             "${_MODULE_SOURCE_TARGET}"
           FRIENDLY_NAME
@@ -236,23 +236,23 @@ function(iree_benchmark_suite)
         )
 
         # Mark dependency so that we have one target to drive them all.
-        add_dependencies(iree-benchmark-suites "${_TRANSLATION_TARGET_NAME}")
-        add_dependencies("${SUITE_SUB_TARGET}" "${_TRANSLATION_TARGET_NAME}")
+        add_dependencies(iree-benchmark-suites "${_COMPILATION_TARGET_NAME}")
+        add_dependencies("${SUITE_SUB_TARGET}" "${_COMPILATION_TARGET_NAME}")
       endif()
 
-      set(_COMPILE_STATS_TRANSLATION_NAME
-        "${_TRANSLATION_NAME}-compile-stats"
+      set(_COMPILE_STATS_COMPILATION_NAME
+        "${_COMPILATION_NAME}-compile-stats"
       )
-      set(_COMPILE_STATS_TRANSLATION_TARGET_NAME
-        "${_PACKAGE_NAME}_${_COMPILE_STATS_TRANSLATION_NAME}"
+      set(_COMPILE_STATS_COMPILATION_TARGET_NAME
+        "${_PACKAGE_NAME}_${_COMPILE_STATS_COMPILATION_NAME}"
       )
       set(_COMPILE_STATS_VMFB_FILE
         "${_VMFB_ARTIFACTS_DIR}/${_MODULE_SOURCE_BASENAME_WITH_HASH}-compile-stats.vmfb"
       )
-      if(IREE_ENABLE_COMPILATION_BENCHMARKS AND NOT TARGET "${_COMPILE_STATS_TRANSLATION_TARGET_NAME}")
+      if(IREE_ENABLE_COMPILATION_BENCHMARKS AND NOT TARGET "${_COMPILE_STATS_COMPILATION_TARGET_NAME}")
         iree_bytecode_module(
           NAME
-            "${_COMPILE_STATS_TRANSLATION_NAME}"
+            "${_COMPILE_STATS_COMPILATION_NAME}"
           MODULE_FILE_NAME
             "${_COMPILE_STATS_VMFB_FILE}"
           SRC
@@ -262,7 +262,7 @@ function(iree_benchmark_suite)
             "--iree-vm-emit-polyglot-zip=true"
             # Disable debug symbols to provide correct component sizes.
             "--iree-llvm-debug-symbols=false"
-            ${_TRANSLATION_ARGS}
+            ${_COMPILATION_ARGS}
           DEPENDS
             "${_MODULE_SOURCE_TARGET}"
           FRIENDLY_NAME
@@ -271,20 +271,20 @@ function(iree_benchmark_suite)
 
         # Mark dependency so that we have one target to drive them all.
         add_dependencies(iree-benchmark-suites
-          "${_COMPILE_STATS_TRANSLATION_TARGET_NAME}"
+          "${_COMPILE_STATS_COMPILATION_TARGET_NAME}"
         )
         add_dependencies("${SUITE_SUB_TARGET}"
-          "${_COMPILE_STATS_TRANSLATION_TARGET_NAME}"
+          "${_COMPILE_STATS_COMPILATION_TARGET_NAME}"
         )
       endif()
 
       if(NOT TARGET "${_FRIENDLY_TARGET_NAME}")
         add_custom_target("${_FRIENDLY_TARGET_NAME}")
       endif()
-      add_dependencies("${_FRIENDLY_TARGET_NAME}" "${_TRANSLATION_TARGET_NAME}")
+      add_dependencies("${_FRIENDLY_TARGET_NAME}" "${_COMPILATION_TARGET_NAME}")
       if(IREE_ENABLE_COMPILATION_BENCHMARKS)
         add_dependencies("${_FRIENDLY_TARGET_NAME}"
-          "${_COMPILE_STATS_TRANSLATION_TARGET_NAME}")
+          "${_COMPILE_STATS_COMPILATION_TARGET_NAME}")
       endif()
 
       set(_RUN_SPEC_DIR "${_ROOT_ARTIFACTS_DIR}/${_MODULE_DIR_NAME}/${_BENCHMARK_DIR_NAME}")
@@ -344,7 +344,7 @@ function(iree_benchmark_suite)
         COMMAND
           "${Python3_EXECUTABLE}" "${IREE_ROOT_DIR}/build_tools/scripts/generate_compilation_flagfile.py"
             --output "${_COMPILATION_FLAGFILE}"
-            -- ${_TRANSLATION_ARGS}
+            -- ${_COMPILATION_ARGS}
         WORKING_DIRECTORY "${_RUN_SPEC_DIR}"
         COMMENT "Generating ${_COMPILATION_FLAGFILE}"
       )

--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -13,9 +13,9 @@ include(CMakeParseArguments)
 # Parameters:
 # NAME: Name of target (see Note).
 # SRC: Source file to compile into a bytecode module.
-# FLAGS: Flags to pass to the translation tool (list of strings).
-# TRANSLATE_TOOL: Translation tool to invoke (CMake target). The default
-#     tool is "iree-compile".
+# FLAGS: Flags to pass to the compiler tool (list of strings).
+# COMPILE_TOOL: Compiler tool to invoke (CMake target). The default tool is
+#     "iree-compile".
 # C_IDENTIFIER: Identifier to use for generate c embed code.
 #     If omitted then no C embed code will be generated.
 # PUBLIC: Add this so that this library will be exported under ${PACKAGE}::
@@ -38,7 +38,7 @@ function(iree_bytecode_module)
   cmake_parse_arguments(
     _RULE
     "PUBLIC;TESTONLY"
-    "NAME;SRC;TRANSLATE_TOOL;C_IDENTIFIER;MODULE_FILE_NAME;FRIENDLY_NAME"
+    "NAME;SRC;COMPILE_TOOL;C_IDENTIFIER;MODULE_FILE_NAME;FRIENDLY_NAME"
     "FLAGS;DEPENDS;DEPS"
     ${ARGN}
   )
@@ -47,11 +47,11 @@ function(iree_bytecode_module)
     return()
   endif()
 
-  # Set default for TRANSLATE_TOOL.
-  if(DEFINED _RULE_TRANSLATE_TOOL)
-    set(_TRANSLATE_TOOL ${_RULE_TRANSLATE_TOOL})
+  # Set default for COMPILE_TOOL.
+  if(DEFINED _RULE_COMPILE_TOOL)
+    set(_COMPILE_TOOL ${_RULE_COMPILE_TOOL})
   else()
-    set(_TRANSLATE_TOOL "iree-compile")
+    set(_COMPILE_TOOL "iree-compile")
   endif()
 
   if(DEFINED _RULE_MODULE_FILE_NAME)
@@ -60,7 +60,7 @@ function(iree_bytecode_module)
     set(_MODULE_FILE_NAME "${_RULE_NAME}.vmfb")
   endif()
 
-  iree_get_executable_path(_TRANSLATE_TOOL_EXECUTABLE ${_TRANSLATE_TOOL})
+  iree_get_executable_path(_COMPILE_TOOL_EXECUTABLE ${_COMPILE_TOOL})
 
   set(_ARGS "${_RULE_FLAGS}")
 
@@ -100,12 +100,11 @@ function(iree_bytecode_module)
     OUTPUT
       "${_MODULE_FILE_NAME}"
     COMMAND
-      ${_TRANSLATE_TOOL_EXECUTABLE}
+      ${_COMPILE_TOOL_EXECUTABLE}
       ${_ARGS}
-    # Changes to either the translation tool or the input source should
-    # trigger rebuilding.
+    # Changes to either the compiler tool or the input sources should rebuild.
     DEPENDS
-      ${_TRANSLATE_TOOL_EXECUTABLE}
+      ${_COMPILE_TOOL_EXECUTABLE}
       ${_LINKER_TOOL_EXECUTABLE}
       ${_RULE_SRC}
       ${_RULE_DEPENDS}

--- a/build_tools/cmake/iree_c_module.cmake
+++ b/build_tools/cmake/iree_c_module.cmake
@@ -12,11 +12,11 @@ include(CMakeParseArguments)
 # NAME: Name of target (see Note).
 # SRC: MLIR source file to compile into a c module.
 # H_FILE_OUTPUT: The H header file to output.
-# TRANSLATE_TOOL: Translation tool to invoke (CMake target). The default
-#     tool is "iree-compile".
-# FLAGS: Flags to pass to the translation tool (list of strings).
+# COMPILE_TOOL: Compiler tool to invoke (CMake target). The default tool is
+#     "iree-compile".
+# FLAGS: Flags to pass to the compiler tool (list of strings).
 # TESTONLY: When added, this target will only be built if user passes
-#    -DIREE_BUILD_TESTS=ON to CMake.
+#     -DIREE_BUILD_TESTS=ON to CMake.
 #
 # Note:
 # By default, iree_c_module will create a library named ${NAME},
@@ -26,7 +26,7 @@ function(iree_c_module)
   cmake_parse_arguments(
     _RULE
     "TESTONLY"
-    "NAME;SRC;H_FILE_OUTPUT;TRANSLATE_TOOL"
+    "NAME;SRC;H_FILE_OUTPUT;COMPILE_TOOL"
     "FLAGS"
     ${ARGN}
   )
@@ -43,14 +43,14 @@ function(iree_c_module)
   iree_package_name(_PACKAGE_NAME)
   set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}_hdrs")
 
-  # Set defaults for TRANSLATE_TOOL.
-  if(DEFINED _RULE_TRANSLATE_TOOL)
-    set(_TRANSLATE_TOOL ${_RULE_TRANSLATE_TOOL})
+  # Set defaults for COMPILE_TOOL.
+  if(DEFINED _RULE_COMPILE_TOOL)
+    set(_COMPILE_TOOL ${_RULE_COMPILE_TOOL})
   else()
-    set(_TRANSLATE_TOOL "iree-compile")
+    set(_COMPILE_TOOL "iree-compile")
   endif()
 
-  iree_get_executable_path(_TRANSLATE_TOOL_EXECUTABLE ${_TRANSLATE_TOOL})
+  iree_get_executable_path(_COMPILE_TOOL_EXECUTABLE ${_COMPILE_TOOL})
 
   set(_ARGS "${_RULE_FLAGS}")
   list(APPEND _ARGS "${CMAKE_CURRENT_SOURCE_DIR}/${_RULE_SRC}")
@@ -59,10 +59,9 @@ function(iree_c_module)
 
   add_custom_command(
     OUTPUT "${_RULE_H_FILE_OUTPUT}"
-    COMMAND ${_TRANSLATE_TOOL_EXECUTABLE} ${_ARGS}
-    # Changes to either the translation tool or the input source should
-    # trigger rebuilding.
-    DEPENDS ${_TRANSLATE_TOOL_EXECUTABLE} ${_RULE_SRC}
+    COMMAND ${_COMPILE_TOOL_EXECUTABLE} ${_ARGS}
+    # Changes to either the compiler tool or the input source should rebuild.
+    DEPENDS ${_COMPILE_TOOL_EXECUTABLE} ${_RULE_SRC}
   )
 
   iree_cc_library(

--- a/build_tools/cmake/iree_hal_cts_test_suite.cmake
+++ b/build_tools/cmake/iree_hal_cts_test_suite.cmake
@@ -106,7 +106,7 @@ function(iree_hal_cts_test_suite)
             "${IREE_ROOT_DIR}/runtime/src/iree/hal/cts/testdata/${_FILE_NAME}.mlir"
           FLAGS
             ${_TRANSLATE_FLAGS}
-          TRANSLATE_TOOL
+          COMPILE_TOOL
             "iree-compile"
           PUBLIC
           TESTONLY

--- a/build_tools/cmake/iree_microbenchmark_suite.cmake
+++ b/build_tools/cmake/iree_microbenchmark_suite.cmake
@@ -10,7 +10,7 @@
 # Parameters:
 #   NAME: Name of target.
 #   SRCS: Source files to compile into a bytecode module (list of strings).
-#   FLAGS: Flags to pass to the translation tool (list of strings).
+#   FLAGS: Flags to pass to the compiler tool (list of strings).
 
 function(iree_microbenchmark_suite)
   if(NOT IREE_BUILD_MICROBENCHMARKS)
@@ -28,11 +28,11 @@ function(iree_microbenchmark_suite)
   iree_package_name(PACKAGE_NAME)
 
   foreach(_SRC IN LISTS _RULE_SRCS)
-    set(_TRANSLATE_TOOL "iree-compile")
+    set(_COMPILE_TOOL "iree-compile")
     set(_TRANSLATE_SRC "${_SRC}")
     set(_MODULE_FILE_NAME "${_RULE_NAME}_${_SRC}.vmfb")
     set(_TARGET_NAME "${PACKAGE_NAME}_${_MODULE_FILE_NAME}")
-    iree_get_executable_path(_TRANSLATE_TOOL_EXECUTABLE "${_TRANSLATE_TOOL}")
+    iree_get_executable_path(_COMPILE_TOOL_EXECUTABLE "${_COMPILE_TOOL}")
     set(_ARGS "${_RULE_FLAGS}")
     get_filename_component(_TRANSLATE_SRC_PATH "${_TRANSLATE_SRC}" REALPATH)
     list(APPEND _ARGS "${_TRANSLATE_SRC_PATH}")
@@ -43,12 +43,11 @@ function(iree_microbenchmark_suite)
       OUTPUT
         "${_MODULE_FILE_NAME}"
       COMMAND
-        "${_TRANSLATE_TOOL_EXECUTABLE}"
+        "${_COMPILE_TOOL_EXECUTABLE}"
         ${_ARGS}
-      # Changes to either the translation tool or the input source should
-      # trigger rebuilding.
+      # Changes to either the compiler tool or the input source should rebuild.
       DEPENDS
-        "${_TRANSLATE_TOOL_EXECUTABLE}"
+        "${_COMPILE_TOOL_EXECUTABLE}"
         "${_TRANSLATE_SRC}"
       VERBATIM
     )

--- a/runtime/src/iree/vm/BUILD
+++ b/runtime/src/iree/vm/BUILD
@@ -271,8 +271,8 @@ iree_bytecode_module(
     testonly = True,
     src = "bytecode_module_benchmark.mlir",
     c_identifier = "iree_vm_bytecode_module_benchmark_module",
+    compile_tool = "//tools:iree-compile",
     flags = ["--compile-mode=vm"],
-    translate_tool = "//tools:iree-compile",
 )
 
 cc_binary_benchmark(
@@ -291,8 +291,8 @@ iree_bytecode_module(
     testonly = True,
     src = "bytecode_module_size_benchmark.mlir",
     c_identifier = "iree_vm_bytecode_module_size_benchmark_module",
+    compile_tool = "//tools:iree-compile",
     flags = ["--compile-mode=vm"],
-    translate_tool = "//tools:iree-compile",
 )
 
 iree_cmake_extra_content(

--- a/runtime/src/iree/vm/CMakeLists.txt
+++ b/runtime/src/iree/vm/CMakeLists.txt
@@ -234,7 +234,7 @@ iree_bytecode_module(
     "bytecode_module_benchmark.mlir"
   C_IDENTIFIER
     "iree_vm_bytecode_module_benchmark_module"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"
@@ -262,7 +262,7 @@ iree_bytecode_module(
     "bytecode_module_size_benchmark.mlir"
   C_IDENTIFIER
     "iree_vm_bytecode_module_size_benchmark_module"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"

--- a/runtime/src/iree/vm/test/BUILD
+++ b/runtime/src/iree/vm/test/BUILD
@@ -59,215 +59,215 @@ c_embed_data(
 iree_bytecode_module(
     name = "arithmetic_ops",
     src = "arithmetic_ops.mlir",
+    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
-    translate_tool = "//tools:iree-compile",
 )
 
 iree_bytecode_module(
     name = "arithmetic_ops_f32",
     src = "arithmetic_ops_f32.mlir",
+    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
-    translate_tool = "//tools:iree-compile",
 )
 
 iree_bytecode_module(
     name = "arithmetic_ops_i64",
     src = "arithmetic_ops_i64.mlir",
+    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
-    translate_tool = "//tools:iree-compile",
 )
 
 iree_bytecode_module(
     name = "assignment_ops",
     src = "assignment_ops.mlir",
+    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
-    translate_tool = "//tools:iree-compile",
 )
 
 iree_bytecode_module(
     name = "assignment_ops_f32",
     src = "assignment_ops_f32.mlir",
+    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
-    translate_tool = "//tools:iree-compile",
 )
 
 iree_bytecode_module(
     name = "assignment_ops_i64",
     src = "assignment_ops_i64.mlir",
+    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
-    translate_tool = "//tools:iree-compile",
 )
 
 iree_bytecode_module(
     name = "buffer_ops",
     src = "buffer_ops.mlir",
+    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
-    translate_tool = "//tools:iree-compile",
 )
 
 iree_bytecode_module(
     name = "call_ops",
     src = "call_ops.mlir",
+    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
-    translate_tool = "//tools:iree-compile",
 )
 
 iree_bytecode_module(
     name = "comparison_ops",
     src = "comparison_ops.mlir",
+    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
-    translate_tool = "//tools:iree-compile",
 )
 
 iree_bytecode_module(
     name = "comparison_ops_f32",
     src = "comparison_ops_f32.mlir",
+    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
-    translate_tool = "//tools:iree-compile",
 )
 
 iree_bytecode_module(
     name = "comparison_ops_i64",
     src = "comparison_ops_i64.mlir",
+    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
-    translate_tool = "//tools:iree-compile",
 )
 
 iree_bytecode_module(
     name = "control_flow_ops",
     src = "control_flow_ops.mlir",
+    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
-    translate_tool = "//tools:iree-compile",
 )
 
 iree_bytecode_module(
     name = "conversion_ops",
     src = "conversion_ops.mlir",
+    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
-    translate_tool = "//tools:iree-compile",
 )
 
 iree_bytecode_module(
     name = "conversion_ops_f32",
     src = "conversion_ops_f32.mlir",
+    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
-    translate_tool = "//tools:iree-compile",
 )
 
 iree_bytecode_module(
     name = "conversion_ops_i64",
     src = "conversion_ops_i64.mlir",
+    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
-    translate_tool = "//tools:iree-compile",
 )
 
 iree_bytecode_module(
     name = "global_ops",
     src = "global_ops.mlir",
+    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
-    translate_tool = "//tools:iree-compile",
 )
 
 iree_bytecode_module(
     name = "global_ops_f32",
     src = "global_ops_f32.mlir",
+    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
-    translate_tool = "//tools:iree-compile",
 )
 
 iree_bytecode_module(
     name = "global_ops_i64",
     src = "global_ops_i64.mlir",
+    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
-    translate_tool = "//tools:iree-compile",
 )
 
 iree_bytecode_module(
     name = "list_ops",
     src = "list_ops.mlir",
+    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
-    translate_tool = "//tools:iree-compile",
 )
 
 iree_bytecode_module(
     name = "list_ops_i64",
     src = "list_ops_i64.mlir",
+    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
-    translate_tool = "//tools:iree-compile",
 )
 
 iree_bytecode_module(
     name = "list_variant_ops",
     src = "list_variant_ops.mlir",
+    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
-    translate_tool = "//tools:iree-compile",
 )
 
 iree_bytecode_module(
     name = "ref_ops",
     src = "ref_ops.mlir",
+    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
-    translate_tool = "//tools:iree-compile",
 )
 
 iree_bytecode_module(
     name = "shift_ops",
     src = "shift_ops.mlir",
+    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
-    translate_tool = "//tools:iree-compile",
 )
 
 iree_bytecode_module(
     name = "shift_ops_i64",
     src = "shift_ops_i64.mlir",
+    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
-    translate_tool = "//tools:iree-compile",
 )

--- a/runtime/src/iree/vm/test/CMakeLists.txt
+++ b/runtime/src/iree/vm/test/CMakeLists.txt
@@ -55,7 +55,7 @@ iree_bytecode_module(
     arithmetic_ops
   SRC
     "arithmetic_ops.mlir"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"
@@ -67,7 +67,7 @@ iree_bytecode_module(
     arithmetic_ops_f32
   SRC
     "arithmetic_ops_f32.mlir"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"
@@ -79,7 +79,7 @@ iree_bytecode_module(
     arithmetic_ops_i64
   SRC
     "arithmetic_ops_i64.mlir"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"
@@ -91,7 +91,7 @@ iree_bytecode_module(
     assignment_ops
   SRC
     "assignment_ops.mlir"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"
@@ -103,7 +103,7 @@ iree_bytecode_module(
     assignment_ops_f32
   SRC
     "assignment_ops_f32.mlir"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"
@@ -115,7 +115,7 @@ iree_bytecode_module(
     assignment_ops_i64
   SRC
     "assignment_ops_i64.mlir"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"
@@ -127,7 +127,7 @@ iree_bytecode_module(
     buffer_ops
   SRC
     "buffer_ops.mlir"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"
@@ -139,7 +139,7 @@ iree_bytecode_module(
     call_ops
   SRC
     "call_ops.mlir"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"
@@ -151,7 +151,7 @@ iree_bytecode_module(
     comparison_ops
   SRC
     "comparison_ops.mlir"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"
@@ -163,7 +163,7 @@ iree_bytecode_module(
     comparison_ops_f32
   SRC
     "comparison_ops_f32.mlir"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"
@@ -175,7 +175,7 @@ iree_bytecode_module(
     comparison_ops_i64
   SRC
     "comparison_ops_i64.mlir"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"
@@ -187,7 +187,7 @@ iree_bytecode_module(
     control_flow_ops
   SRC
     "control_flow_ops.mlir"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"
@@ -199,7 +199,7 @@ iree_bytecode_module(
     conversion_ops
   SRC
     "conversion_ops.mlir"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"
@@ -211,7 +211,7 @@ iree_bytecode_module(
     conversion_ops_f32
   SRC
     "conversion_ops_f32.mlir"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"
@@ -223,7 +223,7 @@ iree_bytecode_module(
     conversion_ops_i64
   SRC
     "conversion_ops_i64.mlir"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"
@@ -235,7 +235,7 @@ iree_bytecode_module(
     global_ops
   SRC
     "global_ops.mlir"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"
@@ -247,7 +247,7 @@ iree_bytecode_module(
     global_ops_f32
   SRC
     "global_ops_f32.mlir"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"
@@ -259,7 +259,7 @@ iree_bytecode_module(
     global_ops_i64
   SRC
     "global_ops_i64.mlir"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"
@@ -271,7 +271,7 @@ iree_bytecode_module(
     list_ops
   SRC
     "list_ops.mlir"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"
@@ -283,7 +283,7 @@ iree_bytecode_module(
     list_ops_i64
   SRC
     "list_ops_i64.mlir"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"
@@ -295,7 +295,7 @@ iree_bytecode_module(
     list_variant_ops
   SRC
     "list_variant_ops.mlir"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"
@@ -307,7 +307,7 @@ iree_bytecode_module(
     ref_ops
   SRC
     "ref_ops.mlir"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"
@@ -319,7 +319,7 @@ iree_bytecode_module(
     shift_ops
   SRC
     "shift_ops.mlir"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"
@@ -331,7 +331,7 @@ iree_bytecode_module(
     shift_ops_i64
   SRC
     "shift_ops_i64.mlir"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
   FLAGS
     "--compile-mode=vm"

--- a/runtime/src/iree/vm/test/emitc/CMakeLists.txt
+++ b/runtime/src/iree/vm/test/emitc/CMakeLists.txt
@@ -54,7 +54,7 @@ iree_c_module(
   FLAGS
     "--compile-mode=vm"
     "--output-format=vm-c"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
 )
 
@@ -68,7 +68,7 @@ iree_c_module(
   FLAGS
     "--compile-mode=vm"
     "--output-format=vm-c"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
 )
 
@@ -82,7 +82,7 @@ iree_c_module(
   FLAGS
     "--compile-mode=vm"
     "--output-format=vm-c"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
 )
 
@@ -96,7 +96,7 @@ iree_c_module(
   FLAGS
     "--compile-mode=vm"
     "--output-format=vm-c"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
 )
 
@@ -110,7 +110,7 @@ iree_c_module(
   FLAGS
     "--compile-mode=vm"
     "--output-format=vm-c"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
 )
 
@@ -124,7 +124,7 @@ iree_c_module(
   FLAGS
     "--compile-mode=vm"
     "--output-format=vm-c"
-    TRANSLATE_TOOL
+    COMPILE_TOOL
     iree-compile
 )
 
@@ -138,7 +138,7 @@ iree_c_module(
   FLAGS
     "--compile-mode=vm"
     "--output-format=vm-c"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
 )
 
@@ -152,7 +152,7 @@ iree_c_module(
   FLAGS
     "--compile-mode=vm"
     "--output-format=vm-c"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
 )
 
@@ -166,7 +166,7 @@ iree_c_module(
   FLAGS
     "--compile-mode=vm"
     "--output-format=vm-c"
-    TRANSLATE_TOOL
+    COMPILE_TOOL
     iree-compile
 )
 
@@ -180,7 +180,7 @@ iree_c_module(
   FLAGS
     "--compile-mode=vm"
     "--output-format=vm-c"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
 )
 
@@ -194,7 +194,7 @@ iree_c_module(
   FLAGS
     "--compile-mode=vm"
     "--output-format=vm-c"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
 )
 
@@ -208,7 +208,7 @@ iree_c_module(
   FLAGS
     "--compile-mode=vm"
     "--output-format=vm-c"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
 )
 
@@ -222,7 +222,7 @@ iree_c_module(
   FLAGS
     "--compile-mode=vm"
     "--output-format=vm-c"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
 )
 
@@ -236,7 +236,7 @@ iree_c_module(
   FLAGS
     "--compile-mode=vm"
     "--output-format=vm-c"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
 )
 
@@ -250,7 +250,7 @@ iree_c_module(
   FLAGS
     "--compile-mode=vm"
     "--output-format=vm-c"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
 )
 
@@ -264,7 +264,7 @@ iree_c_module(
   FLAGS
     "--compile-mode=vm"
     "--output-format=vm-c"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
 )
 
@@ -278,7 +278,7 @@ iree_c_module(
   FLAGS
     "--compile-mode=vm"
     "--output-format=vm-c"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
 )
 
@@ -292,7 +292,7 @@ iree_c_module(
   FLAGS
     "--compile-mode=vm"
     "--output-format=vm-c"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
 )
 
@@ -306,7 +306,7 @@ iree_c_module(
   FLAGS
     "--compile-mode=vm"
     "--output-format=vm-c"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
 )
 
@@ -320,7 +320,7 @@ iree_c_module(
   FLAGS
     "--compile-mode=vm"
     "--output-format=vm-c"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
 )
 
@@ -334,7 +334,7 @@ iree_c_module(
   FLAGS
     "--compile-mode=vm"
     "--output-format=vm-c"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
 )
 
@@ -348,7 +348,7 @@ iree_c_module(
   FLAGS
     "--compile-mode=vm"
     "--output-format=vm-c"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
 )
 
@@ -362,7 +362,7 @@ iree_c_module(
   FLAGS
     "--compile-mode=vm"
     "--output-format=vm-c"
-  TRANSLATE_TOOL
+  COMPILE_TOOL
     iree-compile
 )
 


### PR DESCRIPTION
All uses of `iree-translate` were replaced with `iree-compile` and the `iree-translate` tool was removed. We still have some "translation passes" and "translation info" names in the compiler, but most language can be updated to "compile" and "compilation".

I'm separately planning on updating uses of `--iree-mlir-to-vm-bytecode-module` and related to flags to use the newer `--output-format` and `--compile-mode` flags (or just trusting the default values).