### PR TITLE
Improve lowering of scf.foreach_thread to GPU.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformDialectExtensions/TransformDialectLLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformDialectExtensions/TransformDialectLLVMGPUExtensions.cpp
@@ -36,13 +36,36 @@ void mlir::iree_compiler::registerTransformDialectLLVMGPUExtension(
 // TODO: Maybe we need both a transform.iree.cpu.bufferize and a
 // transform.iree.gpu.bufferize rather than a single common bufferize op?
 
+static FailureOr<SmallVector<int64_t>> joinStaticRanges(
+    ArrayRef<scf::ForeachThreadOp> ops) {
+  SmallVector<int64_t> joinedStaticRange = {1, 1, 1};
+  for (auto op : ops) {
+    for (auto en : llvm::enumerate(op.getNumThreads())) {
+      auto maybeInt = getConstantIntValue(en.value());
+      if (!maybeInt) {
+        op->emitError(
+            "scf.foreach_thread with non-constant workgroup size cannot be "
+            "lowered into the translation_info attr");
+        return failure();
+      }
+      joinedStaticRange[en.index()] =
+          std::max(joinedStaticRange[en.index()], *maybeInt);
+    }
+  }
+  return joinedStaticRange;
+}
+
 //===---------------------------------------------------------------------===//
 // Patterns for ForeachThreadToGpu rewrite.
 //===---------------------------------------------------------------------===//
 
 struct ForeachThreadToGpuRewriter
     : public OpRewritePattern<scf::ForeachThreadOp> {
-  using OpRewritePattern::OpRewritePattern;
+  ForeachThreadToGpuRewriter(ArrayRef<int64_t> globalWorkgroupSizes,
+                             MLIRContext *context)
+      : OpRewritePattern<scf::ForeachThreadOp>(context),
+        globalWorkgroupSizes(globalWorkgroupSizes.begin(),
+                             globalWorkgroupSizes.end()) {}
 
   FailureOr<SmallVector<Value>> returningMatchAndRewrite(
       scf::ForeachThreadOp foreachThreadOp, PatternRewriter &rewriter) const;
@@ -51,6 +74,8 @@ struct ForeachThreadToGpuRewriter
                                 PatternRewriter &rewriter) const override {
     return returningMatchAndRewrite(foreachThreadOp, rewriter);
   }
+
+  SmallVector<int64_t> globalWorkgroupSizes;
 };
 
 FailureOr<SmallVector<Value>>
