### PR TITLE
[spirv] Drop math.ctlz expansion given we have native conversion

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -353,7 +353,6 @@ void ConvertToSPIRVPass::runOnOperation() {
   arith::populateArithmeticToSPIRVPatterns(typeConverter, patterns);
   populateFuncToSPIRVPatterns(typeConverter, patterns);
   populateMathToSPIRVPatterns(typeConverter, patterns);
-  populateExpandCtlzPattern(patterns);
 
   // Pull in standard patterns to convert tensor operations to SPIR-V. These are
   // primarily used to handle tensor-type constants and contain a


### PR DESCRIPTION
A pattern (https://reviews.llvm.org/D127582) was added upstream to
convert math.ctlz to GLSL FindUMsb instructions.