### PR TITLE
Bump pybind requirement to 2.8.0

### DIFF
--- a/compiler/pyproject.toml
+++ b/compiler/pyproject.toml
@@ -9,8 +9,7 @@ requires = [
     # MLIR build depends.
     "numpy",
     "packaging",
-    # Version 2.7.0 excluded: https://github.com/pybind/pybind11/issues/3136
-    "pybind11>=2.6.0,!=2.7.0",
+    "pybind11>=2.8.0",
     "PyYAML",
 ]
 build-backend = "setuptools.build_meta"

--- a/runtime/bindings/python/iree/runtime/build_requirements.txt
+++ b/runtime/bindings/python/iree/runtime/build_requirements.txt
@@ -4,6 +4,6 @@
 #   python -m pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
 
 numpy>=1.19.4
-pybind11>=2.6.1
+pybind11>=2.8.0
 wheel
 PyYAML

--- a/runtime/pyproject.toml
+++ b/runtime/pyproject.toml
@@ -7,8 +7,7 @@ requires = [
     "cmake==3.22.2",
     "ninja==1.10.2",
     "packaging",
-    # Version 2.7.0 excluded: https://github.com/pybind/pybind11/issues/3136
-    "pybind11>=2.6.0,!=2.7.0",
+    "pybind11>=2.8.0",
     "PyYAML",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This is the version required by MLIR:
- https://github.com/llvm/llvm-project/blob/main/mlir/python/requirements.txt
- https://github.com/llvm/llvm-project/blob/68df5c5c13/mlir/cmake/modules/MLIRDetectPythonEnv.cmake#L43

Having installed from the current requirements.txt, I get an error. This
sort of thing is exactly why I think we should have CI use the oldest
versions of things that we claim to support. The current Dockerfile
installs 2.9.0. This version was bumped upstream
[5 months ago](https://github.com/llvm/llvm-project/commit/89a92fb3ba)
and we only just noticed, which means our getting started guide for new
users has been broken that entire time.

I will send a follow-up to downgrade the Dockerfile, though i expect
that may be more contentious.
