### PR TITLE
[vulkan] Disable clz.mlir tests due to Adreno GPU failure

### DIFF
--- a/tests/e2e/tosa_ops/BUILD
+++ b/tests/e2e/tosa_ops/BUILD
@@ -141,7 +141,6 @@ VULKAN_SRCS = enforce_glob(
         "bitwise_xor.mlir",
         "ceil.mlir",
         "clamp.mlir",
-        "clz.mlir",
         "const.mlir",
         "equal.mlir",
         "exp.mlir",
@@ -175,6 +174,9 @@ VULKAN_SRCS = enforce_glob(
         "while.mlir",
     ],
     include = ["*.mlir"],
+    exclude = [
+        "clz.mlir",  # Fails only on Adreno GPUs
+    ],
 )
 
 iree_check_single_backend_test_suite(

--- a/tests/e2e/tosa_ops/CMakeLists.txt
+++ b/tests/e2e/tosa_ops/CMakeLists.txt
@@ -125,7 +125,6 @@ iree_check_single_backend_test_suite(
     "bitwise_xor.mlir"
     "ceil.mlir"
     "clamp.mlir"
-    "clz.mlir"
     "const.mlir"
     "equal.mlir"
     "exp.mlir"


### PR DESCRIPTION
All other Vulkan implementations (Mali, NVIDIA, SwiftShader)
are fine with the code. Even older Adreno GPU drivers are fine..
So pretty much a driver issue. Need to investigate further;
disable it in the meanwhile.