### PR TITLE
Revert "Update candidate release to use the latest commit that passed all checks"

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -21,9 +21,6 @@ on:
       release_id:
         description: 'Release id to upload artifacts to'
         default: ''
-      commit:
-        description: 'Commit to check out'
-        default: ''
 
 jobs:
   build_core:
@@ -69,7 +66,6 @@ jobs:
         with:
           path: 'main_checkout'
           submodules: true
-          ref: ${{ github.event.inputs.commit }}
 
       ##########################################################################
       # OS specific setup

--- a/.github/workflows/schedule_candidate_release.yml
+++ b/.github/workflows/schedule_candidate_release.yml
@@ -13,17 +13,10 @@ jobs:
     # Don't run this in everyone's forks.
     if: github.repository == 'google/iree'
     steps:
-      - name: Get the last green commit
-        id: last_green_commit
-        uses: talentpair/last-green-commit-action@8b4b3bcd4ab5d9ab16875ce20ae012c4ce47ae68
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Checking out repository
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
-          ref: ${{ steps.last_green_commit.outputs.result }}
 
       - name: Compute version
         run: |
@@ -63,4 +56,4 @@ jobs:
           workflow: Build Native Release Packages
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           ref: "${{ env.tag_name }}"
-          inputs: '{"package_suffix": "", "package_version": "${{ env.package_version }}", "release_id": "${{ steps.create_release.outputs.id }}", "commit": "${{ steps.last_green_commit.outputs.result }}"}'
+          inputs: '{"package_suffix": "", "package_version": "${{ env.package_version }}", "release_id": "${{ steps.create_release.outputs.id }}"}'


### PR DESCRIPTION
Breaks the release because the push action attempts to push to the main
branch with an older commit. We should be able to just run a simple
`git push origin "${tag_name}"` to replace that whole silly action, but
testing on my fork right now isn't working, so reverting to unbreak the
release. https://github.com/google/iree/runs/6907189012

Reverts google/iree#9506