### PR TITLE
fix race and replace mutex by atomic iree_task_scope

### DIFF
--- a/runtime/src/iree/base/internal/threading.h
+++ b/runtime/src/iree/base/internal/threading.h
@@ -172,6 +172,8 @@ void iree_thread_request_affinity(iree_thread_t* thread,
 // This has no effect if the thread is not suspended.
 void iree_thread_resume(iree_thread_t* thread);
 
+void iree_thread_yield(void);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/runtime/src/iree/base/internal/threading_darwin.c
+++ b/runtime/src/iree/base/internal/threading_darwin.c
@@ -13,6 +13,7 @@
 #include <mach/mach.h>
 #include <mach/thread_act.h>
 #include <pthread.h>
+#include <sched.h>
 #include <string.h>
 
 #include "iree/base/internal/atomics.h"
@@ -246,5 +247,7 @@ void iree_thread_resume(iree_thread_t* thread) {
 
   IREE_TRACE_ZONE_END(z0);
 }
+
+void iree_thread_yield(void) { sched_yield(); }
 
 #endif  // IREE_PLATFORM_APPLE

--- a/runtime/src/iree/base/internal/threading_pthreads.c
+++ b/runtime/src/iree/base/internal/threading_pthreads.c
@@ -353,4 +353,6 @@ void iree_thread_resume(iree_thread_t* thread) {
   IREE_TRACE_ZONE_END(z0);
 }
 
+void iree_thread_yield(void) { sched_yield(); }
+
 #endif  // IREE_PLATFORM_*

--- a/runtime/src/iree/base/internal/threading_win32.c
+++ b/runtime/src/iree/base/internal/threading_win32.c
@@ -325,4 +325,6 @@ void iree_thread_resume(iree_thread_t* thread) {
   IREE_TRACE_ZONE_END(z0);
 }
 
+void iree_thread_yield(void) { YieldProcessor(); }
+
 #endif  // IREE_PLATFORM_WINDOWS


### PR DESCRIPTION
Just some test-only teardown race.

```
WARNING: ThreadSanitizer: data race (pid=2133510)
  Atomic read of size 1 at 0x7b3400000068 by thread T18:
    #0 pthread_mutex_lock <null> (task_tests+0x2c3748)
    #1 iree_notification_post /usr/local/google/home/benoitjacob/iree/runtime/src/iree/base/internal/synchronization.c:579:3 (task_tests+0x33c96a)
    #2 iree_task_scope_end /usr/local/google/home/benoitjacob/iree/runtime/src/iree/task/scope.c:129:5 (task_tests+0x335320)
    #3 iree_task_retire /usr/local/google/home/benoitjacob/iree/runtime/src/iree/task/task.c:202:5 (task_tests+0x335bbe)
    #4 iree_task_call_execute /usr/local/google/home/benoitjacob/iree/runtime/src/iree/task/task.c:279:5 (task_tests+0x335cee)
    #5 iree_task_worker_execute /usr/local/google/home/benoitjacob/iree/runtime/src/iree/task/worker.c:193:7 (task_tests+0x3378ca)
    #6 iree_task_worker_pump_once /usr/local/google/home/benoitjacob/iree/runtime/src/iree/task/worker.c:256:3 (task_tests+0x3378ca)
    #7 iree_task_worker_pump_until_exit /usr/local/google/home/benoitjacob/iree/runtime/src/iree/task/worker.c:305:12 (task_tests+0x3378ca)
    #8 iree_task_worker_main /usr/local/google/home/benoitjacob/iree/runtime/src/iree/task/worker.c:382:5 (task_tests+0x3378ca)
    #9 iree_thread_start_routine /usr/local/google/home/benoitjacob/iree/runtime/src/iree/base/internal/threading_pthreads.c:130:29 (task_tests+0x33ae9d)

  Previous write of size 1 at 0x7b3400000068 by main thread:
    #0 pthread_mutex_destroy <null> (task_tests+0x2a7d48)
    #1 iree_notification_deinitialize /usr/local/google/home/benoitjacob/iree/runtime/src/iree/base/internal/synchronization.c:575:3 (task_tests+0x33c93e)
    #2 iree_task_scope_deinitialize /usr/local/google/home/benoitjacob/iree/runtime/src/iree/task/scope.c:52:3 (task_tests+0x33505d)
    #3 TaskTest::TearDown() /usr/local/google/home/benoitjacob/iree/runtime/src/iree/task/testing/task_test.h:37:5 (task_tests+0x320ad6)
    #4 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2607:10 (task_tests+0x38733f)
    #5 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2643:14 (task_tests+0x38733f)
    #6 testing::Test::Run() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2690:3 (task_tests+0x351c87)
    #7 testing::TestInfo::Run() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2861:11 (task_tests+0x353812)
    #8 testing::TestSuite::Run() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:3015:28 (task_tests+0x3546fc)
    #9 testing::internal::UnitTestImpl::RunAllTests() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:5855:44 (task_tests+0x36b1c8)
    #10 bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2607:10 (task_tests+0x38866f)
    #11 bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2643:14 (task_tests+0x38866f)
    #12 testing::UnitTest::Run() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:5438:10 (task_tests+0x36a310)
    #13 RUN_ALL_TESTS() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/include/gtest/gtest.h:2490:46 (task_tests+0x33991b)
    #14 main /usr/local/google/home/benoitjacob/iree/runtime/src/iree/testing/gtest_main.cc:17:10 (task_tests+0x33991b)

  Location is heap block of size 200 at 0x7b3400000000 allocated by main thread:
    #0 operator new(unsigned long) <null> (task_tests+0x31b518)
    #1 testing::internal::TestFactoryImpl<(anonymous namespace)::TaskCallTest_IssueFailure_Test>::CreateTest() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/include/gtest/internal/gtest-internal.h:472:40 (task_tests+0x325907)
    #2 testing::Test* testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::TestFactoryBase, testing::Test*>(testing::internal::TestFactoryBase*, testing::Test* (testing::internal::TestFactoryBase::*)(), char const*) /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2607:10 (task_tests+0x3876df)
    #3 testing::Test* testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::TestFactoryBase, testing::Test*>(testing::internal::TestFactoryBase*, testing::Test* (testing::internal::TestFactoryBase::*)(), char const*) /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2643:14 (task_tests+0x3876df)
    #4 testing::TestInfo::Run() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2851:22 (task_tests+0x353766)
    #5 testing::TestSuite::Run() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:3015:28 (task_tests+0x3546fc)
    #6 testing::internal::UnitTestImpl::RunAllTests() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:5855:44 (task_tests+0x36b1c8)
    #7 bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2607:10 (task_tests+0x38866f)
    #8 bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2643:14 (task_tests+0x38866f)
    #9 testing::UnitTest::Run() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:5438:10 (task_tests+0x36a310)
    #10 RUN_ALL_TESTS() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/include/gtest/gtest.h:2490:46 (task_tests+0x33991b)
    #11 main /usr/local/google/home/benoitjacob/iree/runtime/src/iree/testing/gtest_main.cc:17:10 (task_tests+0x33991b)

  Thread T18 'iree-worker-7' (tid=2134125, running) created by main thread at:
    #0 pthread_create <null> (task_tests+0x2a646d)
    #1 iree_thread_create /usr/local/google/home/benoitjacob/iree/runtime/src/iree/base/internal/threading_pthreads.c:180:10 (task_tests+0x33a9a9)
    #2 iree_task_worker_initialize /usr/local/google/home/benoitjacob/iree/runtime/src/iree/task/worker.c:71:26 (task_tests+0x3375ae)
    #3 iree_task_executor_create /usr/local/google/home/benoitjacob/iree/runtime/src/iree/task/executor.c:132:16 (task_tests+0x331eac)
    #4 TaskTest::SetUp() /usr/local/google/home/benoitjacob/iree/runtime/src/iree/task/testing/task_test.h:27:5 (task_tests+0x320957)
    #5 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2607:10 (task_tests+0x38733f)
    #6 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2643:14 (task_tests+0x38733f)
    #7 testing::Test::Run() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2677:3 (task_tests+0x351b0f)
    #8 testing::TestInfo::Run() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2861:11 (task_tests+0x353812)
    #9 testing::TestSuite::Run() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:3015:28 (task_tests+0x3546fc)
    #10 testing::internal::UnitTestImpl::RunAllTests() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:5855:44 (task_tests+0x36b1c8)
    #11 bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2607:10 (task_tests+0x38866f)
    #12 bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2643:14 (task_tests+0x38866f)
    #13 testing::UnitTest::Run() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:5438:10 (task_tests+0x36a310)
    #14 RUN_ALL_TESTS() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/include/gtest/gtest.h:2490:46 (task_tests+0x33991b)
    #15 main /usr/local/google/home/benoitjacob/iree/runtime/src/iree/testing/gtest_main.cc:17:10 (task_tests+0x33991b)
```