### PR TITLE
Add a pass to detach elementwise calculation from named ops

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -38,6 +38,7 @@ iree_compiler_cc_library(
         "ConvertConv2DToImg2Col.cpp",
         "ConvertLinalgMatmulToMmt4D.cpp",
         "DeduplicateExecutables.cpp",
+        "DetachElementwiseFromNamedOps.cpp",
         "DispatchLinalgOnTensors.cpp",
         "DispatchWithTransformDialect.cpp",
         "DumpDispatchGraph.cpp",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -34,6 +34,7 @@ iree_cc_library(
     "ConvertConv2DToImg2Col.cpp"
     "ConvertLinalgMatmulToMmt4D.cpp"
     "DeduplicateExecutables.cpp"
+    "DetachElementwiseFromNamedOps.cpp"
     "DispatchLinalgOnTensors.cpp"
     "DispatchWithTransformDialect.cpp"
     "DumpDispatchGraph.cpp"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DetachElementwiseFromNamedOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DetachElementwiseFromNamedOps.cpp
@@ -1,0 +1,125 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===- DetachElementwiseFromNamedOps.cpp ----------------------------------===//
+//
+// Detaches elementwise ops from Linalg named ops in preparation for following
+// fusion and bufferization.
+//
+//===----------------------------------------------------------------------===//
+
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/StructuredOpsUtils.h"
+#include "mlir/IR/AffineMap.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace Flow {
+
+namespace {
+
+struct DetachElementwisePattern
+    : public OpInterfaceRewritePattern<linalg::ContractionOpInterface> {
+  using OpInterfaceRewritePattern::OpInterfaceRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::ContractionOpInterface interfaceOp,
+                                PatternRewriter &rewriter) const override {
+    auto linalgOp = cast<linalg::LinalgOp>(interfaceOp.getOperation());
+    if (!linalgOp.hasTensorSemantics()) return failure();
+
+    // Nothing to do if the output tensor operand is already a fill op.
+    linalg::OpOperandVector outputOperands = linalgOp.getOutputTensorOperands();
+    if (outputOperands.size() != 1) return failure();
+    Value outputOperand = outputOperands.front()->get();
+    if (outputOperand.getDefiningOp<linalg::FillOp>()) return failure();
+
+    auto outputType = outputOperand.getType().cast<RankedTensorType>();
+    if (!outputType.getElementType().isIntOrFloat()) return failure();
+    auto elementType = outputType.getElementType();
+
+    Location loc = interfaceOp.getLoc();
+
+    // Create a zero tensor as the new output tensor operand to the Linalg
+    // contraction op.
+    SmallVector<Value> dynamicDims;
+    for (unsigned i = 0; i < outputType.getRank(); i++) {
+      if (outputType.isDynamicDim(i))
+        dynamicDims.push_back(
+            rewriter.create<tensor::DimOp>(loc, outputOperand, i));
+    }
+    auto initOp = rewriter.create<linalg::InitTensorOp>(
+        loc, dynamicDims, outputType.getShape(), elementType);
+    Value zero = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getZeroAttr(elementType));
+    Value fill =
+        rewriter.create<linalg::FillOp>(loc, zero, initOp.result()).result();
+
+    // Update the contraction op to use the new zero tensor as output operand.
+    rewriter.updateRootInPlace(linalgOp,
+                               [&]() { linalgOp.setOutputOperand(0, fill); });
+
+    // Create a generic op to add back the original output tensor operand.
+    rewriter.setInsertionPointAfter(linalgOp);
+    auto identityMap = AffineMap::getMultiDimIdentityMap(outputType.getRank(),
+                                                         linalgOp.getContext());
+    SmallVector<AffineMap> maps(3, identityMap);
+    SmallVector<StringRef> iterators(outputType.getRank(),
+                                     getParallelIteratorTypeName());
+    auto genericOp = rewriter.create<linalg::GenericOp>(
+        loc, outputType, ValueRange{linalgOp->getResult(0), outputOperand},
+        fill, maps, iterators,
+        [&](OpBuilder &b, Location nestedLoc, ValueRange args) {
+          Value result;
+          if (elementType.isa<FloatType>()) {
+            result = b.create<arith::AddFOp>(nestedLoc, args[0], args[1]);
+          } else {
+            result = b.create<arith::AddIOp>(nestedLoc, args[0], args[1]);
+          }
+          b.create<linalg::YieldOp>(nestedLoc, result);
+        });
+    linalgOp->getResult(0).replaceAllUsesExcept(genericOp->getResult(0),
+                                                genericOp);
+    return success();
+  }
+};
+
+struct DetachElementwiseFromNamedOpsPass
+    : public DetachElementwiseFromNamedOpsBase<
+          DetachElementwiseFromNamedOpsPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<arith::ArithmeticDialect, linalg::LinalgDialect,
+                    tensor::TensorDialect>();
+  }
+
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<DetachElementwisePattern>(&getContext());
+    if (failed(applyPatternsAndFoldGreedily(getOperation(),
+                                            std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<Pass> createDetachElementwiseFromNamedOpsPass() {
+  return std::make_unique<DetachElementwiseFromNamedOpsPass>();
+}
+
+}  // namespace Flow
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -187,6 +187,7 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
       .addPass(IREE::Flow::createConvertConv2D1x1ToMatmulPass)
       .addPredicatedPass(clEnableConvToImg2Col,
                          IREE::Flow::createConvertConv2DToImg2ColPass)
+      .addPass(IREE::Flow::createDetachElementwiseFromNamedOpsPass)
       // Input should now be legal.
       .addPass(IREE::Flow::createVerifyInputLegalityPass)
       // Catch matmul ops before we do anything else with them.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -90,6 +90,9 @@ std::unique_ptr<Pass> createConvertLinalgMatmulToMmt4DPass(
     CustomKernelsTargetInfo targetInfo);
 std::unique_ptr<Pass> createConvertLinalgMatmulToMmt4DPass(StringRef options);
 
+// Create a pass to detach elementwise ops from named Linalg ops.
+std::unique_ptr<Pass> createDetachElementwiseFromNamedOpsPass();
+
 // Creates a pass to fuse Linalg operations on tensors.
 std::unique_ptr<Pass> createFusionOfTensorOpsPass();
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -50,6 +50,12 @@ def DeduplicateExecutables :
   let constructor = "mlir::iree_compiler::IREE::Flow::createDeduplicateExecutablesPass()";
 }
 