@@ -63,32 +88,68 @@ ForeachThreadToGpuRewriter::returningMatchAndRewrite(
     return foreachThreadOp->emitError(
         "scf.foreach_thread with rank > 3 does not lower to gpu.thread");
 
+  auto maybeWorkgroupSizes = joinStaticRanges({foreachThreadOp});
+  assert(succeeded(maybeWorkgroupSizes) && "unexpected dynamic workgroup size");
+
+  auto workgroupSizes = *maybeWorkgroupSizes;
+
   // Step 1. Create the gpu.thread ops
   Location loc = foreachThreadOp.getLoc();
   IndexType indexType = rewriter.getIndexType();
   SmallVector<Value> threadCount = foreachThreadOp.getNumThreads();
   SmallVector<gpu::Dimension, 3> gpuDims{gpu::Dimension::x, gpu::Dimension::y,
                                          gpu::Dimension::z};
-  SmallVector<Value> threadOps;
-  threadOps.reserve(3);
+  SmallVector<Value, 3> threadOps;
+  threadCount.resize(3, rewriter.create<arith::ConstantIndexOp>(loc, 1));
   for (int64_t idx : llvm::seq<int64_t>(0, threadCount.size())) {
     threadOps.push_back(
         rewriter.create<gpu::ThreadIdOp>(loc, indexType, gpuDims[idx]));
   }
-  threadCount.resize(3, rewriter.create<arith::ConstantIndexOp>(loc, 1));
 
-  // Step 2. Move the body of foreachThreadOp after the op.
+  // Step 2. Maybe create conditionals to predicate the region.
+  Value predicate;
+  for (auto it : llvm::zip(threadOps, workgroupSizes, globalWorkgroupSizes)) {
+    auto threadId = std::get<0>(it);
+    auto workgroupSize = std::get<1>(it);
+    auto globalWorkgroupSize = std::get<2>(it);
+    assert(workgroupSize <= globalWorkgroupSize && "workgroup size overflow");
+    if (workgroupSize == globalWorkgroupSize) continue;
+    Value tmpPredicate = rewriter.create<arith::CmpIOp>(
+        loc, arith::CmpIPredicate::ult, threadId,
+        rewriter.create<arith::ConstantIndexOp>(loc, workgroupSize));
+    predicate =
+        predicate ? rewriter.create<arith::AndIOp>(loc, predicate, tmpPredicate)
+                  : tmpPredicate;
+  }
+
+  // Step 3. Move the body of foreachThreadOp.
   // Erase the terminator first, it will not be used.
   rewriter.eraseOp(foreachThreadOp.getTerminator());
-  Block *block = foreachThreadOp->getBlock();
-  block->getOperations().splice(
-      Block::iterator(foreachThreadOp),
-      foreachThreadOp.getRegion().front().getOperations());
+  Block *targetBlock;
+  Block::iterator insertionPoint;
+  if (predicate) {
+    // Step 3.a. If predicated, move at the beginning.
+    auto ifOp =
+        rewriter.create<scf::IfOp>(loc, predicate, /*withElseRegion=*/false);
+    targetBlock = ifOp.thenBlock();
+    insertionPoint = ifOp.thenBlock()->begin();
+  } else {
+    // Step 3.a. Otherwise, move inline just before foreachThreadOp.
+    targetBlock = foreachThreadOp->getBlock();
+    insertionPoint = Block::iterator(foreachThreadOp);
+  }
+  Block &sourceBlock = foreachThreadOp.getRegion().front();
+  targetBlock->getOperations().splice(insertionPoint,
+                                      sourceBlock.getOperations());
 
-  // Step 3. RAUW thread indices to thread ops.
+  // Step 4. RAUW thread indices to thread ops.
   for (auto it : llvm::zip(foreachThreadOp.getThreadIndices(), threadOps))
     std::get<0>(it).replaceAllUsesWith(std::get<1>(it));
 
+  // Step 5. syncthreads.
+  rewriter.create<gpu::BarrierOp>(loc);
+
+  // Step 6. Erase old op.
   rewriter.eraseOp(foreachThreadOp);
 
   return threadCount;
@@ -104,49 +165,57 @@ ForeachThreadToGpuRewriter::returningMatchAndRewrite(
 DiagnosedSilenceableFailure
 transform_dialect::ForeachThreadToGpuAndTranslationInfo::apply(
     transform::TransformResults &results, transform::TransformState &state) {
+  if (!isa<HAL::ExecutableVariantOp>(state.getTopLevel())) {
+    emitOpError() << "applies only to HAL::ExecutableVariantOp targets";
+    return DiagnosedSilenceableFailure::definiteFailure();
+  }
+
+  DenseMap<func::FuncOp, SmallVector<scf::ForeachThreadOp>>
+      foreachThreadsPerFunc;
+  DenseMap<scf::ForeachThreadOp, func::FuncOp> foreachThreadToFunc;
+  WalkResult walkResult = state.getTopLevel()->walk<WalkOrder::PostOrder>(
+      [&](scf::ForeachThreadOp op) {
+        if (op->getParentOfType<scf::ForeachThreadOp>())
+          return WalkResult::interrupt();
+
+        auto funcOp = op->getParentOfType<func::FuncOp>();
+        foreachThreadToFunc.insert(std::make_pair(op, funcOp));
+        auto it = foreachThreadsPerFunc.find(funcOp);
+        if (it == foreachThreadsPerFunc.end())
+          foreachThreadsPerFunc.insert(
+              std::make_pair(funcOp, SmallVector<scf::ForeachThreadOp>{op}));
+        else
+          it->second.push_back(op);
+        return WalkResult::advance();
+      });
+  if (walkResult.wasInterrupted())
+    return DiagnosedSilenceableFailure::definiteFailure();
+
   llvm::StringMap<IREE::HAL::ExecutableExportOp> exportOps;
   state.getTopLevel()->walk(
       [&](IREE::HAL::ExecutableExportOp op) { exportOps[op.sym_name()] = op; });
 
-  if (state.getTopLevel()
-          ->walk<WalkOrder::PostOrder>([&](scf::ForeachThreadOp op) {
-            auto funcOp = op->getParentOfType<func::FuncOp>();
-            auto exportOp = exportOps.lookup(funcOp.getName());
-            // Step 1. Apply the rewrite.
-            auto workgroupSize = functional::applyReturningPatternAt(
-                ForeachThreadToGpuRewriter(getContext()), op);
-            if (failed(workgroupSize)) return WalkResult::interrupt();
+  walkResult =
+      state.getTopLevel()->walk<WalkOrder::PostOrder>([&](func::FuncOp funcOp) {
+        auto maybeJoinedRanges =
+            joinStaticRanges(foreachThreadsPerFunc.lookup(funcOp));
+        if (failed(maybeJoinedRanges)) return WalkResult::interrupt();
+        for (auto foreachThreadOp : foreachThreadsPerFunc.lookup(funcOp)) {
+          auto workgroupSize = functional::applyReturningPatternAt(
+              ForeachThreadToGpuRewriter(*maybeJoinedRanges, getContext()),
+              foreachThreadOp);
+          if (failed(workgroupSize)) return WalkResult::interrupt();
+        }
+        auto exportOp = exportOps.lookup(funcOp.getName());
+        OpBuilder b(exportOp);
+        auto newAttr = b.getIndexArrayAttr(*maybeJoinedRanges);
+        exportOp->setAttr(exportOp.workgroup_sizeAttrName(), newAttr);
+        return WalkResult::advance();
+      });
 
-            // Step 2. Ensure the workgroupSize is static and extract it.
-            SmallVector<int64_t, 3> staticThreadCount;
-            for (auto en : llvm::enumerate(*workgroupSize)) {
-              auto maybeInt = getConstantIntValue(en.value());
-              if (!maybeInt) {
-                op->emitError("scf.foreach_thread rank #")
-                    << en.index() << " is not a constant and cannot be lowered "
-                    << "into the translation_info attr";
-                return WalkResult::interrupt();
-              }
-              staticThreadCount.push_back(*maybeInt);
-            }
-
-            // Step 3. Check and fill the attribute that requires
-            OpBuilder b(exportOp);
-            auto maybeExistingAttr =
-                exportOp->getAttr(exportOp.workgroup_sizeAttrName());
-            auto newAttr = b.getIndexArrayAttr(staticThreadCount);
-            if (maybeExistingAttr && maybeExistingAttr != newAttr) {
-              exportOp->emitError("multiple mismatching workgroup_size ")
-                  << "attributes found: " << maybeExistingAttr << " and "
-                  << newAttr;
-              return WalkResult::interrupt();
-            }
-            exportOp->setAttr(exportOp.workgroup_sizeAttrName(), newAttr);
-            return WalkResult::advance();
-          })
-          .wasInterrupted())
-    return DiagnosedSilenceableFailure::definiteFailure();
-  return DiagnosedSilenceableFailure::success();
+  return walkResult.wasInterrupted()
+             ? DiagnosedSilenceableFailure::definiteFailure()
+             : DiagnosedSilenceableFailure::success();
 }
 
 #define GET_OP_CLASSES

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformDialectExtensions/TransformDialectLLVMGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformDialectExtensions/TransformDialectLLVMGPUExtensionsOps.td
@@ -13,11 +13,59 @@ include "mlir/Dialect/Transform/IR/TransformInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpBase.td"
 
-def ForeachThreadToGpuAndTranslationInfo : Op<Transform_Dialect, "iree.foreach_thread_to_gpu_and_translation_info",
+def ForeachThreadToGpuAndTranslationInfo : 
+  Op<Transform_Dialect, "iree.foreach_thread_to_gpu_and_translation_info",
     [FunctionalStyleTransformOpTrait, 
      MemoryEffectsOpInterface,
      DeclareOpInterfaceMethods<TransformOpInterface>]> {
-  let description = [{Rewrite an scf.foreach_thread to distributed gpu.thread_id and translation_info attribute}];
+  let description = [{
+    Target the whole hal.executable_variant op and rewrite all scf.foreach_thread
+    to distributed gpu.thread_id and translation_info attribute.
+
+    The mapping of threads to gpu.thread_id is currently one-to-one and in order.
+    Only **bufferized** scf.foreach_thread are currently supported.
+    Only scf.foreach_thread distributed to *8at most 3 dimensions** are currently
+    supported.
+
+    Multiple scf.foreach_thread are supported per function in which case, the
+    max of all the threads is computed and taken for the global gpu.thread_id.
+    If necessary, scf.foreach_thread that do not use the whole thread range 
+    result in predicated computations.
+   
+    Barriers are inserted after each scf.foreach_thread op for now.
+
+    Example:
+
+    ```
+    hal.executable {
+      hal.executable.variant {
+        hal.executable.export {
+          func @foo() {
+            scf.foreach_thread (%i, %j) in (7, 9) {
+              ... // body 1
+            }
+            scf.foreach_thread (%i) in (12) {
+              ... // body 2
+            }
+          }
+    ```
+
+    is translated to:
+
+    ```
+    hal.executable {
+      hal.executable.variant {
+        hal.executable.export ... workgroup_size = [12 : index, 9 : index, 1 : index] {
+          func @foo() {
+            if (threadIdx.x < 7) {
+              ... // body 1
+            }
+            if (threadIdx.y < 1) {
+              ... // body 2
+            }
+          }
+    ```
+  }];
 
   let arguments = (ins);
   let results = (outs);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_foreach_to_gpu_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_foreach_to_gpu_spec.mlir
@@ -2,6 +2,13 @@
 
 transform.with_pdl_patterns {
 ^bb0(%arg0: !pdl.operation):
+  pdl.pattern @pdl_fill_target : benefit(1) {
+    %args = operands
+    %results = types
+    %0 = operation "linalg.fill"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
+    // TODO: we don't want this, but it is the required terminator for pdl.pattern
+    rewrite %0 with "transform.dialect"
+  }
   pdl.pattern @pdl_matmul_target : benefit(1) {
     %args = operands
     %results = types
@@ -12,8 +19,10 @@ transform.with_pdl_patterns {
 
   transform.structured.canonicalized_sequence %arg0 {
   ^bb1(%arg1: !pdl.operation):
-    %0 = pdl_match @pdl_matmul_target in %arg1
-    %tiling_1_result:2 = tile_to_foreach_thread_op %0 {num_threads = [7, 9]}
+    %0 = pdl_match @pdl_fill_target in %arg1
+    %tiling_0_result:2 = tile_to_foreach_thread_op %0 {num_threads = [5, 1]}
+    %1 = pdl_match @pdl_matmul_target in %arg1
+    %tiling_1_result:2 = tile_to_foreach_thread_op %1 {num_threads = [7, 9]}
     transform.iree.bufferize
     transform.iree.foreach_thread_to_gpu_and_translation_info
   }


### PR DESCRIPTION
Target the whole hal.executable_variant op and rewrite all scf.foreach_thread
to distributed gpu.thread_id and translation_info attribute.

The mapping of threads to gpu.thread_id is currently one-to-one and in order.
Only **bufferized** scf.foreach_thread are currently supported.
Only scf.foreach_thread distributed to *8at most 3 dimensions** are currently
supported.

Multiple scf.foreach_thread are supported per function in which case, the
max of all the threads is computed and taken for the global gpu.thread_id.
If necessary, scf.foreach_thread that do not use the whole thread range
result in predicated computations.

Barriers are inserted after each scf.foreach_thread op for now.

Example:

```
hal.executable {
  hal.executable.variant {
    hal.executable.export {
      func @foo() {
        scf.foreach_thread (%i, %j) in (7, 9) {
          ... // body 1
        }
        scf.foreach_thread (%i) in (12) {
          ... // body 2
        }
      }
```

is translated to:

```
hal.executable {
  hal.executable.variant {
    hal.executable.export ... workgroup_size = [12 : index, 9 : index, 1 : index] {
      func @foo() {
        if (threadIdx.x < 7) {
          ... // body 1
        }
        if (threadIdx.y < 1) {
          ... // body 2
        }
      }
```