### PR TITLE
Some updates to build external rocm

### DIFF
--- a/experimental/rocm/CMakeLists.txt
+++ b/experimental/rocm/CMakeLists.txt
@@ -53,7 +53,6 @@ iree_cc_library(
     "${ROCM_HEADERS_API_ROOT}"
   DEPS
     ::dynamic_symbols
-    rocm_headers
     iree::base
     iree::base::core_headers
     iree::base::internal
@@ -65,6 +64,8 @@ iree_cc_library(
     iree::hal::utils::buffer_transfer
     iree::hal::utils::semaphore_base
     iree::schemas::rocm_executable_def_c_fbs
+  COPTS
+    "-D__HIP_PLATFORM_HCC__=1"
   PUBLIC
 )
 
@@ -79,11 +80,11 @@ iree_cc_library(
     "rocm_headers.h"
     "dynamic_symbols.c"
   INCLUDES
+    "${ROCM_HEADERS_API_ROOT}"
     "${CMAKE_CURRENT_LIST_DIR}/../.."
   COPTS
     "-D__HIP_PLATFORM_HCC__=1"
   DEPS
-    rocm_headers
     iree::base::core_headers
     iree::base::internal::dynamic_library
     iree::base::tracing
@@ -102,4 +103,6 @@ iree_cc_test(
     iree::testing::gtest_main
   LABELS
     "driver=rocm"
+  COPTS
+    "-D__HIP_PLATFORM_HCC__=1"
 )

--- a/experimental/rocm/registration/driver_module.c
+++ b/experimental/rocm/registration/driver_module.c
@@ -14,8 +14,8 @@
 #include "iree/base/tracing.h"
 
 static iree_status_t iree_hal_rocm_driver_factory_enumerate(
-    void *self, const iree_hal_driver_info_t **out_driver_infos,
-    iree_host_size_t *out_driver_info_count) {
+    void *self, iree_host_size_t *out_driver_info_count,
+    const iree_hal_driver_info_t **out_driver_infos) {
   // NOTE: we could query supported ROCM versions or featuresets here.
   static const iree_hal_driver_info_t driver_infos[1] = {{
       .driver_name = iree_string_view_literal("rocm"),


### PR DESCRIPTION
I think some cmake paths need to change for rocm runtime to build as an external driver. These changes allowed me to build it in my local environment