### PR TITLE
Use clang-format-12 in presubmits

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -95,8 +95,6 @@ jobs:
     steps:
       - name: Installing dependencies
         run: |
-          sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends clang-format-9
           wget https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/git-clang-format -O /tmp/git-clang-format
           chmod +x /tmp/git-clang-format
       - name: Checking out repository
@@ -106,7 +104,7 @@ jobs:
         run: git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"
       - name: Running clang-format on changed source files
         run: |
-          /tmp/git-clang-format "${GITHUB_BASE_REF?}" --binary=clang-format-9 --style=file
+          /tmp/git-clang-format "${GITHUB_BASE_REF?}" --binary=clang-format-12 --style=file
           git diff --exit-code
 
   tabs:


### PR DESCRIPTION
We have to have some pinned version and there isn't really a strong
reason it has to be the same as our oldest supported version of clang.
Most devs have more recent clang versions, so the later version is
likely to be closer to what people have locally. clang-format-12 is
the newest version installed by default on the GitHub managed runners,
so it also saves us some apt nonsense.

Fixes https://github.com/google/iree/9154