### PR TITLE
Cleanups to TransformDialectInterpreter

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
@@ -25,7 +25,7 @@ def CPU_BufferOpsTileAndVectorize
     : I32EnumAttrCase<"CPUBufferOpsTileAndVectorize", 5>;
 
 def Linalg_TransformInterpCodegen
-    : I32EnumAttrCase<"LinalgTransformInterpCodegen", 6>;
+    : I32EnumAttrCase<"TransformDialectInterpreterCodegen", 6>;
 
 def LLVMGPU_SimpleDistribute
     : I32EnumAttrCase<"LLVMGPUDistribute", 7>;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -217,8 +217,8 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
                 executableLoweringPipeline);
             break;
           case IREE::Codegen::DispatchLoweringPassPipeline::
-              LinalgTransformInterpCodegen:
-            addLinalgTransformInterpPasses(executableLoweringPipeline);
+              TransformDialectInterpreterCodegen:
+            addTransformDialectInterpreterPasses(executableLoweringPipeline);
             break;
           case IREE::Codegen::DispatchLoweringPassPipeline::
               CPUTileFuseAndVectorize:

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -45,6 +45,12 @@ static llvm::cl::opt<bool> clEnableHoistPadding(
     "iree-llvmcpu-enable-hoist-padding",
     llvm::cl::desc("Flag to enable hoist padding"), llvm::cl::init(false));
 
+// MLIR file containing a top-level module that specifies the transformations to
+// apply to form dispatch regions.
+// Defined externally in KernelDispatch.cpp to control the codegen pass
+// pipeline.
+extern llvm::cl::opt<std::string> clCPUCodegenTransformDialectFileName;
+
 //===---------------------------------------------------------------------===//
 // Default allocation functions for CPU backend
 //===---------------------------------------------------------------------===//
@@ -453,9 +459,10 @@ void addCPUDefaultPassPipeline(OpPassManager &passManager) {
   addBufferizePasses(nestedModulePM);
 }
 
