### PR TITLE
[LLVMGPU] Add transform to distribute vectors along warp.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformDialectExtensions/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformDialectExtensions/BUILD
@@ -66,8 +66,13 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:GPUDialect",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:PDLDialect",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:TransformDialect",
+        "@llvm-project//mlir:Transforms",
+        "@llvm-project//mlir:VectorDialect",
+        "@llvm-project//mlir:VectorTransforms",
     ],
 )

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformDialectExtensions/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformDialectExtensions/CMakeLists.txt
@@ -37,9 +37,14 @@ iree_cc_library(
     MLIRFuncDialect
     MLIRGPUOps
     MLIRIR
+    MLIRMemRefDialect
+    MLIRPDLDialect
     MLIRPass
     MLIRSCFDialect
     MLIRTransformDialect
+    MLIRTransforms
+    MLIRVectorDialect
+    MLIRVectorTransforms
     iree::compiler::Dialect::HAL::IR
   PUBLIC
 )

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformDialectExtensions/TransformDialectLLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformDialectExtensions/TransformDialectLLVMGPUExtensions.cpp
@@ -11,9 +11,15 @@
 #include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/PDL/IR/PDLOps.h"
 #include "mlir/Dialect/SCF/SCF.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Dialect/Vector/Transforms/VectorDistribution.h"
+#include "mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/Region.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 using namespace mlir;
 using namespace mlir::iree_compiler;
@@ -147,6 +153,303 @@ transform_dialect::ForeachThreadToGpuAndTranslationInfo::apply(
           .wasInterrupted())
     return DiagnosedSilenceableFailure::definiteFailure();
   return DiagnosedSilenceableFailure::success();
