### PR TITLE
Replacing `--driver=` with `--device=` and adding list flags.

### DIFF
--- a/build_tools/bazel/iree_check_test.bzl
+++ b/build_tools/bazel/iree_check_test.bzl
@@ -67,7 +67,7 @@ def iree_check_test(
     native_test(
         name = name,
         args = [
-            "--driver=%s" % driver,
+            "--device=%s" % driver,
             "$(location :%s)" % bytecode_module_name,
         ] + runner_args,
         data = [":%s" % bytecode_module_name],

--- a/build_tools/bazel/iree_trace_runner_test.bzl
+++ b/build_tools/bazel/iree_trace_runner_test.bzl
@@ -65,7 +65,7 @@ def iree_trace_runner_test(
     native_test(
         name = name,
         args = [
-            "--driver=%s" % driver,
+            "--device=%s" % driver,
             "$(location :%s)" % trace,
         ] + runner_args,
         data = [

--- a/build_tools/benchmarks/comparisons/common/benchmark_command.py
+++ b/build_tools/benchmarks/comparisons/common/benchmark_command.py
@@ -129,7 +129,7 @@ class IreeBenchmarkCommand(BenchmarkCommand):
 
   def generate_benchmark_command(self) -> list[str]:
     command = super().generate_benchmark_command()
-    command.append("--driver=" + self.driver)
+    command.append("--device=" + self.driver)
     command.append("--task_topology_group_count=" + str(self.num_threads))
     command.append("--benchmark_repetitions=" + str(self.num_runs))
     return command

--- a/build_tools/cmake/iree_benchmark_suite.cmake
+++ b/build_tools/cmake/iree_benchmark_suite.cmake
@@ -300,7 +300,7 @@ function(iree_benchmark_suite)
         COMMAND
           "${Python3_EXECUTABLE}" "${IREE_ROOT_DIR}/build_tools/scripts/generate_flagfile.py"
             --module_file="${_MODULE_FILE_FLAG}"
-            --driver=${_RULE_DRIVER}
+            --device=${_RULE_DRIVER}
             --entry_function=${_MODULE_ENTRY_FUNCTION}
             --function_inputs=${_MODULE_FUNCTION_INPUTS}
             "${_ADDITIONAL_ARGS_CL}"

--- a/build_tools/cmake/iree_native_test.cmake
+++ b/build_tools/cmake/iree_native_test.cmake
@@ -14,7 +14,7 @@ include(CMakeParseArguments)
 #
 # Parameters:
 # NAME: name of target
-# DRIVER: If specified, will pass --driver=DRIVER to the test binary and adds
+# DRIVER: If specified, will pass --device=DRIVER to the test binary and adds
 #     a driver label to the test.
 # TEST_INPUT_FILE_ARG: If specified, the input file will be added to DATA and
 #     its device path appended to ARGS. Note that the device path may be
@@ -24,7 +24,7 @@ include(CMakeParseArguments)
 #     a separate device (e.g. Android), these files will be pushed to the
 #     device. TEST_INPUT_FILE_ARG is automatically added if specified.
 # ARGS: additional arguments passed to the test binary. TEST_INPUT_FILE_ARG and
-#     --driver=DRIVER are automatically added if specified.
+#     --device=DRIVER are automatically added if specified.
 # SRC: binary target to run as the test.
 # LABELS: Additional labels to apply to the test. The package path is added
 #     automatically.
@@ -69,7 +69,7 @@ function(iree_native_test)
 
   # If driver was specified, add the corresponding test arg and label.
   if(DEFINED _RULE_DRIVER)
-    list(APPEND _RULE_ARGS "--driver=${_RULE_DRIVER}")
+    list(APPEND _RULE_ARGS "--device=${_RULE_DRIVER}")
     list(APPEND _RULE_LABELS "driver=${_RULE_DRIVER}")
   endif()
 

--- a/build_tools/kokoro/gcp_ubuntu/cmake/linux/riscv64/tests/lit.cfg.py
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/linux/riscv64/tests/lit.cfg.py
@@ -20,7 +20,7 @@ config.environment["TEST_CMD"] = (
     (os.getenv("QEMU_RV64_BIN"), os.getenv("RISCV_TOOLCHAIN_ROOT")))
 
 config.environment["TEST_MODULE_CMD"] = (
-    "%s %s/tools/iree-run-module --driver=local-task" %
+    "%s %s/tools/iree-run-module --device=local-task" %
     (config.environment["TEST_CMD"], os.getenv("BUILD_RISCV_DIR")))
 
 config.test_exec_root = os.getenv("BUILD_RISCV_DIR") + \

--- a/build_tools/scripts/generate_flagfile.py
+++ b/build_tools/scripts/generate_flagfile.py
@@ -19,11 +19,11 @@ def parse_arguments():
                       required=True,
                       metavar="<module-file>",
                       help="The name of the module file")
-  parser.add_argument("--driver",
+  parser.add_argument("--device",
                       type=str,
                       required=True,
-                      metavar="<driver>",
-                      help="The name of the IREE driver")
+                      metavar="<device>",
+                      help="The name of the HAL device")
   parser.add_argument("--entry_function",
                       type=str,
                       required=True,
@@ -50,7 +50,7 @@ def parse_arguments():
 
 def main(args):
   lines = [
-      f"--driver={args.driver}", f"--module_file={args.module_file}",
+      f"--device={args.device}", f"--module_file={args.module_file}",
       f"--entry_function={args.entry_function}"
   ]
   lines.extend([

--- a/docs/developers/design_docs/cuda_backend.md
+++ b/docs/developers/design_docs/cuda_backend.md
@@ -85,7 +85,7 @@ $ ../iree-build/tools/iree-compile \
 
 # Run the module through CUDA HAL backend.
 $ ../iree-build/tools/iree-run-module \
-  --driver=cuda \
+  --device=cuda \
   --module_file=/tmp/mhlo-add.vmfb \
   --entry_function=add \
   --function_input="4xf32=[1 2 3 4]" \

--- a/docs/developers/developing_iree/benchmarking.md
+++ b/docs/developers/developing_iree/benchmarking.md
@@ -31,7 +31,7 @@ and then benchmark an exported function in that module:
 ```shell
 $ bazel run //tools:iree-benchmark-module -- \
   --module_file=/tmp/module.fb \
-  --driver=local-task \
+  --device=local-task \
   --entry_function=abs \
   --function_input=f32=-2
 ```
@@ -78,7 +78,7 @@ Now we'll actually invoke the binary:
 ```shell
 $ ./bazel-bin/tools/iree-benchmark-module \
   --module_file=/tmp/module.fb \
-  --driver=local-task \
+  --device=local-task \
   --entry_function=abs \
   --function_input=f32=-2
 ```
@@ -122,7 +122,7 @@ in that module:
 ```shell
 $ build/tools/iree-benchmark-module
   --module_file=/tmp/fullyconnected.vmfb
-  --driver=local-task
+  --device=local-task
 ```
 
 If no `entry_function` is specified, `iree-benchmark-module` will register a

--- a/docs/developers/developing_iree/developer_overview.md
+++ b/docs/developers/developing_iree/developer_overview.md
@@ -140,7 +140,7 @@ above on IREE's VMVX driver:
 ```shell
 $ ../iree-build/tools/iree-run-module \
   --module_file=/tmp/simple_abs_vmvx.vmfb \
-  --driver=local-task \
+  --device=local-task \
   --entry_function=abs \
   --function_input=f32=-2
 ```
@@ -165,7 +165,7 @@ $ ../iree-build/tools/iree-compile \
 ```shell
 $ ../iree-build/tools/iree-check-module \
   /tmp/abs.vmfb \
-  --driver=local-task
+  --device=local-task
 ```
 
 ### iree-run-mlir

--- a/docs/developers/developing_iree/e2e_benchmarking.md
+++ b/docs/developers/developing_iree/e2e_benchmarking.md
@@ -117,7 +117,7 @@ on VMVX run:
 ```shell
 $ tools/iree-benchmark-module \
   --module_file=/tmp/iree/modules/MatrixOpsStaticModule/iree_vmvx/compiled.vmfb \
-  --driver=local-task \
+  --device=local-task \
   --entry_function=matmul_lhs_batch \
   --function_input=256x64x32xf32=2 \
   --function_input=32x16xf32=3
@@ -221,7 +221,7 @@ $ adb push /tmp/iree/modules/MatrixOpsStaticModule/iree_vmvx/* \
 ```shell
 $ adb shell /data/local/tmp/iree-benchmark-module \
   --module_file="/data/local/tmp/MatrixOpsStaticModule/iree_vmvx/compiled.vmfb" \
-  --driver=local-task \
+  --device=local-task \
   --entry_function=matmul_lhs_batch \
   --function_input=256x64x32xf32=2 \
   --function_input=32x16xf32=3

--- a/docs/developers/developing_iree/profiling_cpu_events.md
+++ b/docs/developers/developing_iree/profiling_cpu_events.md
@@ -63,7 +63,7 @@ subsequent commands analyzing the profile. Example:
 ```shell
 perf record -o /tmp/perf.data \
   ./tools/iree-benchmark-module \
-    --driver=local-task \
+    --device=local-task \
     ... command-line arguments of iree-benchmark-module as usual ...
 ```
 
@@ -73,7 +73,7 @@ by, with the `-e` flag. For instance, to sample by L1 cache misses, one may do:
 ```shell
 perf record -o /tmp/perf.data -e L1-dcache-load-misses \
   ./tools/iree-benchmark-module \
-    --driver=local-task \
+    --device=local-task \
     ... command-line arguments of iree-benchmark-module as usual ...
 ```
 
@@ -150,7 +150,7 @@ First, we record on the device:
 adb shell \
   simpleperf record -e raw-l1d-cache-refill -o /data/local/tmp/perf.data \
     /data/local/tmp/iree-benchmark-module \
-      --driver=local-task \
+      --device=local-task \
       ... command-line arguments of iree-benchmark-module as usual ...
 ```
 

--- a/docs/developers/developing_iree/profiling_vulkan_gpu.md
+++ b/docs/developers/developing_iree/profiling_vulkan_gpu.md
@@ -45,7 +45,7 @@ $ /path/to/iree/build/tools/iree-compile -- \
 # Then package the Android app
 $ /path/to/iree/source/tools/android/run_module_app/build_apk.sh \
   ./build-apk \
-  --driver vulkan \
+  --device vulkan \
   --module_file /tmp/mhlo-dot.vmfb \
   --entry_function dot \
   --function_input=...

--- a/docs/developers/developing_iree/profiling_with_tracy.md
+++ b/docs/developers/developing_iree/profiling_with_tracy.md
@@ -126,7 +126,7 @@ Example:
 
 ```shell
 TRACY_NO_EXIT=1 /data/local/tmp/iree-benchmark-module \
-  --driver=local-task \
+  --device=local-task \
   --module_file=/data/local/tmp/android_module.fbvm \
   --entry_function=serving_default \
   --function_input=1x384xi32 \

--- a/docs/website/docs/building-from-source/android.md
+++ b/docs/website/docs/building-from-source/android.md
@@ -127,7 +127,7 @@ adb push /tmp/simple_abs_vmvx.vmfb /data/local/tmp/
 Run the tool:
 
 ``` shell
-adb shell /data/local/tmp/iree-run-module --driver=local-task \
+adb shell /data/local/tmp/iree-run-module --device=local-task \
   --module_file=/data/local/tmp/simple_abs_vmvx.vmfb \
   --entry_function=abs \
   --function_input="f32=-5"

--- a/docs/website/docs/building-from-source/riscv.md
+++ b/docs/website/docs/building-from-source/riscv.md
@@ -117,7 +117,7 @@ ${QEMU_BIN} \
   -cpu rv64 \
   -L ${RISCV_TOOLCHAIN_ROOT}/sysroot/ \
   ../iree-build-riscv/tools/iree-run-module \
-  --driver=local-task \
+  --device=local-task \
   --module_file=/tmp/simple_abs_vmvx.vmfb \
   --entry_function=abs \
   --function_input=f32=-5
@@ -163,7 +163,7 @@ ${QEMU_BIN} \
   -cpu rv64,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
   -L ${RISCV_TOOLCHAIN_ROOT}/sysroot/ \
   ../iree-build-riscv/tools/iree-run-module \
-  --driver=local-task \
+  --device=local-task \
   --module_file=mobilenet_cpu.vmfb \
   --entry_function=predict \
   --function_input="1x224x224x3xf32=0"

--- a/docs/website/docs/deployment-configurations/cpu.md
+++ b/docs/website/docs/deployment-configurations/cpu.md
@@ -126,7 +126,7 @@ In the build directory, run the following command:
 
 ``` shell hl_lines="2"
 tools/iree-run-module \
-    --driver=local-task \
+    --device=local-task \
     --module_file=mobilenet_cpu.vmfb \
     --entry_function=predict \
     --function_input="1x224x224x3xf32=0"

--- a/docs/website/docs/deployment-configurations/gpu-cuda-rocm.md
+++ b/docs/website/docs/deployment-configurations/gpu-cuda-rocm.md
@@ -158,7 +158,7 @@ In the build directory, run the following command:
 
     ``` shell hl_lines="2"
     tools/iree-run-module \
-        --driver=cuda \
+        --device=cuda \
         --module_file=mobilenet-cuda.vmfb \
         --entry_function=predict \
         --function_input="1x224x224x3xf32=0"
@@ -168,7 +168,7 @@ In the build directory, run the following command:
 
     ``` shell hl_lines="2"
     tools/iree-run-module \
-        --driver=rocm \
+        --device=rocm \
         --module_file=mobilenet-rocm.vmfb \
         --entry_function=predict \
         --function_input="1x224x224x3xf32=0"

--- a/docs/website/docs/deployment-configurations/gpu-vulkan.md
+++ b/docs/website/docs/deployment-configurations/gpu-vulkan.md
@@ -176,7 +176,7 @@ In the build directory, run the following command:
 
 ``` shell hl_lines="2"
 tools/iree-run-module \
-    --driver=vulkan \
+    --device=vulkan \
     --module_file=mobilenet-vulkan.vmfb \
     --entry_function=predict \
     --function_input="1x224x224x3xf32=0"

--- a/experimental/rocm/rocm_driver.c
+++ b/experimental/rocm/rocm_driver.c
@@ -135,9 +135,9 @@ static iree_status_t iree_hal_rocm_driver_query_available_devices(
     uint8_t* buffer_ptr =
         (uint8_t*)device_infos + device_count * sizeof(iree_hal_device_info_t);
     for (iree_host_size_t i = 0; i < device_count; ++i) {
-      hipDevice_t device;
-      iree_status_t status = ROCM_RESULT_TO_STATUS(
-          &driver->syms, hipDeviceGet(&device, i), "hipDeviceGet");
+      hipDevice_t device = 0;
+      status = ROCM_RESULT_TO_STATUS(&driver->syms, hipDeviceGet(&device, i),
+                                     "hipDeviceGet");
       if (!iree_status_is_ok(status)) break;
       buffer_ptr = iree_hal_rocm_populate_device_info(
           device, &driver->syms, buffer_ptr, &device_infos[i]);
@@ -150,6 +150,18 @@ static iree_status_t iree_hal_rocm_driver_query_available_devices(
     iree_allocator_free(host_allocator, device_infos);
   }
   return status;
+}
+
+static iree_status_t iree_hal_rocm_driver_dump_device_info(
+    iree_hal_driver_t* base_driver, iree_hal_device_id_t device_id,
+    iree_string_builder_t* builder) {
+  iree_hal_rocm_driver_t* driver = iree_hal_rocm_driver_cast(base_driver);
+  hipDevice_t device = (hipDevice_t)device_id;
+  if (!device) return iree_ok_status();
+  // TODO: dump detailed device info.
+  (void)driver;
+  (void)device;
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_rocm_driver_select_default_device(
@@ -219,6 +231,7 @@ static iree_status_t iree_hal_rocm_driver_create_device_by_path(
 static const iree_hal_driver_vtable_t iree_hal_rocm_driver_vtable = {
     .destroy = iree_hal_rocm_driver_destroy,
     .query_available_devices = iree_hal_rocm_driver_query_available_devices,
+    .dump_device_info = iree_hal_rocm_driver_dump_device_info,
     .create_device_by_id = iree_hal_rocm_driver_create_device_by_id,
     .create_device_by_path = iree_hal_rocm_driver_create_device_by_path,
 };

--- a/experimental/web/run_native_benchmarks.sh
+++ b/experimental/web/run_native_benchmarks.sh
@@ -34,7 +34,7 @@ IREE_BENCHMARK_MODULE_PATH=iree-benchmark-module
 echo "Benchmarking DeepLabV3..."
 "${IREE_BENCHMARK_MODULE_PATH?}" \
     --module_file=./deeplabv3_native.vmfb \
-    --driver=local-task \
+    --device=local-task \
     --task_topology_group_count=1 \
     --entry_function=main \
     --function_input=1x257x257x3xf32 \
@@ -44,7 +44,7 @@ echo ""
 echo "Benchmarking MobileSSD..."
 "${IREE_BENCHMARK_MODULE_PATH?}" \
     --module_file=./mobile_ssd_v2_float_coco_native.vmfb \
-    --driver=local-task \
+    --device=local-task \
     --task_topology_group_count=1 \
     --entry_function=main \
     --function_input=1x320x320x3xf32 \
@@ -54,7 +54,7 @@ echo ""
 echo "Benchmarking PoseNet..."
 "${IREE_BENCHMARK_MODULE_PATH?}" \
     --module_file=./posenet_native.vmfb \
-    --driver=local-task \
+    --device=local-task \
     --task_topology_group_count=1 \
     --entry_function=main \
     --function_input=1x353x257x3xf32 \
@@ -64,7 +64,7 @@ echo ""
 echo "Benchmarking MobileBertSquad..."
 "${IREE_BENCHMARK_MODULE_PATH?}" \
     --module_file=./mobilebertsquad_native.vmfb \
-    --driver=local-task \
+    --device=local-task \
     --task_topology_group_count=1 \
     --entry_function=main \
     --function_input=1x384xi32 \
@@ -76,7 +76,7 @@ echo ""
 echo "Benchmarking MobileNetV2..."
 "${IREE_BENCHMARK_MODULE_PATH?}" \
     --module_file=./mobilenet_v2_1.0_224_native.vmfb \
-    --driver=local-task \
+    --device=local-task \
     --task_topology_group_count=1 \
     --entry_function=main \
     --function_input=1x224x224x3xf32 \
@@ -86,7 +86,7 @@ echo ""
 echo "Benchmarking MobileNetV3Small..."
 "${IREE_BENCHMARK_MODULE_PATH?}" \
     --module_file=./MobileNetV3SmallStaticBatch_native.vmfb \
-    --driver=local-task \
+    --device=local-task \
     --task_topology_group_count=1 \
     --entry_function=main \
     --function_input=1x224x224x3xf32 \

--- a/experimental/web/testing/parse_test_list.py
+++ b/experimental/web/testing/parse_test_list.py
@@ -73,7 +73,7 @@ def parse_ctest_dump(ctest_dump_path, build_dir):
 
       # Parse the 'command' list into the source file and its arguments.
       #   /path/to/test_runner.js  # such as iree-check-module.js or test.js
-      #   arg 1                    # such as --driver=local-task
+      #   arg 1                    # such as --device=local-task
       #   arg 2                    # such as check_vmvx_op.mlir_module.vmfb
       test_source_absolute_path = test["command"][0]
       parsed_test["sourceFile"] = get_normalized_relative_path(

--- a/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/trace_utils.py
+++ b/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/trace_utils.py
@@ -285,7 +285,7 @@ class Trace:
         serialized_inputs = self.calls[0].serialized_inputs
         flagfile = [
             f"--module_file={compiled_path}",
-            f"--driver={self.backend_driver}",
+            f"--device={self.backend_driver}",
             f"--entry_function={entry_function}",
         ] + [f"--function_input={input}" for input in serialized_inputs]
         with open(os.path.join(trace_dir, "flagfile"), "w") as f:

--- a/runtime/src/iree/base/status.h
+++ b/runtime/src/iree/base/status.h
@@ -222,7 +222,8 @@ typedef struct iree_status_handle_t* iree_status_t;
 #define IREE_STATUS_IMPL_GET_EXPR_(expr, ...) expr
 #define IREE_STATUS_IMPL_GET_ARGS_(expr, ...) __VA_ARGS__
 #define IREE_STATUS_IMPL_GET_MACRO_(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, \
-                                    _10, _11, _12, _13, _14, ...)           \
+                                    _10, _11, _12, _13, _14, _15, _16, _17, \
+                                    ...)                                    \
   IREE_STATUS_IMPL_IDENTITY_(                                               \
       IREE_STATUS_IMPL_IDENTITY_(IREE_STATUS_IMPL_GET_EXPR_)(__VA_ARGS__))
 
@@ -242,7 +243,9 @@ typedef struct iree_status_handle_t* iree_status_t;
       IREE_STATUS_IMPL_MAKE_ANNOTATE_F_, IREE_STATUS_IMPL_MAKE_ANNOTATE_F_, \
       IREE_STATUS_IMPL_MAKE_ANNOTATE_F_, IREE_STATUS_IMPL_MAKE_ANNOTATE_F_, \
       IREE_STATUS_IMPL_MAKE_ANNOTATE_F_, IREE_STATUS_IMPL_MAKE_ANNOTATE_F_, \
-      IREE_STATUS_IMPL_MAKE_ANNOTATE_, IREE_STATUS_IMPL_MAKE_EMPTY_))       \
+      IREE_STATUS_IMPL_MAKE_ANNOTATE_F_, IREE_STATUS_IMPL_MAKE_ANNOTATE_F_, \
+      IREE_STATUS_IMPL_MAKE_ANNOTATE_F_, IREE_STATUS_IMPL_MAKE_ANNOTATE_,   \
+      IREE_STATUS_IMPL_MAKE_EMPTY_))                                        \
   (file, line, IREE_STATUS_IMPL_GET_EXPR_(__VA_ARGS__),                     \
    IREE_STATUS_IMPL_GET_ARGS_(__VA_ARGS__))
 
@@ -255,17 +258,19 @@ typedef struct iree_status_handle_t* iree_status_t;
   IREE_STATUS_IMPL_IDENTITY_(iree_status_annotate_f( \
       var,                                           \
       IREE_STATUS_IMPL_IDENTITY_(IREE_STATUS_IMPL_GET_ARGS_)(__VA_ARGS__)))
-#define IREE_STATUS_IMPL_ANNOTATE_SWITCH_(...)                                 \
-  IREE_STATUS_IMPL_IDENTITY_(IREE_STATUS_IMPL_IDENTITY_(                       \
-      IREE_STATUS_IMPL_GET_MACRO_)(                                            \
-      __VA_ARGS__, IREE_STATUS_IMPL_ANNOTATE_F_, IREE_STATUS_IMPL_ANNOTATE_F_, \
-      IREE_STATUS_IMPL_ANNOTATE_F_, IREE_STATUS_IMPL_ANNOTATE_F_,              \
-      IREE_STATUS_IMPL_ANNOTATE_F_, IREE_STATUS_IMPL_ANNOTATE_F_,              \
-      IREE_STATUS_IMPL_ANNOTATE_F_, IREE_STATUS_IMPL_ANNOTATE_F_,              \
-      IREE_STATUS_IMPL_ANNOTATE_F_, IREE_STATUS_IMPL_ANNOTATE_F_,              \
-      IREE_STATUS_IMPL_ANNOTATE_F_, IREE_STATUS_IMPL_ANNOTATE_F_,              \
-      IREE_STATUS_IMPL_ANNOTATE_, IREE_STATUS_IMPL_PASS_))                     \
-  (IREE_STATUS_IMPL_GET_EXPR_(__VA_ARGS__),                                    \
+#define IREE_STATUS_IMPL_ANNOTATE_SWITCH_(...)                        \
+  IREE_STATUS_IMPL_IDENTITY_(                                         \
+      IREE_STATUS_IMPL_IDENTITY_(IREE_STATUS_IMPL_GET_MACRO_)(        \
+          __VA_ARGS__, IREE_STATUS_IMPL_ANNOTATE_F_,                  \
+          IREE_STATUS_IMPL_ANNOTATE_F_, IREE_STATUS_IMPL_ANNOTATE_F_, \
+          IREE_STATUS_IMPL_ANNOTATE_F_, IREE_STATUS_IMPL_ANNOTATE_F_, \
+          IREE_STATUS_IMPL_ANNOTATE_F_, IREE_STATUS_IMPL_ANNOTATE_F_, \
+          IREE_STATUS_IMPL_ANNOTATE_F_, IREE_STATUS_IMPL_ANNOTATE_F_, \
+          IREE_STATUS_IMPL_ANNOTATE_F_, IREE_STATUS_IMPL_ANNOTATE_F_, \
+          IREE_STATUS_IMPL_ANNOTATE_F_, IREE_STATUS_IMPL_ANNOTATE_F_, \
+          IREE_STATUS_IMPL_ANNOTATE_F_, IREE_STATUS_IMPL_ANNOTATE_F_, \
+          IREE_STATUS_IMPL_ANNOTATE_, IREE_STATUS_IMPL_PASS_))        \
+  (IREE_STATUS_IMPL_GET_EXPR_(__VA_ARGS__),                           \
    IREE_STATUS_IMPL_GET_ARGS_(__VA_ARGS__))
 #define IREE_STATUS_IMPL_RETURN_IF_API_ERROR_(var, ...)                      \
   iree_status_t var = (IREE_STATUS_IMPL_IDENTITY_(                           \

--- a/runtime/src/iree/hal/device.h
+++ b/runtime/src/iree/hal/device.h
@@ -70,7 +70,9 @@ typedef uint32_t iree_hal_device_feature_t;
 typedef struct iree_hal_device_info_t {
   // Opaque handle used by drivers. Not valid across driver instances.
   iree_hal_device_id_t device_id;
-  // Name of the device as returned by the API.
+  // Stable driver-specific path used to reference the device.
+  iree_string_view_t path;
+  // Human-readable name of the device as returned by the API.
   iree_string_view_t name;
 } iree_hal_device_info_t;
 

--- a/runtime/src/iree/hal/driver.c
+++ b/runtime/src/iree/hal/driver.c
@@ -33,6 +33,18 @@ IREE_API_EXPORT iree_status_t iree_hal_driver_query_available_devices(
   return status;
 }
 
+IREE_API_EXPORT iree_status_t iree_hal_driver_dump_device_info(
+    iree_hal_driver_t* driver, iree_hal_device_id_t device_id,
+    iree_string_builder_t* builder) {
+  IREE_ASSERT_ARGUMENT(driver);
+  IREE_ASSERT_ARGUMENT(builder);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status =
+      _VTABLE_DISPATCH(driver, dump_device_info)(driver, device_id, builder);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 IREE_API_EXPORT iree_status_t iree_hal_driver_create_device_by_ordinal(
     iree_hal_driver_t* driver, iree_host_size_t device_ordinal,
     iree_host_size_t param_count, const iree_string_pair_t* params,

--- a/runtime/src/iree/hal/driver.h
+++ b/runtime/src/iree/hal/driver.h
@@ -70,6 +70,22 @@ IREE_API_EXPORT iree_status_t iree_hal_driver_query_available_devices(
     iree_host_size_t* out_device_info_count,
     iree_hal_device_info_t** out_device_infos);
 
+// Appends detailed info about a device with the given |device_id| to |builder|.
+// Only IDs as queried from the driver may be used.
+//
+// !!! WARNING !!!
+// This information may contain personally identifiable information and should
+// only be used for diagnostics: don't mindlessly report this in analytics.
+//
+// Callers should ensure the builder is at a newline before calling and drivers
+// should append a trailing newline if they append any information.
+//
+// Returns success whether or not any information was added to the builder;
+// not all drivers or devices have information.
+IREE_API_EXPORT iree_status_t iree_hal_driver_dump_device_info(
+    iree_hal_driver_t* driver, iree_hal_device_id_t device_id,
+    iree_string_builder_t* builder);
+
 // Creates a device with the given |device_ordinal| as enumerated by
 // iree_hal_driver_query_available_devices. The ordering of devices is driver
 // dependent and may vary across driver instances and processes.
@@ -141,6 +157,10 @@ typedef struct iree_hal_driver_vtable_t {
       iree_hal_driver_t* driver, iree_allocator_t host_allocator,
       iree_host_size_t* out_device_info_count,
       iree_hal_device_info_t** out_device_infos);
+
+  iree_status_t(IREE_API_PTR* dump_device_info)(iree_hal_driver_t* driver,
+                                                iree_hal_device_id_t device_id,
+                                                iree_string_builder_t* builder);
 
   iree_status_t(IREE_API_PTR* create_device_by_id)(
       iree_hal_driver_t* driver, iree_hal_device_id_t device_id,

--- a/runtime/src/iree/hal/drivers/cuda/cuda_driver.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_driver.c
@@ -15,6 +15,12 @@
 #include "iree/hal/drivers/cuda/dynamic_symbols.h"
 #include "iree/hal/drivers/cuda/status_util.h"
 
+// Maximum device name length we support.
+#define IREE_HAL_CUDA_MAX_DEVICE_NAME_LENGTH 128
+
+#define CUDEVICE_TO_DEVICE_ID(device) (iree_hal_device_id_t)((device) + 1)
+#define DEVICE_ID_TO_CUDEVICE(device_id) (CUdevice)((device_id)-1)
+
 typedef struct iree_hal_cuda_driver_t {
   iree_hal_resource_t resource;
   iree_allocator_t host_allocator;
@@ -27,9 +33,6 @@ typedef struct iree_hal_cuda_driver_t {
   // CUDA symbols.
   iree_hal_cuda_dynamic_symbols_t syms;
 } iree_hal_cuda_driver_t;
-
-// Pick a fixed lenght size for device names.
-#define IREE_MAX_CUDA_DEVICE_NAME_LENGTH 100
 
 static const iree_hal_driver_vtable_t iree_hal_cuda_driver_vtable;
 
@@ -102,23 +105,60 @@ IREE_API_EXPORT iree_status_t iree_hal_cuda_driver_create(
   return status;
 }
 
+static iree_status_t iree_hal_cuda_init(iree_hal_cuda_driver_t* driver) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, CU_RESULT_TO_STATUS(&driver->syms, cuInit(0), "cuInit"));
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
 // Populates device information from the given CUDA physical device handle.
 // |out_device_info| must point to valid memory and additional data will be
 // appended to |buffer_ptr| and the new pointer is returned.
-static uint8_t* iree_hal_cuda_populate_device_info(
+static iree_status_t iree_hal_cuda_populate_device_info(
     CUdevice device, iree_hal_cuda_dynamic_symbols_t* syms, uint8_t* buffer_ptr,
-    iree_hal_device_info_t* out_device_info) {
-  char device_name[IREE_MAX_CUDA_DEVICE_NAME_LENGTH];
-  CUDA_IGNORE_ERROR(syms,
-                    cuDeviceGetName(device_name, sizeof(device_name), device));
-  memset(out_device_info, 0, sizeof(*out_device_info));
-  out_device_info->device_id = (iree_hal_device_id_t)device;
+    uint8_t** out_buffer_ptr, iree_hal_device_info_t* out_device_info) {
+  *out_buffer_ptr = buffer_ptr;
 
-  iree_string_view_t device_name_string =
+  char device_name[IREE_HAL_CUDA_MAX_DEVICE_NAME_LENGTH];
+  CUDA_RETURN_IF_ERROR(
+      syms, cuDeviceGetName(device_name, sizeof(device_name), device),
+      "cuDeviceGetName");
+  memset(out_device_info, 0, sizeof(*out_device_info));
+  out_device_info->device_id = CUDEVICE_TO_DEVICE_ID(device);
+
+  // This matches the output of `nvidia-smi -L`.
+  CUuuid device_uuid;
+  CUDA_RETURN_IF_ERROR(syms, cuDeviceGetUuid_v2(&device_uuid, device),
+                       "cuDeviceGetUuid_v2");
+  char device_path_str[40 + 1] = {0};
+  snprintf(device_path_str, sizeof(device_path_str),
+           "GPU-"
+           "%02x%02x%02x%02x-"
+           "%02x%02x-"
+           "%02x%02x-"
+           "%02x%02x-"
+           "%02x%02x%02x%02x%02x%02x",
+           (uint8_t)device_uuid.bytes[0], (uint8_t)device_uuid.bytes[1],
+           (uint8_t)device_uuid.bytes[2], (uint8_t)device_uuid.bytes[3],
+           (uint8_t)device_uuid.bytes[4], (uint8_t)device_uuid.bytes[5],
+           (uint8_t)device_uuid.bytes[6], (uint8_t)device_uuid.bytes[7],
+           (uint8_t)device_uuid.bytes[8], (uint8_t)device_uuid.bytes[9],
+           (uint8_t)device_uuid.bytes[10], (uint8_t)device_uuid.bytes[11],
+           (uint8_t)device_uuid.bytes[12], (uint8_t)device_uuid.bytes[13],
+           (uint8_t)device_uuid.bytes[14], (uint8_t)device_uuid.bytes[15]);
+  buffer_ptr += iree_string_view_append_to_buffer(
+      iree_make_cstring_view(device_path_str), &out_device_info->path,
+      (char*)buffer_ptr);
+
+  iree_string_view_t device_name_str =
       iree_make_string_view(device_name, strlen(device_name));
   buffer_ptr += iree_string_view_append_to_buffer(
-      device_name_string, &out_device_info->name, (char*)buffer_ptr);
-  return buffer_ptr;
+      device_name_str, &out_device_info->name, (char*)buffer_ptr);
+
+  *out_buffer_ptr = buffer_ptr;
+  return iree_ok_status();
 }
 
 // Return true if the device support all the extension required.
@@ -132,6 +172,10 @@ static iree_status_t iree_hal_cuda_driver_query_available_devices(
     iree_host_size_t* out_device_info_count,
     iree_hal_device_info_t** out_device_infos) {
   iree_hal_cuda_driver_t* driver = iree_hal_cuda_driver_cast(base_driver);
+
+  // Ensure CUDA is initialized before querying it.
+  IREE_RETURN_IF_ERROR(iree_hal_cuda_init(driver));
+
   // Query the number of available CUDA devices.
   int device_count = 0;
   CUDA_RETURN_IF_ERROR(&driver->syms, cuDeviceGetCount(&device_count),
@@ -141,7 +185,7 @@ static iree_status_t iree_hal_cuda_driver_query_available_devices(
   iree_hal_device_info_t* device_infos = NULL;
   iree_host_size_t total_size = device_count * sizeof(iree_hal_device_info_t);
   for (iree_host_size_t i = 0; i < device_count; ++i) {
-    total_size += IREE_MAX_CUDA_DEVICE_NAME_LENGTH * sizeof(char);
+    total_size += IREE_HAL_CUDA_MAX_DEVICE_NAME_LENGTH * sizeof(char);
   }
   iree_status_t status =
       iree_allocator_malloc(host_allocator, total_size, (void**)&device_infos);
@@ -151,12 +195,14 @@ static iree_status_t iree_hal_cuda_driver_query_available_devices(
         (uint8_t*)device_infos + device_count * sizeof(iree_hal_device_info_t);
     for (iree_host_size_t i = 0; i < device_count; ++i) {
       CUdevice device;
-      iree_status_t status = CU_RESULT_TO_STATUS(
-          &driver->syms, cuDeviceGet(&device, i), "cuDeviceGet");
+      status = CU_RESULT_TO_STATUS(&driver->syms, cuDeviceGet(&device, i),
+                                   "cuDeviceGet");
       if (!iree_status_is_ok(status)) break;
       if (!iree_hal_cuda_is_valid_device(driver, device)) continue;
-      buffer_ptr = iree_hal_cuda_populate_device_info(
-          device, &driver->syms, buffer_ptr, &device_infos[valid_device_count]);
+      status = iree_hal_cuda_populate_device_info(
+          device, &driver->syms, buffer_ptr, &buffer_ptr,
+          &device_infos[valid_device_count]);
+      if (!iree_status_is_ok(status)) break;
       valid_device_count++;
     }
   }
@@ -167,6 +213,18 @@ static iree_status_t iree_hal_cuda_driver_query_available_devices(
     iree_allocator_free(host_allocator, device_infos);
   }
   return status;
+}
+
+static iree_status_t iree_hal_cuda_driver_dump_device_info(
+    iree_hal_driver_t* base_driver, iree_hal_device_id_t device_id,
+    iree_string_builder_t* builder) {
+  iree_hal_cuda_driver_t* driver = iree_hal_cuda_driver_cast(base_driver);
+  CUdevice device = (CUdevice)device_id;
+  if (!device) return iree_ok_status();
+  // TODO: dump detailed device info.
+  (void)driver;
+  (void)device;
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_cuda_driver_select_default_device(
@@ -199,16 +257,19 @@ static iree_status_t iree_hal_cuda_driver_create_device_by_id(
   iree_hal_cuda_driver_t* driver = iree_hal_cuda_driver_cast(base_driver);
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, CU_RESULT_TO_STATUS(&driver->syms, cuInit(0), "cuInit"));
+  // Ensure CUDA is initialized before querying it.
+  IREE_RETURN_IF_ERROR(iree_hal_cuda_init(driver));
+
   // Use either the specified device (enumerated earlier) or whatever default
   // one was specified when the driver was created.
-  CUdevice device = (CUdevice)device_id;
-  if (device == 0) {
+  CUdevice device = 0;
+  if (device_id == IREE_HAL_DEVICE_ID_DEFAULT) {
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
         z0, iree_hal_cuda_driver_select_default_device(
                 base_driver, &driver->syms, driver->default_device_index,
                 host_allocator, &device));
+  } else {
+    device = DEVICE_ID_TO_CUDEVICE(device_id);
   }
 
   iree_string_view_t device_name = iree_make_cstring_view("cuda");
@@ -222,23 +283,158 @@ static iree_status_t iree_hal_cuda_driver_create_device_by_id(
   return status;
 }
 
+static bool iree_hal_cuda_parse_uuid(iree_string_view_t value,
+                                     CUuuid* out_uuid) {
+  /* clang-format off */
+  static const char kHexValue[256] = {
+      0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0,  1,  2,  3,  4,  5,  6, 7, 8, 9, 0, 0, 0, 0, 0, 0,  // '0'..'9'
+      0, 10, 11, 12, 13, 14, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0,  // 'A'..'F'
+      0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 10, 11, 12, 13, 14, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0,  // 'a'..'f'
+      0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+  };
+  /* clang-format on */
+  for (int i = 0; i < IREE_ARRAYSIZE(out_uuid->bytes); ++i) {
+    iree_string_view_consume_prefix(&value, IREE_SV("-"));
+    if (value.size < 2) return false;
+    out_uuid->bytes[i] = (kHexValue[value.data[0] & 0xFF] << 4) +
+                         kHexValue[value.data[1] & 0xFF];
+    value = iree_string_view_remove_prefix(value, 2);
+  }
+  // Should have consumed all characters.
+  return iree_string_view_is_empty(value);
+}
+
+static iree_status_t iree_hal_cuda_driver_create_device_by_uuid(
+    iree_hal_driver_t* base_driver, iree_string_view_t driver_name,
+    const CUuuid* device_uuid, iree_host_size_t param_count,
+    const iree_string_pair_t* params, iree_allocator_t host_allocator,
+    iree_hal_device_t** out_device) {
+  iree_hal_cuda_driver_t* driver = iree_hal_cuda_driver_cast(base_driver);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Ensure CUDA is initialized before querying it.
+  IREE_RETURN_IF_ERROR(iree_hal_cuda_init(driver));
+
+  // CUDA doesn't have an API to do this so we need to scan all devices to
+  // find the one with the matching UUID.
+  int device_count = 0;
+  CUDA_RETURN_IF_ERROR(&driver->syms, cuDeviceGetCount(&device_count),
+                       "cuDeviceGetCount");
+  CUdevice device = 0;
+  bool found_device = false;
+  for (int i = 0; i < device_count; i++) {
+    CUDA_RETURN_IF_ERROR(&driver->syms, cuDeviceGet(&device, i), "cuDeviceGet");
+    CUuuid query_uuid;
+    CUDA_RETURN_IF_ERROR(&driver->syms, cuDeviceGetUuid_v2(&query_uuid, device),
+                         "cuDeviceGetUuid_v2");
+    if (memcmp(&device_uuid->bytes[0], &query_uuid.bytes[0],
+               sizeof(device_uuid)) == 0) {
+      found_device = true;
+      break;
+    }
+  }
+  if (!found_device) {
+    return iree_make_status(
+        IREE_STATUS_NOT_FOUND,
+        "CUDA device with UUID GPU-"
+        "%02x%02x%02x%02x-"
+        "%02x%02x-"
+        "%02x%02x-"
+        "%02x%02x-"
+        "%02x%02x%02x%02x%02x%02x"
+        " not found",
+        (uint8_t)device_uuid->bytes[0], (uint8_t)device_uuid->bytes[1],
+        (uint8_t)device_uuid->bytes[2], (uint8_t)device_uuid->bytes[3],
+        (uint8_t)device_uuid->bytes[4], (uint8_t)device_uuid->bytes[5],
+        (uint8_t)device_uuid->bytes[6], (uint8_t)device_uuid->bytes[7],
+        (uint8_t)device_uuid->bytes[8], (uint8_t)device_uuid->bytes[9],
+        (uint8_t)device_uuid->bytes[10], (uint8_t)device_uuid->bytes[11],
+        (uint8_t)device_uuid->bytes[12], (uint8_t)device_uuid->bytes[13],
+        (uint8_t)device_uuid->bytes[14], (uint8_t)device_uuid->bytes[15]);
+  }
+
+  iree_status_t status = iree_hal_cuda_driver_create_device_by_id(
+      base_driver, CUDEVICE_TO_DEVICE_ID(device), param_count, params,
+      host_allocator, out_device);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+static iree_status_t iree_hal_cuda_driver_create_device_by_index(
+    iree_hal_driver_t* base_driver, iree_string_view_t driver_name,
+    int device_index, iree_host_size_t param_count,
+    const iree_string_pair_t* params, iree_allocator_t host_allocator,
+    iree_hal_device_t** out_device) {
+  iree_hal_cuda_driver_t* driver = iree_hal_cuda_driver_cast(base_driver);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Ensure CUDA is initialized before querying it.
+  IREE_RETURN_IF_ERROR(iree_hal_cuda_init(driver));
+
+  CUdevice device = 0;
+  CUDA_RETURN_IF_ERROR(&driver->syms, cuDeviceGet(&device, device_index),
+                       "cuDeviceGet");
+
+  iree_status_t status = iree_hal_cuda_driver_create_device_by_id(
+      base_driver, CUDEVICE_TO_DEVICE_ID(device), param_count, params,
+      host_allocator, out_device);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 static iree_status_t iree_hal_cuda_driver_create_device_by_path(
     iree_hal_driver_t* base_driver, iree_string_view_t driver_name,
     iree_string_view_t device_path, iree_host_size_t param_count,
     const iree_string_pair_t* params, iree_allocator_t host_allocator,
     iree_hal_device_t** out_device) {
-  if (!iree_string_view_is_empty(device_path)) {
-    return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                            "device paths not yet implemented");
+  if (iree_string_view_is_empty(device_path)) {
+    return iree_hal_cuda_driver_create_device_by_id(
+        base_driver, IREE_HAL_DEVICE_ID_DEFAULT, param_count, params,
+        host_allocator, out_device);
   }
-  return iree_hal_cuda_driver_create_device_by_id(
-      base_driver, IREE_HAL_DEVICE_ID_DEFAULT, param_count, params,
-      host_allocator, out_device);
+
+  if (iree_string_view_consume_prefix(&device_path, IREE_SV("GPU-"))) {
+    // UUID as returned by cuDeviceGetUuid_v2.
+    CUuuid device_uuid;
+    if (!iree_hal_cuda_parse_uuid(device_path, &device_uuid)) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "invalid GPU UUID: '%.*s'", (int)device_path.size,
+                              device_path.data);
+    }
+    return iree_hal_cuda_driver_create_device_by_uuid(
+        base_driver, driver_name, &device_uuid, param_count, params,
+        host_allocator, out_device);
+  }
+
+  // Try to parse as a device index.
+  int device_index = 0;
+  if (iree_string_view_atoi_int32(device_path, &device_index)) {
+    return iree_hal_cuda_driver_create_device_by_index(
+        base_driver, driver_name, device_index, param_count, params,
+        host_allocator, out_device);
+  }
+
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED, "unsupported device path");
 }
 
 static const iree_hal_driver_vtable_t iree_hal_cuda_driver_vtable = {
     .destroy = iree_hal_cuda_driver_destroy,
     .query_available_devices = iree_hal_cuda_driver_query_available_devices,
+    .dump_device_info = iree_hal_cuda_driver_dump_device_info,
     .create_device_by_id = iree_hal_cuda_driver_create_device_by_id,
     .create_device_by_path = iree_hal_cuda_driver_create_device_by_path,
 };

--- a/runtime/src/iree/hal/drivers/cuda/dynamic_symbol_tables.h
+++ b/runtime/src/iree/hal/drivers/cuda/dynamic_symbol_tables.h
@@ -10,6 +10,7 @@ CU_PFN_DECL(cuDeviceGet, CUdevice*, int)
 CU_PFN_DECL(cuDeviceGetCount, int*)
 CU_PFN_DECL(cuDeviceGetName, char*, int, CUdevice)
 CU_PFN_DECL(cuDeviceGetAttribute, int*, CUdevice_attribute, CUdevice)
+CU_PFN_DECL(cuDeviceGetUuid_v2, CUuuid*, CUdevice)
 CU_PFN_DECL(cuGetErrorName, CUresult, const char**)
 CU_PFN_DECL(cuGetErrorString, CUresult, const char**)
 CU_PFN_DECL(cuGraphAddMemcpyNode, CUgraphNode*, CUgraph, const CUgraphNode*,

--- a/runtime/src/iree/hal/drivers/local_sync/registration/driver_module.c
+++ b/runtime/src/iree/hal/drivers/local_sync/registration/driver_module.c
@@ -18,7 +18,7 @@ static iree_status_t iree_hal_local_sync_driver_factory_enumerate(
     const iree_hal_driver_info_t** out_driver_infos) {
   static const iree_hal_driver_info_t default_driver_info = {
       .driver_name = IREE_SVL("local-sync"),
-      .full_name = IREE_SVL("Local executable execution using a lightweight "
+      .full_name = IREE_SVL("Local execution using a lightweight "
                             "inline synchronous queue"),
   };
   *out_driver_info_count = 1;

--- a/runtime/src/iree/hal/drivers/local_sync/sync_driver.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_driver.c
@@ -112,6 +112,17 @@ static iree_status_t iree_hal_sync_driver_query_available_devices(
       (void**)out_device_infos);
 }
 
+static iree_status_t iree_hal_sync_driver_dump_device_info(
+    iree_hal_driver_t* base_driver, iree_hal_device_id_t device_id,
+    iree_string_builder_t* builder) {
+  iree_hal_sync_driver_t* driver = iree_hal_sync_driver_cast(base_driver);
+  // TODO(benvanik): dump detailed device info.
+  // Could do executable loaders, CPU features, etc. Ideally would share some
+  // with the other local drivers.
+  (void)driver;
+  return iree_ok_status();
+}
+
 static iree_status_t iree_hal_sync_driver_create_device_by_id(
     iree_hal_driver_t* base_driver, iree_hal_device_id_t device_id,
     iree_host_size_t param_count, const iree_string_pair_t* params,
@@ -139,6 +150,7 @@ static iree_status_t iree_hal_sync_driver_create_device_by_path(
 static const iree_hal_driver_vtable_t iree_hal_sync_driver_vtable = {
     .destroy = iree_hal_sync_driver_destroy,
     .query_available_devices = iree_hal_sync_driver_query_available_devices,
+    .dump_device_info = iree_hal_sync_driver_dump_device_info,
     .create_device_by_id = iree_hal_sync_driver_create_device_by_id,
     .create_device_by_path = iree_hal_sync_driver_create_device_by_path,
 };

--- a/runtime/src/iree/hal/drivers/local_task/registration/driver_module.c
+++ b/runtime/src/iree/hal/drivers/local_task/registration/driver_module.c
@@ -20,7 +20,7 @@ static iree_status_t iree_hal_local_task_driver_factory_enumerate(
   static const iree_hal_driver_info_t driver_infos[1] = {
       {
           .driver_name = IREE_SVL("local-task"),
-          .full_name = IREE_SVL("Local executable execution using the "
+          .full_name = IREE_SVL("Local execution using the "
                                 "IREE multithreading task system"),
       },
   };

--- a/runtime/src/iree/hal/drivers/local_task/task_driver.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_driver.c
@@ -118,6 +118,17 @@ static iree_status_t iree_hal_task_driver_query_available_devices(
       (void**)out_device_infos);
 }
 
+static iree_status_t iree_hal_task_driver_dump_device_info(
+    iree_hal_driver_t* base_driver, iree_hal_device_id_t device_id,
+    iree_string_builder_t* builder) {
+  iree_hal_task_driver_t* driver = iree_hal_task_driver_cast(base_driver);
+  // TODO(benvanik): dump detailed device info.
+  // Could do executable loaders, CPU features, etc. Ideally would share some
+  // with the other local drivers.
+  (void)driver;
+  return iree_ok_status();
+}
+
 static iree_status_t iree_hal_task_driver_create_device_by_id(
     iree_hal_driver_t* base_driver, iree_hal_device_id_t device_id,
     iree_host_size_t param_count, const iree_string_pair_t* params,
@@ -146,6 +157,7 @@ static iree_status_t iree_hal_task_driver_create_device_by_path(
 static const iree_hal_driver_vtable_t iree_hal_task_driver_vtable = {
     .destroy = iree_hal_task_driver_destroy,
     .query_available_devices = iree_hal_task_driver_query_available_devices,
+    .dump_device_info = iree_hal_task_driver_dump_device_info,
     .create_device_by_id = iree_hal_task_driver_create_device_by_id,
     .create_device_by_path = iree_hal_task_driver_create_device_by_path,
 };

--- a/runtime/src/iree/modules/check/test/failure.mlir
+++ b/runtime/src/iree/modules/check/test/failure.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-check-module --expect_failure - | FileCheck %s
-// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vulkan-spirv --iree-mlir-to-vm-bytecode-module %s | iree-check-module --driver=vulkan --expect_failure - | FileCheck %s)
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vulkan-spirv --iree-mlir-to-vm-bytecode-module %s | iree-check-module --device=vulkan --expect_failure - | FileCheck %s)
 
 // CHECK-LABEL: expect_failure.expect_true_of_false
 // CHECK: Expected 0 to be nonzero

--- a/runtime/src/iree/modules/check/test/success.mlir
+++ b/runtime/src/iree/modules/check/test/success.mlir
@@ -1,5 +1,5 @@
-// RUN: iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-check-module --driver=local-task -
-// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vulkan-spirv --iree-mlir-to-vm-bytecode-module %s | iree-check-module --driver=vulkan -)
+// RUN: iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-check-module --device=local-task -
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vulkan-spirv --iree-mlir-to-vm-bytecode-module %s | iree-check-module --device=vulkan -)
 
 func.func @expect_true() {
   %true = util.unfoldable_constant 1 : i32

--- a/runtime/src/iree/tooling/device_util.c
+++ b/runtime/src/iree/tooling/device_util.c
@@ -11,6 +11,10 @@
 #include "iree/base/tracing.h"
 #include "iree/hal/drivers/init.h"
 
+//===----------------------------------------------------------------------===//
+// Shared driver registry
+//===----------------------------------------------------------------------===//
+
 static iree_once_flag iree_hal_driver_registry_init_flag = IREE_ONCE_FLAG_INIT;
 static void iree_hal_driver_registry_init_from_flags(void) {
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -18,8 +22,233 @@ static void iree_hal_driver_registry_init_from_flags(void) {
       iree_hal_driver_registry_default()));
   IREE_TRACE_ZONE_END(z0);
 }
+
 iree_hal_driver_registry_t* iree_hal_available_driver_registry(void) {
   iree_call_once(&iree_hal_driver_registry_init_flag,
                  iree_hal_driver_registry_init_from_flags);
   return iree_hal_driver_registry_default();
 }
+
+//===----------------------------------------------------------------------===//
+// Driver and device listing commands
+//===----------------------------------------------------------------------===//
+
+static void iree_hal_flags_print_action_header(void) {
+  fprintf(stdout,
+          "# "
+          "===================================================================="
+          "========\n");
+}
+
+static void iree_hal_flags_print_action_separator(void) {
+  fprintf(stdout,
+          "# "
+          "===-----------------------------------------------------------"
+          "-----------===\n");
+}
+
+static void iree_hal_flags_print_action_flag(iree_string_view_t flag_name,
+                                             void* storage, FILE* file) {
+  fprintf(file, "# --%.*s\n", (int)flag_name.size, flag_name.data);
+}
+
+static iree_status_t iree_hal_flags_list_drivers(iree_string_view_t flag_name,
+                                                 void* storage,
+                                                 iree_string_view_t value) {
+  iree_allocator_t host_allocator = iree_allocator_system();
+
+  iree_hal_flags_print_action_header();
+  fprintf(stdout, "# Available HAL drivers\n");
+  iree_hal_flags_print_action_header();
+  fprintf(
+      stdout,
+      "# Use --list_devices={driver name} to enumerate available devices.\n\n");
+
+  iree_hal_driver_registry_t* driver_registry =
+      iree_hal_available_driver_registry();
+  iree_host_size_t driver_info_count = 0;
+  iree_hal_driver_info_t* driver_infos = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_driver_registry_enumerate(
+      driver_registry, host_allocator, &driver_info_count, &driver_infos));
+
+  for (iree_host_size_t i = 0; i < driver_info_count; ++i) {
+    const iree_hal_driver_info_t* driver_info = &driver_infos[i];
+    fprintf(stdout, "%16.*s: %.*s\n", (int)driver_info->driver_name.size,
+            driver_info->driver_name.data, (int)driver_info->full_name.size,
+            driver_info->full_name.data);
+  }
+
+  iree_allocator_free(host_allocator, driver_infos);
+
+  exit(0);
+  return iree_ok_status();
+}
+
+IREE_FLAG_CALLBACK(iree_hal_flags_list_drivers,
+                   iree_hal_flags_print_action_flag, NULL, list_drivers,
+                   "Lists all available HAL drivers compiled into the binary.");
+
+static iree_status_t iree_hal_flags_list_driver_device(
+    iree_string_view_t driver_name, iree_hal_driver_t* driver,
+    const iree_hal_device_info_t* device_info, iree_allocator_t host_allocator,
+    FILE* file) {
+  fprintf(file, "%.*s://%.*s\n", (int)driver_name.size, driver_name.data,
+          (int)device_info->path.size, device_info->path.data);
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_flags_list_driver_devices(
+    iree_hal_driver_registry_t* driver_registry, iree_string_view_t driver_name,
+    iree_allocator_t host_allocator, FILE* file) {
+  iree_hal_driver_t* driver = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_driver_registry_try_create(
+      driver_registry, driver_name, host_allocator, &driver));
+
+  iree_host_size_t device_info_count = 0;
+  iree_hal_device_info_t* device_infos = NULL;
+  iree_status_t status = iree_hal_driver_query_available_devices(
+      driver, host_allocator, &device_info_count, &device_infos);
+
+  for (iree_host_size_t i = 0;
+       iree_status_is_ok(status) && i < device_info_count; ++i) {
+    status = iree_hal_flags_list_driver_device(
+        driver_name, driver, &device_infos[i], host_allocator, file);
+  }
+
+  iree_allocator_free(host_allocator, device_infos);
+  iree_hal_driver_release(driver);
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_flags_list_devices(iree_string_view_t flag_name,
+                                                 void* storage,
+                                                 iree_string_view_t value) {
+  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_hal_driver_registry_t* driver_registry =
+      iree_hal_available_driver_registry();
+
+  if (iree_string_view_is_empty(value)) {
+    // List all devices on all drivers.
+    iree_host_size_t driver_info_count = 0;
+    iree_hal_driver_info_t* driver_infos = NULL;
+    IREE_RETURN_IF_ERROR(iree_hal_driver_registry_enumerate(
+        driver_registry, host_allocator, &driver_info_count, &driver_infos));
+    for (iree_host_size_t i = 0; i < driver_info_count; ++i) {
+      const iree_hal_driver_info_t* driver_info = &driver_infos[i];
+      IREE_RETURN_IF_ERROR(iree_hal_flags_list_driver_devices(
+          driver_registry, driver_info->driver_name, host_allocator, stdout));
+    }
+    iree_allocator_free(host_allocator, driver_infos);
+  } else {
+    // List all devices from a particular driver.
+    IREE_RETURN_IF_ERROR(iree_hal_flags_list_driver_devices(
+        driver_registry, value, host_allocator, stdout));
+  }
+
+  exit(0);
+  return iree_ok_status();
+}
+
+IREE_FLAG_CALLBACK(
+    iree_hal_flags_list_devices, iree_hal_flags_print_action_flag, NULL,
+    list_devices,
+    "Lists all available HAL devices from all drivers or a specific driver.\n"
+    "Examples:\n"
+    "  Show all devices from all drivers: --list_devices\n"
+    "  Show all devices from a particular driver: --list_devices=vulkan\n");
+
+static iree_status_t iree_hal_flags_dump_driver_device(
+    iree_string_view_t driver_name, iree_hal_driver_t* driver,
+    const iree_hal_device_info_t* device_info, iree_allocator_t host_allocator,
+    FILE* file) {
+  iree_hal_flags_print_action_separator();
+  fprintf(file, "# --device=%.*s://%.*s\n", (int)driver_name.size,
+          driver_name.data, (int)device_info->path.size,
+          device_info->path.data);
+  // TODO(benvanik): driver full name.
+  fprintf(file, "#   %.*s\n", (int)device_info->name.size,
+          device_info->name.data);
+  iree_hal_flags_print_action_separator();
+
+  iree_string_builder_t builder;
+  iree_string_builder_initialize(host_allocator, &builder);
+
+  IREE_RETURN_IF_ERROR(iree_hal_driver_dump_device_info(
+      driver, device_info->device_id, &builder));
+  if (iree_string_builder_size(&builder) > 0) {
+    fprintf(file, "%.*s", (int)iree_string_builder_size(&builder),
+            iree_string_builder_buffer(&builder));
+  }
+
+  iree_string_builder_deinitialize(&builder);
+
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_flags_dump_driver_devices(
+    iree_hal_driver_registry_t* driver_registry, iree_string_view_t driver_name,
+    iree_allocator_t host_allocator, FILE* file) {
+  iree_hal_flags_print_action_header();
+  fprintf(stdout, "# Enumerated devices for driver '%.*s'\n",
+          (int)driver_name.size, driver_name.data);
+  iree_hal_flags_print_action_header();
+  fprintf(stdout, "\n");
+
+  iree_hal_driver_t* driver = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_driver_registry_try_create(
+      driver_registry, driver_name, host_allocator, &driver));
+
+  iree_host_size_t device_info_count = 0;
+  iree_hal_device_info_t* device_infos = NULL;
+  iree_status_t status = iree_hal_driver_query_available_devices(
+      driver, host_allocator, &device_info_count, &device_infos);
+
+  for (iree_host_size_t i = 0;
+       iree_status_is_ok(status) && i < device_info_count; ++i) {
+    status = iree_hal_flags_dump_driver_device(
+        driver_name, driver, &device_infos[i], host_allocator, file);
+  }
+
+  iree_allocator_free(host_allocator, device_infos);
+  iree_hal_driver_release(driver);
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_flags_dump_devices(iree_string_view_t flag_name,
+                                                 void* storage,
+                                                 iree_string_view_t value) {
+  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_hal_driver_registry_t* driver_registry =
+      iree_hal_available_driver_registry();
+
+  if (iree_string_view_is_empty(value)) {
+    // List all devices on all drivers.
+    iree_host_size_t driver_info_count = 0;
+    iree_hal_driver_info_t* driver_infos = NULL;
+    IREE_RETURN_IF_ERROR(iree_hal_driver_registry_enumerate(
+        driver_registry, host_allocator, &driver_info_count, &driver_infos));
+    for (iree_host_size_t i = 0; i < driver_info_count; ++i) {
+      if (i) fprintf(stdout, "\n");
+      const iree_hal_driver_info_t* driver_info = &driver_infos[i];
+      IREE_RETURN_IF_ERROR(iree_hal_flags_dump_driver_devices(
+          driver_registry, driver_info->driver_name, host_allocator, stdout));
+    }
+    iree_allocator_free(host_allocator, driver_infos);
+  } else {
+    // List all devices from a particular driver.
+    IREE_RETURN_IF_ERROR(iree_hal_flags_dump_driver_devices(
+        driver_registry, value, host_allocator, stdout));
+  }
+
+  exit(0);
+  return iree_ok_status();
+}
+
+IREE_FLAG_CALLBACK(
+    iree_hal_flags_dump_devices, iree_hal_flags_print_action_flag, NULL,
+    dump_devices,
+    "Dumps detailed information on all available HAL devices from all drivers\n"
+    " or a specific driver.\n"
+    "Examples:\n"
+    "  Show all devices from all drivers: --dump_devices\n"
+    "  Show all devices from a particular driver: --dump_devices=vulkan\n");

--- a/runtime/src/iree/tooling/device_util.c
+++ b/runtime/src/iree/tooling/device_util.c
@@ -29,6 +29,11 @@ iree_hal_driver_registry_t* iree_hal_available_driver_registry(void) {
   return iree_hal_driver_registry_default();
 }
 
+iree_string_view_t iree_hal_default_device_uri(void) {
+  // TODO(benvanik): query the registry and find the first available :shrug:
+  return IREE_SV("local-task");
+}
+
 //===----------------------------------------------------------------------===//
 // Driver and device listing commands
 //===----------------------------------------------------------------------===//
@@ -252,3 +257,117 @@ IREE_FLAG_CALLBACK(
     "Examples:\n"
     "  Show all devices from all drivers: --dump_devices\n"
     "  Show all devices from a particular driver: --dump_devices=vulkan\n");
+
+//===----------------------------------------------------------------------===//
+// Device selection
+//===----------------------------------------------------------------------===//
+
+// Common case is for 1 device, so to keep our memory profiles simpler we allow
+// for storing a single device inline in the struct. As soon as more than one
+// device is used we grow it.
+typedef struct iree_hal_devices_flag_t {
+  iree_host_size_t capacity;
+  iree_host_size_t count;
+  union {
+    iree_string_view_t inline_uri;  // only if count == 1
+    iree_string_view_t* uris;       // only if count > 1
+  };
+} iree_hal_devices_flag_t;
+iree_hal_devices_flag_t iree_hal_devices_flag = {
+    .capacity = 1,  // inline
+    .count = 0,
+    .uris = NULL,
+};
+
+static iree_status_t iree_hal_flags_parse_device(iree_string_view_t flag_name,
+                                                 void* storage,
+                                                 iree_string_view_t value) {
+  iree_hal_devices_flag_t* flag = (iree_hal_devices_flag_t*)storage;
+  if (flag->count == 0) {
+    // Inline storage (common case).
+    flag->count = 1;
+    flag->inline_uri = value;
+  } else if (flag->count == 1) {
+    // Switching from inline storage to external storage.
+    iree_host_size_t new_capacity = 4;
+    iree_string_view_t* uris = NULL;
+    IREE_RETURN_IF_ERROR(iree_allocator_malloc(
+        iree_allocator_system(), sizeof(iree_string_view_t*) * new_capacity,
+        (void**)&uris));
+    uris[0] = flag->inline_uri;
+    flag->capacity = new_capacity;
+    flag->uris = uris;
+    flag->uris[flag->count++] = value;
+  } else {
+    // Growing external storage list.
+    iree_host_size_t new_capacity = iree_max(4, flag->capacity * 2);
+    IREE_RETURN_IF_ERROR(iree_allocator_realloc(
+        iree_allocator_system(), sizeof(iree_string_view_t*) * new_capacity,
+        (void**)&flag->uris));
+    flag->capacity = new_capacity;
+    flag->uris[flag->count++] = value;
+  }
+  return iree_ok_status();
+}
+
+static void iree_hal_flags_print_devices(iree_string_view_t flag_name,
+                                         void* storage, FILE* file) {
+  iree_hal_devices_flag_t* flag = (iree_hal_devices_flag_t*)storage;
+  if (flag->count == 0) {
+    fprintf(file, "# --%.*s=driver://path?params\n", (int)flag_name.size,
+            flag_name.data);
+  } else if (flag->count == 1) {
+    fprintf(file, "--%.*s=%.*s\n", (int)flag_name.size, flag_name.data,
+            (int)flag->inline_uri.size, flag->inline_uri.data);
+  } else {
+    for (iree_host_size_t i = 0; i < flag->count; ++i) {
+      const iree_string_view_t device_uri = flag->uris[i];
+      fprintf(file, "--%.*s=%.*s\n", (int)flag_name.size, flag_name.data,
+              (int)device_uri.size, device_uri.data);
+    }
+  }
+}
+
+IREE_FLAG_CALLBACK(
+    iree_hal_flags_parse_device, iree_hal_flags_print_devices,
+    &iree_hal_devices_flag, device,
+    "Specifies one or more HAL devices to use for execution.\n"
+    "Use --list_devices/--dump_devices to see available devices and their\n"
+    "canonical URI used with this flag.");
+
+// TODO(#5724): remove this and replace with an iree_hal_device_set_t.
+void iree_hal_get_devices_flag_list(iree_host_size_t* out_count,
+                                    iree_string_view_t** out_list) {
+  *out_count = iree_hal_devices_flag.count;
+  if (iree_hal_devices_flag.count == 1) {
+    *out_list = &iree_hal_devices_flag.inline_uri;
+  } else {
+    *out_list = iree_hal_devices_flag.uris;
+  }
+}
+
+iree_status_t iree_hal_create_device_from_flags(
+    iree_string_view_t default_device, iree_allocator_t host_allocator,
+    iree_hal_device_t** out_device) {
+  iree_string_view_t device_uri = default_device;
+  const iree_hal_devices_flag_t* flag = &iree_hal_devices_flag;
+  if (flag->count == 0) {
+    // No devices specified. Use default if provided.
+    if (iree_string_view_is_empty(default_device)) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "no device specified; use --list_devices to see the "
+          "available devices and specify one with --device=");
+    }
+  } else if (flag->count > 1) {
+    // Too many devices for the single device creation function.
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "too many devices specified; only one --device= "
+                            "flag may be provided with this API");
+  } else {
+    // Exactly one device specified.
+    device_uri = flag->inline_uri;
+  }
+  return iree_hal_create_device(iree_hal_available_driver_registry(),
+                                device_uri, host_allocator, out_device);
+}

--- a/runtime/src/iree/tooling/device_util.h
+++ b/runtime/src/iree/tooling/device_util.h
@@ -17,6 +17,22 @@ extern "C" {
 // Returns a driver registry initialized with all linked driver registered.
 iree_hal_driver_registry_t* iree_hal_available_driver_registry(void);
 
+// Returns a device URI for a default device to be used when no other devices
+// are specified by the user. It may not work; it's always better to specify
+// flags and tools should encourage that.
+iree_string_view_t iree_hal_default_device_uri(void);
+
+// TODO(#5724): remove this and replace with an iree_hal_device_set_t.
+void iree_hal_get_devices_flag_list(iree_host_size_t* out_count,
+                                    iree_string_view_t** out_list);
+
+// Creates a single device from the --device= flag.
+// Uses the |default_device| if no flags were specified.
+// Fails if more than one device was specified.
+iree_status_t iree_hal_create_device_from_flags(
+    iree_string_view_t default_device, iree_allocator_t host_allocator,
+    iree_hal_device_t** out_device);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/runtime/src/iree/tooling/trace_replay.h
+++ b/runtime/src/iree/tooling/trace_replay.h
@@ -30,7 +30,8 @@ typedef struct iree_trace_replay_t {
   iree_vm_context_flags_t context_flags;
 
   iree_hal_driver_registry_t* driver_registry;
-  iree_string_view_t driver;
+  iree_host_size_t device_uri_count;
+  const iree_string_view_t* device_uris;
 
   iree_vm_context_t* context;
   iree_hal_device_t* device;
@@ -49,9 +50,12 @@ iree_status_t iree_trace_replay_initialize(
 void iree_trace_replay_deinitialize(iree_trace_replay_t* replay,
                                     iree_trace_replay_shutdown_flags_t flags);
 
+// TODO(#5724): remove this and instead provide a device set on initialize.
 // Overrides the HAL driver used in the trace with the given |driver|.
-void iree_trace_replay_set_hal_driver_override(iree_trace_replay_t* replay,
-                                               iree_string_view_t driver);
+// |device_uris| must remain valid for the lifetime of the replay instance.
+void iree_trace_replay_set_hal_devices_override(
+    iree_trace_replay_t* replay, iree_host_size_t device_uri_count,
+    const iree_string_view_t* device_uris);
 
 // Replays the given |event_node| against the replay context.
 // Automatically switches between the default iree_trace_replay_event_* methods.

--- a/tools/android/run_module_app/README.md
+++ b/tools/android/run_module_app/README.md
@@ -44,7 +44,7 @@ In general, we need to
       Android API level.
    1. Copy the VM FlatBuffer as `assets/module.vmfb`, write the entry function
       input buffers, and HAL driver into `assets/entry_function.txt`,
-      `assets/inputs.txt`, and `assets/driver.txt`, respectively.
+      `assets/inputs.txt`, and `assets/device.txt`, respectively.
    1. Copy the shared library under `lib/<android-abi>/`.
    1. Compile resources under [`res/`](./res) directory into an Android DEX
       file.

--- a/tools/android/run_module_app/build_apk.sh
+++ b/tools/android/run_module_app/build_apk.sh
@@ -25,7 +25,7 @@ echo ""
 
 print_usage_and_exit() {
   echo "Usage: $0 <artifact-directory> "
-  echo "       --driver <driver>"
+  echo "       --device <device>"
   echo "       --module_file <input-module-file> "
   echo "       --entry_function <entry-function> "
   echo "       --function_inputs_file <input-buffer-file> "
@@ -34,9 +34,9 @@ print_usage_and_exit() {
 
 while (( "$#" )); do
   case "$1" in
-    --driver)
+    --device)
       if [[ -n "$2" ]] && [[ ${2:0:1} != "-" ]]; then
-        IREE_DRIVER=$2
+        IREE_DEVICE=$2
         shift 2
       else
         echo "Error: missing argument for $1" >&2
@@ -88,7 +88,7 @@ done
 
 if [[ -z "${IREE_ARTIFACT_ROOT}" ]] || [[ -z "${IREE_INPUT_MODULE_FILE}" ]] || \
    [[ -z "${IREE_ENTRY_FUNCTION}" ]] || [[ -z "${IREE_INPUT_BUFFER_FILE}" ]] || \
-   [[ -z "${IREE_DRIVER}" ]]; then
+   [[ -z "${IREE_DEVICE}" ]]; then
   echo "Error: missing necessary parameters" >&2
   print_usage_and_exit
 fi
@@ -231,7 +231,7 @@ mkdir -p "${IREE_ASSET_DIR?}"
 cp "${IREE_INPUT_MODULE_FILE?}" "${IREE_ASSET_DIR?}/module.vmfb"
 cp "${IREE_INPUT_BUFFER_FILE?}" "${IREE_ASSET_DIR?}/inputs.txt"
 echo -n "${IREE_ENTRY_FUNCTION?}" > "${IREE_ASSET_DIR?}/entry_function.txt"
-echo -n "${IREE_DRIVER?}" > "${IREE_ASSET_DIR?}/driver.txt"
+echo -n "${IREE_DEVICE?}" > "${IREE_ASSET_DIR?}/device.txt"
 
 echo ">>> Compiling app resources <<<"
 

--- a/tools/android/run_module_app/src/main.cc
+++ b/tools/android/run_module_app/src/main.cc
@@ -31,14 +31,14 @@ const char* kAppTag = "iree-run-module";
 const char kModuleFileName[] = "module.vmfb";
 const char kEntryFunctionFileName[] = "entry_function.txt";
 const char kInputsFileName[] = "inputs.txt";
-const char kDriverFileName[] = "driver.txt";
+const char kDeviceFileName[] = "device.txt";
 
 // A struct containing information regarding one IREE VM module invocation.
 struct IreeModuleInvocation {
   std::string module;
   std::string entry_function;
   std::string inputs;
-  std::string driver;
+  std::string device;
 };
 
 // A class for loading IREE module invocation information from Android apk asset
@@ -54,7 +54,7 @@ class ModuleLoader {
     IREE_RETURN_IF_ERROR(
         ReadFileAsset(kEntryFunctionFileName, &invocation.entry_function));
     IREE_RETURN_IF_ERROR(ReadFileAsset(kInputsFileName, &invocation.inputs));
-    IREE_RETURN_IF_ERROR(ReadFileAsset(kDriverFileName, &invocation.driver));
+    IREE_RETURN_IF_ERROR(ReadFileAsset(kDeviceFileName, &invocation.device));
     *out_invocation = std::move(invocation);
     return OkStatus();
   }
@@ -104,7 +104,7 @@ Status RunModule(const IreeModuleInvocation& invocation) {
   iree_hal_device_t* device = nullptr;
   IREE_RETURN_IF_ERROR(iree_hal_create_device(
       iree_hal_available_driver_registry(),
-      iree_make_string_view(invocation.driver.data(), invocation.driver.size()),
+      iree_make_string_view(invocation.device.data(), invocation.device.size()),
       iree_allocator_system(), &device));
   iree_vm_module_t* hal_module = nullptr;
   IREE_RETURN_IF_ERROR(
@@ -178,7 +178,7 @@ void RunModuleAppMain(android_app* app) {
   if (status.ok()) {
     LOGI("entry function: '%s'", invocation.entry_function.c_str());
     LOGI("inputs:\n%s", invocation.inputs.c_str());
-    LOGI("driver: '%s'", invocation.driver.c_str());
+    LOGI("device: '%s'", invocation.device.c_str());
     status = RunModule(invocation);
     if (!status.ok()) LOGE("%s", status.ToString().c_str());
   } else {

--- a/tools/iree-benchmark-module-main.cc
+++ b/tools/iree-benchmark-module-main.cc
@@ -91,8 +91,6 @@ IREE_FLAG(string, entry_function, "",
           "to run. If this is not set, all the exported functions will be "
           "benchmarked and they are expected to not have input arguments.");
 
-IREE_FLAG(string, driver, "local-task", "Backend driver to use.");
-
 IREE_FLAG(bool, print_statistics, false,
           "Prints runtime statistics to stderr on exit.");
 
@@ -315,9 +313,8 @@ class IREEBenchmark {
         iree_vm_instance_create(iree_allocator_system(), &instance_));
 
     // Create IREE's device and module.
-    IREE_RETURN_IF_ERROR(iree_hal_create_device(
-        iree_hal_available_driver_registry(), IREE_SV(FLAG_driver),
-        iree_allocator_system(), &device_));
+    IREE_RETURN_IF_ERROR(iree_hal_create_device_from_flags(
+        iree_hal_default_device_uri(), iree_allocator_system(), &device_));
     IREE_RETURN_IF_ERROR(
         iree_hal_module_create(device_, iree_allocator_system(), &hal_module_));
     IREE_RETURN_IF_ERROR(iree_vm_bytecode_module_create(

--- a/tools/iree-check-module-main.cc
+++ b/tools/iree-check-module-main.cc
@@ -42,8 +42,6 @@
 
 IREE_FLAG(bool, trace_execution, false, "Traces VM execution to stderr.");
 
-IREE_FLAG(string, driver, "local-task", "Backend driver to use.");
-
 IREE_FLAG(
     bool, expect_failure, false,
     "Whether running module is expected to fail. If set, failing "
@@ -113,9 +111,8 @@ iree_status_t Run(std::string module_file_path, int* out_exit_code) {
       iree_allocator_system(), &input_module));
 
   iree_hal_device_t* device = nullptr;
-  IREE_RETURN_IF_ERROR(iree_hal_create_device(
-      iree_hal_available_driver_registry(), IREE_SV(FLAG_driver),
-      iree_allocator_system(), &device));
+  IREE_RETURN_IF_ERROR(iree_hal_create_device_from_flags(
+      iree_hal_default_device_uri(), iree_allocator_system(), &device));
   iree_vm_module_t* hal_module = nullptr;
   IREE_RETURN_IF_ERROR(
       iree_hal_module_create(device, iree_allocator_system(), &hal_module));

--- a/tools/iree-e2e-matmul-test.c
+++ b/tools/iree-e2e-matmul-test.c
@@ -24,8 +24,6 @@
 
 IREE_FLAG(bool, trace_execution, false, "Traces VM execution to stderr.");
 
-IREE_FLAG(string, driver, "local-task", "Backend driver to use.");
-
 static const char* emoji(bool good) { return good ? "🦄" : "🐞"; }
 
 /*****************************************************************************
@@ -1139,8 +1137,15 @@ static iree_status_t run_trace_file(iree_string_view_t root_path, FILE* file,
       FLAG_trace_execution ? IREE_VM_CONTEXT_FLAG_TRACE_EXECUTION
                            : IREE_VM_CONTEXT_FLAG_NONE,
       iree_hal_available_driver_registry(), iree_allocator_system(), &replay));
-  iree_trace_replay_set_hal_driver_override(
-      &replay, iree_make_cstring_view(FLAG_driver));
+
+  // Query device overrides, if any. When omitted the devices from the trace
+  // file will be used.
+  // TODO(#5724): remove this and instead provide a device set on initialize.
+  iree_host_size_t device_uri_count = 0;
+  iree_string_view_t* device_uris = NULL;
+  iree_hal_get_devices_flag_list(&device_uri_count, &device_uris);
+  iree_trace_replay_set_hal_devices_override(&replay, device_uri_count,
+                                             device_uris);
 
   yaml_parser_t parser;
   if (!yaml_parser_initialize(&parser)) {

--- a/tools/iree-run-module-main.cc
+++ b/tools/iree-run-module-main.cc
@@ -35,8 +35,6 @@ IREE_FLAG(string, entry_function, "",
 
 IREE_FLAG(bool, trace_execution, false, "Traces VM execution to stderr.");
 
-IREE_FLAG(string, driver, "local-task", "Backend driver to use.");
-
 IREE_FLAG(int32_t, print_max_element_count, 1024,
           "Prints up to the maximum number of elements of output tensors, "
           "eliding the remainder.");
@@ -111,9 +109,8 @@ iree_status_t Run() {
       iree_allocator_system(), &input_module));
 
   iree_hal_device_t* device = nullptr;
-  IREE_RETURN_IF_ERROR(iree_hal_create_device(
-      iree_hal_available_driver_registry(), IREE_SV(FLAG_driver),
-      iree_allocator_system(), &device));
+  IREE_RETURN_IF_ERROR(iree_hal_create_device_from_flags(
+      iree_hal_default_device_uri(), iree_allocator_system(), &device));
   iree_vm_module_t* hal_module = nullptr;
   IREE_RETURN_IF_ERROR(
       iree_hal_module_create(device, iree_allocator_system(), &hal_module));

--- a/tools/iree-run-trace-main.c
+++ b/tools/iree-run-trace-main.c
@@ -22,8 +22,6 @@ IREE_FLAG(bool, trace_execution, false, "Traces VM execution to stderr.");
 IREE_FLAG(bool, print_statistics, false,
           "Prints runtime statistics to stderr on exit.");
 
-IREE_FLAG(string, driver, "local-task", "Backend driver to use.");
-
 // Runs the trace in |file| using |root_path| as the base for any path lookups
 // required for external files referenced in |file|.
 static iree_status_t iree_run_trace_file(iree_string_view_t root_path,
@@ -35,8 +33,15 @@ static iree_status_t iree_run_trace_file(iree_string_view_t root_path,
       FLAG_trace_execution ? IREE_VM_CONTEXT_FLAG_TRACE_EXECUTION
                            : IREE_VM_CONTEXT_FLAG_NONE,
       iree_hal_available_driver_registry(), iree_allocator_system(), &replay));
-  iree_trace_replay_set_hal_driver_override(
-      &replay, iree_make_cstring_view(FLAG_driver));
+
+  // Query device overrides, if any. When omitted the devices from the trace
+  // file will be used.
+  // TODO(#5724): remove this and instead provide a device set on initialize.
+  iree_host_size_t device_uri_count = 0;
+  iree_string_view_t* device_uris = NULL;
+  iree_hal_get_devices_flag_list(&device_uri_count, &device_uris);
+  iree_trace_replay_set_hal_devices_override(&replay, device_uri_count,
+                                             device_uris);
 
   yaml_parser_t parser;
   if (!yaml_parser_initialize(&parser)) {

--- a/tools/test/benchmark_flags.txt
+++ b/tools/test/benchmark_flags.txt
@@ -2,7 +2,7 @@
 // HELP: --module_file
 // HELP: --benchmark_list_tests
 
-// RUN: ( iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --benchmark_list_tests --driver=local-task --benchmark_list_tests ) | FileCheck --check-prefix=LIST-BENCHMARKS %s
+// RUN: ( iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --benchmark_list_tests --device=local-task --benchmark_list_tests ) | FileCheck --check-prefix=LIST-BENCHMARKS %s
 module {
   // LIST-BENCHMARKS: BM_foo1
   func.func @foo1() -> tensor<4xf32> {

--- a/tools/test/iree-benchmark-module.mlir
+++ b/tools/test/iree-benchmark-module.mlir
@@ -1,6 +1,6 @@
-// RUN: iree-compile --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=local-task --entry_function=abs --function_input=f32=-2 | FileCheck %s
-// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-hal-target-backends=vulkan-spirv --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=vulkan --entry_function=abs --function_input=f32=-2 | FileCheck %s)
-// RUN: iree-compile --iree-hal-target-backends=dylib-llvm-aot --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=local-task --entry_function=abs --function_input=f32=-2 | FileCheck %s
+// RUN: iree-compile --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --device=local-task --entry_function=abs --function_input=f32=-2 | FileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-hal-target-backends=vulkan-spirv --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --device=vulkan --entry_function=abs --function_input=f32=-2 | FileCheck %s)
+// RUN: iree-compile --iree-hal-target-backends=dylib-llvm-aot --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --device=local-task --entry_function=abs --function_input=f32=-2 | FileCheck %s
 
 // CHECK-LABEL: BM_abs
 func.func @abs(%input : tensor<f32>) -> (tensor<f32>) {

--- a/tools/test/iree-run-module.mlir
+++ b/tools/test/iree-run-module.mlir
@@ -1,6 +1,6 @@
-// RUN: (iree-compile --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-run-module --driver=local-task --entry_function=abs --function_input=f32=-2) | FileCheck %s
-// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || ((iree-compile --iree-hal-target-backends=vulkan-spirv --iree-mlir-to-vm-bytecode-module %s | iree-run-module --driver=vulkan --entry_function=abs --function_input=f32=-2) | FileCheck %s)
-// RUN: (iree-compile --iree-hal-target-backends=dylib-llvm-aot --iree-mlir-to-vm-bytecode-module %s | iree-run-module --driver=local-task --entry_function=abs --function_input=f32=-2) | FileCheck %s
+// RUN: (iree-compile --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-run-module --device=local-task --entry_function=abs --function_input=f32=-2) | FileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || ((iree-compile --iree-hal-target-backends=vulkan-spirv --iree-mlir-to-vm-bytecode-module %s | iree-run-module --device=vulkan --entry_function=abs --function_input=f32=-2) | FileCheck %s)
+// RUN: (iree-compile --iree-hal-target-backends=dylib-llvm-aot --iree-mlir-to-vm-bytecode-module %s | iree-run-module --device=local-task --entry_function=abs --function_input=f32=-2) | FileCheck %s
 
 // CHECK-LABEL: EXEC @abs
 func.func @abs(%input : tensor<f32>) -> (tensor<f32>) {

--- a/tools/test/multiple_args.mlir
+++ b/tools/test/multiple_args.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-compile --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-run-module --entry_function=multi_input --function_input="2xi32=[1 2]" --function_input="2xi32=[3 4]" | FileCheck %s
 // RUN: iree-run-mlir --iree-hal-target-backends=vmvx --function-input='2xi32=[1 2]' --function-input='2xi32=[3 4]' %s | FileCheck %s
-// RUN: iree-compile --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=local-task --entry_function=multi_input --function_input="2xi32=[1 2]" --function_input="2xi32=[3 4]" | FileCheck --check-prefix=BENCHMARK %s
+// RUN: iree-compile --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --device=local-task --entry_function=multi_input --function_input="2xi32=[1 2]" --function_input="2xi32=[3 4]" | FileCheck --check-prefix=BENCHMARK %s
 
 // BENCHMARK-LABEL: BM_multi_input
 // CHECK-LABEL: EXEC @multi_input

--- a/tools/test/multiple_exported_functions.mlir
+++ b/tools/test/multiple_exported_functions.mlir
@@ -1,5 +1,5 @@
-// RUN: iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=local-task | FileCheck %s
-// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vulkan-spirv --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=vulkan | FileCheck %s)
+// RUN: iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --device=local-task | FileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vulkan-spirv --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --device=vulkan | FileCheck %s)
 
 module {
   func.func @foo1() -> tensor<4xf32> {

--- a/tools/test/repeated_return.mlir
+++ b/tools/test/repeated_return.mlir
@@ -1,5 +1,5 @@
 // RUN: (iree-compile --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-run-module --entry_function=many_tensor) | FileCheck %s
-// RUN: iree-compile --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=local-task --entry_function=many_tensor | FileCheck --check-prefix=BENCHMARK %s
+// RUN: iree-compile --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --device=local-task --entry_function=many_tensor | FileCheck --check-prefix=BENCHMARK %s
 // RUN: iree-run-mlir --iree-hal-target-backends=vmvx %s | FileCheck %s
 
 // BENCHMARK-LABEL: BM_many_tensor

--- a/tools/test/scalars.mlir
+++ b/tools/test/scalars.mlir
@@ -1,5 +1,5 @@
 // RUN: (iree-compile --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-run-module --entry_function=scalar --function_input=42) | FileCheck %s
-// RUN: iree-compile --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=local-task --entry_function=scalar --function_input=42 | FileCheck --check-prefix=BENCHMARK %s
+// RUN: iree-compile --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --device=local-task --entry_function=scalar --function_input=42 | FileCheck --check-prefix=BENCHMARK %s
 // RUN: (iree-run-mlir --iree-hal-target-backends=vmvx --function-input=42 %s) | FileCheck %s
 
 // BENCHMARK-LABEL: BM_scalar


### PR DESCRIPTION
This gives us consistent behavior across the various command line tools and prepares for multiple devices and device sets (#5724).

Adds the following flags:
* `--list_drivers`: list all available drivers compiled into the tool
* `--list_devices`: list all devices from all drivers
* `--list_devices={driver}`: list all devices from a single driver
* `--dump_devices`: dump detailed information about all devices from all drivers
* `--dump_devices={driver}`: dump detailed information about all devices from a single driver
* `--device={uri}`: specify one or more devices to use (today only 1 is used)

Example usage: https://gist.github.com/benvanik/059c5773068b114ea393bf5b95d791c2
Currently none of the HAL drivers are putting anything interesting in their dump output but we can iterate on what we put there (not intended as a full vulkaninfo/nvidia-smi replacement, but showing relevant information to our usage).

Most of the implementation is hidden in `device_utils.c` but if we ever want programmatic access to list/dump we can add an API for them.

NOTE: we are moving towards multiple devices: there are several bits of infra that are always assuming single devices and those will not be compatible with multi-device usage.

Progress on #9343.