### PR TITLE
Use simple `git push` command instead of complex action

### DIFF
--- a/.github/workflows/schedule_candidate_release.yml
+++ b/.github/workflows/schedule_candidate_release.yml
@@ -31,11 +31,7 @@ jobs:
           git tag "${tag_name}"
 
       - name: Pushing changes
-        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6  # v0.6.0
-        with:
-          github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
-          branch: ${{ github.ref_name }}
-          tags: true
+        run: git push origin "${tag_name}"
 
       - name: Create Release
         id: create_release


### PR DESCRIPTION
That whole push action can be replaced with a single git command. I
think I've made this discovery before and suggest we be a bit more
judicious when deciding whether to use third party actions. The
`actions/checkout` action will persist credentials by default, so after
that there's no reason to use a custom action for something that can be
done with a git command. Also, every time an error includes a js stack
trace I die a little inside.

The impetus for this was that we really want that push to only push the
single tag we just added, but the way it's set up it *has* to push a
ref. Before, it was pushing main, which just happened to work because
we were also running the action on the tip of main, so it was generally
a noop. But with the introduction of logic to release from a green
commit and not necessarily tip of tree, this meant trying to push an
older commit to main, which predictably failed (but with a gross js
stack trace): https://github.com/google/iree/runs/6907189012.

I tried to switch us to the built-in `GITHUB_TOKEN` as well, but it
seems that even with the customizable permissions, it still won't can't
have permissions to launch other workflows. We should probably switch
to workflow calls:
https://docs.github.com/en/actions/using-workflows/reusing-workflows

Tested:
Ran this on my fork:
https://github.com/GMNGeoffrey/iree/actions/runs/2505270167