### PR TITLE
Rename PadTensorToSubTensorInsert to more representative PadTensorToInsertSlice

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -54,7 +54,7 @@ iree_compiler_cc_library(
         "OptimizeNumerics.cpp",
         "OutlineDispatchRegions.cpp",
         "PadLinalgOps.cpp",
-        "PadTensorToSubTensorInsert.cpp",
+        "PadTensorToTensorInsertSlice.cpp",
         "PassDetail.h",
         "Passes.cpp",
         "SplitReduction.cpp",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -50,7 +50,7 @@ iree_cc_library(
     "OptimizeNumerics.cpp"
     "OutlineDispatchRegions.cpp"
     "PadLinalgOps.cpp"
-    "PadTensorToSubTensorInsert.cpp"
+    "PadTensorToTensorInsertSlice.cpp"
     "PassDetail.h"
     "Passes.cpp"
     "SplitReduction.cpp"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/PadTensorToTensorInsertSlice.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/PadTensorToTensorInsertSlice.cpp
@@ -4,9 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-//===- PadTensorToSubTensorInsert.cpp - Pass to legalize linalg.pad_tensor-===//
+//===- PadTensorToInsertSlice.cpp - Pass to legalize linalg.pad_tensor-===//
 //
-// Pass to convert linalg.pad_tensor to linalg.fill + subtensor_insert
+// Pass to convert linalg.pad_tensor to linalg.fill + tensor.insert_slice
 // operations which is the only way Vulkan backend can lower it to a single
 // kernel.
 //
@@ -31,8 +31,9 @@ namespace IREE {
 namespace Flow {
 
 namespace {
-/// Pattern to convert a linalg.pad_tensor operation into a fill + subtensor
-/// insert. This is needed till pad_tensor op can be fused with its consumers.
+/// Pattern to convert a linalg.pad_tensor operation into a fill + tensor
+/// insert_slice. This is needed till pad_tensor op can be fused with its
+/// consumers.
 struct PadTensorOpConversion : public OpRewritePattern<tensor::PadOp> {
   using OpRewritePattern<tensor::PadOp>::OpRewritePattern;
 
@@ -102,8 +103,9 @@ struct PadTensorOpConversion : public OpRewritePattern<tensor::PadOp> {
   }
 };
 
-struct PadTensorToSubTensorInsertPass
-    : public PadTensorToSubTensorInsertBase<PadTensorToSubTensorInsertPass> {
+struct PadTensorToTensorInsertSlicePass
+    : public PadTensorToTensorInsertSliceBase<
+          PadTensorToTensorInsertSlicePass> {
   void getDependentDialects(DialectRegistry &registry) const override {
     registry
         .insert<linalg::LinalgDialect, memref::MemRefDialect, func::FuncDialect,
@@ -123,8 +125,8 @@ struct PadTensorToSubTensorInsertPass
 
 }  // namespace
 
-std::unique_ptr<Pass> createPadTensorToSubTensorInsertPass() {
-  return std::make_unique<PadTensorToSubTensorInsertPass>();
+std::unique_ptr<Pass> createPadTensorToTensorInsertSlicePass() {
+  return std::make_unique<PadTensorToTensorInsertSlicePass>();
 }
 
 }  // namespace Flow

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -214,7 +214,7 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
   FunctionLikeNest(passManager)
       // Pad tensors.
       .addPredicatedPass((!clEnableFusePaddingIntoConsumerOps),
-                         IREE::Flow::createPadTensorToSubTensorInsertPass)
+                         IREE::Flow::createPadTensorToTensorInsertSlicePass)
 
       // Preprocess the input to a form more amenable for fusion
       // - Convert all elementwise ops to Linalg

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -81,7 +81,7 @@ std::unique_ptr<Pass> createConvertConv2DToImg2ColPass();
 
 // Pass to convert a linalg.pad_tensor operation into a linalg.fill +
 // subtensor_insert. This allows lowering the operation into a single kernel.
-std::unique_ptr<Pass> createPadTensorToSubTensorInsertPass();
+std::unique_ptr<Pass> createPadTensorToTensorInsertSlicePass();
 
 // Pass to convert a linalg.matmul into linalg.mmt4d given some target ISA
 // information currently passed as pass options.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -155,10 +155,10 @@ def ConvertLinalgMatmulToMmt4D :
   ];
 }
 
-def PadTensorToSubTensorInsert :
-    Pass<"iree-flow-pad-tensor-to-subtensor-insert", ""> {
-  let summary = "Convert linalg.pad_tensor into linalg.fill + subtensor_insert";
-  let constructor = "mlir::iree_compiler::IREE::Flow::createPadTensorToSubTensorInsertPass()";
+def PadTensorToTensorInsertSlice :
+    Pass<"iree-flow-pad-tensor-to-tensor-insert-slice", ""> {
+  let summary = "Convert linalg.pad_tensor into linalg.fill + tensor.insert_slice";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createPadTensorToTensorInsertSlicePass()";
 }
 
 def DumpDispatchGraph : Pass<"iree-flow-dump-dispatch-graph-pass"> {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/pad_tensor_to_tensor.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/pad_tensor_to_tensor.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --iree-flow-pad-tensor-to-subtensor-insert --canonicalize %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-flow-pad-tensor-to-tensor-insert-slice --canonicalize %s | FileCheck %s
 
 module  {
   func.func @pad_tensor(%arg0 : tensor<?x?xf32>, %arg1 : tensor<f32>, %arg2 : index, %arg3 : index) -> tensor<?x?xf32> {


### PR DESCRIPTION
-subtensor_insert has been replaced by tensor.insert_slice, so renaming the pass to make it more representative of current op naming.