### PR TITLE
Add print stats pass

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -95,20 +95,20 @@ static llvm::cl::opt<bool> clNormalizeInputIndexingMap(
     llvm::cl::desc("Enable normalizing input indexing map to identity"),
     llvm::cl::init(false));
 
-static llvm::cl::opt<bool> clDumpDispatchGraph(
-    "iree-flow-dump-dispatch-graph",
-    llvm::cl::desc("Dump a dot graph for dispatches"), llvm::cl::init(false));
-
-static llvm::cl::opt<std::string> clDumpDispatchGraphOutputFile(
-    "iree-flow-dump-dispatch-graph-output-file",
-    llvm::cl::desc("Output file name for a dispatch graph dump"),
-    llvm::cl::init("dispatch.dot"));
-
 static llvm::cl::opt<std::string> clDispatchTransformFileName(
     "iree-flow-dispatch-use-transform-dialect",
     llvm::cl::desc("mlir file containing a top-level module that specifies "
                    "the transformations to apply to form dispatch regions."),
     llvm::cl::init(""));
+
+static llvm::cl::opt<bool> clDumpGraphAfterOutlining(
+    "iree-flow-dump-graph-after-outlining",
+    llvm::cl::desc("Dump a graph after outlining"), llvm::cl::init(false));
+
+static llvm::cl::opt<std::string> clDumpGraphAfterOutliningOutputFile(
+    "iree-flow-dump-graph-after-outlining-output-file",
+    llvm::cl::desc("Output file name for the graph after outlining"),
+    llvm::cl::init("graph-after-outlining.dot"));
 
 static llvm::cl::opt<bool> clDumpStatsAfterOutlining(
     "iree-flow-dump-stats-after-outlining",
@@ -277,10 +277,10 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
   passManager.addPass(IREE::Flow::createOutlineDispatchRegionsPass());
 
   /// Print the dispatch graph in the Graphviz format.
-  if (clDumpDispatchGraph) {
+  if (clDumpGraphAfterOutlining) {
     std::string errorMessage;
     static auto dotFile =
-        openOutputFile(clDumpDispatchGraphOutputFile, &errorMessage);
+        openOutputFile(clDumpGraphAfterOutliningOutputFile, &errorMessage);
     if (!dotFile) {
       llvm::errs() << errorMessage << "\n";
     } else {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -38,6 +38,23 @@ def ConvertConv2DToImg2Col :
   let constructor = "mlir::iree_compiler::IREE::Flow::createConvertConv2DToImg2ColPass()";
 }
 
+def ConvertLinalgMatmulToMmt4D :
+    Pass<"iree-flow-convert-linalg-matmul-to-mmt4d", ""> {
+  let summary = "Convert linalg.matmul to linalg.mmt4d";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createConvertLinalgMatmulToMmt4DPass()";
+  let options = [
+    Option<"arch", "arch", "std::string",
+           /*default=*/"",
+           "Target architecture, e.g. aarch64">,
+    Option<"features", "features", "std::string",
+           /*default=*/"",
+           "Additional CPU feature flags, e.g. +dotprod">,
+    Option<"enableGenericSlow", "enable_generic_slow", "bool",
+           /*default=*/"false",
+           "For tests only. Use mmt4d even for cases that are not expected to compile to efficient code by using some arbitrary generic tile shape.">,
+  ];
+}
+
 def ConvertToFlow :
     Pass<"iree-flow-convert-to-flow", ""> {
   let summary = "Convert operations to flow. Currently just a test pass.";
@@ -65,6 +82,23 @@ def DispatchWithTransformDialect :
     Option<"transformFileName", "transform-file-name", "std::string", /*default=*/"",
            "File name containing a transform dialect specification to apply.">
   ];
+}
+
+def DumpDispatchGraph : Pass<"iree-flow-dump-dispatch-graph-pass"> {
+  let summary = "Print visualization of dispatches";
+  let options = [
+    Option<"maxLabelLen", "max-label-len", "unsigned",
+            /*default=*/"20", "Limit attribute/type length to number of chars">,
+    Option<"printAttrs", "print-attrs", "bool",
+           /*default=*/"true", "Print attributes of operations">,
+    Option<"printControlFlowEdges", "print-control-flow-edges", "bool",
+           /*default=*/"false", "Print control flow edges">,
+    Option<"printDataFlowEdges", "print-data-flow-edges", "bool",
+           /*default=*/"true", "Print data flow edges">,
+    Option<"printResultTypes", "print-result-types", "bool",
+            /*default=*/"true", "Print result types of operations">
+  ];
+  let constructor = "mlir::iree_compiler::IREE::Flow::createDumpDispatchGraphPass()";
 }
 
 def ExpandTensorShapes :
@@ -132,44 +166,10 @@ def PadLinalgOps :
   let constructor = "mlir::iree_compiler::IREE::Flow::createPadLinalgOpsToIntegerMultiplePass()";
 }
 
-def ConvertLinalgMatmulToMmt4D :
-    Pass<"iree-flow-convert-linalg-matmul-to-mmt4d", ""> {
-  let summary = "Convert linalg.matmul to linalg.mmt4d";
-  let constructor = "mlir::iree_compiler::IREE::Flow::createConvertLinalgMatmulToMmt4DPass()";
-  let options = [
-    Option<"arch", "arch", "std::string",
-           /*default=*/"",
-           "Target architecture, e.g. aarch64">,
-    Option<"features", "features", "std::string",
-           /*default=*/"",
-           "Additional CPU feature flags, e.g. +dotprod">,
-    Option<"enableGenericSlow", "enable_generic_slow", "bool",
-           /*default=*/"false",
-           "For tests only. Use mmt4d even for cases that are not expected to compile to efficient code by using some arbitrary generic tile shape.">,
-  ];
-}
-
 def PadTensorToSubTensorInsert :
     Pass<"iree-flow-pad-tensor-to-subtensor-insert", ""> {
   let summary = "Convert linalg.pad_tensor into linalg.fill + subtensor_insert";
   let constructor = "mlir::iree_compiler::IREE::Flow::createPadTensorToSubTensorInsertPass()";
-}
-
-def DumpDispatchGraph : Pass<"iree-flow-dump-dispatch-graph-pass"> {
-  let summary = "Print visualization of dispatches";
-  let options = [
-    Option<"maxLabelLen", "max-label-len", "unsigned",
-            /*default=*/"20", "Limit attribute/type length to number of chars">,
-    Option<"printAttrs", "print-attrs", "bool",
-           /*default=*/"true", "Print attributes of operations">,
-    Option<"printControlFlowEdges", "print-control-flow-edges", "bool",
-           /*default=*/"false", "Print control flow edges">,
-    Option<"printDataFlowEdges", "print-data-flow-edges", "bool",
-           /*default=*/"true", "Print data flow edges">,
-    Option<"printResultTypes", "print-result-types", "bool",
-            /*default=*/"true", "Print result types of operations">
-  ];
-  let constructor = "mlir::iree_compiler::IREE::Flow::createDumpDispatchGraphPass()";
 }
 
 def SplitReduction :


### PR DESCRIPTION
[flow] add options to print out operation statistics

Use `--iree-flow-dump-stats-after-outlining`. It dumps the operation                                                                                                                                                        
statistics after outlining dispatch regions.                                                                                                                                                                                
                                                                                                                                                                                                                            
The default file name is `stats-after-outlining.json`, but it can be                                                                                                                                                        
changed by `--iree-flow-dump-stats-after-outlining-output-file`.                                                                                                                                                            
                                                                                                                                                                                                                            
Here is an example output for miniLM.                                                                                                                                                                                       
                                                                                                                                                                                                                            
```                                                                                                                                                                                                                         
{                                                                                                                                                                                                                           
  "arith.addf" : 476,                                                                                                                                                                                                       
  "arith.constant" : 667,                                                                                                                                                                                                   
  "arith.divf" : 74,                                                                                                                                                                                                        
  "arith.index_cast" : 3,                                                                                                                                                                                                   
  "arith.maxf" : 24,                                                                                                                                                                                                        
  "arith.minf" : 12,                                                                                                                                                                                                        
  "arith.mulf" : 402,                                                                                                                                                                                                       
  "arith.sitofp" : 1,                                                                                                                                                                                                       
  "arith.subf" : 63,                                                                                                                                                                                                        
  "builtin.module" : 272,                                                                                                                                                                                                   
  "flow.dispatch" : 271,                                                                                                                                                                                                    
  "flow.dispatch.tensor.load" : 611,                                                                                                                                                                                        
  "flow.dispatch.tensor.store" : 271,                                                                                                                                                                                       
  "flow.executable" : 271,                                                                                                                                                                                                  
  "flow.executable.export" : 271,                                                                                                                                                                                           
  "flow.executable_end" : 271,                                                                                                                                                                                              
  "flow.tensor.reshape" : 52,                                                                                                                                                                                               
  "flow.tensor.slice" : 1,                                                                                                                                                                                                  
  "func.func" : 272,                                                                                                                                                                                                        
  "func.return" : 272,                                                                                                                                                                                                      
  "hal.tensor.export" : 2,                                                                                                                                                                                                  
  "hal.tensor.import" : 3,                                                                                                                                                                                                  
  "linalg.batch_matmul" : 24,                                                                                                                                                                                               
  "linalg.fill" : 171,                                                                                                                                                                                                      
  "linalg.generic" : 248,                                                                                                                                                                                                   
  "linalg.index" : 1,                                                                                                                                                                                                       
  "linalg.init_tensor" : 271,                                                                                                                                                                                               
  "linalg.matmul" : 73,                                                                                                                                                                                                     
  "linalg.yield" : 516,                                                                                                                                                                                                     
  "math.exp" : 12,                                                                                                                                                                                                          
  "math.rsqrt" : 25,                                                                                                                                                                                                        
  "math.tanh" : 1,                                                                                                                                                                                                          
  "tensor.extract" : 3                                                                                                                                                                                                      
}                                                                                                                                                                                                                           
```

`--iree-flow-dump-dispatch-graph` is renamed by `--iree-flow-dump-graph-after-outlining` to match the naming style.

The PR also adds `--iree-flow-dump-graph-after-deduplication` and `--iree-flow-dump-stats-after-deduplication`.