### PR TITLE
Add e2e tests for large aligned matrix for cuda only

### DIFF
--- a/tests/e2e/matmul/BUILD
+++ b/tests/e2e/matmul/BUILD
@@ -216,3 +216,25 @@ py_binary(
     "valhall-unknown-android11",
     "ampere-unknown-linux",
 ]]
+
+# Check tests
+iree_check_single_backend_test_suite(
+    name = "check_cuda",
+    srcs = enforce_glob(
+        [
+            # currently only enabled on cuda as it can be slow on other backends.
+            "large_linalg_matmul.mlir",
+        ],
+        include = ["*.mlir"],
+    ),
+    driver = "cuda",
+    tags = [
+        # CUDA cuInit fails with sanitizer on.
+        "noasan",
+        "nomsan",
+        "notsan",
+        "noubsan",
+        "requires-gpu-nvidia",
+    ],
+    target_backend = "cuda",
+)

--- a/tests/e2e/matmul/BUILD
+++ b/tests/e2e/matmul/BUILD
@@ -7,6 +7,7 @@
 # End-to-end matrix multiplication tests.
 
 load("//build_tools/bazel:iree_trace_runner_test.bzl", "iree_generated_trace_runner_test")
+load("//build_tools/bazel:iree_check_test.bzl", "iree_check_single_backend_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -220,13 +221,11 @@ py_binary(
 # Check tests
 iree_check_single_backend_test_suite(
     name = "check_cuda",
-    srcs = enforce_glob(
+    srcs =
         [
             # currently only enabled on cuda as it can be slow on other backends.
             "large_linalg_matmul.mlir",
         ],
-        include = ["*.mlir"],
-    ),
     driver = "cuda",
     tags = [
         # CUDA cuInit fails with sanitizer on.

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -290,4 +290,21 @@ iree_generated_trace_runner_test(
     "requires-gpu-nvidia"
 )
 
+iree_check_single_backend_test_suite(
+  NAME
+    check_cuda
+  SRCS
+    "large_linalg_matmul.mlir"
+  TARGET_BACKEND
+    "cuda"
+  DRIVER
+    "cuda"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-nvidia"
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/tests/e2e/matmul/large_linalg_matmul.mlir
+++ b/tests/e2e/matmul/large_linalg_matmul.mlir
@@ -1,0 +1,13 @@
+// Test large aligned linalg matmul to make sure we go through the optimized
+// path for GPUs.
+func.func @large_aligned() {
+  %lhs = util.unfoldable_constant dense<1.0> : tensor<2048x1024xf32>
+  %rhs = util.unfoldable_constant dense<0.4> : tensor<1024x512xf32>
+  %c0 = arith.constant 0.0 : f32
+  %init = linalg.init_tensor[2048, 512] : tensor<2048x512xf32>
+  %CC = linalg.fill ins(%c0 : f32) outs(%init : tensor<2048x512xf32>) -> tensor<2048x512xf32>
+  %D = linalg.matmul ins(%lhs, %rhs: tensor<2048x1024xf32>, tensor<1024x512xf32>)
+                    outs(%CC: tensor<2048x512xf32>) -> tensor<2048x512xf32>
+  check.expect_almost_eq_const(%D, dense<409.596> : tensor<2048x512xf32>) : tensor<2048x512xf32>
+  return
+}


### PR DESCRIPTION
As discussed, add back tests for large aligned matmul for cuda target
only.