### PR TITLE
[flow] Do not create constant nodes in the dispatch graph.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DumpDispatchGraph.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DumpDispatchGraph.cpp
@@ -328,9 +328,7 @@ class DumpDispatchGraphPass
   }
 
   void annotateOperation(raw_ostream &os, Operation *op, AsmState &state) {
-    // A scalar constant op will be printed directly when printing the
-    // operand.
-    if (isScalarConstantOp(op)) return;
+    if (isa<arith::ConstantOp>(op)) return;
 
     if (isa<func::ReturnOp>(op)) return;
 
@@ -504,9 +502,8 @@ class DumpDispatchGraphPass
   Node processOperation(Operation *op) {
     Node node;
 
-    if (isScalarConstantOp(op)) {
-      // don't handle scalar constant because it creates too many edges
-      // from a single constant.
+    if (isa<arith::ConstantOp>(op)) {
+      // Do not handle constant because it creates too many edges.
       return node;
     }
 


### PR DESCRIPTION
In the previous code, we hid only scalar constants, which works pretty well for
most benchmarks but a benchmark like resnet-50 creates too many edges from
tensor constants too, so let's hide all constant nodes.