### PR TITLE
Always add local_task and VMVX if building the compiler.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,12 @@ option(IREE_HAL_EXECUTABLE_LOADER_EMBEDDED_ELF "Enables the embedded dynamic lib
 option(IREE_HAL_EXECUTABLE_LOADER_SYSTEM_LIBRARY "Enables the system dynamic library loader for local HAL drivers" ${IREE_HAL_EXECUTABLE_LOADER_SYSTEM_LIBRARY_DEFAULT})
 option(IREE_HAL_EXECUTABLE_LOADER_VMVX_MODULE "Enables the VMVX module loader for local HAL drivers" ${IREE_HAL_EXECUTABLE_LOADER_VMVX_MODULE_DEFAULT})
 
+if(IREE_BUILD_COMPILER)
+  # The compiler requires the local task driver with the VMVX loader.
+  set(IREE_HAL_DRIVER_LOCAL_TASK ON)
+  set(IREE_HAL_EXECUTABLE_LOADER_VMVX_MODULE ON)
+endif()
+
 message(STATUS "IREE HAL drivers:")
 if(IREE_HAL_DRIVER_CUDA)
   message(STATUS "  - cuda")

--- a/runtime/src/iree/hal/drivers/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/CMakeLists.txt
@@ -121,10 +121,10 @@ endif()
 if(IREE_HAL_DRIVER_LOCAL_TASK)
   add_subdirectory(local_task)
   list(APPEND _INIT_INTERNAL_DEPS iree::hal::drivers::local_task::registration)
-else()
-  # Always include local_task, but mark its targets as EXCLUDE_FROM_ALL if the
-  # option is not set. This allows for direct dependencies (notably so the
-  # compiler can rely on _a_ runtime driver always existing), without linking
+elseif(IREE_BUILD_COMPILER)
+  # If building the compiler, always include local_task, but mark its targets
+  # as EXCLUDE_FROM_ALL if the option is not set. This allows for direct
+  # dependencies (like the compiler's ConstEval component), without linking
   # into the global registry.
   add_subdirectory(local_task EXCLUDE_FROM_ALL)
 endif()

--- a/runtime/src/iree/hal/drivers/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/CMakeLists.txt
@@ -121,12 +121,6 @@ endif()
 if(IREE_HAL_DRIVER_LOCAL_TASK)
   add_subdirectory(local_task)
   list(APPEND _INIT_INTERNAL_DEPS iree::hal::drivers::local_task::registration)
-elseif(IREE_BUILD_COMPILER)
-  # If building the compiler, always include local_task, but mark its targets
-  # as EXCLUDE_FROM_ALL if the option is not set. This allows for direct
-  # dependencies (like the compiler's ConstEval component), without linking
-  # into the global registry.
-  add_subdirectory(local_task EXCLUDE_FROM_ALL)
 endif()
 if(IREE_HAL_DRIVER_VULKAN)
   add_subdirectory(vulkan)

--- a/runtime/src/iree/hal/drivers/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/CMakeLists.txt
@@ -121,6 +121,12 @@ endif()
 if(IREE_HAL_DRIVER_LOCAL_TASK)
   add_subdirectory(local_task)
   list(APPEND _INIT_INTERNAL_DEPS iree::hal::drivers::local_task::registration)
+else()
+  # Always include local_task, but mark its targets as EXCLUDE_FROM_ALL if the
+  # option is not set. This allows for direct dependencies (notably so the
+  # compiler can rely on _a_ runtime driver always existing), without linking
+  # into the global registry.
+  add_subdirectory(local_task EXCLUDE_FROM_ALL)
 endif()
 if(IREE_HAL_DRIVER_VULKAN)
   add_subdirectory(vulkan)


### PR DESCRIPTION
Fixes https://github.com/google/iree/issues/8196

The [`ConstEval`](https://github.com/google/iree/tree/main/compiler/src/iree/compiler/ConstEval) compiler component unconditionally depends on VMVX and the `local-task` HAL driver. The compiler needs _some_ reference implementation available, but we still want to be able to prune the set of built and automatically registered drivers in the runtime.

This is one solution we liked - if the compiler is enabled, force its requirements enabled too.