+}
+
+//===---------------------------------------------------------------------===//
+// VectorDistributionOp.
+//===---------------------------------------------------------------------===//
+
+/// Emit shared local memory allocation in case it is needed when lowering the
+/// warp operations.
+static Value allocateGlobalSharedMemory(Location loc, OpBuilder &builder,
+                                        vector::WarpExecuteOnLane0Op warpOp,
+                                        Type type) {
+  MemRefType memrefType;
+  if (auto vectorType = type.dyn_cast<VectorType>()) {
+    memrefType =
+        MemRefType::get(vectorType.getShape(), vectorType.getElementType(), {},
+                        gpu::GPUDialect::getWorkgroupAddressSpace());
+  } else {
+    memrefType = MemRefType::get({1}, type, {},
+                                 gpu::GPUDialect::getWorkgroupAddressSpace());
+  }
+  return builder.create<memref::AllocOp>(loc, memrefType);
+}
+
+/// Emit warp reduction code sequence for a given input.
+static Value warpReduction(Location loc, OpBuilder &builder, Value input,
+                           vector::CombiningKind kind, uint32_t size) {
+  Value laneVal = input;
+  // Parallel reduction using butterfly shuffles.
+  for (uint64_t i = 1; i < size; i <<= 1) {
+    Value shuffled = builder
+                         .create<gpu::ShuffleOp>(loc, laneVal, i,
+                                                 /*width=*/size,
+                                                 /*mode=*/gpu::ShuffleMode::XOR)
+                         .result();
+    laneVal = makeArithReduction(builder, loc, kind, laneVal, shuffled);
+  }
+  return laneVal;
+}
+
+namespace {
+
+/// Pattern to convert InsertElement to broadcast, this is a workaround until
+/// MultiDimReduction distribution is supported.
+class InsertElementToBroadcast final
+    : public OpRewritePattern<vector::InsertElementOp> {
+ public:
+  using OpRewritePattern<vector::InsertElementOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::InsertElementOp insertOp,
+                                PatternRewriter &rewriter) const override {
+    if (insertOp.getDestVectorType().getNumElements() != 1) return failure();
+    rewriter.replaceOpWithNewOp<vector::BroadcastOp>(
+        insertOp, insertOp.getDestVectorType(), insertOp.getSource());
+    return success();
+  }
+};
+
+}  // namespace
+
+// TODO: Figure out the proper canonicalization and drop the complexity here.
+// TODO: More sophisticated detection for matching
+//   (threadIdx.x == 0 && other stuff not involving threadIdx.x)
+static LogicalResult isThreadIdxxZeroPredicate(scf::IfOp ifOp) {
+  if (!ifOp || ifOp.getNumResults() > 0 ||
+      ifOp.getThenRegion().getBlocks().size() != 1 ||
+      !ifOp.getElseRegion().empty())
+    return failure();
+  auto pred = ifOp.getCondition().getDefiningOp<arith::CmpIOp>();
+  if (!pred) return failure();
+  auto EQ = arith::CmpIPredicate::eq;
+  auto SLT = arith::CmpIPredicate::slt;
+  auto SLE = arith::CmpIPredicate::sle;
+  auto ULT = arith::CmpIPredicate::ult;
+  auto ULE = arith::CmpIPredicate::ule;
+  if (auto threadIdOp = pred.getLhs().getDefiningOp<gpu::ThreadIdOp>()) {
+    if (pred.getPredicate() == EQ && isConstantIntValue(pred.getRhs(), 0))
+      return success();
+    if (pred.getPredicate() == SLE && isConstantIntValue(pred.getRhs(), 0))
+      return success();
+    if (pred.getPredicate() == ULE && isConstantIntValue(pred.getRhs(), 0))
+      return success();
+    if (pred.getPredicate() == SLT && isConstantIntValue(pred.getRhs(), 1))
+      return success();
+    if (pred.getPredicate() == ULT && isConstantIntValue(pred.getRhs(), 1))
+      return success();
+  }
+  auto SGT = arith::CmpIPredicate::sgt;
+  auto SGE = arith::CmpIPredicate::sge;
+  auto UGT = arith::CmpIPredicate::ugt;
+  auto UGE = arith::CmpIPredicate::uge;
+  if (auto threadIdOp = pred.getRhs().getDefiningOp<gpu::ThreadIdOp>()) {
+    if (pred.getPredicate() == EQ && isConstantIntValue(pred.getLhs(), 0))
+      return success();
+    if (pred.getPredicate() == SGE && isConstantIntValue(pred.getLhs(), 0))
+      return success();
+    if (pred.getPredicate() == UGE && isConstantIntValue(pred.getLhs(), 0))
+      return success();
+    if (pred.getPredicate() == SGT && isConstantIntValue(pred.getLhs(), 1))
+      return success();
+    if (pred.getPredicate() == UGT && isConstantIntValue(pred.getLhs(), 1))
+      return success();
+  }
+  return failure();
+}
+
+struct VectorDistributionResult {
+  Operation *res;
+};
+
+static FailureOr<VectorDistributionResult> vectorDistribution(
+    PatternRewriter &rewriter, Location loc, scf::IfOp ifOp,
+    int64_t workgroupSizeX, int64_t warpSize) {
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(ifOp);
+
+  // Bail if cond is not `if (threadIdx.x == 0)`.
+  if (failed(isThreadIdxxZeroPredicate(ifOp)))
+    return ifOp->emitError("unmet prerequisite: isThreadIdxxZeroPredicate");
+
+  // All the code below will be executed on a single warp given a fixed
+  // (threadIdxy, threadIdxz).
+  Value threadIdxx = rewriter.create<gpu::ThreadIdOp>(
+      loc, rewriter.getIndexType(), gpu::Dimension::x);
+
+  assert(workgroupSizeX % warpSize == 0);
+  if (workgroupSizeX != warpSize) {
+    // Add a guard for `threadIdxx < warp size` around the WarpExecuteOnLane0Op.
+    Value predicate = rewriter.create<arith::CmpIOp>(
+        loc, arith::CmpIPredicate::ult, threadIdxx,
+        rewriter.create<arith::ConstantIndexOp>(loc, warpSize));
+    // Note: return-less IfOp is built with a terminator, no need to add one.
+    auto newIfOp =
+        rewriter.create<scf::IfOp>(loc, predicate, /*withElseRegion=*/false);
+    rewriter.setInsertionPointToStart(&newIfOp.getThenRegion().front());
+  }
+  auto warpOp = rewriter.create<vector::WarpExecuteOnLane0Op>(
+      loc, TypeRange(), threadIdxx, warpSize);
+
+  // Move the code from the previous ifOp to the WarpExecuteOnLane0Op.
+  Block &sourceBlock = ifOp.getThenRegion().front();
+  Block &targetBlock = warpOp.getWarpRegion().front();
+  Block::iterator insertionPoint = targetBlock.begin();
+  targetBlock.getOperations().splice(insertionPoint,
+                                     sourceBlock.getOperations(),
+                                     sourceBlock.without_terminator().begin(),
+                                     sourceBlock.without_terminator().end());
+  rewriter.setInsertionPointToEnd(&targetBlock);
+  rewriter.create<vector::YieldOp>(loc);
+
+  // Erase old op.
+  rewriter.eraseOp(ifOp);
+
+  // Hoist the scalar code outside of the warp region.
+  // Note: moving code does not require a listener.
+  vector::moveScalarUniformCode(warpOp);
+
+  return VectorDistributionResult{warpOp};
+}
+
+static LogicalResult applyMultiReductionLoweringPatterns(Operation *target) {
+  assert(target->hasTrait<OpTrait::IsIsolatedFromAbove>());
+
+  MLIRContext *ctx = target->getContext();
+  RewritePatternSet patterns(ctx);
+  vector::populateVectorMultiReductionLoweringPatterns(
+      patterns, vector::VectorMultiReductionLowering::InnerReduction);
+  patterns.add<InsertElementToBroadcast>(ctx);
+  return applyPatternsAndFoldGreedily(target, std::move(patterns));
+}
+
+static LogicalResult applyVectorTransferWriteDistribution(Operation *target) {
+  assert(target->hasTrait<OpTrait::IsIsolatedFromAbove>());
+
+  auto distributionFn = [](vector::TransferWriteOp writeOp) {
+    // Create a map (d0, d1) -> (d1) to distribute along the inner
+    // dimension. Once we support n-d distribution we can add more
+    // complex cases.
+    int64_t vecRank = writeOp.getVectorType().getRank();
+    OpBuilder builder(writeOp.getContext());
+    auto map =
+        AffineMap::get(vecRank, 0, builder.getAffineDimExpr(vecRank - 1));
+    return map;
+  };
+  MLIRContext *ctx = target->getContext();
+  RewritePatternSet patterns(ctx);
+  vector::populateDistributeTransferWriteOpPatterns(patterns, distributionFn);
+  return applyPatternsAndFoldGreedily(target, std::move(patterns));
+}
+
+static LogicalResult applyPropagateVectorDistribution(Operation *target) {
+  assert(target->hasTrait<OpTrait::IsIsolatedFromAbove>());
+
+  MLIRContext *ctx = target->getContext();
+  RewritePatternSet patterns(ctx);
+  vector::populatePropagateWarpVectorDistributionPatterns(patterns);
+  vector::populateDistributeReduction(patterns, warpReduction);
+  return applyPatternsAndFoldGreedily(target, std::move(patterns));
+}
+
+static LogicalResult applyWarpExecuteOnLane0ToScf(Operation *target) {
+  assert(target->hasTrait<OpTrait::IsIsolatedFromAbove>());
+
+  MLIRContext *ctx = target->getContext();
+  RewritePatternSet patterns(ctx);
+  vector::WarpExecuteOnLane0LoweringOptions options;
+  options.warpAllocationFn = allocateGlobalSharedMemory;
+  options.warpSyncronizationFn = [](Location loc, OpBuilder &builder,
+                                    vector::WarpExecuteOnLane0Op warpOp) {};
+  vector::populateWarpExecuteOnLane0OpToScfForPattern(patterns, options);
+  return applyPatternsAndFoldGreedily(target, std::move(patterns));
+}
+
+LogicalResult distributeWarpExecuteOnLane0(Operation *target) {
+  assert(target->hasTrait<OpTrait::IsIsolatedFromAbove>());
+
+  // TODO: Pass transform::TransformState &state and attach Listener with
+  // auto &listener = state.addExtension<::detail::TrackingListener>();
+  // auto detachListener = llvm::make_scope_exit(
+  //   [&] { state.removeExtension<::detail::TrackingListener>(); });
+  // if (failed(mapBlockArguments(state)))
+  //   return DiagnosedSilenceableFailure::definiteFailure();
+
+  // MultiReduction lowering is necessary until we have explicit support for
+  // distributing that op.
+  if (failed(applyMultiReductionLoweringPatterns(target))) return failure();
+  if (failed(applyVectorTransferWriteDistribution(target))) return failure();
+  if (failed(applyPropagateVectorDistribution(target))) return failure();
+  if (failed(applyWarpExecuteOnLane0ToScf(target))) return failure();
+  return success();
+}
+
+// TODO: Refactor in a generic util that can be reused.
+static IREE::HAL::ExecutableExportOp getExecutableExportOpForFunc(
+    IREE::HAL::ExecutableVariantOp halExecutableVariantOp,
+    func::FuncOp funcOp) {
+  IREE::HAL::ExecutableExportOp exportOp;
+  halExecutableVariantOp->walk([&](IREE::HAL::ExecutableExportOp op) {
+    if (op.sym_name() != funcOp.getName()) WalkResult::advance();
+    exportOp = op;
+    WalkResult::interrupt();
+  });
+  return exportOp;
+}
+
+// TODO: Upstream this.
+template <typename OpTy>
+static OpTy getSelfOrParentOfType(Operation *op) {
+  auto opOfType = dyn_cast<OpTy>(op);
+  if (!opOfType) opOfType = op->getParentOfType<OpTy>();
+  return opOfType;
+}
+
+LogicalResult transform_dialect::VectorDistributionOp::applyToOne(
+    Operation *target) {
+  if (!target->hasTrait<OpTrait::IsIsolatedFromAbove>()) {
+    InFlightDiagnostic diag = emitOpError()
+                              << "applies only to isolated-from-above targets";
+    diag.attachNote(target->getLoc()) << "non-isolated target";
+    return diag;
+  }
+
+  auto halExecutableVariantOp =
+      getSelfOrParentOfType<IREE::HAL::ExecutableVariantOp>(target);
+  auto funcOp = getSelfOrParentOfType<func::FuncOp>(target);
+  assert(funcOp);
+  IREE::HAL::ExecutableExportOp exportOp =
+      getExecutableExportOpForFunc(halExecutableVariantOp, funcOp);
+  assert(exportOp && "missing export op");
+
+  auto maybeAttr = exportOp.workgroup_size();
+  if (!maybeAttr)
+    return exportOp->emitError("export op must have workgroup_size attribute");
+
+  int64_t workgroupSizeX = (*maybeAttr)[0].cast<IntegerAttr>().getInt();
+
+  int64_t warpSize = getWarpSize();
+  if (workgroupSizeX % warpSize != 0) {
+    return exportOp->emitError()
+           << "vector distribution requires workgroup size for x to be a "
+           << "multiple of the warp size: " << workgroupSizeX << " vs "
+           << warpSize;
+  }
+
+  WalkResult walkResult = target->walk([&](scf::IfOp ifOp) {
+    functional::detail::SimpleRewriter rewriter(getContext());
+    rewriter.setInsertionPoint(ifOp);
+    FailureOr<VectorDistributionResult> vectorDistributionResult =
+        vectorDistribution(rewriter, target->getLoc(), ifOp, workgroupSizeX,
+                           warpSize);
+    if (failed(vectorDistributionResult) ||
+        failed(distributeWarpExecuteOnLane0(target))) {
+      target->emitError("failed to apply");
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return walkResult.wasInterrupted() ? failure() : success();
 }
 
 #define GET_OP_CLASSES

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformDialectExtensions/TransformDialectLLVMGPUExtensions.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformDialectExtensions/TransformDialectLLVMGPUExtensions.h
@@ -9,11 +9,12 @@
 
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
 
-#define GET_OP_CLASSES
-#include "iree/compiler/Codegen/LLVMGPU/TransformDialectExtensions/TransformDialectLLVMGPUExtensionsOps.h.inc"
-
 namespace mlir {
 class DialectRegistry;
+
+namespace vector {
+class VectorDialect;
+}  // namespace vector
 
 namespace iree_compiler {
 
@@ -34,5 +35,8 @@ class TransformDialectLLVMGPUExtensions
 }  // namespace IREE
 }  // namespace iree_compiler
 }  // namespace mlir
+
+#define GET_OP_CLASSES
+#include "iree/compiler/Codegen/LLVMGPU/TransformDialectExtensions/TransformDialectLLVMGPUExtensionsOps.h.inc"
 
 #endif  // IREE_COMPILER_CODEGEN_LLVMGPU_TRANSFORMDIALECTEXTENSIONS_TRANSFORMDIALECTLLVMGPUEXTENSIONS_H_

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformDialectExtensions/TransformDialectLLVMGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformDialectExtensions/TransformDialectLLVMGPUExtensionsOps.td
@@ -26,4 +26,82 @@ def ForeachThreadToGpuAndTranslationInfo : Op<Transform_Dialect, "iree.foreach_t
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 }
 
+def VectorDistributionOp : Op<Transform_Dialect, "iree.vector_distribution",
+    [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
+     TransformEachOpTrait, TransformOpInterface]> {
+  let description = [{
+    Given a target that is isolated from above, rewrite ops predicated by 
+    `if (threadIdx.x == 0)` to distributed form running **on a single warp**.
+
+    The warp size is determined by the `warp_size` attribute (it is generally 
+    32 but we do not want to hardcode it).
+
+    This rewrite only applies if it can be determined from the IR (i.e. from 
+    the surrounding IREE::HAL::ExecutableExportOp) that the number of threads
+    along the warp dimension is a multiple of the warp size. The transformation
+    bails on non-perfect multiples of the warp size that would not properly 
+    distribute.
+
+    Example:
+
+    ```
+    hal.executable.export public @foo ... { workgroup_size = [64: index, 1: index, 1: index] }
+    builtin.module {
+      func.func @foo() {
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %0 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : memref<128xf32>
+        %1 = gpu.thread_id  x
+        %2 = arith.cmpi ult, %1, %c1 : index
+        scf.if %2 {
+          %3 = arith.constant dense<1.0> : vector<128xf32>
+          vector.transfer_write %3, %0[%c0] : vector<128xf32>, memref<128xf32>
+        }
+      }
+    }
+    ```
+
+    distributes to:
+
+    ```
+    hal.executable.export public @foo ... { workgroup_size = [64: index, 1: index, 1: index] }
+    builtin.module {
+      func.func @foo() {
+        %c0 = arith.constant 0 : index
+        %c4 = arith.constant 4 : index
+        %c32 = arith.constant 32 : index
+        %cst = arith.constant dense<1.000000e+00> : vector<128xf32>
+        %0 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : memref<128xf32>
+        %1 = gpu.thread_id  x
+        %2 = arith.cmpi ult, %1, %c32 : index
+        // Single-warp guard filters out threads 32-63.
+        scf.if %2 {
+          %3 = arith.cmpi eq, %1, %c0 : index
+          %4 = memref.alloc() : memref<128xf32, 3>
+          // Single-thread guard runs on thread 0 only.
+          scf.if %3 {
+            vector.store %cst, %4[%c0] : memref<128xf32, 3>, vector<128xf32>
+          }
+          %5 = arith.muli %1, %c4 : index
+          %6 = vector.load %4[%5] : memref<128xf32, 3>, vector<4xf32>
+          %7 = affine.apply #map()[%1]
+          vector.transfer_write %6, %0[%7] {in_bounds = [true]} : vector<4xf32>, memref<128xf32>
+        }
+      }
+    }
+    ```
+  }];
+
+  let arguments = (ins PDL_Operation:$target,
+                   DefaultValuedAttr<I64Attr, "{}">:$warp_size);
+  let results = (outs);
+
+  let assemblyFormat = "$target attr-dict";
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+
+  let extraClassDeclaration = [{
+    ::mlir::LogicalResult applyToOne(::mlir::Operation *target);
+  }];
+}
+
 #endif // IREE_COMPILER_CODEGEN_LLVMGPU_TRANSFORMDIALECTEXTENSIONS_TRANSFORMDIALECTLLVMGPUEXTENSIONS

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD
@@ -30,6 +30,7 @@ iree_lit_test_suite(
             "linalg_transform.mlir",
             "legalize.mlir",
             "tensorcore_vectorization.mlir",
+            "transform_dialect_vector_distribution.mlir",
             "vector_to_gpu.mlir",
             "vectorization.mlir",
             "warp_reduction.mlir",
@@ -40,12 +41,14 @@ iree_lit_test_suite(
         exclude = [
             "transform_dialect_codegen_bufferize_spec.mlir",
             "transform_dialect_codegen_foreach_to_gpu_spec.mlir",
+            "transform_dialect_codegen_vector_distribution_spec.mlir",
         ],
     ),
     cfg = "//compiler:lit.cfg.py",
     data = [
         "transform_dialect_codegen_bufferize_spec.mlir",
         "transform_dialect_codegen_foreach_to_gpu_spec.mlir",
+        "transform_dialect_codegen_vector_distribution_spec.mlir",
     ],
     tools = [
         "//tools:iree-opt",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_lit_test_suite(
     "reduce_bank_conflicts.mlir"
     "rocdl_pipeline_test.mlir"
     "tensorcore_vectorization.mlir"
+    "transform_dialect_vector_distribution.mlir"
     "vector_to_gpu.mlir"
     "vectorization.mlir"
     "warp_reduction.mlir"
@@ -34,6 +35,7 @@ iree_lit_test_suite(
   DATA
     transform_dialect_codegen_bufferize_spec.mlir
     transform_dialect_codegen_foreach_to_gpu_spec.mlir
+    transform_dialect_codegen_vector_distribution_spec.mlir
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_distribution_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_distribution_spec.mlir
@@ -1,0 +1,23 @@
+// RUN: iree-opt
+
+transform.with_pdl_patterns {
+^bb0(%arg0: !pdl.operation):
+
+  pdl.pattern @pdl_if_op_target : benefit(1) {
+    %args = operands
+    %results = types
+    %0 = operation "scf.if"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
+    
+    // TODO: we don't want this, but it is the required terminator for pdl.pattern
+    rewrite %0 with "transform.dialect"
+  }
+
+  // Step 3: tile to scf.for reduction by 1x32, vectorize 1x32, 
+  // distribute vector along 32 on threadidx.x.
+  transform.sequence %arg0 {
+  ^bb1(%arg1: !pdl.operation):
+    %if_op = pdl_match @pdl_if_op_target in %arg1
+    %isolated = transform.get_closest_isolated_parent %if_op
+    transform.iree.vector_distribution %isolated { warp_size = 32 }
+  }
+}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_vector_distribution.mlir
@@ -1,0 +1,44 @@
+// RUN: iree-opt %s --pass-pipeline='hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target-pass))' --iree-codegen-llvmgpu-use-transform-dialect=%p/transform_dialect_codegen_vector_distribution_spec.mlir | FileCheck %s
+
+#executable_layout = #hal.executable.layout<push_constants = 0, sets = [#hal.descriptor_set.layout<0, bindings = [#hal.descriptor_set.binding<0, storage_buffer>, #hal.descriptor_set.binding<1, storage_buffer>]>]>
+#executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb", {target_arch = "sm_35"}>
+
+hal.executable private @reduce_dispatch_0 {
+  hal.executable.variant public @cuda_nvptx_fb, target = #executable_target_cuda_nvptx_fb {
+    hal.executable.export public @reduce_dispatch_0 ordinal(0) layout(#executable_layout) { workgroup_size = [64: index, 1: index, 1: index] }
+    builtin.module {
+      func.func @reduce_dispatch_0() {
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %0 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : memref<128xf32>
+        memref.assume_alignment %0, 64 : memref<128xf32>
+        %1 = gpu.thread_id  x
+        %2 = arith.cmpi ult, %1, %c1 : index
+
+        // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+        // CHECK-DAG: %[[C4:.*]] = arith.constant 4 : index
+        // CHECK-DAG: %[[C32:.*]] = arith.constant 32 : index
+        // CHECK-DAG: %[[V128:.*]] = arith.constant dense<1.000000e+00> : vector<128xf32>
+        // CHECK: %[[TIDX:.*]] = gpu.thread_id  x
+        // CHECK: %[[COND32:.*]] = arith.cmpi ult, %[[TIDX]], %[[C32]] : index
+        // Single-warp guard filters out threads 32-63.
+        // CHECK: scf.if %[[COND32]] {
+        // CHECK:   %[[COND1:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
+        // CHECK:   %[[ALLOC:.*]] = memref.alloc() : memref<128xf32, 3>
+        // Single-thread guard runs on thread 0 only.
+        // CHECK:   scf.if %[[COND1]] {
+        // CHECK:     vector.store %{{.*}} : memref<128xf32, 3>, vector<128xf32>
+        // CHECK:   %[[IDX:.*]] = arith.muli %[[TIDX]], %[[C4]] : index
+        // CHECK:   %[[LOADED:.*]] = vector.load %{{.*}}[%[[IDX]]] : memref<128xf32, 3>, vector<4xf32>
+        // CHECK:   vector.transfer_write %[[LOADED]], %{{.*}} {in_bounds = [true]} : vector<4xf32>, memref<128xf32>
+        scf.if %2 {
+          %3 = arith.constant dense<1.0> : vector<128xf32>
+          vector.transfer_write %3, %0[%c0] : vector<128xf32>, memref<128xf32>
+        }
+
+        
+        return
+      }
+    }
+  }
+}


### PR DESCRIPTION
This revision adds a transform dialect extension op that performs the following.

Given a target that is isolated from above, rewrite ops predicated by
`if (threadIdx.x == 0)` to distributed form running ***on a single warp***.

The warp size is determined by the `warp_size` transform op attribute (it is generally
32 but we do not want to hardcode it).

This rewrite only applies if it can be determined from the IR (i.e. from
the surrounding IREE::HAL::ExecutableExportOp) that the ***number of threads
along the warp dimension is a multiple of the warp size***.

The transformation bails on non-perfect multiples of the warp size that would not properly
distribute.

Example:

```
hal.executable.export public @foo ... { workgroup_size = [64: index, 1: index, 1: index] }
builtin.module {
  func.func @foo() {
    %c0 = arith.constant 0 : index
    %c1 = arith.constant 1 : index
    %0 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : memref<128xf32>
    %1 = gpu.thread_id  x
    %2 = arith.cmpi ult, %1, %c1 : index
    scf.if %2 {
      %3 = arith.constant dense<1.0> : vector<128xf32>
      vector.transfer_write %3, %0[%c0] : vector<128xf32>, memref<128xf32>
    }
  }
}
```

distributes to:

```
hal.executable.export public @foo ... { workgroup_size = [64: index, 1: index, 1: index] }
builtin.module {
  func.func @foo() {
    %c0 = arith.constant 0 : index
    %c4 = arith.constant 1 : index
    %cst = arith.constant dense<1.000000e+00> : vector<128xf32>
    %0 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : memref<128xf32>
    %1 = gpu.thread_id  x
    %2 = arith.cmpi ult, %1, %c32 : index

    // Single-warp guard filters out threads 32-63.
    scf.if %2 {
      %3 = arith.cmpi eq, %1, %c0 : index
      %4 = memref.alloc() : memref<128xf32, 3>

      // Single-thread guard runs on thread 0 only.
      scf.if %3 {
        vector.store %cst, %4[%c0] : memref<128xf32, 3>, vector<128xf32>
      }
      %5 = arith.muli %1, %c4 : index
      %6 = vector.load %4[%5] : memref<128xf32, 3>, vector<4xf32>
      %7 = affine.apply #map()[%1]
      vector.transfer_write %6, %0[%7] {in_bounds = [true]} : vector<4xf32>, memref<128xf32>
    }
  }
}
```

Previous transformations are expected to set the IR in a form in which the `if (threadIdx.x == 0)` predicate is present.