### PR TITLE
Adding MSVC x86-32 ELF loading.

### DIFF
--- a/runtime/src/iree/hal/local/elf/CMakeLists.txt
+++ b/runtime/src/iree/hal/local/elf/CMakeLists.txt
@@ -93,14 +93,15 @@ iree_cc_library(
 
 # TODO(*): figure out how to make this work on Bazel+Windows.
 if(MSVC)
-  if(CMAKE_SYSTEM_PROCESSOR MATCHES "amd64.*|x86_64.*|AMD64.*")
+  # CMake + MASM does not work well and CMake ends up passing all our C/C++
+  # flags confusing MASM. We invoke MASM directly (ml.exe/ml64.exe) to keep it
+  # quiet.
+  if(MSVC_C_ARCHITECTURE_ID MATCHES 64 OR MSVC_CXX_ARCHITECTURE_ID MATCHES 64)
     set_source_files_properties(
       arch/x86_64_msvc.asm
       PROPERTIES
       LANGUAGE ASM_MASM
     )
-    # CMake + MASM does not work well and CMake ends up passing all our C/C++
-    # flags confusing MASM. We invoke MASM directly (ml64.exe) to keep it quiet.
     target_sources(iree_hal_local_elf_arch PRIVATE "arch/x86_64_msvc.obj")
     add_custom_command(
       OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/arch/x86_64_msvc.obj

--- a/runtime/src/iree/hal/local/elf/arch/x86_32.c
+++ b/runtime/src/iree/hal/local/elf/arch/x86_32.c
@@ -131,14 +131,7 @@ iree_status_t iree_elf_arch_apply_relocations(
 // Non-volatile:
 //   EBX, ESP, EBP, ESI, EDI
 //
-// Everything but Windows uses this convention (linux/bsd/mac/etc) and as such
-// we can just use nice little C thunks.
-
-#if defined(IREE_PLATFORM_WINDOWS)
-
-#error "TODO(#6554): need cdecl -> sysv ABI shims in x86_32_msvc.asm"
-
-#else
+// MSVC shares this convention for the default cdecl calls.
 
 void iree_elf_call_v_v(const void* symbol_ptr) {
   typedef void (*ptr_t)(void);
@@ -169,7 +162,5 @@ int iree_elf_thunk_i_p(const void* symbol_ptr, void* a0) {
   typedef int (*ptr_t)(void*);
   return ((ptr_t)symbol_ptr)(a0);
 }
-
-#endif  // IREE_PLATFORM_WINDOWS
 
 #endif  // IREE_ARCH_X86_32


### PR DESCRIPTION
Turns out that cdecl is cdecl.

Fixes #6554.