### PR TITLE
Fix float->[u]int conversion

### DIFF
--- a/runtime/src/iree/vm/ops.h
+++ b/runtime/src/iree/vm/ops.h
@@ -324,7 +324,7 @@ static inline int32_t vm_cast_f32si32(float operand) {
   return (int32_t)lroundf(operand);
 }
 static inline int32_t vm_cast_f32ui32(float operand) {
-  return (uint32_t)lroundf(operand);
+  return (uint32_t)llroundf(operand);
 }
 static inline float vm_bitcast_i32f32(int32_t operand) {
   float result;

--- a/runtime/src/iree/vm/test/conversion_ops_f32.mlir
+++ b/runtime/src/iree/vm/test/conversion_ops_f32.mlir
@@ -58,10 +58,12 @@ vm.module @conversion_ops_f32 {
 
   vm.export @test_cast_f32_si32_int_max
   vm.func @test_cast_f32_si32_int_max() {
-    %c1 = vm.const.f32 2147483647.0
+    // This is the maximum value that is representable precisely as both i32
+    // and f32. An exponent of 30 with all mantissa bits set.
+    %c1 = vm.const.f32 0x4effffff
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.cast.f32.si32 %c1dno : f32 -> i32
-    %c2 = vm.const.i32 -2147483648
+    %c2 = vm.const.i32 0x7FFFFF80
     vm.check.eq %v, %c2, "cast floating-point value to a signed integer" : i32
     vm.return
   }
@@ -96,12 +98,14 @@ vm.module @conversion_ops_f32 {
     vm.return
   }
 
-  vm.export @test_cast_f32_ui32_int_max
-  vm.func @test_cast_f32_ui32_int_max() {
-    %c1 = vm.const.f32 4294967295.0
+  vm.export @test_cast_f32_ui32_int_big
+  vm.func @test_cast_f32_ui32_int_big() {
+    // This is the maximum value that is representable precisely as both ui32
+    // and f32. An exponent of 31 with all mantissa bits set.
+    %c1 = vm.const.f32 0x4f7fffff
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.cast.f32.ui32 %c1dno : f32 -> i32
-    %c2 = vm.const.i32 0
+    %c2 = vm.const.i32 0xFFFFFF00
     vm.check.eq %v, %c2, "cast floating-point value to an unsigned integer" : i32
     vm.return
   }


### PR DESCRIPTION
The current code is actually exercising undefined behavior. `lroundf`
can't be used for converting to uint32 because `long int` is only
guaranteed to be at least a 32-bit signed integer. The floats used in
the tests are also ones that can't be represented precisely in an f32.

Note that the f32->ui32 test was actually explicitly *testing*
overflow previously, as it was asserting that the rounded value ended
up being zero.