### PR TITLE
Add CMake option to allow external project to use IREE CMake Macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ option(IREE_ENABLE_COMPILER_TRACING "Enables instrumented compiler tracing." OFF
 option(IREE_ENABLE_THREADING "Builds IREE in with thread library support." ON)
 option(IREE_ENABLE_CLANG_TIDY "Builds IREE in with clang tidy enabled on IREE's libraries." OFF)
 
+option(IREE_ENABLE_MACRO_FOR_EXTERNAL_PROJECT "Use IREE macros to build objects in external projects." OFF)
+
 # TODO(#8469): remove the dependency on cpuinfo entirely.
 option(IREE_ENABLE_CPUINFO "Enables runtime use of cpuinfo for processor topology detection." ON)
 

--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -66,7 +66,10 @@ function(iree_package_ns PACKAGE_NS)
   # the corresponding rule in:
   #   build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
   # Some sub-trees form their own roots for package purposes. Rewrite them.
-  if(_RELATIVE_PATH MATCHES "^compiler/src/(.*)")
+  if(IREE_ENABLE_MACRO_FOR_EXTERNAL_PROJECT)
+    # Use relative path directly for the external project.
+    set(_PACKAGE "${_RELATIVE_PATH}")
+  elseif(_RELATIVE_PATH MATCHES "^compiler/src/(.*)")
     # compiler/src/iree/compiler -> iree/compiler
     set(_PACKAGE "${CMAKE_MATCH_1}")
   elseif(_RELATIVE_PATH MATCHES "^runtime/src/(.*)")


### PR DESCRIPTION
Define a CMake option to use the relative path in creating the CMake
IREE namespace alias, which is then used by other CMake IREE Macros.

This allows external project to use IREE macros like `iree_cc_binary` or
`iree_cc_library` to build objects.

For IREE codebase, this should be a no-op feature.