+def DetachElementwiseFromNamedOps :
+    Pass<"iree-flow-detach-elementwise-from-named-ops", ""> {
+  let summary = "Detaches elementwise ops from named Linalg ops";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createDetachElementwiseFromNamedOpsPass()";
+}
+
 def DispatchLinalgOnTensors :
     InterfacePass<"iree-flow-dispatch-linalg-on-tensors-pass", "mlir::FunctionOpInterface"> {
   let summary = "Dispatch Linalg operations on tensors by using tile and distribute";

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD
@@ -23,6 +23,7 @@ iree_lit_test_suite(
             "conv1x1_to_matmul.mlir",
             "conv2d_to_img2col.mlir",
             "deduplicate_executables.mlir",
+            "detach_elementwise_from_named_ops.mlir",
             "dispatch_linalg_on_tensors.mlir",
             "dispatch_linalg_on_tensors_fusion.mlir",
             "dispatch_linalg_on_tensors_fusion_with_transpose.mlir",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -20,6 +20,7 @@ iree_lit_test_suite(
     "conv1x1_to_matmul.mlir"
     "conv2d_to_img2col.mlir"
     "deduplicate_executables.mlir"
+    "detach_elementwise_from_named_ops.mlir"
     "dispatch_linalg_on_tensors.mlir"
     "dispatch_linalg_on_tensors_fusion.mlir"
     "dispatch_linalg_on_tensors_fusion_with_transpose.mlir"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/detach_elementwise_from_named_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/detach_elementwise_from_named_ops.mlir
@@ -1,0 +1,56 @@
+// RUN: iree-opt --split-input-file --iree-flow-detach-elementwise-from-named-ops --mlir-print-local-scope %s | FileCheck %s
+
+func.func @matmul(%a: tensor<?x64xf32>, %b: tensor<64x?xf32>, %c: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = linalg.matmul ins(%a, %b : tensor<?x64xf32>, tensor<64x?xf32>) outs(%c : tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+
+// CHECK-LABEL: func @matmul
+//  CHECK-SAME: (%[[A:.+]]: tensor<?x64xf32>, %[[B:.+]]: tensor<64x?xf32>, %[[C:.+]]: tensor<?x?xf32>)
+
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[F0:.+]] = arith.constant 0.000000e+00 : f32
+
+//       CHECK:   %[[DIM0:.+]] = tensor.dim %[[C]], %[[C0]]
+//       CHECK:   %[[DIM1:.+]] = tensor.dim %[[C]], %[[C1]]
+//       CHECK:   %[[INIT:.+]] = linalg.init_tensor [%[[DIM0]], %[[DIM1]]]
+//       CHECK:   %[[FILL:.+]] = linalg.fill ins(%[[F0]] : f32) outs(%[[INIT]] : tensor<?x?xf32>)
+//       CHECK:   %[[MM:.+]] = linalg.matmul
+//  CHECK-SAME:     ins(%[[A]], %[[B]] : tensor<?x64xf32>, tensor<64x?xf32>)
+//  CHECK-SAME:     outs(%[[FILL]] : tensor<?x?xf32>)
+//       CHECK:   %[[EW:.+]] = linalg.generic {
+//  CHECK-SAME:     indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>]
+//  CHECK-SAME:     iterator_types = ["parallel", "parallel"]}
+//  CHECK-SAME:     ins(%[[MM]], %[[C]] : tensor<?x?xf32>, tensor<?x?xf32>)
+//  CHECK-SAME:     outs(%[[FILL]] : tensor<?x?xf32>)
+//       CHECK:   ^{{.+}}(%[[ARG0:.+]]: f32, %[[ARG1:.+]]: f32, %{{.+}}: f32):
+//       CHECK:     %[[ADD:.+]] = arith.addf %[[ARG0]], %[[ARG1]] : f32
+//       CHECK:     linalg.yield %[[ADD]] : f32
+//       CHECK:   return %[[EW]]
+
+// -----
+
+func.func @batch_matmul(%a: tensor<?x8x?xi32>, %b: tensor<?x?x16xi32>, %c: tensor<?x8x16xi32>) -> tensor<?x8x16xi32> {
+  %0 = linalg.batch_matmul ins(%a, %b : tensor<?x8x?xi32>, tensor<?x?x16xi32>) outs(%c : tensor<?x8x16xi32>) -> tensor<?x8x16xi32>
+  return %0 : tensor<?x8x16xi32>
+}
+
+// CHECK-LABEL: func @batch_matmul
+//  CHECK-SAME: (%[[A:.+]]: tensor<?x8x?xi32>, %[[B:.+]]: tensor<?x?x16xi32>, %[[C:.+]]: tensor<?x8x16xi32>)
+
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[I0:.+]] = arith.constant 0 : i32
+
+//       CHECK:   %[[DIM0:.+]] = tensor.dim %[[C]], %[[C0]] : tensor<?x8x16xi32>
+//       CHECK:   %[[INIT:.+]] = linalg.init_tensor [%[[DIM0]], 8, 16] : tensor<?x8x16xi32>
+//       CHECK:   %[[FILL:.+]] = linalg.fill ins(%[[I0]] : i32) outs(%[[INIT]] : tensor<?x8x16xi32>) -> tensor<?x8x16xi32>
+//       CHECK:   %[[MM:.+]] = linalg.batch_matmul
+//  CHECK-SAME:     ins(%[[A]], %[[B]] : tensor<?x8x?xi32>, tensor<?x?x16xi32>)
+//  CHECK-SAME:     outs(%[[FILL]] : tensor<?x8x16xi32>)
+//       CHECK:   %[[EW:.+]] = linalg.generic
+//  CHECK-SAME:     ins(%[[MM]], %arg2 : tensor<?x8x16xi32>, tensor<?x8x16xi32>)
+//  CHECK-SAME:     outs(%[[FILL]] : tensor<?x8x16xi32>)
+//       CHECK:     %[[ADD:.+]] = arith.addi
+//       CHECK:     linalg.yield %[[ADD]] : i32
+//       CHECK:   return %[[EW]]


### PR DESCRIPTION
This helps to put named op usages in a more canonical form
for further fusion and also makes easier for bufferization
to avoid extra allocations.

Fixes https://github.com/google/iree/issues/9524