### PR TITLE
Switching from cuDeviceGetUuid_v2 to cuDeviceGetUuid for older CUDA.

### DIFF
--- a/runtime/src/iree/hal/drivers/cuda/cuda_driver.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_driver.c
@@ -130,8 +130,8 @@ static iree_status_t iree_hal_cuda_populate_device_info(
 
   // This matches the output of `nvidia-smi -L`.
   CUuuid device_uuid;
-  CUDA_RETURN_IF_ERROR(syms, cuDeviceGetUuid_v2(&device_uuid, device),
-                       "cuDeviceGetUuid_v2");
+  CUDA_RETURN_IF_ERROR(syms, cuDeviceGetUuid(&device_uuid, device),
+                       "cuDeviceGetUuid");
   char device_path_str[40 + 1] = {0};
   snprintf(device_path_str, sizeof(device_path_str),
            "GPU-"
@@ -337,8 +337,8 @@ static iree_status_t iree_hal_cuda_driver_create_device_by_uuid(
   for (int i = 0; i < device_count; i++) {
     CUDA_RETURN_IF_ERROR(&driver->syms, cuDeviceGet(&device, i), "cuDeviceGet");
     CUuuid query_uuid;
-    CUDA_RETURN_IF_ERROR(&driver->syms, cuDeviceGetUuid_v2(&query_uuid, device),
-                         "cuDeviceGetUuid_v2");
+    CUDA_RETURN_IF_ERROR(&driver->syms, cuDeviceGetUuid(&query_uuid, device),
+                         "cuDeviceGetUuid");
     if (memcmp(&device_uuid->bytes[0], &query_uuid.bytes[0],
                sizeof(device_uuid)) == 0) {
       found_device = true;
@@ -408,7 +408,7 @@ static iree_status_t iree_hal_cuda_driver_create_device_by_path(
   }
 
   if (iree_string_view_consume_prefix(&device_path, IREE_SV("GPU-"))) {
-    // UUID as returned by cuDeviceGetUuid_v2.
+    // UUID as returned by cuDeviceGetUuid.
     CUuuid device_uuid;
     if (!iree_hal_cuda_parse_uuid(device_path, &device_uuid)) {
       return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,

--- a/runtime/src/iree/hal/drivers/cuda/dynamic_symbol_tables.h
+++ b/runtime/src/iree/hal/drivers/cuda/dynamic_symbol_tables.h
@@ -10,7 +10,7 @@ CU_PFN_DECL(cuDeviceGet, CUdevice*, int)
 CU_PFN_DECL(cuDeviceGetCount, int*)
 CU_PFN_DECL(cuDeviceGetName, char*, int, CUdevice)
 CU_PFN_DECL(cuDeviceGetAttribute, int*, CUdevice_attribute, CUdevice)
-CU_PFN_DECL(cuDeviceGetUuid_v2, CUuuid*, CUdevice)
+CU_PFN_DECL(cuDeviceGetUuid, CUuuid*, CUdevice)
 CU_PFN_DECL(cuGetErrorName, CUresult, const char**)
 CU_PFN_DECL(cuGetErrorString, CUresult, const char**)
 CU_PFN_DECL(cuGraphAddMemcpyNode, CUgraphNode*, CUgraph, const CUgraphNode*,


### PR DESCRIPTION
v2 was added in 11.4 (June 2021). We'll want to support v2 but there's
not enough dynamic symbol goo in the CUDA driver to handle fallbacks
yet and I'm not sure anyone is using MIG yet (what v2 is for).