### PR TITLE
Remove explicit `--iree-mlir-to-vm-bytecode-module` flag usage.

### DIFF
--- a/build_tools/bazel/iree_bytecode_module.bzl
+++ b/build_tools/bazel/iree_bytecode_module.bzl
@@ -13,8 +13,8 @@ load("//build_tools/embed_data:build_defs.bzl", "c_embed_data")
 def iree_bytecode_module(
         name,
         src,
-        module_name = None,
         flags,
+        module_name = None,
         compile_tool = "//tools:iree-compile",
         linker_tool = "@llvm-project//lld:lld",
         c_identifier = "",
@@ -27,12 +27,12 @@ def iree_bytecode_module(
         src: mlir source file to be compiled to an IREE module.
         flags: additional flags to pass to the compiler.
             `--output-format=vm-bytecode` is included automatically.
+        module_name: Optional name for the generated IREE module.
+            Defaults to `name.vmfb`.
         compile_tool: the compiler to use to generate the module.
             Defaults to iree-compile.
         linker_tool: the linker to use.
             Defaults to the lld from the llvm-project directory.
-        module_name: Optional name for the generated IREE module.
-            Defaults to `name.vmfb`.
         c_identifier: Optional. Enables embedding the module as C data.
         deps: Optional. Dependencies to add to the generated library.
         **kwargs: any additional attributes to pass to the underlying rules.

--- a/build_tools/bazel/iree_bytecode_module.bzl
+++ b/build_tools/bazel/iree_bytecode_module.bzl
@@ -13,8 +13,8 @@ load("//build_tools/embed_data:build_defs.bzl", "c_embed_data")
 def iree_bytecode_module(
         name,
         src,
-        module = None,
-        flags = ["--iree-mlir-to-vm-bytecode-module"],
+        module_name = None,
+        flags,
         compile_tool = "//tools:iree-compile",
         linker_tool = "@llvm-project//lld:lld",
         c_identifier = "",
@@ -25,35 +25,36 @@ def iree_bytecode_module(
     Args:
         name: Name of the target
         src: mlir source file to be compiled to an IREE module.
-        flags: additional flags to pass to the compiler. Bytecode
-            translation and backend flags are passed automatically.
+        flags: additional flags to pass to the compiler.
+            `--output-format=vm-bytecode` is included automatically.
         compile_tool: the compiler to use to generate the module.
             Defaults to iree-compile.
         linker_tool: the linker to use.
             Defaults to the lld from the llvm-project directory.
-        module: Optional. Specifies the  path to use for the enerated IREE module (.vmfb).
+        module_name: Optional name for the generated IREE module.
+            Defaults to `name.vmfb`.
         c_identifier: Optional. Enables embedding the module as C data.
         deps: Optional. Dependencies to add to the generated library.
         **kwargs: any additional attributes to pass to the underlying rules.
     """
 
-    if not module:
-        module = "%s.vmfb" % (name)
+    if not module_name:
+        module_name = "%s.vmfb" % (name)
 
     native.genrule(
         name = name,
         srcs = [src],
         outs = [
-            module,
+            module_name,
         ],
         cmd = " && ".join([
             " ".join([
                 "$(location %s)" % (compile_tool),
-                " ".join(flags),
+                " ".join(["--output-format=vm-bytecode"] + flags),
                 "--iree-llvm-embedded-linker-path=$(location %s)" % (linker_tool),
                 "--iree-llvm-wasm-linker-path=$(location %s)" % (linker_tool),
                 # Note: --iree-llvm-system-linker-path is left unspecified.
-                "-o $(location %s)" % (module),
+                "-o $(location %s)" % (module_name),
                 "$(location %s)" % (src),
             ]),
         ]),
@@ -68,7 +69,7 @@ def iree_bytecode_module(
         c_embed_data(
             name = "%s_c" % (name),
             identifier = c_identifier,
-            srcs = [module],
+            srcs = [module_name],
             c_file_output = "%s_c.c" % (name),
             h_file_output = "%s_c.h" % (name),
             flatten = True,

--- a/build_tools/bazel/iree_check_test.bzl
+++ b/build_tools/bazel/iree_check_test.bzl
@@ -35,13 +35,14 @@ def iree_check_test(
       driver: driver to run the module with. This can be omitted to test only
           compilation, but consider omiting the driver as a hacky abuse of the
           rule since compilation on its own not use iree-check-module.
-      compiler_flags: additional flags to pass to the compiler. Bytecode translation and backend
-          flags are passed automatically.
-      runner_args: additional runner_args to pass to iree-check-module. The driver and input file
-          are passed automatically.
-      tags: additional tags to apply to the generated test. A tag "driver=DRIVER" is added
-          automatically.
-      target_cpu_features: currently unimplemented (must be empty), will eventually allow specifying target CPU features.
+      compiler_flags: additional flags to pass to the compiler. Bytecode output
+          format and backend flags are passed automatically.
+      runner_args: additional runner_args to pass to iree-check-module. The
+          driver and input file are passed automatically.
+      tags: additional tags to apply to the generated test. A tag
+          "driver=DRIVER" is added automatically.
+      target_cpu_features: currently unimplemented (must be empty), will
+          eventually allow specifying target CPU features.
       timeout: timeout for the generated tests.
       **kwargs: any additional attributes to pass to the underlying native_test.
     """
@@ -54,7 +55,6 @@ def iree_check_test(
         name = bytecode_module_name,
         src = src,
         flags = [
-            "--iree-mlir-to-vm-bytecode-module",
             "--mlir-print-op-on-diagnostic=false",
             "--iree-hal-target-backends=%s" % target_backend,
         ] + compiler_flags,
@@ -99,16 +99,20 @@ def iree_check_single_backend_test_suite(
       driver: driver to run the module with. This can be omitted to test only
           compilation, but consider omiting the driver as a hacky abuse of the
           rule since compilation on its own not use iree-check-module.
-      compiler_flags: additional flags to pass to the compiler. Bytecode translation and backend
-          flags are passed automatically.
-      runner_args: additional runner_args to pass to the underlying iree-check-module tests. The
-          driver and input file are passed automatically. To use different runner_args per test,
-          create a separate suite or iree_check_test.
-      target_cpu_features: currently unimplemented (must be empty), will eventually allow specifying target CPU features.
-      tags: tags to apply to the generated tests. Note that as in standard test suites, manual
-          is treated specially and will also apply to the test suite itself.
+      compiler_flags: additional flags to pass to the compiler. Bytecode output
+          format and backend flags are passed automatically.
+      runner_args: additional runner_args to pass to the underlying
+          iree-check-module tests. The driver and input file are passed
+          automatically. To use different runner_args per test, create a
+          separate suite or iree_check_test.
+      target_cpu_features: currently unimplemented (must be empty), will
+          eventually allow specifying target CPU features.
+      tags: tags to apply to the generated tests. Note that as in standard test
+          suites, manual is treated specially and will also apply to the test
+          suite itself.
       timeout: timeout for the generated tests.
-      **kwargs: any additional attributes to pass to the underlying tests and test suite.
+      **kwargs: any additional attributes to pass to the underlying tests and
+          test suite.
     """
 
     # We haven't implemented this so far because we have been using target_cpu_features so far only
@@ -168,18 +172,23 @@ def iree_check_test_suite(
     Args:
       name: name of the generated test suite.
       srcs: source mlir files containing the module.
-      target_backends_and_drivers: backend/driver pairs to compile and run the module, respectively.
-      compiler_flags: additional flags to pass to the compiler. Bytecode translation and backend
-          flags are passed automatically.
-      runner_args: additional runner_args to pass to the underlying iree-check-module tests. The
-          driver and input file are passed automatically. To use different runner_args per test,
-          create a separate suite or iree_check_test.
-      tags: tags to apply to the generated tests. Note that as in standard test suites, manual
-          is treated specially and will also apply to the test suite itself.
-      target_cpu_features_variants: list of target cpu features variants. Currently unimplemented, so each
-            entry must be either "default" or start with "aarch64:" so as Bazel builds are currently x86-only,
-            we know that it is correct to ignore this.
-      **kwargs: any additional attributes to pass to the underlying tests and test suite.
+      target_backends_and_drivers: backend/driver pairs to compile and run the
+          module, respectively.
+      compiler_flags: additional flags to pass to the compiler. Bytecode output
+          format and backend flags are passed automatically.
+      runner_args: additional runner_args to pass to the underlying
+          iree-check-module tests. The driver and input file are passed
+          automatically. To use different runner_args per test, create a
+          separate suite or iree_check_test.
+      tags: tags to apply to the generated tests. Note that as in standard test
+          suites, manual is treated specially and will also apply to the test
+          suite itself.
+      target_cpu_features_variants: list of target cpu features variants.
+          Currently unimplemented, so each entry must be either "default" or
+          start with "aarch64:" so as Bazel builds are currently x86-only, we
+          know that it is correct to ignore this.
+      **kwargs: any additional attributes to pass to the underlying tests and
+          test suite.
     """
 
     for target_cpu_features in target_cpu_features_variants:

--- a/build_tools/bazel/iree_trace_runner_test.bzl
+++ b/build_tools/bazel/iree_trace_runner_test.bzl
@@ -12,7 +12,7 @@ load("//build_tools/bazel:native_binary.bzl", "native_test")
 def iree_trace_runner_test(
         name,
         src,
-        module,
+        module_name,
         target_backend,
         driver,
         trace_runner,
@@ -30,19 +30,22 @@ def iree_trace_runner_test(
         src: mlir source file to be compiled to an IREE module.
         target_backend: target backend to compile for.
         driver: driver to run the module with.
-        compiler_flags: additional flags to pass to the compiler. Bytecode output
-            format and backend flags are passed automatically.
-        runner_args: additional args to pass to the trace-runner program. The driver
-            and input file flags are passed automatically.
-        tags: Additional labels to apply to the test. "driver=${DRIVER}" is added
-            automatically.
+        compiler_flags: additional flags to pass to the compiler. Bytecode
+            output format and backend flags are passed automatically.
+        runner_args: additional args to pass to the trace-runner program. The
+            driver and input file flags are passed automatically.
+        tags: Additional labels to apply to the test. "driver=${DRIVER}" is
+            added automatically.
         trace_runner: trace-runner program to run.
         trace: trace file input to the trace-runner program.
-        module: specifies the  path to use for the enerated IREE module (.vmfb). Mandatory,
-            unlike in iree_check_test, because trace files (.yaml) reference a specific module file path.
+        module_name: specifies the  path to use for the enerated IREE module
+            (.vmfb). Mandatory, unlike in iree_check_test, because trace files
+            (.yaml) reference a specific module file path.
         timeout: timeout for the generated tests.
-        target_cpu_features: currently unimplemented (must be empty), will eventually allow specifying target CPU features.
-        **kwargs: any additional attributes to pass to the underlying tests and test suite.
+        target_cpu_features: currently unimplemented (must be empty), will
+            eventually allow specifying target CPU features.
+        **kwargs: any additional attributes to pass to the underlying tests and
+            test suite.
     """
 
     if target_cpu_features:
@@ -51,7 +54,7 @@ def iree_trace_runner_test(
     bytecode_module_name = name + "_bytecode_module"
     iree_bytecode_module(
         name = bytecode_module_name,
-        module = module,
+        module_name = module_name,
         src = src,
         flags = [
             "--mlir-print-op-on-diagnostic=false",
@@ -97,24 +100,27 @@ def iree_single_backend_generated_trace_runner_test(
 
     Args:
         name: Name of the target
-        generator: Target to run to generate the source file and trace files. It will be
-            invoked with the following standard flags, in addition to generator_args:
+        generator: Target to run to generate the source file and trace files.
+            It will be invoked with the following standard flags, in addition
+            to generator_args:
             --output_code=(current binary dir)/name.mlir
             --output_trace=(current binary dir)/name.yaml
             --module_path=(current binary dir)/name.vmfb
         generator_args: additional args to pass to the generator program.
         target_backend: target backend to compile for.
         driver: driver to run the module with.
-        compiler_flags: additional flags to pass to the compiler. Bytecode output
-            format and backend flags are passed automatically.
-        runner_args: additional args to pass to the trace-runner program. The driver
-            and input file flags are passed automatically.
-        tags: Additional labels to apply to the test. "driver=${DRIVER}" is added
-            automatically.
+        compiler_flags: additional flags to pass to the compiler. Bytecode
+            output format and backend flags are passed automatically.
+        runner_args: additional args to pass to the trace-runner program. The
+            driver and input file flags are passed automatically.
+        tags: Additional labels to apply to the test. "driver=${DRIVER}" is
+            added automatically.
         trace_runner: trace-runner program to run.
         timeout: timeout for the generated tests.
-        target_cpu_features: currently unimplemented (must be empty), will eventually allow specifying target CPU features.
-        **kwargs: any additional attributes to pass to the underlying tests and test suite.
+        target_cpu_features: currently unimplemented (must be empty), will
+            eventually allow specifying target CPU features.
+        **kwargs: any additional attributes to pass to the underlying tests and
+            test suite.
     """
 
     if target_cpu_features:
@@ -122,7 +128,7 @@ def iree_single_backend_generated_trace_runner_test(
 
     src = "%s.mlir" % (name)
     trace = "%s.yaml" % (name)
-    module = "%s.vmfb" % (name)
+    module_name = "%s.vmfb" % (name)
     native.genrule(
         name = "%s_generate" % (name),
         outs = [src, trace],
@@ -134,7 +140,7 @@ def iree_single_backend_generated_trace_runner_test(
             # Explanation for why "$(RULEDIR)/%s" instead of "$(location %s)" below:
             # module_path points to a file that does not yet exist as it will
             # be generated by iree_bytecode_module below iree_trace_runner_test.
-            "--module_path=$(RULEDIR)/%s" % (module),
+            "--module_path=$(RULEDIR)/%s" % (module_name),
         ] + [('"%s"' % arg) for arg in generator_args]),
         tools = [generator],
         message = "Generating code and trace for test %s..." % (name),
@@ -144,7 +150,7 @@ def iree_single_backend_generated_trace_runner_test(
     iree_trace_runner_test(
         name = name,
         src = src,
-        module = module,
+        module_name = module_name,
         target_backend = target_backend,
         driver = driver,
         trace_runner = trace_runner,
@@ -172,23 +178,26 @@ def iree_generated_trace_runner_test(
 
     Args:
         name: Name of the target
-        generator: Target to run to generate the source file and trace files. It will be
-            invoked with the following standard flags, in addition to generator_args:
+        generator: Target to run to generate the source file and trace files.
+            It will be invoked with the following standard flags, in addition
+            to generator_args:
             --output_code=(current binary dir)/name.mlir
             --output_trace=(current binary dir)/name.yaml
             --module_path=(current binary dir)/name.vmfb
         generator_args: additional args to pass to the generator program.
-        target_backends_and_drivers: backend/driver pairs to compile and run the module.
-        compiler_flags: additional flags to pass to the compiler. Bytecode output
-            format and backend flags are passed automatically.
-        runner_args: additional args to pass to the trace-runner program. The driver
-            and input file flags are passed automatically.
-        tags: Additional labels to apply to the test. "driver=${DRIVER}" is added
-            automatically.
+        target_backends_and_drivers: backend/driver pairs to compile and run
+            the module.
+        compiler_flags: additional flags to pass to the compiler. Bytecode
+            output format and backend flags are passed automatically.
+        runner_args: additional args to pass to the trace-runner program. The
+            driver and input file flags are passed automatically.
+        tags: Additional labels to apply to the test. "driver=${DRIVER}" is
+            added automatically.
         trace_runner: trace-runner program to run.
         timeout: timeout for the generated tests.
-        target_cpu_features_variants: list of target cpu features variants. Currently unimplemented, so each
-            entry must be either "default" or start with "aarch64:" so as Bazel builds are currently x86-only,
+        target_cpu_features_variants: list of target cpu features variants.
+            Currently unimplemented, so each entry must be either "default" or
+            start with "aarch64:" so as Bazel builds are currently x86-only,
             we know that it is correct to ignore this.
         **kwargs: any additional attributes to pass to the underlying tests and test suite.
     """

--- a/build_tools/bazel/iree_trace_runner_test.bzl
+++ b/build_tools/bazel/iree_trace_runner_test.bzl
@@ -30,8 +30,8 @@ def iree_trace_runner_test(
         src: mlir source file to be compiled to an IREE module.
         target_backend: target backend to compile for.
         driver: driver to run the module with.
-        compiler_flags: additional flags to pass to the compiler. Bytecode
-            translation and backend flags are passed automatically.
+        compiler_flags: additional flags to pass to the compiler. Bytecode output
+            format and backend flags are passed automatically.
         runner_args: additional args to pass to the trace-runner program. The driver
             and input file flags are passed automatically.
         tags: Additional labels to apply to the test. "driver=${DRIVER}" is added
@@ -54,7 +54,6 @@ def iree_trace_runner_test(
         module = module,
         src = src,
         flags = [
-            "--iree-mlir-to-vm-bytecode-module",
             "--mlir-print-op-on-diagnostic=false",
             "--iree-hal-target-backends=%s" % target_backend,
         ] + compiler_flags,
@@ -106,8 +105,8 @@ def iree_single_backend_generated_trace_runner_test(
         generator_args: additional args to pass to the generator program.
         target_backend: target backend to compile for.
         driver: driver to run the module with.
-        compiler_flags: additional flags to pass to the compiler. Bytecode
-            translation and backend flags are passed automatically.
+        compiler_flags: additional flags to pass to the compiler. Bytecode output
+            format and backend flags are passed automatically.
         runner_args: additional args to pass to the trace-runner program. The driver
             and input file flags are passed automatically.
         tags: Additional labels to apply to the test. "driver=${DRIVER}" is added
@@ -180,8 +179,8 @@ def iree_generated_trace_runner_test(
             --module_path=(current binary dir)/name.vmfb
         generator_args: additional args to pass to the generator program.
         target_backends_and_drivers: backend/driver pairs to compile and run the module.
-        compiler_flags: additional flags to pass to the compiler. Bytecode
-            translation and backend flags are passed automatically.
+        compiler_flags: additional flags to pass to the compiler. Bytecode output
+            format and backend flags are passed automatically.
         runner_args: additional args to pass to the trace-runner program. The driver
             and input file flags are passed automatically.
         tags: Additional labels to apply to the test. "driver=${DRIVER}" is added

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
@@ -440,6 +440,7 @@ class BuildFileFunctions(object):
   def iree_bytecode_module(self,
                            name,
                            src,
+                           module_name=None,
                            flags=None,
                            compile_tool=None,
                            c_identifier=None,
@@ -447,6 +448,8 @@ class BuildFileFunctions(object):
                            testonly=None):
     name_block = _convert_string_arg_block("NAME", name, quote=False)
     src_block = _convert_string_arg_block("SRC", src)
+    module_name_block = _convert_string_arg_block("MODULE_FILE_NAME",
+                                                  module_name)
     c_identifier_block = _convert_string_arg_block("C_IDENTIFIER", c_identifier)
     compile_tool_block = _convert_target_block("COMPILE_TOOL", compile_tool)
     flags_block = _convert_string_list_block("FLAGS", flags)
@@ -456,6 +459,7 @@ class BuildFileFunctions(object):
     self.converter.body += (f"iree_bytecode_module(\n"
                             f"{name_block}"
                             f"{src_block}"
+                            f"{module_name_block}"
                             f"{c_identifier_block}"
                             f"{compile_tool_block}"
                             f"{flags_block}"

--- a/build_tools/benchmarks/comparisons/setup_desktop.sh
+++ b/build_tools/benchmarks/comparisons/setup_desktop.sh
@@ -56,7 +56,8 @@ MODEL_NAME="mobilebert_float_384_gpu"
 bazel-bin/iree_tf_compiler/iree-import-tflite "${TFLITE_MODEL_DIR}/${MODEL_NAME}.tflite" -o "${IREE_MODEL_DIR}/${MODEL_NAME}.mlir"
 # Build for CUDA.
 echo "Compiling ${MODEL_NAME}.vmfb for cuda..."
-"${IREE_COMPILE_PATH}" --iree-input-type=tosa --iree-mlir-to-vm-bytecode-module \
+"${IREE_COMPILE_PATH}" \
+  --iree-input-type=tosa \
   --iree-hal-target-backends=cuda \
   --iree-hal-cuda-llvm-target-arch=sm_80 \
   --iree-llvm-debug-symbols=false \
@@ -66,7 +67,8 @@ echo "Compiling ${MODEL_NAME}.vmfb for cuda..."
   --o "${IREE_MODEL_DIR}/cuda/${MODEL_NAME}.vmfb"
 # Build for x86.
 echo "Compiling ${MODEL_NAME}.vmfb for dylib..."
-"${IREE_COMPILE_PATH}" --iree-input-type=tosa --iree-mlir-to-vm-bytecode-module \
+"${IREE_COMPILE_PATH}" \
+  --iree-input-type=tosa \
   --iree-llvm-target-cpu-features=host \
   --iree-hal-target-backends=dylib-llvm-aot \
   --iree-llvm-debug-symbols=false \

--- a/build_tools/benchmarks/comparisons/setup_mobile.sh
+++ b/build_tools/benchmarks/comparisons/setup_mobile.sh
@@ -65,7 +65,8 @@ mkdir -p "${IREE_MODEL_DIR}/dylib"
 MODEL_NAME="mobilebert_float_384_gpu"
 bazel-bin/iree_tf_compiler/iree-import-tflite "${TFLITE_MODEL_DIR}/${MODEL_NAME}.tflite" -o "${IREE_MODEL_DIR}/${MODEL_NAME}.mlir"
 echo "Compiling ${MODEL_NAME}.vmfb for aarch64..."
-"${IREE_COMPILE_PATH}" --iree-input-type=tosa --iree-mlir-to-vm-bytecode-module \
+"${IREE_COMPILE_PATH}" \
+  --iree-input-type=tosa \
   --iree-hal-target-backends=dylib-llvm-aot \
   --iree-llvm-target-triple=aarch64-none-linux-android29 \
   --iree-llvm-debug-symbols=false \
@@ -75,7 +76,8 @@ echo "Compiling ${MODEL_NAME}.vmfb for aarch64..."
   --o "${IREE_MODEL_DIR}/dylib/${MODEL_NAME}.vmfb"
 
 echo "Compiling ${MODEL_NAME}_mmt4d.vmfb for aarch64..."
-"${IREE_COMPILE_PATH}" --iree-input-type=tosa --iree-mlir-to-vm-bytecode-module \
+"${IREE_COMPILE_PATH}" \
+  --iree-input-type=tosa \
   --iree-hal-target-backends=dylib-llvm-aot \
   --iree-llvm-target-triple=aarch64-none-linux-android29 \
   "--iree-flow-mmt4d-target-options=arch=aarch64 features=+dotprod" \
@@ -88,7 +90,8 @@ echo "Compiling ${MODEL_NAME}_mmt4d.vmfb for aarch64..."
 
 if [[ "${GPU_TYPE}" = "mali" ]]; then
   echo "Compiling ${MODEL_NAME}.vmfb for vulkan mali..."
-  "${IREE_COMPILE_PATH}" --iree-input-type=tosa --iree-mlir-to-vm-bytecode-module \
+  "${IREE_COMPILE_PATH}" \
+    --iree-input-type=tosa \
     --iree-hal-target-backends=vulkan-spirv \
     --iree-vulkan-target-triple=valhall-unknown-android11 \
     --iree-llvm-debug-symbols=false \
@@ -98,7 +101,8 @@ if [[ "${GPU_TYPE}" = "mali" ]]; then
     --o "${IREE_MODEL_DIR}/vulkan/${MODEL_NAME}.vmfb"
 else
   echo "Compiling ${MODEL_NAME}.vmfb for vulkan adreno..."
-  "${IREE_COMPILE_PATH}" --iree-input-type=tosa --iree-mlir-to-vm-bytecode-module \
+  "${IREE_COMPILE_PATH}" \
+    --iree-input-type=tosa \
     --iree-hal-target-backends=vulkan-spirv \
     --iree-vulkan-target-triple=adreno-unknown-android11 \
     --iree-llvm-debug-symbols=false \
@@ -167,4 +171,3 @@ fi
 adb push "${SOURCE_DIR}/build_tools/benchmarks/comparisons" /data/local/tmp/
 adb shell "su root /data/data/com.termux/files/usr/bin/python /data/local/tmp/comparisons/run_benchmarks.py --device_name=Pixel6  --mode=mobile --base_dir=${DEVICE_ROOT_DIR} --output_dir=${DEVICE_ROOT_DIR}/output"
 adb shell cat "${DEVICE_ROOT_DIR}/output/result.csv"
-

--- a/build_tools/cmake/iree_benchmark_suite.cmake
+++ b/build_tools/cmake/iree_benchmark_suite.cmake
@@ -197,7 +197,6 @@ function(iree_benchmark_suite)
 
       # The full list of compilation flags.
       set(_COMPILATION_ARGS "")
-      list(APPEND _COMPILATION_ARGS "--iree-mlir-to-vm-bytecode-module")
       list(APPEND _COMPILATION_ARGS "--mlir-print-op-on-diagnostic=false")
       list(APPEND _COMPILATION_ARGS "--iree-hal-target-backends=${_RULE_TARGET_BACKEND}")
       list(SORT _RULE_COMPILATION_FLAGS)

--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -15,20 +15,20 @@ include(CMakeParseArguments)
 # SRC: Source file to compile into a bytecode module.
 # FLAGS: Flags to pass to the compiler tool (list of strings).
 #     `--output-format=vm-bytecode` is included automatically.
+# MODULE_FILE_NAME: Optional. When specified, sets the output bytecode module
+#    file name. When not specified, a default file name will be generated from
+#    ${NAME}.
 # COMPILE_TOOL: Compiler tool to invoke (CMake target). The default tool is
 #     "iree-compile".
 # C_IDENTIFIER: Identifier to use for generate c embed code.
 #     If omitted then no C embed code will be generated.
+# FRIENDLY_NAME: Optional. Name to use to display build progress info.
 # PUBLIC: Add this so that this library will be exported under ${PACKAGE}::
 #     Also in IDE, target will appear in ${PACKAGE} folder while non PUBLIC
 #     will be in ${PACKAGE}/internal.
-# DEPS: Library dependencies to add to the generated embed cc library.
 # TESTONLY: When added, this target will only be built if IREE_BUILD_TESTS=ON.
-# MODULE_FILE_NAME: Optional. When specified, sets the output bytecode module
-#    file name. When not specified, a default file name will be generated from
-#    ${NAME}.
 # DEPENDS: Optional. Additional dependencies beyond SRC and the tools.
-# FRIENDLY_NAME: Optional. Name to use to display build progress info.
+# DEPS: Library dependencies to add to the generated embed cc library.
 #
 # Note:
 # By default, iree_bytecode_module will create a module target named ${NAME} and
@@ -39,7 +39,7 @@ function(iree_bytecode_module)
   cmake_parse_arguments(
     _RULE
     "PUBLIC;TESTONLY"
-    "NAME;SRC;COMPILE_TOOL;C_IDENTIFIER;MODULE_FILE_NAME;FRIENDLY_NAME"
+    "NAME;SRC;MODULE_FILE_NAME;COMPILE_TOOL;C_IDENTIFIER;FRIENDLY_NAME"
     "FLAGS;DEPENDS;DEPS"
     ${ARGN}
   )

--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -8,12 +8,13 @@ include(CMakeParseArguments)
 
 # iree_bytecode_module()
 #
-# CMake function to imitate Bazel's iree_bytecode_module rule.
+# Builds an IREE bytecode module.
 #
 # Parameters:
 # NAME: Name of target (see Note).
 # SRC: Source file to compile into a bytecode module.
 # FLAGS: Flags to pass to the compiler tool (list of strings).
+#     `--output-format=vm-bytecode` is included automatically.
 # COMPILE_TOOL: Compiler tool to invoke (CMake target). The default tool is
 #     "iree-compile".
 # C_IDENTIFIER: Identifier to use for generate c embed code.
@@ -62,7 +63,8 @@ function(iree_bytecode_module)
 
   iree_get_executable_path(_COMPILE_TOOL_EXECUTABLE ${_COMPILE_TOOL})
 
-  set(_ARGS "${_RULE_FLAGS}")
+  set(_ARGS "--output-format=vm-bytecode")
+  list(APPEND _ARGS "${_RULE_FLAGS}")
 
   get_filename_component(_SRC_PATH "${_RULE_SRC}" REALPATH)
   list(APPEND _ARGS "${_SRC_PATH}")

--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -55,7 +55,6 @@ TARGET_BACKEND=${_RULE_TARGET_BACKEND}.")
     SRC
       "${_RULE_SRC}"
     FLAGS
-      "--iree-mlir-to-vm-bytecode-module"
       "--mlir-print-op-on-diagnostic=false"
       "--iree-hal-target-backends=${_RULE_TARGET_BACKEND}"
       ${_RULE_FLAGS}
@@ -76,8 +75,8 @@ endfunction()
 #   DRIVER: driver to run the module with. This can be omitted to test only
 #       compilation, but consider omiting the driver as a hacky abuse of the
 #       rule since compilation on its own not use iree-check-module.
-#   COMPILER_FLAGS: additional flags to pass to the compiler. Bytecode
-#       translation and backend flags are passed automatically.
+#   COMPILER_FLAGS: additional flags to pass to the compiler. Bytecode output
+#       format and backend flags are passed automatically.
 #   RUNNER_ARGS: additional args to pass to iree-check-module. The driver
 #       and input file are passed automatically.
 #   LABELS: Additional labels to apply to the test. The package path and
@@ -199,13 +198,13 @@ endfunction()
 #   DRIVER: driver to run the module with. This can be omitted to test only
 #       compilation, but consider omiting the driver as a hacky abuse of the
 #       rule since compilation on its own not use iree-check-module.
-#   COMPILER_FLAGS: additional flags to pass to the compiler. Bytecode
-#       translation and backend flags are passed automatically.
+#   COMPILER_FLAGS: additional flags to pass to the compiler. Bytecode output
+#       format and backend flags are passed automatically.
 #   RUNNER_ARGS: additional args to pass to the underlying iree-check-module
 #       tests. The driver and input file are passed automatically. To use
 #       different args per test, create a separate suite or iree_check_test.
-#   LABELS: Additional labels to apply to the generated tests. The package path is
-#       added automatically.
+#   LABELS: Additional labels to apply to the generated tests. The package path
+#       is added automatically.
 #   TARGET_CPU_FEATURES: If specified, a string passed as argument to
 #       --iree-llvm-target-cpu-features.
 function(iree_check_single_backend_test_suite)

--- a/build_tools/cmake/iree_trace_runner_test.cmake
+++ b/build_tools/cmake/iree_trace_runner_test.cmake
@@ -16,8 +16,8 @@ include(CMakeParseArguments)
 #   SRC: mlir source file to be compiled to an IREE module.
 #   TARGET_BACKEND: target backend to compile for.
 #   DRIVER: driver to run the module with.
-#   COMPILER_FLAGS: additional flags to pass to the compiler. Bytecode
-#       translation and backend flags are passed automatically.
+#   COMPILER_FLAGS: additional flags to pass to the compiler. Bytecode output
+#       format and backend flags are passed automatically.
 #   RUNNER_ARGS: additional args to pass to the trace-runner program. The driver
 #       and input file flags are passed automatically.
 #   LABELS: Additional labels to apply to the test. The package path and
@@ -116,8 +116,8 @@ endfunction()
 #   GENERATOR_ARGS: additional args to pass to the generator program.
 #   TARGET_BACKEND: target backend to compile for.
 #   DRIVER: driver to run the module with.
-#   COMPILER_FLAGS: additional flags to pass to the compiler. Bytecode
-#       translation and backend flags are passed automatically.
+#   COMPILER_FLAGS: additional flags to pass to the compiler. Bytecode output
+#       format and backend flags are passed automatically.
 #   RUNNER_ARGS: additional args to pass to the trace-runner program. The driver
 #       and input file flags are passed automatically.
 #   LABELS: Additional labels to apply to the test. The package path and
@@ -268,8 +268,8 @@ endfunction()
 #       TARGET_BACKENDS argument (due to cmake limitations they are separate list
 #       arguments). The lengths must exactly match. If no backends or drivers are
 #       specified, a test will be generated for every supported pair.
-#   COMPILER_FLAGS: additional flags to pass to the compiler. Bytecode
-#       translation and backend flags are passed automatically.
+#   COMPILER_FLAGS: additional flags to pass to the compiler. Bytecode output
+#       format and backend flags are passed automatically.
 #   RUNNER_ARGS: additional args to pass to the trace-runner program. The driver
 #       and input file flags are passed automatically.
 #   LABELS: Additional labels to apply to the test. The package path and

--- a/build_tools/kokoro/gcp_ubuntu/cmake/linux/riscv64/test.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/linux/riscv64/test.sh
@@ -21,22 +21,22 @@ export RISCV_TOOLCHAIN_ROOT=${RISCV_RV64_LINUX_TOOLCHAIN_ROOT?}
 
 function generate_dylib_vmfb {
   local target="${1}"; shift
-  local translate_arg=(
-    --iree-mlir-to-vm-bytecode-module --iree-hal-target-backends=dylib-llvm-aot
+  local compile_args=(
+    --iree-hal-target-backends=dylib-llvm-aot
     --iree-llvm-embedded-linker-path=${BUILD_HOST_DIR?}/install/bin/lld
     --iree-llvm-target-triple=riscv64
     --iree-llvm-target-cpu=generic-rv64
     --iree-llvm-target-abi=lp64d
   )
   if [[ "${target}" == "mhlo" ]]; then
-    translate_arg+=(
+    compile_args+=(
       --iree-input-type=mhlo
       --iree-llvm-target-cpu-features="+m,+a,+f,+d,+c"
     )
   elif [[ "${target}" == "tosa" ]]; then
     local input_file="${1}"; shift
     iree-import-tflite -o "${BUILD_RISCV_DIR?}/tosa.mlir" "${input_file}"
-    translate_arg+=(
+    compile_args+=(
       --iree-input-type=tosa
       --iree-llvm-target-cpu-features="+m,+a,+f,+d,+c"
       "${BUILD_RISCV_DIR?}/tosa.mlir"
@@ -44,7 +44,7 @@ function generate_dylib_vmfb {
   elif [[ "${target}" == "tosa-rvv" ]]; then
     local input_file="${1}"; shift
     iree-import-tflite -o "${BUILD_RISCV_DIR?}/tosa.mlir" "${input_file}"
-    translate_arg+=(
+    compile_args+=(
       --iree-input-type=tosa
       --iree-llvm-target-cpu-features="+m,+a,+f,+d,+c,+v"
       --riscv-v-fixed-length-vector-lmul-max=8
@@ -52,7 +52,7 @@ function generate_dylib_vmfb {
       "${BUILD_RISCV_DIR?}/tosa.mlir"
     )
   fi
-  "${BUILD_HOST_DIR?}/install/bin/iree-compile" "${translate_arg[@]}" "$@"
+  "${BUILD_HOST_DIR?}/install/bin/iree-compile" "${compile_args[@]}" "$@"
 }
 
 generate_dylib_vmfb mhlo \

--- a/compiler/src/iree/compiler/API/python/iree/compiler/tools/core.py
+++ b/compiler/src/iree/compiler/API/python/iree/compiler/tools/core.py
@@ -189,9 +189,6 @@ def build_compile_command_line(input_file: str, tfs: TempFileSaver,
   if options.output_file:
     cl.append(f"-o={options.output_file}")
 
-  # Translation to perform.
-  cl.append("--iree-mlir-to-vm-bytecode-module")
-
   # Tool paths.
   lld_path = find_tool("iree-lld")
   cl.append(f"--iree-llvm-embedded-linker-path={lld_path}")

--- a/compiler/src/iree/compiler/Tools/init_llvmir_translations.h
+++ b/compiler/src/iree/compiler/Tools/init_llvmir_translations.h
@@ -7,7 +7,7 @@
 // Configures a context with hooks to translate custom extensions to LLVMIR.
 // Note that this has nothing to do with the named translations that are
 // globally registered as part of init_translations.h for the purpose of
-// driving iree-translate. This is maintained separately to other dialect
+// driving iree-compile. This is maintained separately to other dialect
 // initializations because it causes a transitive dependency on LLVMIR.
 
 #ifndef IREE_COMPILER_TOOLS_INIT_LLVMIR_TRANSLATIONS_H_

--- a/compiler/src/iree/compiler/Tools/iree_compile_lib.cc
+++ b/compiler/src/iree/compiler/Tools/iree_compile_lib.cc
@@ -196,7 +196,7 @@ int mlir::iree_compiler::runIreecMain(int argc, char **argv) {
     outputFormat = OutputFormat::vm_bytecode;
   }
 
-  // Defualt output format.
+  // Default output format.
   if (outputFormat == OutputFormat::none) {
     outputFormat = OutputFormat::vm_bytecode;
   }

--- a/docs/developers/debugging/tf_integrations_test_repro.md
+++ b/docs/developers/debugging/tf_integrations_test_repro.md
@@ -40,5 +40,8 @@ Note that the command can only be run under `integrations/tensorflow/test/python
 5. This will create an `iree_input.mlir` in the temp directory specified. Those can then be fed into `iree-compile` (built locally to reproduce the error)
 
 ```
-iree-compile --iree-mlir-to-vm-bytecode-module --iree-hal-target-backends=dylib-llvm-aot --iree-input-type=mhlo iree_input.mlir
+iree-compile \
+  --iree-hal-target-backends=dylib-llvm-aot \
+  --iree-input-type=mhlo \
+  iree_input.mlir
 ```

--- a/docs/developers/design_docs/cuda_backend.md
+++ b/docs/developers/design_docs/cuda_backend.md
@@ -75,13 +75,12 @@ func @add(%lhs: tensor<4xf32>, %rhs: tensor<4xf32>) -> tensor<4xf32> {
 ```
 
 ```shell
-# First translate into a VM bytecode module.
+# First compile into a VM bytecode module.
 $ ../iree-build/tools/iree-compile \
- --iree-input-type=mhlo \
- --iree-mlir-to-vm-bytecode-module \
- --iree-hal-target-backends=cuda \
- /tmp/add.mlir \
- -o /tmp/mhlo-add.vmfb
+  --iree-input-type=mhlo \
+  --iree-hal-target-backends=cuda \
+  /tmp/add.mlir \
+  -o /tmp/mhlo-add.vmfb
 
 # Run the module through CUDA HAL backend.
 $ ../iree-build/tools/iree-run-module \

--- a/docs/developers/developing_iree/benchmarking.md
+++ b/docs/developers/developing_iree/benchmarking.md
@@ -20,7 +20,6 @@ To use `iree-benchmark-module`, generate an IREE module for the target backend:
 
 ```shell
 $ bazel run //tools:iree-compile -- \
-  --iree-mlir-to-vm-bytecode-module \
   --iree-hal-target-backends=vmvx \
   $PWD/samples/models/simple_abs.mlir \
   -o /tmp/module.fb
@@ -109,7 +108,6 @@ dispatch functions, generate an IREE module with the
 ```shell
 $ build/tools/iree-compile \
   --iree-input-type=mhlo \
-  --iree-mlir-to-vm-bytecode-module \
   --iree-flow-export-benchmark-funcs \
   --iree-hal-target-backends=vmvx \
   tests/e2e/models/fullyconnected.mlir \

--- a/docs/developers/developing_iree/developer_overview.md
+++ b/docs/developers/developing_iree/developer_overview.md
@@ -156,7 +156,6 @@ runner for the IREE
 ```shell
 $ ../iree-build/tools/iree-compile \
   --iree-input-type=mhlo \
-  --iree-mlir-to-vm-bytecode-module \
   --iree-hal-target-backends=vmvx \
   $PWD/tests/e2e/xla_ops/abs.mlir \
   -o /tmp/abs.vmfb

--- a/docs/developers/developing_iree/profiling_vulkan_gpu.md
+++ b/docs/developers/developing_iree/profiling_vulkan_gpu.md
@@ -34,10 +34,9 @@ func @dot(%lhs: tensor<2x4xf32>, %rhs: tensor<4x2xf32>) -> tensor<2x2xf32> {
 ```
 
 ```shell
-# First translate into a VM bytecode module
+# First compile into a VM bytecode module
 $ /path/to/iree/build/tools/iree-compile -- \
   --iree-input-type=mhlo \
-  --iree-mlir-to-vm-bytecode-module \
   --iree-hal-target-backends=vulkan-spirv \
   /path/to/mhlo-dot.mlir \
   -o /tmp/mhlo-dot.vmfb

--- a/docs/website/docs/building-from-source/android.md
+++ b/docs/website/docs/building-from-source/android.md
@@ -110,7 +110,6 @@ Invoke the host compiler tools to produce a bytecode module FlatBuffer:
 
 ``` shell
 ../iree-build/install/bin/iree-compile \
-  --iree-mlir-to-vm-bytecode-module \
   --iree-hal-target-backends=vmvx \
   samples/models/simple_abs.mlir \
   -o /tmp/simple_abs_vmvx.vmfb

--- a/docs/website/docs/building-from-source/riscv.md
+++ b/docs/website/docs/building-from-source/riscv.md
@@ -104,7 +104,6 @@ Invoke the host compiler tools to produce a bytecode module FlatBuffer:
 
 ``` shell
 ../iree-build/install/bin/iree-compile \
-  --iree-mlir-to-vm-bytecode-module \
   --iree-hal-target-backends=vmvx \
   samples/models/simple_abs.mlir \
   -o /tmp/simple_abs_vmvx.vmfb
@@ -146,7 +145,6 @@ with the additional command-line flags
 
 ```shell hl_lines="3 4 5 6 7 8"
 tools/iree-compile \
-  --iree-mlir-to-vm-bytecode-module \
   --iree-hal-target-backends=dylib-llvm-aot \
   --iree-llvm-target-triple=riscv64 \
   --iree-llvm-target-cpu=generic-rv64 \

--- a/docs/website/docs/deployment-configurations/bare-metal.md
+++ b/docs/website/docs/deployment-configurations/bare-metal.md
@@ -28,7 +28,6 @@ The model can be compiled with the following command (assuming the path to
 
 ```shell
 iree-compile \
-    --iree-mlir-to-vm-bytecode-module \
     --iree-stream-partitioning-favor=min-peak-memory \
     --iree-hal-target-backends=dylib-llvm-aot \
     --iree-llvm-target-triple=x86_64-pc-linux-elf \

--- a/docs/website/docs/deployment-configurations/cpu.md
+++ b/docs/website/docs/deployment-configurations/cpu.md
@@ -88,8 +88,7 @@ system's `PATH`):
 
 ``` shell hl_lines="3"
 iree-compile \
-    --iree-mlir-to-vm-bytecode-module \
-    --iree-hal-target-backends=dylib-llvm-aot \
+    --iree-hal-target-backends=cpu \
     iree_input.mlir -o mobilenet_cpu.vmfb
 ```
 

--- a/docs/website/docs/deployment-configurations/gpu-cuda-rocm.md
+++ b/docs/website/docs/deployment-configurations/gpu-cuda-rocm.md
@@ -101,7 +101,6 @@ IREE's TensorFlow importer. We can now compile them for each GPU by running the 
 
     ``` shell hl_lines="3-5"
     iree-compile \
-        --iree-mlir-to-vm-bytecode-module \
         --iree-hal-target-backends=cuda \
         --iree-hal-cuda-llvm-target-arch=<...> \
         --iree-hal-cuda-disable-loop-nounroll-wa \
@@ -127,7 +126,6 @@ IREE's TensorFlow importer. We can now compile them for each GPU by running the 
 
     ``` shell hl_lines="3-6"
     tools/iree-compile \
-        --iree-mlir-to-vm-bytecode-module \
         --iree-hal-target-backends=rocm \
         --iree-rocm-target-chip=<...> \
         --iree-rocm-link-bc=true \

--- a/docs/website/docs/deployment-configurations/gpu-vulkan.md
+++ b/docs/website/docs/deployment-configurations/gpu-vulkan.md
@@ -146,7 +146,6 @@ system's `PATH`):
 
 ``` shell hl_lines="3 4"
 iree-compile \
-    --iree-mlir-to-vm-bytecode-module \
     --iree-hal-target-backends=vulkan-spirv \
     --iree-vulkan-target-triple=<...> \
     iree_input.mlir -o mobilenet-vulkan.vmfb

--- a/docs/website/docs/getting-started/tflite.md
+++ b/docs/website/docs/getting-started/tflite.md
@@ -42,9 +42,8 @@ iree-import-tflite ${TFLITE_PATH} -o ${IMPORT_PATH}
 
 # Compile for the CPU backend
 iree-compile \
-    --iree-mlir-to-vm-bytecode-module \
     --iree-input-type=tosa \
-    --iree-hal-target-backends=dylib-llvm-aot \
+    --iree-hal-target-backends=cpu \
     ${IMPORT_PATH} \
     -o ${MODULE_PATH}
 ```

--- a/experimental/web/sample_dynamic/build_sample.sh
+++ b/experimental/web/sample_dynamic/build_sample.sh
@@ -48,7 +48,6 @@ COMPILE_TOOL="${INSTALL_ROOT?}/bin/iree-compile"
 compile_sample() {
   echo "  Compiling '$1' sample..."
   ${COMPILE_TOOL?} $2 \
-    --iree-mlir-to-vm-bytecode-module \
     --iree-input-type=mhlo \
     --iree-hal-target-backends=llvm \
     --iree-llvm-target-triple=wasm32-unknown-emscripten \

--- a/experimental/web/sample_static/build_sample.sh
+++ b/experimental/web/sample_static/build_sample.sh
@@ -50,7 +50,6 @@ INPUT_PATH="${ROOT_DIR?}/samples/models/mnist.mlir"
 
 echo "=== Compiling MLIR to static library output (.vmfb, .h, .o) ==="
 ${COMPILE_TOOL?} ${INPUT_PATH} \
-  --iree-mlir-to-vm-bytecode-module \
   --iree-input-type=mhlo \
   --iree-hal-target-backends=llvm \
   --iree-llvm-target-triple=wasm32-unknown-unknown \

--- a/runtime/bindings/tflite/testdata/BUILD
+++ b/runtime/bindings/tflite/testdata/BUILD
@@ -21,7 +21,6 @@ iree_bytecode_module(
         "--iree-input-type=mhlo",
         "--iree-native-bindings-support=false",
         "--iree-tflite-bindings-support",
-        "--iree-mlir-to-vm-bytecode-module",
         "--iree-hal-target-backends=vmvx",
     ],
 )
@@ -35,7 +34,6 @@ iree_bytecode_module(
         "--iree-input-type=mhlo",
         "--iree-native-bindings-support=false",
         "--iree-tflite-bindings-support",
-        "--iree-mlir-to-vm-bytecode-module",
         "--iree-hal-target-backends=vmvx",
     ],
 )
@@ -49,7 +47,6 @@ iree_bytecode_module(
         "--iree-input-type=mhlo",
         "--iree-native-bindings-support=false",
         "--iree-tflite-bindings-support",
-        "--iree-mlir-to-vm-bytecode-module",
         "--iree-hal-target-backends=vmvx",
     ],
 )

--- a/runtime/bindings/tflite/testdata/CMakeLists.txt
+++ b/runtime/bindings/tflite/testdata/CMakeLists.txt
@@ -21,7 +21,6 @@ iree_bytecode_module(
     "--iree-input-type=mhlo"
     "--iree-native-bindings-support=false"
     "--iree-tflite-bindings-support"
-    "--iree-mlir-to-vm-bytecode-module"
     "--iree-hal-target-backends=vmvx"
   PUBLIC
   TESTONLY
@@ -38,7 +37,6 @@ iree_bytecode_module(
     "--iree-input-type=mhlo"
     "--iree-native-bindings-support=false"
     "--iree-tflite-bindings-support"
-    "--iree-mlir-to-vm-bytecode-module"
     "--iree-hal-target-backends=vmvx"
   PUBLIC
   TESTONLY
@@ -55,7 +53,6 @@ iree_bytecode_module(
     "--iree-input-type=mhlo"
     "--iree-native-bindings-support=false"
     "--iree-tflite-bindings-support"
-    "--iree-mlir-to-vm-bytecode-module"
     "--iree-hal-target-backends=vmvx"
   PUBLIC
   TESTONLY

--- a/runtime/src/iree/hal/local/elf/testdata/generate.sh
+++ b/runtime/src/iree/hal/local/elf/testdata/generate.sh
@@ -16,7 +16,7 @@
 # run the script:
 #   $ ./iree/hal/local/elf/testdata/generate.sh
 
-# Uncomment to see the iree-translate commands issued:
+# Uncomment to see the iree-compile commands issued:
 # set -x
 set -e
 
@@ -24,24 +24,24 @@ ROOT_DIR=$(git rev-parse --show-toplevel)
 TESTDATA="${ROOT_DIR}/iree/hal/local/elf/testdata"
 
 # $1: file name ("foo_arm_32.so")
-# $2: list of iree-translate arguments for targeting
+# $2: list of iree-compile arguments for targeting
 function compile_and_extract_library() {
   local so_name=$1
   shift
-  local translate_args=("$@")
+  local compile_args=("$@")
 
   echo "Updating ${TESTDATA}/${so_name}"
 
   CMD=(
-    iree-translate
-      -iree-mlir-to-hal-executable
+    iree-compile
+      --compile-mode=hal-executable
       ${TESTDATA}/elementwise_mul.mlir
       -o="${TESTDATA}/${so_name}"
 
       --iree-hal-target-backends=dylib-llvm-aot
       --iree-llvm-debug-symbols=false
 
-      "${translate_args[@]}"
+      "${compile_args[@]}"
   )
   "${CMD[@]}"
 }

--- a/runtime/src/iree/hal/local/executable_library_benchmark.md
+++ b/runtime/src/iree/hal/local/executable_library_benchmark.md
@@ -80,8 +80,8 @@ to many different formats/architectures.
 2. Translate the executable into the binary form consumed by the IREE loaders:
 
 ```
-iree-translate \
-    --iree-mlir-to-hal-executable \
+iree-compile \
+    --compile-mode=hal-executable \
     iree/hal/local/testdata/elementwise_mul.mlir \
     -o=elementwise_mul.so \
     --iree-hal-target-backends=dylib-llvm-aot \

--- a/runtime/src/iree/modules/check/test/failure.mlir
+++ b/runtime/src/iree/modules/check/test/failure.mlir
@@ -1,5 +1,5 @@
-// RUN: iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-check-module --expect_failure - | FileCheck %s
-// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vulkan-spirv --iree-mlir-to-vm-bytecode-module %s | iree-check-module --driver=vulkan --expect_failure - | FileCheck %s)
+// RUN: iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vmvx %s | iree-check-module --expect_failure - | FileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vulkan-spirv %s | iree-check-module --driver=vulkan --expect_failure - | FileCheck %s)
 
 // CHECK-LABEL: expect_failure.expect_true_of_false
 // CHECK: Expected 0 to be nonzero

--- a/runtime/src/iree/modules/check/test/success.mlir
+++ b/runtime/src/iree/modules/check/test/success.mlir
@@ -1,5 +1,5 @@
-// RUN: iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-check-module --driver=local-task -
-// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vulkan-spirv --iree-mlir-to-vm-bytecode-module %s | iree-check-module --driver=vulkan -)
+// RUN: iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vmvx %s | iree-check-module --driver=local-task -
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vulkan-spirv %s | iree-check-module --driver=vulkan -)
 
 func.func @expect_true() {
   %true = util.unfoldable_constant 1 : i32

--- a/runtime/src/iree/modules/check/test/unavailable.mlir
+++ b/runtime/src/iree/modules/check/test/unavailable.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-run-module --module_file=- --entry_function=expect_true_of_false | FileCheck %s
+// RUN: iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vmvx %s | iree-run-module --module_file=- --entry_function=expect_true_of_false | FileCheck %s
 
 // Tests that even if the check module is not available (in this case because
 // we are running with iree-run-module instead of iree-check-module) the

--- a/runtime/src/iree/runtime/testdata/BUILD
+++ b/runtime/src/iree/runtime/testdata/BUILD
@@ -28,7 +28,6 @@ iree_bytecode_module(
     c_identifier = "iree_runtime_testdata_simple_mul_module",
     flags = [
         "--iree-input-type=mhlo",
-        "--iree-mlir-to-vm-bytecode-module",
         "--iree-hal-target-backends=vmvx",
     ],
 )

--- a/runtime/src/iree/runtime/testdata/CMakeLists.txt
+++ b/runtime/src/iree/runtime/testdata/CMakeLists.txt
@@ -23,7 +23,6 @@ iree_bytecode_module(
     "iree_runtime_testdata_simple_mul_module"
   FLAGS
     "--iree-input-type=mhlo"
-    "--iree-mlir-to-vm-bytecode-module"
     "--iree-hal-target-backends=vmvx"
   PUBLIC
 )

--- a/samples/simple_embedding/BUILD
+++ b/samples/simple_embedding/BUILD
@@ -47,7 +47,6 @@ iree_bytecode_module(
     c_identifier = "iree_samples_simple_embedding_test_module_vmvx",
     flags = [
         "--iree-input-type=mhlo",
-        "--iree-mlir-to-vm-bytecode-module",
         "--iree-hal-target-backends=vmvx",
     ],
 )
@@ -101,7 +100,6 @@ iree_bytecode_module(
     c_identifier = "iree_samples_simple_embedding_test_module_dylib_x86_64",
     flags = [
         "--iree-input-type=mhlo",
-        "--iree-mlir-to-vm-bytecode-module",
         "--iree-hal-target-backends=dylib-llvm-aot",
         "--iree-llvm-target-triple=x86_64-pc-linux-elf",
         "--iree-llvm-debug-symbols=false",
@@ -116,7 +114,6 @@ iree_bytecode_module(
     c_identifier = "iree_samples_simple_embedding_test_module_dylib_riscv_32",
     flags = [
         "--iree-input-type=mhlo",
-        "--iree-mlir-to-vm-bytecode-module",
         "--iree-hal-target-backends=dylib-llvm-aot",
         "--iree-llvm-target-triple=riscv32-pc-linux-elf",
         "--iree-llvm-target-cpu=generic-rv32",
@@ -134,7 +131,6 @@ iree_bytecode_module(
     c_identifier = "iree_samples_simple_embedding_test_module_dylib_riscv_64",
     flags = [
         "--iree-input-type=mhlo",
-        "--iree-mlir-to-vm-bytecode-module",
         "--iree-hal-target-backends=dylib-llvm-aot",
         "--iree-llvm-target-triple=riscv64-pc-linux-elf",
         "--iree-llvm-target-cpu=generic-rv64",
@@ -152,7 +148,6 @@ iree_bytecode_module(
     c_identifier = "iree_samples_simple_embedding_test_module_dylib_arm_32",
     flags = [
         "--iree-input-type=mhlo",
-        "--iree-mlir-to-vm-bytecode-module",
         "--iree-hal-target-backends=dylib-llvm-aot",
         "--iree-llvm-target-triple=armv7a-pc-linux-elf",
         "--iree-llvm-target-float-abi=hard",
@@ -168,7 +163,6 @@ iree_bytecode_module(
     c_identifier = "iree_samples_simple_embedding_test_module_dylib_arm_64",
     flags = [
         "--iree-input-type=mhlo",
-        "--iree-mlir-to-vm-bytecode-module",
         "--iree-hal-target-backends=dylib-llvm-aot",
         "--iree-llvm-target-triple=aarch64-pc-linux-elf",
         "--iree-llvm-debug-symbols=false",
@@ -256,7 +250,6 @@ iree_bytecode_module(
     c_identifier = "iree_samples_simple_embedding_test_module_vulkan",
     flags = [
         "--iree-input-type=mhlo",
-        "--iree-mlir-to-vm-bytecode-module",
         "--iree-hal-target-backends=vulkan-spirv",
         "--iree-llvm-debug-symbols=false",
     ],
@@ -307,7 +300,6 @@ endif()
 #     c_identifier = "iree_samples_simple_embedding_test_module_cuda",
 #     flags = [
 #         "--iree-input-type=mhlo",
-#         "--iree-mlir-to-vm-bytecode-module",
 #         "--iree-hal-target-backends=cuda",
 #         "--iree-llvm-debug-symbols=false",
 #     ],

--- a/samples/simple_embedding/CMakeLists.txt
+++ b/samples/simple_embedding/CMakeLists.txt
@@ -40,7 +40,6 @@ iree_bytecode_module(
     "iree_samples_simple_embedding_test_module_vmvx"
   FLAGS
     "--iree-input-type=mhlo"
-    "--iree-mlir-to-vm-bytecode-module"
     "--iree-hal-target-backends=vmvx"
   PUBLIC
 )
@@ -88,7 +87,6 @@ iree_bytecode_module(
     "iree_samples_simple_embedding_test_module_dylib_x86_64"
   FLAGS
     "--iree-input-type=mhlo"
-    "--iree-mlir-to-vm-bytecode-module"
     "--iree-hal-target-backends=dylib-llvm-aot"
     "--iree-llvm-target-triple=x86_64-pc-linux-elf"
     "--iree-llvm-debug-symbols=false"
@@ -106,7 +104,6 @@ iree_bytecode_module(
     "iree_samples_simple_embedding_test_module_dylib_riscv_32"
   FLAGS
     "--iree-input-type=mhlo"
-    "--iree-mlir-to-vm-bytecode-module"
     "--iree-hal-target-backends=dylib-llvm-aot"
     "--iree-llvm-target-triple=riscv32-pc-linux-elf"
     "--iree-llvm-target-cpu=generic-rv32"
@@ -127,7 +124,6 @@ iree_bytecode_module(
     "iree_samples_simple_embedding_test_module_dylib_riscv_64"
   FLAGS
     "--iree-input-type=mhlo"
-    "--iree-mlir-to-vm-bytecode-module"
     "--iree-hal-target-backends=dylib-llvm-aot"
     "--iree-llvm-target-triple=riscv64-pc-linux-elf"
     "--iree-llvm-target-cpu=generic-rv64"
@@ -148,7 +144,6 @@ iree_bytecode_module(
     "iree_samples_simple_embedding_test_module_dylib_arm_32"
   FLAGS
     "--iree-input-type=mhlo"
-    "--iree-mlir-to-vm-bytecode-module"
     "--iree-hal-target-backends=dylib-llvm-aot"
     "--iree-llvm-target-triple=armv7a-pc-linux-elf"
     "--iree-llvm-target-float-abi=hard"
@@ -167,7 +162,6 @@ iree_bytecode_module(
     "iree_samples_simple_embedding_test_module_dylib_arm_64"
   FLAGS
     "--iree-input-type=mhlo"
-    "--iree-mlir-to-vm-bytecode-module"
     "--iree-hal-target-backends=dylib-llvm-aot"
     "--iree-llvm-target-triple=aarch64-pc-linux-elf"
     "--iree-llvm-debug-symbols=false"
@@ -245,7 +239,6 @@ iree_bytecode_module(
     "iree_samples_simple_embedding_test_module_vulkan"
   FLAGS
     "--iree-input-type=mhlo"
-    "--iree-mlir-to-vm-bytecode-module"
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-llvm-debug-symbols=false"
   PUBLIC

--- a/samples/static_library/CMakeLists.txt
+++ b/samples/static_library/CMakeLists.txt
@@ -16,7 +16,6 @@ set(_COMPILE_TOOL_EXECUTABLE $<TARGET_FILE:iree-compile>)
 ## Example with VM bytecode module.
 # Setup args for iree-compile.
 set(_COMPILE_ARGS)
-list(APPEND _COMPILE_ARGS "--iree-mlir-to-vm-bytecode-module")
 list(APPEND _COMPILE_ARGS "--iree-hal-target-backends=dylib-llvm-aot")
 list(APPEND _COMPILE_ARGS "--iree-llvm-link-embedded=false")
 list(APPEND _COMPILE_ARGS "--iree-llvm-link-static")

--- a/tests/compiler_driver/smoketest.mlir
+++ b/tests/compiler_driver/smoketest.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-compile --split-input-file --iree-input-type=mhlo \
-// RUN:   --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module \
+// RUN:   --iree-hal-target-backends=vmvx \
 // RUN:   --iree-vm-bytecode-module-output-format=flatbuffer-text %s | FileCheck %s
 
 // CHECK-LABEL: "name": "simple_module"

--- a/tools/iree-run-mlir-main.cc
+++ b/tools/iree-run-mlir-main.cc
@@ -229,7 +229,7 @@ Status PrepareModule(std::string target_backend,
     mlir_module->dump();
   }
 
-  // NOTE: if we have an output file specified then we could translate into that
+  // NOTE: if we have an output file specified then we could compile into that
   // for greater efficiency. Today we assume that users aren't passing multi-GB
   // models through this tool (or if they are they have the memory to run them).
   auto bytecode_options =

--- a/tools/test/benchmark_flags.txt
+++ b/tools/test/benchmark_flags.txt
@@ -2,7 +2,7 @@
 // HELP: --module_file
 // HELP: --benchmark_list_tests
 
-// RUN: ( iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --benchmark_list_tests --driver=local-task --benchmark_list_tests ) | FileCheck --check-prefix=LIST-BENCHMARKS %s
+// RUN: ( iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vmvx %s | iree-benchmark-module --benchmark_list_tests --driver=local-task --benchmark_list_tests ) | FileCheck --check-prefix=LIST-BENCHMARKS %s
 module {
   // LIST-BENCHMARKS: BM_foo1
   func.func @foo1() -> tensor<4xf32> {

--- a/tools/test/iree-benchmark-module.mlir
+++ b/tools/test/iree-benchmark-module.mlir
@@ -1,6 +1,6 @@
-// RUN: iree-compile --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=local-task --entry_function=abs --function_input=f32=-2 | FileCheck %s
-// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-hal-target-backends=vulkan-spirv --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=vulkan --entry_function=abs --function_input=f32=-2 | FileCheck %s)
-// RUN: iree-compile --iree-hal-target-backends=dylib-llvm-aot --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=local-task --entry_function=abs --function_input=f32=-2 | FileCheck %s
+// RUN: iree-compile --iree-hal-target-backends=vmvx %s | iree-benchmark-module --driver=local-task --entry_function=abs --function_input=f32=-2 | FileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-hal-target-backends=vulkan-spirv %s | iree-benchmark-module --driver=vulkan --entry_function=abs --function_input=f32=-2 | FileCheck %s)
+// RUN: iree-compile --iree-hal-target-backends=dylib-llvm-aot %s | iree-benchmark-module --driver=local-task --entry_function=abs --function_input=f32=-2 | FileCheck %s
 
 // CHECK-LABEL: BM_abs
 func.func @abs(%input : tensor<f32>) -> (tensor<f32>) {

--- a/tools/test/iree-run-module.mlir
+++ b/tools/test/iree-run-module.mlir
@@ -1,6 +1,6 @@
-// RUN: (iree-compile --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-run-module --driver=local-task --entry_function=abs --function_input=f32=-2) | FileCheck %s
-// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || ((iree-compile --iree-hal-target-backends=vulkan-spirv --iree-mlir-to-vm-bytecode-module %s | iree-run-module --driver=vulkan --entry_function=abs --function_input=f32=-2) | FileCheck %s)
-// RUN: (iree-compile --iree-hal-target-backends=dylib-llvm-aot --iree-mlir-to-vm-bytecode-module %s | iree-run-module --driver=local-task --entry_function=abs --function_input=f32=-2) | FileCheck %s
+// RUN: (iree-compile --iree-hal-target-backends=vmvx %s | iree-run-module --driver=local-task --entry_function=abs --function_input=f32=-2) | FileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || ((iree-compile --iree-hal-target-backends=vulkan-spirv %s | iree-run-module --driver=vulkan --entry_function=abs --function_input=f32=-2) | FileCheck %s)
+// RUN: (iree-compile --iree-hal-target-backends=dylib-llvm-aot %s | iree-run-module --driver=local-task --entry_function=abs --function_input=f32=-2) | FileCheck %s
 
 // CHECK-LABEL: EXEC @abs
 func.func @abs(%input : tensor<f32>) -> (tensor<f32>) {

--- a/tools/test/multiple_args.mlir
+++ b/tools/test/multiple_args.mlir
@@ -1,6 +1,6 @@
-// RUN: iree-compile --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-run-module --entry_function=multi_input --function_input="2xi32=[1 2]" --function_input="2xi32=[3 4]" | FileCheck %s
+// RUN: iree-compile --iree-hal-target-backends=vmvx %s | iree-run-module --entry_function=multi_input --function_input="2xi32=[1 2]" --function_input="2xi32=[3 4]" | FileCheck %s
 // RUN: iree-run-mlir --iree-hal-target-backends=vmvx --function-input='2xi32=[1 2]' --function-input='2xi32=[3 4]' %s | FileCheck %s
-// RUN: iree-compile --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=local-task --entry_function=multi_input --function_input="2xi32=[1 2]" --function_input="2xi32=[3 4]" | FileCheck --check-prefix=BENCHMARK %s
+// RUN: iree-compile --iree-hal-target-backends=vmvx %s | iree-benchmark-module --driver=local-task --entry_function=multi_input --function_input="2xi32=[1 2]" --function_input="2xi32=[3 4]" | FileCheck --check-prefix=BENCHMARK %s
 
 // BENCHMARK-LABEL: BM_multi_input
 // CHECK-LABEL: EXEC @multi_input

--- a/tools/test/multiple_exported_functions.mlir
+++ b/tools/test/multiple_exported_functions.mlir
@@ -1,5 +1,5 @@
-// RUN: iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=local-task | FileCheck %s
-// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vulkan-spirv --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=vulkan | FileCheck %s)
+// RUN: iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vmvx %s | iree-benchmark-module --driver=local-task | FileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vulkan-spirv %s | iree-benchmark-module --driver=vulkan | FileCheck %s)
 
 module {
   func.func @foo1() -> tensor<4xf32> {

--- a/tools/test/repeated_return.mlir
+++ b/tools/test/repeated_return.mlir
@@ -1,5 +1,5 @@
-// RUN: (iree-compile --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-run-module --entry_function=many_tensor) | FileCheck %s
-// RUN: iree-compile --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=local-task --entry_function=many_tensor | FileCheck --check-prefix=BENCHMARK %s
+// RUN: (iree-compile --iree-hal-target-backends=vmvx %s | iree-run-module --entry_function=many_tensor) | FileCheck %s
+// RUN: iree-compile --iree-hal-target-backends=vmvx %s | iree-benchmark-module --driver=local-task --entry_function=many_tensor | FileCheck --check-prefix=BENCHMARK %s
 // RUN: iree-run-mlir --iree-hal-target-backends=vmvx %s | FileCheck %s
 
 // BENCHMARK-LABEL: BM_many_tensor

--- a/tools/test/scalars.mlir
+++ b/tools/test/scalars.mlir
@@ -1,5 +1,5 @@
-// RUN: (iree-compile --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-run-module --entry_function=scalar --function_input=42) | FileCheck %s
-// RUN: iree-compile --iree-hal-target-backends=vmvx --iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=local-task --entry_function=scalar --function_input=42 | FileCheck --check-prefix=BENCHMARK %s
+// RUN: (iree-compile --iree-hal-target-backends=vmvx %s | iree-run-module --entry_function=scalar --function_input=42) | FileCheck %s
+// RUN: iree-compile --iree-hal-target-backends=vmvx %s | iree-benchmark-module --driver=local-task --entry_function=scalar --function_input=42 | FileCheck --check-prefix=BENCHMARK %s
 // RUN: (iree-run-mlir --iree-hal-target-backends=vmvx --function-input=42 %s) | FileCheck %s
 
 // BENCHMARK-LABEL: BM_scalar


### PR DESCRIPTION
That flag is deprecated in favor of the (default) `--output-format=vm-bytecode`.

`iree_bytecode_module()` now always passes `--output-format=vm-bytecode` explicitly, while samples/docs/scripts depend on the implicit default mode. In the future (see discussion on https://github.com/google/iree/pull/9431), we can have `iree_c_module()` always pass `--output-format=vm-c`.

Also in this commit:
* Passing comment updates
* A few changes to `--iree-hal-target-backends=cpu`