### PR TITLE
Add a flag for controlling the max stack allocation limit allowed on CPU backend

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/check_ir_before_llvm_conversion.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/check_ir_before_llvm_conversion.mlir
@@ -10,7 +10,7 @@ module {
 
 // -----
 
-// expected-error @+1 {{expected total size of stack allocation is not greater than 32 KB, but got 65536 bytes}}
+// expected-error @+1 {{expected total size of stack allocation is not greater than 32768 bytes, but got 65536 bytes}}
 module {
   func.func @static_big_allocas(%arg0: index) {
     %0 = memref.alloca() : memref<16384xi32>
@@ -21,7 +21,7 @@ module {
 // -----
 
 #map = affine_map<(d0) -> (-d0, 16384)>
-// expected-error @+1 {{expected total size of stack allocation is not greater than 32 KB, but got 65536 bytes}}
+// expected-error @+1 {{expected total size of stack allocation is not greater than 32768 bytes, but got 65536 bytes}}
 module {
   func.func @dynamic_big_allocas(%arg0: index) {
     %0 = affine.min #map(%arg0)


### PR DESCRIPTION
The flag is meant for quick triaging. The default value is expected to
be 32KB.

Issue #9469 