-void addLinalgTransformInterpPasses(OpPassManager &passManager) {
-  // Give control to the linalg_transform dialect.
-  passManager.addPass(createLinalgTransformInterpreterPass());
+void addTransformDialectInterpreterPasses(OpPassManager &passManager) {
+  // Give control to the transform dialect.
+  passManager.addPass(createTransformDialectInterpreterPass(
+      clCPUCodegenTransformDialectFileName));
 
   // Dropping the schedule is only needed if we want to embed the transform in
   // the module: we should drop the schedule once applied.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/linalg_transform.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/linalg_transform.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt %s  --pass-pipeline='hal.executable(hal.executable.variant(iree-llvmcpu-lower-executable-target))' --iree-codegen-use-transform-dialect --codegen-transform-dialect-file-name=%p/linalg_transform_spec.mlir | FileCheck %s
+// RUN: iree-opt %s  --pass-pipeline='hal.executable(hal.executable.variant(iree-llvmcpu-lower-executable-target))' --iree-codegen-use-transform-dialect=%p/linalg_transform_spec.mlir | FileCheck %s
 
 #device_target_cpu = #hal.device.target<"cpu", {executable_targets = [#hal.executable.target<"llvm", "embedded-elf-x86_64", {cpu_features = "", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "x86_64-unknown-unknown-eabi-elf"}>]}>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [#hal.descriptor_set.layout<0, bindings = [#hal.descriptor_set.binding<0, storage_buffer>, #hal.descriptor_set.binding<1, storage_buffer>, #hal.descriptor_set.binding<2, storage_buffer>]>]>

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -282,7 +282,7 @@ void addConvTileAndDecomposeExpertPassPipeline(OpPassManager &passManager);
 /// Populates the passes from Sandbox for testing transformations from sandbox.
 /// Unlike other pipelines this pass mangaer is nested at the
 /// `hal.executable.variant` op.
-void addLinalgTransformInterpPasses(OpPassManager &passManager);
+void addTransformDialectInterpreterPasses(OpPassManager &passManager);
 
 /// Populates the passes needed to multi level tile, fuse and vectorize lowering
 /// of linalg ops on tensors to vectors operations.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -82,6 +82,8 @@ iree_compiler_cc_library(
         "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
         "//llvm-external-projects/iree-dialects:IREELinalgExtPasses",
         "//llvm-external-projects/iree-dialects:IREELinalgExtTransformOps",
+        "//llvm-external-projects/iree-dialects:IREELinalgTransformDialect",
+        "//llvm-external-projects/iree-dialects:IREELinalgTransformDialectPasses",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Affine",
         "@llvm-project//mlir:ArithmeticDialect",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -62,6 +62,8 @@ iree_cc_library(
     IREELinalgExtDialect
     IREELinalgExtPasses
     IREELinalgExtTransformOps
+    IREELinalgTransformDialect
+    IREELinalgTransformDialectPasses
     LLVMSupport
     MLIRAffine
     MLIRArithmetic

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_transform_dialect.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_transform_dialect.mlir
@@ -31,4 +31,3 @@ func.func @foo5() -> index {
   %0 = arith.constant 5 : index
   return %0 : index
 }
-

--- a/integrations/tensorflow/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/Passes.h
+++ b/integrations/tensorflow/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/Passes.h
@@ -10,7 +10,7 @@ namespace mlir {
 namespace linalg {
 namespace transform {
 
-void registerLinalgTransformInterpreterPass();
+void registerTransformDialectInterpreterPass();
 void registerLinalgTransformExpertExpansionPass();
 void registerDropSchedulePass();
 
@@ -20,6 +20,6 @@ void registerDropSchedulePass();
 
 namespace mlir {
 class Pass;
-std::unique_ptr<Pass> createLinalgTransformInterpreterPass();
+std::unique_ptr<Pass> createTransformDialectInterpreterPass();
 std::unique_ptr<Pass> createDropSchedulePass();
 } // namespace mlir

--- a/integrations/tensorflow/iree-dialects/lib/CAPI/Dialects.cpp
+++ b/integrations/tensorflow/iree-dialects/lib/CAPI/Dialects.cpp
@@ -51,7 +51,7 @@ MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(
     mlir::linalg::transform::LinalgTransformDialect)
 
 void mlirIREELinalgTransformRegisterPasses() {
-  mlir::linalg::transform::registerLinalgTransformInterpreterPass();
+  mlir::linalg::transform::registerTransformDialectInterpreterPass();
   mlir::linalg::transform::registerLinalgTransformExpertExpansionPass();
   mlir::linalg::transform::registerDropSchedulePass();
 }
@@ -74,7 +74,7 @@ void ireeRegisterTransformDialectExtensions(MlirContext context) {
 
 void mlirIREETransformRegisterPasses() {
   mlir::linalg::transform::registerDropSchedulePass();
-  mlir::linalg::transform::registerLinalgTransformInterpreterPass();
+  mlir::linalg::transform::registerTransformDialectInterpreterPass();
 }
 
 //===----------------------------------------------------------------------===//

--- a/integrations/tensorflow/iree-dialects/tools/iree-dialects-opt/iree-dialects-opt.cpp
+++ b/integrations/tensorflow/iree-dialects/tools/iree-dialects-opt/iree-dialects-opt.cpp
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
   // Local dialect passes.
   mlir::iree_compiler::IREE::PYDM::registerPasses();
   mlir::iree_compiler::IREE::LinalgExt::registerPasses();
-  mlir::linalg::transform::registerLinalgTransformInterpreterPass();
+  mlir::linalg::transform::registerTransformDialectInterpreterPass();
   mlir::linalg::transform::registerLinalgTransformExpertExpansionPass();
   mlir::linalg::transform::registerDropSchedulePass();
   // Local test passes.

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/Passes.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/Passes.h
@@ -4,13 +4,14 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "mlir/Support/LLVM.h"
 #include <memory>
 
 namespace mlir {
 namespace linalg {
 namespace transform {
 
-void registerLinalgTransformInterpreterPass();
+void registerTransformDialectInterpreterPass();
 void registerLinalgTransformExpertExpansionPass();
 void registerDropSchedulePass();
 
@@ -20,6 +21,11 @@ void registerDropSchedulePass();
 
 namespace mlir {
 class Pass;
-std::unique_ptr<Pass> createLinalgTransformInterpreterPass();
+
+// Pass to schedule a dispatch region by using the transform dialect.
+// The schedule is specified by the transform module that is parsed from
+// `transformFileName`.
+std::unique_ptr<Pass> createTransformDialectInterpreterPass(
+    llvm::StringRef transformFileName = llvm::StringRef());
 std::unique_ptr<Pass> createDropSchedulePass();
 } // namespace mlir

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/TransformInterpreterUtils.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/TransformInterpreterUtils.h
@@ -1,0 +1,40 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_DIALECTS_LINALG_TRANSFORM_TRANSFORM_INTERPRETER_UTILS_H
+#define IREE_DIALECTS_LINALG_TRANSFORM_TRANSFORM_INTERPRETER_UTILS_H
+
+#include <memory>
+
+namespace mlir {
+class Operation;
+class LogicalResult;
+namespace transform {
+class TransformOpInterface;
+
+/// Utility to parse the content of a `transformFileName` mlir file containing
+/// a transform dialect specification.
+LogicalResult
+parseTransformModuleFromFile(MLIRContext *context,
+                             llvm::StringRef transformFileName,
+                             OwningOpRef<ModuleOp> &transformModule);
+
+/// Utility to extract the `TransformOpInterface` ops that have the trait
+/// `PossibleTopLevelTransformOpTrait`. Such ops are
+LogicalResult
+extractTopLevelTransformOps(Region &r,
+                            SmallVectorImpl<TransformOpInterface> &res);
+
+/// Utility to run a transform dialect specification contained in a
+/// `transformRegion`, on a `target` op.
+/// Since the transform dialect may use PDL which may modify the IR, the
+/// underlying implementation clones the transform dialect operations before
+/// applying them.
+LogicalResult applyTransformsInRegion(Region &transformRegion,
+                                      Operation *target);
+} // namespace transform
+} // namespace mlir
+#endif // IREE_DIALECTS_LINALG_TRANSFORM_TRANSFORM_INTERPRETER_UTILS_H

--- a/llvm-external-projects/iree-dialects/lib/CAPI/Dialects.cpp
+++ b/llvm-external-projects/iree-dialects/lib/CAPI/Dialects.cpp
@@ -51,7 +51,7 @@ MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(
     mlir::linalg::transform::LinalgTransformDialect)
 
 void mlirIREELinalgTransformRegisterPasses() {
-  mlir::linalg::transform::registerLinalgTransformInterpreterPass();
+  mlir::linalg::transform::registerTransformDialectInterpreterPass();
   mlir::linalg::transform::registerLinalgTransformExpertExpansionPass();
   mlir::linalg::transform::registerDropSchedulePass();
 }
@@ -74,7 +74,7 @@ void ireeRegisterTransformDialectExtensions(MlirContext context) {
 
 void mlirIREETransformRegisterPasses() {
   mlir::linalg::transform::registerDropSchedulePass();
-  mlir::linalg::transform::registerLinalgTransformInterpreterPass();
+  mlir::linalg::transform::registerTransformDialectInterpreterPass();
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/Passes/TransformInterpreter.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/Passes/TransformInterpreter.cpp
@@ -7,6 +7,7 @@
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.h"
 #include "iree-dialects/Dialect/LinalgTransform/Passes.h"
+#include "iree-dialects/Dialect/LinalgTransform/TransformInterpreterUtils.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/Dialect/Arithmetic/Transforms/BufferizableOpInterfaceImpl.h"
@@ -27,78 +28,84 @@
 #include "mlir/Dialect/Vector/Transforms/BufferizableOpInterfaceImpl.h"
 #include "mlir/Parser/Parser.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassRegistry.h"
 #include "mlir/Support/FileUtilities.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/Support/SourceMgr.h"
-#include <mlir/Pass/PassRegistry.h>
 
-#define DEBUG_TYPE "transform-interpreter"
+#define DEBUG_TYPE "transform-dialect-interpreter"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE << "]: ")
 
 using namespace mlir;
 
-static llvm::cl::opt<std::string> clTransformFileName(
-    "codegen-transform-dialect-file-name",
-    llvm::cl::desc("mlir file containing a top-level module that specifies "
-                   "the transformations to apply."),
-    llvm::cl::init(""));
+LogicalResult mlir::transform::parseTransformModuleFromFile(
+    MLIRContext *context, llvm::StringRef transformFileName,
+    OwningOpRef<ModuleOp> &transformModule) {
+  if (transformFileName.empty()) {
+    llvm::errs() << "no transform file name specified, assuming the transform "
+                    "module is embedded in the IR next to the top-level";
+    return success();
+  }
+  // Parse transformFileName content into a ModuleOp.
+  std::string errorMessage;
+  auto memoryBuffer = mlir::openInputFile(transformFileName, &errorMessage);
+  if (!memoryBuffer) {
+    llvm::errs() << "failed to parse transform file: " << transformFileName;
+    return failure();
+  }
+  // Tell sourceMgr about this buffer, the parser will pick it up.
+  llvm::SourceMgr sourceMgr;
+  sourceMgr.AddNewSourceBuffer(std::move(memoryBuffer), llvm::SMLoc());
+  transformModule =
+      OwningOpRef<ModuleOp>(parseSourceFile<ModuleOp>(sourceMgr, context));
+  return success();
+}
+
+LogicalResult mlir::transform::applyTransformsInRegion(Region &transformRegion,
+                                                       Operation *target) {
+  SmallVector<transform::TransformOpInterface> transforms;
+  if (failed(
+          transform::extractTopLevelTransformOps(transformRegion, transforms)))
+    return failure();
+
+  transform::TransformState state(transformRegion, target);
+  for (transform::TransformOpInterface transform : transforms) {
+    auto xform = cast<transform::TransformOpInterface>(transform->clone());
+    auto g = llvm::make_scope_exit([&]() { xform->erase(); });
+    if (failed(state.applyTransform(xform)))
+      return failure();
+  }
+  return success();
+}
+
+LogicalResult mlir::transform::extractTopLevelTransformOps(
+    Region &r, SmallVectorImpl<TransformOpInterface> &res) {
+  assert(r.getBlocks().size() == 1 &&
+         "Expected single-block region to extract transform ops from");
+  r.walk<WalkOrder::PreOrder>([&](transform::TransformOpInterface transform) {
+    if (transform->hasTrait<transform::PossibleTopLevelTransformOpTrait>()) {
+      assert(llvm::none_of(res, [&](transform::TransformOpInterface seen) {
+        return seen->isAncestor(transform);
+      }));
+      res.push_back(transform);
+      return WalkResult::skip();
+    }
+    return WalkResult::advance();
+  });
+  return success();
+}
 
 namespace {
-/// Simple pass that applies transform dialect ops directly contained in a
-/// module.
-class LinalgTransformInterp : public PassWrapper<LinalgTransformInterp, Pass> {
+
+/// Pass declaration.
+/// Interpreter pass that applies transform dialect ops for codegen.
+/// This needs to be its own pass because the registration mechanism and ops
+/// available are different than for other interpreters.
+class TransformDialectInterpreter
+    : public PassWrapper<TransformDialectInterpreter, Pass> {
 public:
-  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(LinalgTransformInterp)
-
-  StringRef getArgument() const override { return "linalg-transform-interp"; }
-
-  StringRef getDescription() const override {
-    return "apply transform dialect operations one by one";
-  }
-
-  bool canScheduleOn(RegisteredOperationName name) const override {
-    return true;
-  }
-
-  void runOnOperation() override {
-    Operation *topLevel = getOperation();
-    if (topLevel->getNumRegions() != 1 ||
-        !llvm::hasSingleElement(topLevel->getRegion(0))) {
-      topLevel->emitError() << "can only run '" << getArgument()
-                            << "' on single-region single-block operations";
-      return signalPassFailure();
-    }
-
-    if (clTransformFileName.empty()) {
-      transform::TransformState state(topLevel->getRegion(0), topLevel);
-      Block &body = topLevel->getRegion(0).front();
-      for (auto op : body.getOps<transform::TransformOpInterface>()) {
-        if (failed(state.applyTransform(op)))
-          return signalPassFailure();
-      }
-      return;
-    }
-
-    // If a transform file is specified, parse its content into a ModuleOp.
-    std::string errorMessage;
-    auto memoryBuffer = openInputFile(clTransformFileName, &errorMessage);
-    if (!memoryBuffer) {
-      llvm::errs() << errorMessage << "\n";
-      return signalPassFailure();
-    }
-    // Tell sourceMgr about this buffer, the parser will pick it up.
-    llvm::SourceMgr sourceMgr;
-    sourceMgr.AddNewSourceBuffer(std::move(memoryBuffer), llvm::SMLoc());
-    OwningOpRef<ModuleOp> transformModule(
-        parseSourceFile<ModuleOp>(sourceMgr, &getContext()));
-    transform::TransformState state(
-        transformModule->getOperation()->getRegion(0), topLevel);
-    for (auto op : transformModule->getBody()
-                       ->getOps<transform::TransformOpInterface>()) {
-      if (failed(state.applyTransform(op)))
-        return signalPassFailure();
-    }
-  }
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TransformDialectInterpreter)
 
   void getDependentDialects(DialectRegistry &registry) const override {
     // TODO: this is only necessary to make registry subset happy when running
@@ -132,12 +139,85 @@ public:
     tensor::registerBufferizableOpInterfaceExternalModels(registry);
     vector::registerBufferizableOpInterfaceExternalModels(registry);
   }
+
+  StringRef getArgument() const override {
+    return "transform-dialect-interpreter";
+  }
+
+  StringRef getDescription() const override {
+    return "apply transform dialect operations one by one";
+  }
+
+  bool canScheduleOn(RegisteredOperationName name) const override {
+    return true;
+  }
+
+  TransformDialectInterpreter(StringRef transformFileName = StringRef()) {
+    this->transformFileName = transformFileName.str();
+  }
+  TransformDialectInterpreter(const TransformDialectInterpreter &pass) {
+    this->transformFileName = pass.transformFileName;
+    // TODO: if we really don't like shared_ptr, we could also clone the
+    // transformModule here.
+    sharedTransformModule = pass.sharedTransformModule;
+  }
+
+  LogicalResult initialize(MLIRContext *context) override {
+    OwningOpRef<ModuleOp> module;
+    if (failed(transform::parseTransformModuleFromFile(
+            context, transformFileName, module)))
+      return failure();
+    sharedTransformModule =
+        std::make_shared<OwningOpRef<ModuleOp>>(std::move(module));
+    return success();
+  }
+
+  void runOnOperation() override {
+    Operation *target = getOperation();
+    bool parsedTransform = (sharedTransformModule && *sharedTransformModule);
+    assert(parsedTransform || (target->getNumRegions() == 1 &&
+                               target->getRegion(0).getBlocks().size() == 1) &&
+                                  "Cannot extract transform from op");
+    Region &transformRegion = parsedTransform
+                                  ? (*sharedTransformModule)->getRegion()
+                                  : target->getRegion(0);
+    if (failed(transform::applyTransformsInRegion(transformRegion, target)))
+      return signalPassFailure();
+  }
+
+protected:
+  Pass::Option<std::string> transformFileName{
+      *this, "transform-file-name",
+      ::llvm::cl::desc(
+          "File name containing a transform dialect specification to apply.")};
+
+private:
+  // The parsed transform module to be used for scheduling.
+  // TODO: Figure a better way to build a transform module and transport it in
+  // the proper places in the IR as it is transformed by IREE so that it is
+  // available with better ownership semantics.
+  // Note: we wrap the OwningOpRef to get the desired destruction mechanism.
+  // Note: shared_ptr is not great but we know the sharedTransformModule is
+  // readonly.
+  // Alternatives comprise:
+  //   1. no shared_ptr but copying the module with every pass clone that the
+  //      OpPassManager decides to perform.
+  //   2. lifting ownership of the parsed transform module higher up in the
+  //      IREE stack. This may be only shift the problem as we have passes
+  //      building pass managers in IREE.
+  //   3. build better support to embed the transformation module in the
+  //      input IR and transport it to the place of use in IREE. This is deemed
+  //      too intrusive atm.
+  //   4. (future) config/resources mechanism that is being proposed in core?
+  std::shared_ptr<OwningOpRef<ModuleOp>> sharedTransformModule;
 };
 
 struct DropSchedulePass : public PassWrapper<DropSchedulePass, Pass> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(DropSchedulePass)
 
-  StringRef getArgument() const final { return "linalg-drop-schedule"; }
+  StringRef getArgument() const final {
+    return "transform-dialect-drop-schedule";
+  }
 
   StringRef getDescription() const final {
     return "Drop the schedule from the operation";
@@ -159,9 +239,10 @@ struct DropSchedulePass : public PassWrapper<DropSchedulePass, Pass> {
 };
 } // namespace
 
-/// Create a Linalg Transform interpreter pass.
-std::unique_ptr<Pass> mlir::createLinalgTransformInterpreterPass() {
-  return std::make_unique<LinalgTransformInterp>();
+/// Create a Transform dialect interpreter pass.
+std::unique_ptr<Pass>
+mlir::createTransformDialectInterpreterPass(llvm::StringRef transformFileName) {
+  return std::make_unique<TransformDialectInterpreter>(transformFileName);
 }
 
 /// Create a Linalg pass to drop the schedule from the module.
@@ -174,7 +255,7 @@ void mlir::linalg::transform::registerDropSchedulePass() {
   PassRegistration<DropSchedulePass>();
 }
 
-/// Registration hook for the Linalg Transform interpreter pass.
-void mlir::linalg::transform::registerLinalgTransformInterpreterPass() {
-  PassRegistration<LinalgTransformInterp>();
+/// Registration hook for the Transform dialect interpreter pass.
+void mlir::linalg::transform::registerTransformDialectInterpreterPass() {
+  PassRegistration<TransformDialectInterpreter>();
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/foreach-thread-to-async.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/foreach-thread-to-async.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-dialects-opt %s  --linalg-transform-interp --split-input-file | FileCheck %s
+// RUN: iree-dialects-opt %s  --transform-dialect-interpreter --split-input-file | FileCheck %s
 
 // CHECK-DAG: #[[$MUL_MAP:.*]] = affine_map<(d0)[s0] -> (d0 * s0)>
 // CHECK-DAG: #[[$SUB_MAP:.*]] = affine_map<(d0)[s0, s1] -> (-(d0 * s0) + s1, s0)>
@@ -10,21 +10,29 @@
 #map4 = affine_map<(d0) -> (d0)>
 
 module {
-
-  // CHECK-LABEL: func.func @static_tile_buffers
+  // CHECK-LABEL: func.func @static_tile
   //  CHECK-SAME:   %[[CHUNK_SIZE:[0-9a-z]+]]: index
   //  CHECK-SAME:   %[[IN:[0-9a-z]+]]: memref<?xf32>
   //  CHECK-SAME:   %[[OUT:[0-9a-z]+]]: memref<?xf32>
-  func.func @static_tile_buffers(%arg0: index, %arg1: memref<?xf32>, %arg2: memref<?xf32>) {
+  func.func @static_tile(%arg0: index, %arg1: memref<?xf32>, %arg2: memref<?xf32>) {
     %cst = arith.constant 4.200000e+01 : f32
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %0 = memref.dim %arg2, %c0 : memref<?xf32>
     %1 = affine.apply #map0(%0)[%arg0]
 
-    // CHECK: %[[C1:.*]] = arith.constant 1 : index
     // CHECK: %[[M:.*]] = memref.dim %{{.*}}, %{{.*}} : memref<?xf32>
-    // CHECK: scf.for %[[IV:.*]] = {{.*}} step %[[C1]] {
+    // CHECK: %[[group:.*]] = async.create_group {{.*}}: !async.group
+    // CHECK: scf.for %[[IV:.*]] = {{.*}}
+    // CHECK:   %[[token:.*]] = async.execute {
+    // CHECK:     subview
+    // CHECK:     subview
+    // CHECK:     linalg.generic
+    // CHECK:     async.yield
+    // CHECK:   }
+    // CHECK:   async.add_to_group %[[token]], %[[group]] : !async.token
+    // CHECK: }
+    // CHECK: async.await_all %[[group]]
     scf.foreach_thread (%arg3) in (%1) -> () {
         %3 = affine.apply #map1(%arg3)[%arg0]
         %4 = affine.apply #map2(%0, %3)
@@ -39,9 +47,6 @@ module {
           %9 = arith.mulf %arg4, %cst : f32
           linalg.yield %9 : f32
         }
-
-        // Nothing is yielded, skip the terminator.
-        // CHECK-NOT: scf.yield
     }
     return
   }
@@ -57,7 +62,7 @@ module {
     transform.structured.canonicalized_sequence %arg0 {
     ^bb1(%arg1: !pdl.operation):
       %0 = pdl_match @match_foreach_thread in %arg1
-      %1 = foreach_thread_to_scf_for %0
+      %1 = foreach_thread_to_async %0
     }
   }
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/foreach-thread-to-scf-for.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/foreach-thread-to-scf-for.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-dialects-opt %s  --linalg-transform-interp --split-input-file | FileCheck %s
+// RUN: iree-dialects-opt %s  --transform-dialect-interpreter --split-input-file | FileCheck %s
 
 // CHECK-DAG: #[[$MUL_MAP:.*]] = affine_map<(d0)[s0] -> (d0 * s0)>
 // CHECK-DAG: #[[$SUB_MAP:.*]] = affine_map<(d0)[s0, s1] -> (-(d0 * s0) + s1, s0)>
@@ -10,29 +10,21 @@
 #map4 = affine_map<(d0) -> (d0)>
 
 module {
-  // CHECK-LABEL: func.func @static_tile
+
+  // CHECK-LABEL: func.func @static_tile_buffers
   //  CHECK-SAME:   %[[CHUNK_SIZE:[0-9a-z]+]]: index
   //  CHECK-SAME:   %[[IN:[0-9a-z]+]]: memref<?xf32>
   //  CHECK-SAME:   %[[OUT:[0-9a-z]+]]: memref<?xf32>
-  func.func @static_tile(%arg0: index, %arg1: memref<?xf32>, %arg2: memref<?xf32>) {
+  func.func @static_tile_buffers(%arg0: index, %arg1: memref<?xf32>, %arg2: memref<?xf32>) {
     %cst = arith.constant 4.200000e+01 : f32
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %0 = memref.dim %arg2, %c0 : memref<?xf32>
     %1 = affine.apply #map0(%0)[%arg0]
 
+    // CHECK: %[[C1:.*]] = arith.constant 1 : index
     // CHECK: %[[M:.*]] = memref.dim %{{.*}}, %{{.*}} : memref<?xf32>
-    // CHECK: %[[group:.*]] = async.create_group {{.*}}: !async.group
-    // CHECK: scf.for %[[IV:.*]] = {{.*}}
-    // CHECK:   %[[token:.*]] = async.execute {
-    // CHECK:     subview
-    // CHECK:     subview
-    // CHECK:     linalg.generic
-    // CHECK:     async.yield
-    // CHECK:   }
-    // CHECK:   async.add_to_group %[[token]], %[[group]] : !async.token
-    // CHECK: }
-    // CHECK: async.await_all %[[group]]
+    // CHECK: scf.for %[[IV:.*]] = {{.*}} step %[[C1]] {
     scf.foreach_thread (%arg3) in (%1) -> () {
         %3 = affine.apply #map1(%arg3)[%arg0]
         %4 = affine.apply #map2(%0, %3)
@@ -47,6 +39,9 @@ module {
           %9 = arith.mulf %arg4, %cst : f32
           linalg.yield %9 : f32
         }
+
+        // Nothing is yielded, skip the terminator.
+        // CHECK-NOT: scf.yield
     }
     return
   }
@@ -62,7 +57,7 @@ module {
     transform.structured.canonicalized_sequence %arg0 {
     ^bb1(%arg1: !pdl.operation):
       %0 = pdl_match @match_foreach_thread in %arg1
-      %1 = foreach_thread_to_async %0
+      %1 = foreach_thread_to_scf_for %0
     }
   }
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/fuse-in-containing-op.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/fuse-in-containing-op.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-dialects-opt %s  --linalg-transform-interp --split-input-file | FileCheck %s
+// RUN: iree-dialects-opt %s  --transform-dialect-interpreter --split-input-file | FileCheck %s
 
 #map0 = affine_map<()[s0] -> (64 ceildiv s0)>
 #map1 = affine_map<(d0)[s0] -> (d0 * s0)>

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/fuse-operands.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/fuse-operands.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-dialects-opt %s  --linalg-transform-interp --split-input-file | FileCheck %s
+// RUN: iree-dialects-opt %s  --transform-dialect-interpreter --split-input-file | FileCheck %s
 
 #map0 = affine_map<()[s0] -> (64 ceildiv s0)>
 #map1 = affine_map<(d0)[s0] -> (d0 * s0)>

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tiling-to-foreach-thread-op.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tiling-to-foreach-thread-op.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-dialects-opt %s --linalg-transform-interp --split-input-file | FileCheck %s
+// RUN: iree-dialects-opt %s --transform-dialect-interpreter --split-input-file | FileCheck %s
 
 // Offset per thread:
 // CHECK-DAG: affine_map<(d0)[s0] -> (d0 * (s0 ceildiv 10))>

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/bufferize.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/bufferize.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-dialects-opt --linalg-transform-interp %s | FileCheck %s
+// RUN: iree-dialects-opt --transform-dialect-interpreter %s | FileCheck %s
 
 // CHECK-LABEL: func.func @matmul_tensors(
 // CHECK-SAME:    %[[TA:[0-9a-z]+]]: memref<128x128xf32

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/double-tiling.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/double-tiling.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-dialects-opt --linalg-transform-interp --split-input-file %s | FileCheck %s
+// RUN: iree-dialects-opt --transform-dialect-interpreter --split-input-file %s | FileCheck %s
 
 // This test is verifying that a non-trivial 2*tiling+padding+vectorization transformation completes successfully
 

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/drop-schedule.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/drop-schedule.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-dialects-opt --linalg-drop-schedule %s | FileCheck %s
+// RUN: iree-dialects-opt --transform-dialect-drop-schedule %s | FileCheck %s
 
 func.func @matmul_tensors(
   %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32> { linalg.inplaceable = true})

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/failure.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/failure.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-dialects-opt --linalg-transform-interp --split-input-file --verify-diagnostics --allow-unregistered-dialect %s
+// RUN: iree-dialects-opt --transform-dialect-interpreter --split-input-file --verify-diagnostics --allow-unregistered-dialect %s
 
 func.func public @no_outlining() {
   // expected-note @below {{target op}}

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/fuse-and-peel.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/fuse-and-peel.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-dialects-opt --linalg-transform-interp %s | FileCheck %s
+// RUN: iree-dialects-opt --transform-dialect-interpreter %s | FileCheck %s
 
 // CHECK-LABEL: func.func @fuse_unary
 func.func @fuse_unary(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/fuse.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/fuse.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-dialects-opt --linalg-transform-interp %s | FileCheck %s
+// RUN: iree-dialects-opt --transform-dialect-interpreter %s | FileCheck %s
 
 
 // CHECK-LABEL: func.func @fuse_unary

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/generalize.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/generalize.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-dialects-opt --linalg-transform-interp %s | FileCheck %s
+// RUN: iree-dialects-opt --transform-dialect-interpreter %s | FileCheck %s
 
 
 // CHECK-LABEL: func.func @generalize_unary

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/interchange.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/interchange.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-dialects-opt --linalg-transform-interp %s | FileCheck %s
+// RUN: iree-dialects-opt --transform-dialect-interpreter %s | FileCheck %s
 
 //       CHECK: #[[$MAP:.*]] = affine_map<(d0, d1) -> (d1, d0)>
 

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/pad.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/pad.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-dialects-opt --linalg-transform-interp %s | FileCheck %s
+// RUN: iree-dialects-opt --transform-dialect-interpreter %s | FileCheck %s
 
 #map = affine_map<()[s0] -> (-s0 + 12, 5)>
 

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/peel.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/peel.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-dialects-opt --linalg-transform-interp %s | FileCheck %s
+// RUN: iree-dialects-opt --transform-dialect-interpreter %s | FileCheck %s
 
 
 //  CHECK-DAG: #[[MAP0:.*]] = affine_map<()[s0, s1, s2] -> (s1 - (-s0 + s1) mod s2)>

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/print.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/print.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-dialects-opt --linalg-transform-interp %s | FileCheck %s
+// RUN: iree-dialects-opt --transform-dialect-interpreter %s | FileCheck %s
 
 // CHECK-LABEL: IR printer: test print
 // CHECK-NEXT:  module

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/scalarize.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/scalarize.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-dialects-opt --linalg-transform-interp %s | FileCheck %s
+// RUN: iree-dialects-opt --transform-dialect-interpreter %s | FileCheck %s
 
 func.func @fun_to_benchmark(%arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32>) ->
     tensor<128x128xf32> attributes {passthrough = ["noinline", ["target-cpu", "skylake-avx512"], ["prefer-vector-width", "512"]]} {

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/selective-targeting.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/selective-targeting.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-dialects-opt %s --linalg-transform-interp --split-input-file | FileCheck %s
+// RUN: iree-dialects-opt %s --transform-dialect-interpreter --split-input-file | FileCheck %s
 
 // CHECK-LABEL: func.func @matmul_tensors_1(
 func.func @matmul_tensors_1(

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/single-tiling-full-script.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/single-tiling-full-script.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-dialects-opt --linalg-transform-interp %s | FileCheck %s
+// RUN: iree-dialects-opt --transform-dialect-interpreter %s | FileCheck %s
 
 // CHECK-LABEL: func @matmul_tensors
 // CHECK-NOT: linalg

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/tile-and-peel.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/tile-and-peel.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-dialects-opt --linalg-transform-interp %s | FileCheck %s
+// RUN: iree-dialects-opt --transform-dialect-interpreter %s | FileCheck %s
 
 // CHECK-LABEL: func.func @matmul_tensors(
 func.func @matmul_tensors(

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/tile-interchange.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/tile-interchange.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-dialects-opt --linalg-transform-interp --split-input-file %s | FileCheck %s
+// RUN: iree-dialects-opt --transform-dialect-interpreter --split-input-file %s | FileCheck %s
 
 #map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/tile.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/tile.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-dialects-opt --linalg-transform-interp %s | FileCheck %s
+// RUN: iree-dialects-opt --transform-dialect-interpreter %s | FileCheck %s
 
 // CHECK-LABEL: func.func @matmul_tensors(
 // CHECK-SAME:    %[[TA:[0-9a-z]+]]: tensor<128x128xf32>

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/vectorize.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/vectorize.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-dialects-opt --linalg-transform-interp --codegen-transform-dialect-file-name=%p/vectorize-transforms.mlir %s | FileCheck %s
+// RUN: iree-dialects-opt --transform-dialect-interpreter=transform-file-name=%p/vectorize-transforms.mlir %s | FileCheck %s
 
 // CHECK-LABEL: func.func @matmul_tensors(
 // CHECK-SAME:    %[[TA:[0-9a-z]+]]: tensor<128x128xf32>
@@ -18,4 +18,26 @@ func.func @matmul_tensors(
     -> tensor<128x128xf32>
 
   return %0 : tensor<128x128xf32>
+}
+
+// Some dummy functions to exercise TSAN under parallelism.
+func.func @foo1() -> index {
+  %0 = arith.constant 1 : index
+  return %0 : index
+}
+func.func @foo2() -> index {
+  %0 = arith.constant 2 : index
+  return %0 : index
+}
+func.func @foo3() -> index {
+  %0 = arith.constant 3 : index
+  return %0 : index
+}
+func.func @foo4() -> index {
+  %0 = arith.constant 4 : index
+  return %0 : index
+}
+func.func @foo5() -> index {
+  %0 = arith.constant 5 : index
+  return %0 : index
 }

--- a/llvm-external-projects/iree-dialects/tools/iree-dialects-opt/iree-dialects-opt.cpp
+++ b/llvm-external-projects/iree-dialects/tools/iree-dialects-opt/iree-dialects-opt.cpp
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
   // Local dialect passes.
   mlir::iree_compiler::IREE::PYDM::registerPasses();
   mlir::iree_compiler::IREE::LinalgExt::registerPasses();
-  mlir::linalg::transform::registerLinalgTransformInterpreterPass();
+  mlir::linalg::transform::registerTransformDialectInterpreterPass();
   mlir::linalg::transform::registerLinalgTransformExpertExpansionPass();
   mlir::linalg::transform::registerDropSchedulePass();
   // Local test passes.

--- a/tests/e2e/linalg_transform/linalg_transform.mlir
+++ b/tests/e2e/linalg_transform/linalg_transform.mlir
@@ -2,7 +2,7 @@
 /// Specify the dispatch region formation with the transform dialect.
 // RUN:   --iree-flow-dispatch-use-transform-dialect=%p/transform_dialect_dispatch_spec.mlir \
 /// Specify the codegen strategy with the transform dialect.
-// RUN:   --iree-codegen-use-transform-dialect --codegen-transform-dialect-file-name=%p/transform_dialect_codegen_spec.mlir \
+// RUN:   --iree-codegen-use-transform-dialect=%p/transform_dialect_codegen_spec.mlir \
 // RUN: | FileCheck %s
 
 func.func @matmul_static() -> tensor<5x5xf32> {


### PR DESCRIPTION
The introduction of DispatchWithTransformDialect has exhibited some multi-threading behavior issue.
Adapt the fixes in the TransformDialectInterpreter pass so that it can be used in IREE beyond simple unit tests.

Ideally there should be a single interpreter pass but the dialect registration between the two is quite different.

Common logic is factored out in util functions that may or may not graduate to core.