### PR TITLE
Adding support for TRACY_FIBERS.

### DIFF
--- a/runtime/bindings/python/tests/vm_test.py
+++ b/runtime/bindings/python/tests/vm_test.py
@@ -124,7 +124,7 @@ class VmTest(unittest.TestCase):
     instance = iree.runtime.VmInstance()
     context1 = iree.runtime.VmContext(instance)
     context2 = iree.runtime.VmContext(instance)
-    self.assertGreater(context2.context_id, context1.context_id)
+    self.assertNotEqual(context2.context_id, context1.context_id)
 
   def test_module_basics(self):
     m = create_simple_static_mul_module()

--- a/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
+++ b/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
@@ -562,7 +562,7 @@ static iree_status_t iree_hal_vmvx_module_loader_try_load(
         bytecode_module,
     };
     status = iree_vm_context_create_with_modules(
-        executable_loader->instance, IREE_VM_CONTEXT_FLAG_NONE,
+        executable_loader->instance, IREE_VM_CONTEXT_FLAG_CONCURRENT,
         IREE_ARRAYSIZE(modules), modules, executable_loader->host_allocator,
         &context);
   }

--- a/runtime/src/iree/vm/context.h
+++ b/runtime/src/iree/vm/context.h
@@ -41,6 +41,12 @@ enum iree_vm_context_flag_bits_t {
   // All invocations made to this context - including initializers - will be
   // traced. For fine-grained control use `iree_vm_invocation_flags_t`.
   IREE_VM_CONTEXT_FLAG_TRACE_EXECUTION = 1u << 0,
+
+  // Context allows concurrent execution.
+  // Multiple OS threads may call into the context concurrently. Synchronization
+  // is not performed by the context and callers must ensure the executing
+  // programs support concurrency.
+  IREE_VM_CONTEXT_FLAG_CONCURRENT = 1u << 1,
 };
 typedef uint32_t iree_vm_context_flags_t;
 

--- a/runtime/src/iree/vm/invocation.c
+++ b/runtime/src/iree/vm/invocation.c
@@ -184,9 +184,11 @@ static iree_status_t iree_vm_invoke_within(
   call.function = function;
   call.arguments = arguments;
   call.results = results;
+  IREE_TRACE_FIBER_ENTER((char*)iree_vm_context_id(context));
   iree_vm_execution_result_t result;
   iree_status_t status =
       function.module->begin_call(function.module->self, stack, &call, &result);
+  IREE_TRACE_FIBER_LEAVE();
   if (!iree_status_is_ok(status)) {
     iree_vm_function_call_release(&call, &signature);
     return status;


### PR DESCRIPTION
Currently off by default but our instrumentation has been updated to support it.

When enabled this makes `iree_vm_context_t` appear alongside OS threads in the Tracy UI:
![image](https://user-images.githubusercontent.com/75337/173461102-47db9987-2402-4b3b-b383-ca5c91735f0a.png)

This will make tracking multiple overlapping contexts much easier, especially when running on fiber loops in the task system.