### PR TITLE
Adding `--vulkan_debug_verbosity=` flag and disabling debug layers in release.

### DIFF
--- a/runtime/src/iree/hal/drivers/vulkan/api.h
+++ b/runtime/src/iree/hal/drivers/vulkan/api.h
@@ -217,6 +217,9 @@ typedef struct iree_hal_vulkan_driver_options_t {
   // the instance and its devices are created.
   iree_hal_vulkan_features_t requested_features;
 
+  // Cutoff for debug output: 0=none, 1=errors, 2=warnings, 3=info, 4=debug.
+  int32_t debug_verbosity;
+
   // TODO(benvanik): remove this single setting - it would be nice instead to
   // pass a list to force device enumeration/matrix expansion or omit entirely
   // to have auto-discovered options based on capabilities. Right now this

--- a/runtime/src/iree/hal/drivers/vulkan/api.h
+++ b/runtime/src/iree/hal/drivers/vulkan/api.h
@@ -224,13 +224,6 @@ typedef struct iree_hal_vulkan_driver_options_t {
   // options.
   // Options to use for all devices created by the driver.
   iree_hal_vulkan_device_options_t device_options;
-
-  // TODO(benvanik): change to something more canonically vulkan (like
-  // VkPhysicalDeviceProperties::deviceID).
-  // Index of the default Vulkan device to use within the list of available
-  // devices. Devices are discovered via vkEnumeratePhysicalDevices then
-  // considered "available" if compatible with the |requested_features|.
-  int default_device_index;
 } iree_hal_vulkan_driver_options_t;
 
 IREE_API_EXPORT void iree_hal_vulkan_driver_options_initialize(

--- a/runtime/src/iree/hal/drivers/vulkan/debug_reporter.h
+++ b/runtime/src/iree/hal/drivers/vulkan/debug_reporter.h
@@ -26,7 +26,7 @@ typedef struct iree_hal_vulkan_debug_reporter_t
 
 iree_status_t iree_hal_vulkan_debug_reporter_allocate(
     VkInstance instance, iree::hal::vulkan::DynamicSymbols* syms,
-    const VkAllocationCallbacks* allocation_callbacks,
+    int32_t min_verbosity, const VkAllocationCallbacks* allocation_callbacks,
     iree_allocator_t host_allocator,
     iree_hal_vulkan_debug_reporter_t** out_reporter);
 

--- a/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.cc
@@ -19,9 +19,6 @@ IREE_FLAG(bool, vulkan_validation_layers, true,
 IREE_FLAG(bool, vulkan_debug_utils, true,
           "Enables VK_EXT_debug_utils, records markers, and logs errors.");
 
-IREE_FLAG(int32_t, vulkan_default_index, 0,
-          "Index of the default Vulkan device.");
-
 IREE_FLAG(bool, vulkan_tracing, true,
           "Enables Vulkan tracing (if IREE tracing is enabled).");
 
@@ -56,8 +53,6 @@ static iree_status_t iree_hal_vulkan_create_driver_with_flags(
   if (FLAG_vulkan_tracing) {
     driver_options.requested_features |= IREE_HAL_VULKAN_FEATURE_ENABLE_TRACING;
   }
-
-  driver_options.default_device_index = FLAG_vulkan_default_index;
 
   // Load the Vulkan library. This will fail if the library cannot be found or
   // does not have the expected functions.

--- a/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.cc
@@ -24,6 +24,9 @@ IREE_FLAG(bool, vulkan_validation_layers, IREE_HAL_VULKAN_DEBUG_FLAG_DEFAULT,
           "Enables standard Vulkan validation layers.");
 IREE_FLAG(bool, vulkan_debug_utils, IREE_HAL_VULKAN_DEBUG_FLAG_DEFAULT,
           "Enables VK_EXT_debug_utils, records markers, and logs errors.");
+IREE_FLAG(int32_t, vulkan_debug_verbosity, 2,
+          "Cutoff for debug output; "
+          "0=none, 1=errors, 2=warnings, 3=info, 4=debug.");
 
 IREE_FLAG(bool, vulkan_tracing, true,
           "Enables Vulkan tracing (if IREE tracing is enabled).");
@@ -55,6 +58,7 @@ static iree_status_t iree_hal_vulkan_create_driver_with_flags(
   if (FLAG_vulkan_debug_utils) {
     driver_options.requested_features |=
         IREE_HAL_VULKAN_FEATURE_ENABLE_DEBUG_UTILS;
+    driver_options.debug_verbosity = FLAG_vulkan_debug_verbosity;
   }
   if (FLAG_vulkan_tracing) {
     driver_options.requested_features |= IREE_HAL_VULKAN_FEATURE_ENABLE_TRACING;

--- a/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.cc
@@ -14,9 +14,15 @@
 #include "iree/base/tracing.h"
 #include "iree/hal/drivers/vulkan/api.h"
 
-IREE_FLAG(bool, vulkan_validation_layers, true,
+#ifndef NDEBUG
+#define IREE_HAL_VULKAN_DEBUG_FLAG_DEFAULT true
+#else
+#define IREE_HAL_VULKAN_DEBUG_FLAG_DEFAULT false
+#endif  // !NDEBUG
+
+IREE_FLAG(bool, vulkan_validation_layers, IREE_HAL_VULKAN_DEBUG_FLAG_DEFAULT,
           "Enables standard Vulkan validation layers.");
-IREE_FLAG(bool, vulkan_debug_utils, true,
+IREE_FLAG(bool, vulkan_debug_utils, IREE_HAL_VULKAN_DEBUG_FLAG_DEFAULT,
           "Enables VK_EXT_debug_utils, records markers, and logs errors.");
 
 IREE_FLAG(bool, vulkan_tracing, true,

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_driver.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_driver.cc
@@ -33,7 +33,6 @@ typedef struct iree_hal_vulkan_driver_t {
   iree_string_view_t identifier;
 
   iree_hal_vulkan_device_options_t device_options;
-  int default_device_index;
 
   iree_hal_vulkan_features_t enabled_features;
 
@@ -69,7 +68,6 @@ IREE_API_EXPORT void iree_hal_vulkan_driver_options_initialize(
   out_options->api_version = VK_API_VERSION_1_2;
   out_options->requested_features = 0;
   iree_hal_vulkan_device_options_initialize(&out_options->device_options);
-  out_options->default_device_index = 0;
 }
 
 // Returns a VkApplicationInfo struct populated with the default app info.
@@ -128,7 +126,6 @@ static iree_status_t iree_hal_vulkan_driver_create_internal(
       (char*)driver + total_size - identifier.size);
   memcpy(&driver->device_options, &options->device_options,
          sizeof(driver->device_options));
-  driver->default_device_index = options->default_device_index;
   driver->enabled_features = options->requested_features;
   driver->syms = iree::add_ref(instance_syms);
   driver->instance = instance;
@@ -562,14 +559,13 @@ static iree_status_t iree_hal_vulkan_driver_create_device_by_id(
   iree_hal_vulkan_driver_t* driver = iree_hal_vulkan_driver_cast(base_driver);
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  // Use either the specified device (enumerated earlier) or whatever default
-  // one was specified when the driver was created.
+  // Use either the specified device (enumerated earlier) or whatever the Vulkan
+  // driver considers device 0.
   VkPhysicalDevice physical_device = (VkPhysicalDevice)device_id;
   if (physical_device == VK_NULL_HANDLE) {
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
         z0, iree_hal_vulkan_driver_find_device_by_index(
-                base_driver, driver->default_device_index, host_allocator,
-                &physical_device));
+                base_driver, 0, host_allocator, &physical_device));
   }
 
   // TODO(benvanik): remove HAL module dependence on the identifier for matching

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_driver.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_driver.cc
@@ -67,6 +67,7 @@ IREE_API_EXPORT void iree_hal_vulkan_driver_options_initialize(
   memset(out_options, 0, sizeof(*out_options));
   out_options->api_version = VK_API_VERSION_1_2;
   out_options->requested_features = 0;
+  out_options->debug_verbosity = 0;
   iree_hal_vulkan_device_options_initialize(&out_options->device_options);
 }
 
@@ -105,8 +106,8 @@ static iree_status_t iree_hal_vulkan_driver_create_internal(
   iree_hal_vulkan_debug_reporter_t* debug_reporter = NULL;
   if (instance_extensions.debug_utils) {
     IREE_RETURN_IF_ERROR(iree_hal_vulkan_debug_reporter_allocate(
-        instance, instance_syms, /*allocation_callbacks=*/NULL, host_allocator,
-        &debug_reporter));
+        instance, instance_syms, options->debug_verbosity,
+        /*allocation_callbacks=*/NULL, host_allocator, &debug_reporter));
   }
 
   iree_hal_vulkan_driver_t* driver = NULL;


### PR DESCRIPTION
Users with release builds can turn the layers on using the flags but they won't be enabled by default - which more closely matches user-intended behavior when running benchmarks/their own applications/etc in release builds.