### PR TITLE
Always pass `--output-format=vm-c` in iree_c_module.

### DIFF
--- a/build_tools/bazel/iree_c_module.bzl
+++ b/build_tools/bazel/iree_c_module.bzl
@@ -27,7 +27,8 @@ def iree_c_module(
         name: Name of the target
         src: mlir source file to be compiled to an IREE module.
         h_file_output: The H header file to output.
-        flags: flags to pass to the compile tool.
+        flags: additional flags to pass to the compile tool.
+            `--output-format=vm-c` is included automatically.
         deps: Optional. Dependencies to add to the generated library.
         compile_tool: the compiler to use to generate the module.
             Defaults to iree-compile.
@@ -41,7 +42,7 @@ def iree_c_module(
         cmd = " && ".join([
             " ".join([
                 "$(location %s)" % (compile_tool),
-                " ".join(flags),
+                " ".join(["--output-format=vm-c"] + flags),
                 "-o $(location %s)" % (h_file_output),
                 "$(location %s)" % (src),
             ]),

--- a/build_tools/cmake/iree_c_module.cmake
+++ b/build_tools/cmake/iree_c_module.cmake
@@ -14,7 +14,8 @@ include(CMakeParseArguments)
 # H_FILE_OUTPUT: The H header file to output.
 # COMPILE_TOOL: Compiler tool to invoke (CMake target). The default tool is
 #     "iree-compile".
-# FLAGS: Flags to pass to the compiler tool (list of strings).
+# FLAGS: Additional flags to pass to the compile tool (list of strings).
+#     `--output-format=vm-c` is included automatically.
 # TESTONLY: When added, this target will only be built if user passes
 #     -DIREE_BUILD_TESTS=ON to CMake.
 #
@@ -52,7 +53,8 @@ function(iree_c_module)
 
   iree_get_executable_path(_COMPILE_TOOL_EXECUTABLE ${_COMPILE_TOOL})
 
-  set(_ARGS "${_RULE_FLAGS}")
+  set(_ARGS "--output-format=vm-c")
+  list(APPEND _ARGS "${_RULE_FLAGS}")
   list(APPEND _ARGS "${CMAKE_CURRENT_SOURCE_DIR}/${_RULE_SRC}")
   list(APPEND _ARGS "-o")
   list(APPEND _ARGS "${_RULE_H_FILE_OUTPUT}")

--- a/runtime/src/iree/vm/test/emitc/BUILD
+++ b/runtime/src/iree/vm/test/emitc/BUILD
@@ -56,7 +56,6 @@ iree_c_module(
     src = "//runtime/src/iree/vm/test:arithmetic_ops.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "arithmetic_ops.h",
 )
@@ -66,7 +65,6 @@ iree_c_module(
     src = "//runtime/src/iree/vm/test:arithmetic_ops_f32.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "arithmetic_ops_f32.h",
 )
@@ -76,7 +74,6 @@ iree_c_module(
     src = "//runtime/src/iree/vm/test:arithmetic_ops_i64.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "arithmetic_ops_i64.h",
 )
@@ -86,7 +83,6 @@ iree_c_module(
     src = "//runtime/src/iree/vm/test:assignment_ops.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "assignment_ops.h",
 )
@@ -96,7 +92,6 @@ iree_c_module(
     src = "//runtime/src/iree/vm/test:assignment_ops_f32.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "assignment_ops_f32.h",
 )
@@ -106,7 +101,6 @@ iree_c_module(
     src = "//runtime/src/iree/vm/test:assignment_ops_i64.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "assignment_ops_i64.h",
 )
@@ -116,7 +110,6 @@ iree_c_module(
     src = "//runtime/src/iree/vm/test:buffer_ops.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "buffer_ops.h",
 )
@@ -126,7 +119,6 @@ iree_c_module(
     src = "//runtime/src/iree/vm/test:call_ops.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "call_ops.h",
 )
@@ -136,7 +128,6 @@ iree_c_module(
     src = "//runtime/src/iree/vm/test:comparison_ops.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "comparison_ops.h",
 )
@@ -146,7 +137,6 @@ iree_c_module(
     src = "//runtime/src/iree/vm/test:comparison_ops_f32.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "comparison_ops_f32.h",
 )
@@ -156,7 +146,6 @@ iree_c_module(
     src = "//runtime/src/iree/vm/test:comparison_ops_i64.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "comparison_ops_i64.h",
 )
@@ -166,7 +155,6 @@ iree_c_module(
     src = "//runtime/src/iree/vm/test:control_flow_ops.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "control_flow_ops.h",
 )
@@ -176,7 +164,6 @@ iree_c_module(
     src = "//runtime/src/iree/vm/test:conversion_ops.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "conversion_ops.h",
 )
@@ -186,7 +173,6 @@ iree_c_module(
     src = "//runtime/src/iree/vm/test:conversion_ops_f32.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "conversion_ops_f32.h",
 )
@@ -196,7 +182,6 @@ iree_c_module(
     src = "//runtime/src/iree/vm/test:conversion_ops_i64.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "conversion_ops_i64.h",
 )
@@ -206,7 +191,6 @@ iree_c_module(
     src = "//runtime/src/iree/vm/test:global_ops.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "global_ops.h",
 )
@@ -216,7 +200,6 @@ iree_c_module(
     src = "//runtime/src/iree/vm/test:global_ops_f32.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "global_ops_f32.h",
 )
@@ -226,7 +209,6 @@ iree_c_module(
     src = "//runtime/src/iree/vm/test:global_ops_i64.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "global_ops_i64.h",
 )
@@ -236,7 +218,6 @@ iree_c_module(
     src = "//runtime/src/iree/vm/test:list_ops.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "list_ops.h",
 )
@@ -246,7 +227,6 @@ iree_c_module(
     src = "//runtime/src/iree/vm/test:list_variant_ops.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "list_variant_ops.h",
 )
@@ -256,7 +236,6 @@ iree_c_module(
     src = "//runtime/src/iree/vm/test:ref_ops.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "ref_ops.h",
 )
@@ -266,7 +245,6 @@ iree_c_module(
     src = "//runtime/src/iree/vm/test:shift_ops.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "shift_ops.h",
 )
@@ -276,7 +254,6 @@ iree_c_module(
     src = "//runtime/src/iree/vm/test:shift_ops_i64.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "shift_ops_i64.h",
 )

--- a/runtime/src/iree/vm/test/emitc/CMakeLists.txt
+++ b/runtime/src/iree/vm/test/emitc/CMakeLists.txt
@@ -53,7 +53,6 @@ iree_c_module(
     "arithmetic_ops.h"
   FLAGS
     "--compile-mode=vm"
-    "--output-format=vm-c"
   COMPILE_TOOL
     iree-compile
 )
@@ -67,7 +66,6 @@ iree_c_module(
     "arithmetic_ops_f32.h"
   FLAGS
     "--compile-mode=vm"
-    "--output-format=vm-c"
   COMPILE_TOOL
     iree-compile
 )
@@ -81,7 +79,6 @@ iree_c_module(
     "arithmetic_ops_i64.h"
   FLAGS
     "--compile-mode=vm"
-    "--output-format=vm-c"
   COMPILE_TOOL
     iree-compile
 )
@@ -95,7 +92,6 @@ iree_c_module(
     "assignment_ops.h"
   FLAGS
     "--compile-mode=vm"
-    "--output-format=vm-c"
   COMPILE_TOOL
     iree-compile
 )
@@ -109,7 +105,6 @@ iree_c_module(
     "assignment_ops_f32.h"
   FLAGS
     "--compile-mode=vm"
-    "--output-format=vm-c"
   COMPILE_TOOL
     iree-compile
 )
@@ -123,7 +118,6 @@ iree_c_module(
     "assignment_ops_i64.h"
   FLAGS
     "--compile-mode=vm"
-    "--output-format=vm-c"
     COMPILE_TOOL
     iree-compile
 )
@@ -137,7 +131,6 @@ iree_c_module(
     "buffer_ops.h"
   FLAGS
     "--compile-mode=vm"
-    "--output-format=vm-c"
   COMPILE_TOOL
     iree-compile
 )
@@ -151,7 +144,6 @@ iree_c_module(
     "call_ops.h"
   FLAGS
     "--compile-mode=vm"
-    "--output-format=vm-c"
   COMPILE_TOOL
     iree-compile
 )
@@ -165,7 +157,6 @@ iree_c_module(
     "comparison_ops.h"
   FLAGS
     "--compile-mode=vm"
-    "--output-format=vm-c"
     COMPILE_TOOL
     iree-compile
 )
@@ -179,7 +170,6 @@ iree_c_module(
     "comparison_ops_f32.h"
   FLAGS
     "--compile-mode=vm"
-    "--output-format=vm-c"
   COMPILE_TOOL
     iree-compile
 )
@@ -193,7 +183,6 @@ iree_c_module(
     "comparison_ops_i64.h"
   FLAGS
     "--compile-mode=vm"
-    "--output-format=vm-c"
   COMPILE_TOOL
     iree-compile
 )
@@ -207,7 +196,6 @@ iree_c_module(
     "control_flow_ops.h"
   FLAGS
     "--compile-mode=vm"
-    "--output-format=vm-c"
   COMPILE_TOOL
     iree-compile
 )
@@ -221,7 +209,6 @@ iree_c_module(
     "conversion_ops.h"
   FLAGS
     "--compile-mode=vm"
-    "--output-format=vm-c"
   COMPILE_TOOL
     iree-compile
 )
@@ -235,7 +222,6 @@ iree_c_module(
     "conversion_ops_f32.h"
   FLAGS
     "--compile-mode=vm"
-    "--output-format=vm-c"
   COMPILE_TOOL
     iree-compile
 )
@@ -249,7 +235,6 @@ iree_c_module(
     "conversion_ops_i64.h"
   FLAGS
     "--compile-mode=vm"
-    "--output-format=vm-c"
   COMPILE_TOOL
     iree-compile
 )
@@ -263,7 +248,6 @@ iree_c_module(
     "global_ops.h"
   FLAGS
     "--compile-mode=vm"
-    "--output-format=vm-c"
   COMPILE_TOOL
     iree-compile
 )
@@ -277,7 +261,6 @@ iree_c_module(
     "global_ops_f32.h"
   FLAGS
     "--compile-mode=vm"
-    "--output-format=vm-c"
   COMPILE_TOOL
     iree-compile
 )
@@ -291,7 +274,6 @@ iree_c_module(
     "global_ops_i64.h"
   FLAGS
     "--compile-mode=vm"
-    "--output-format=vm-c"
   COMPILE_TOOL
     iree-compile
 )
@@ -305,7 +287,6 @@ iree_c_module(
     "list_ops.h"
   FLAGS
     "--compile-mode=vm"
-    "--output-format=vm-c"
   COMPILE_TOOL
     iree-compile
 )
@@ -319,7 +300,6 @@ iree_c_module(
     "list_variant_ops.h"
   FLAGS
     "--compile-mode=vm"
-    "--output-format=vm-c"
   COMPILE_TOOL
     iree-compile
 )
@@ -333,7 +313,6 @@ iree_c_module(
     "ref_ops.h"
   FLAGS
     "--compile-mode=vm"
-    "--output-format=vm-c"
   COMPILE_TOOL
     iree-compile
 )
@@ -347,7 +326,6 @@ iree_c_module(
     "shift_ops.h"
   FLAGS
     "--compile-mode=vm"
-    "--output-format=vm-c"
   COMPILE_TOOL
     iree-compile
 )
@@ -361,7 +339,6 @@ iree_c_module(
     "shift_ops_i64.h"
   FLAGS
     "--compile-mode=vm"
-    "--output-format=vm-c"
   COMPILE_TOOL
     iree-compile
 )

--- a/samples/emitc_modules/BUILD
+++ b/samples/emitc_modules/BUILD
@@ -18,7 +18,6 @@ iree_c_module(
     src = "add.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "add_module.h",
 )
@@ -42,7 +41,6 @@ iree_c_module(
     src = "import_module_a.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "import_module_a.h",
 )
@@ -52,7 +50,6 @@ iree_c_module(
     src = "import_module_b.mlir",
     flags = [
         "--compile-mode=vm",
-        "--output-format=vm-c",
     ],
     h_file_output = "import_module_b.h",
 )

--- a/samples/emitc_modules/CMakeLists.txt
+++ b/samples/emitc_modules/CMakeLists.txt
@@ -16,7 +16,7 @@ iree_c_module(
   H_FILE_OUTPUT
     "add_module.h"
   FLAGS
-    "--iree-hal-target-backends=vmvx"
+    "--compile-mode=vm"
 )
 
 iree_cc_test(
@@ -58,7 +58,7 @@ iree_c_module(
   H_FILE_OUTPUT
     "import_module_a.h"
   FLAGS
-    "--iree-hal-target-backends=vmvx"
+    "--compile-mode=vm"
 )
 
 iree_c_module(
@@ -69,5 +69,5 @@ iree_c_module(
   H_FILE_OUTPUT
     "import_module_b.h"
   FLAGS
-    "--iree-hal-target-backends=vmvx"
+    "--compile-mode=vm"
 )

--- a/samples/emitc_modules/CMakeLists.txt
+++ b/samples/emitc_modules/CMakeLists.txt
@@ -16,7 +16,6 @@ iree_c_module(
   H_FILE_OUTPUT
     "add_module.h"
   FLAGS
-    "--iree-mlir-to-vm-c-module"
     "--iree-hal-target-backends=vmvx"
 )
 
@@ -59,7 +58,6 @@ iree_c_module(
   H_FILE_OUTPUT
     "import_module_a.h"
   FLAGS
-    "--iree-mlir-to-vm-c-module"
     "--iree-hal-target-backends=vmvx"
 )
 
@@ -71,6 +69,5 @@ iree_c_module(
   H_FILE_OUTPUT
     "import_module_b.h"
   FLAGS
-    "--iree-mlir-to-vm-c-module"
     "--iree-hal-target-backends=vmvx"
 )


### PR DESCRIPTION
This matches how iree_bytecode_module always passes `--output-format=vm-bytecode`.

Follow-up to https://github.com/google/iree/pull/9431