### PR TITLE
[vulkan] Re-enable tosa.clz tests

### DIFF
--- a/tests/e2e/tosa_ops/BUILD
+++ b/tests/e2e/tosa_ops/BUILD
@@ -141,6 +141,7 @@ VULKAN_SRCS = enforce_glob(
         "bitwise_xor.mlir",
         "ceil.mlir",
         "clamp.mlir",
+        "clz.mlir",
         "const.mlir",
         "equal.mlir",
         "exp.mlir",
@@ -174,9 +175,6 @@ VULKAN_SRCS = enforce_glob(
         "while.mlir",
     ],
     include = ["*.mlir"],
-    exclude = [
-        "clz.mlir",  # Fails only on Adreno GPUs
-    ],
 )
 
 iree_check_single_backend_test_suite(

--- a/tests/e2e/tosa_ops/CMakeLists.txt
+++ b/tests/e2e/tosa_ops/CMakeLists.txt
@@ -125,6 +125,7 @@ iree_check_single_backend_test_suite(
     "bitwise_xor.mlir"
     "ceil.mlir"
     "clamp.mlir"
+    "clz.mlir"
     "const.mlir"
     "equal.mlir"
     "exp.mlir"


### PR DESCRIPTION
This reverts commit 88be147d1ec09bfd69aabc17ce8a733daa740077
given now we have a workaround for the Adreno GPU issue.