### PR TITLE
Remove FlowBufferizationState.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -132,7 +132,6 @@ static LogicalResult runIREEOneShotBufferize(
     Operation *op, const OneShotBufferizationOptions &options) {
   OneShotAnalysisState state(op, options);
   if (failed(analyzeOp(op, state))) return failure();
-  if (failed(createSubSpanBuffers(op, state))) return failure();
   if (options.testAnalysisOnly) return success();
   return bufferizeOp(op, state);
 }

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.h
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.h
@@ -17,9 +17,6 @@ namespace iree_compiler {
 // Register all interfaces needed for bufferization.
 void registerBufferizationInterfaces(DialectRegistry &registry);
 
-LogicalResult createSubSpanBuffers(Operation *op,
-                                   bufferization::AnalysisState &state);
-
 // Eliminate init_tensor ops that are anchored on flow store ops.
 LogicalResult storeTensorOpAnchoredInitTensorEliminationStep(
     RewriterBase &rewriter, Operation *op, bufferization::AnalysisState &state);


### PR DESCRIPTION
This is in preparation of recent bufferization changes that no longer
allow access to dialect state in `bufferize` interface methods.